### PR TITLE
[HUDI-7046] Fix partial merging logic based on projected reader schema

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/merge/SparkRecordMergingUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/merge/SparkRecordMergingUtils.java
@@ -115,6 +115,7 @@ public class SparkRecordMergingUtils {
       InternalRow newPartialRow = newer.getData();
 
       Map<Integer, StructField> mergedIdToFieldMapping = mergedSchemaPair.getLeft();
+      Map<String, Integer> oldNameToIdMapping = getCachedFieldNameToIdMapping(oldSchema);
       Map<String, Integer> newPartialNameToIdMapping = getCachedFieldNameToIdMapping(newSchema);
       List<Object> values = new ArrayList<>(mergedIdToFieldMapping.size());
       for (int fieldId = 0; fieldId < mergedIdToFieldMapping.size(); fieldId++) {
@@ -125,7 +126,7 @@ public class SparkRecordMergingUtils {
           values.add(newPartialRow.get(ordInPartialUpdate, structField.dataType()));
         } else {
           // The field does not exist in the newer record; picks the value from older record
-          values.add(oldRow.get(fieldId, structField.dataType()));
+          values.add(oldRow.get(oldNameToIdMapping.get(structField.name()), structField.dataType()));
         }
       }
       InternalRow mergedRow = new GenericInternalRow(values.toArray());

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -174,4 +174,18 @@ public abstract class HoodieReaderContext<T> {
     meta.put(INTERNAL_META_SCHEMA, schema);
     return meta;
   }
+
+  /**
+   * Updates the schema and reset the ordering value in existing metadata mapping of a record.
+   *
+   * @param meta   Metadata in a mapping.
+   * @param schema New schema to set.
+   * @return The input metadata mapping.
+   */
+  public Map<String, Object> updateSchemaAndResetOrderingValInMetadata(Map<String, Object> meta,
+                                                                       Schema schema) {
+    meta.remove(INTERNAL_META_ORDERING_FIELD);
+    meta.put(INTERNAL_META_SCHEMA, schema);
+    return meta;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
@@ -86,9 +86,12 @@ public class HoodieKeyBasedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
   @Override
   public void processNextDataRecord(T record, Map<String, Object> metadata, Object recordKey) throws IOException {
     Pair<Option<T>, Map<String, Object>> existingRecordMetadataPair = records.get(recordKey);
-    Option<T> mergedRecord = doProcessNextDataRecord(record, metadata, existingRecordMetadataPair);
-    if (mergedRecord.isPresent()) {
-      records.put(recordKey, Pair.of(Option.ofNullable(readerContext.seal(mergedRecord.get())), metadata));
+    Option<Pair<T, Map<String, Object>>> mergedRecordAndMetadata =
+        doProcessNextDataRecord(record, metadata, existingRecordMetadataPair);
+    if (mergedRecordAndMetadata.isPresent()) {
+      records.put(recordKey, Pair.of(
+          Option.ofNullable(readerContext.seal(mergedRecordAndMetadata.get().getLeft())),
+          mergedRecordAndMetadata.get().getRight()));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
@@ -114,9 +114,12 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieBaseFileG
   @Override
   public void processNextDataRecord(T record, Map<String, Object> metadata, Object recordPosition) throws IOException {
     Pair<Option<T>, Map<String, Object>> existingRecordMetadataPair = records.get(recordPosition);
-    Option<T> mergedRecord = doProcessNextDataRecord(record, metadata, existingRecordMetadataPair);
-    if (mergedRecord.isPresent()) {
-      records.put(recordPosition, Pair.of(Option.ofNullable(readerContext.seal(mergedRecord.get())), metadata));
+    Option<Pair<T, Map<String, Object>>> mergedRecordAndMetadata =
+        doProcessNextDataRecord(record, metadata, existingRecordMetadataPair);
+    if (mergedRecordAndMetadata.isPresent()) {
+      records.put(recordPosition, Pair.of(
+          Option.ofNullable(readerContext.seal(mergedRecordAndMetadata.get().getLeft())),
+          mergedRecordAndMetadata.get().getRight()));
     }
   }
 


### PR DESCRIPTION
### Change Logs

This PR fixes the logic of merging partial updates with projected reader schema, i.e., the reader schema contains a subset of fields from the table schema based on the query.
- When processing log records in `HoodieBaseFileGroupRecordBuffer#doProcessNextDataRecord`, the schema of the combined record is also updated in the metadata since the schema can change due to partial merging;
- A bug of getting the field values from the older record in `SparkRecordMergingUtils#mergePartialRecords` is fixed.
- The partial update tests in `TestPartialUpdateForMergeInto` are enhanced to cover partial merging logic.

### Impact

Makes sure the partial merging logic is correct.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
