### PR TITLE
[HUDI-7050]Flink HoodieHiveCatalog supports hadoop parameters

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/HadoopConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/HadoopConfigurations.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * Utilities for fetching hadoop configurations.
  */
 public class HadoopConfigurations {
-  private static final String HADOOP_PREFIX = "hadoop.";
+  public static final String HADOOP_PREFIX = "hadoop.";
   private static final String PARQUET_PREFIX = "parquet.";
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogFactory.java
@@ -40,6 +40,7 @@ public class HoodieCatalogFactory implements CatalogFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieCatalogFactory.class);
 
   public static final String IDENTIFIER = "hudi";
+  public static final String HADOOP_PREFIX = "hadoop.";
 
   @Override
   public String factoryIdentifier() {
@@ -50,7 +51,7 @@ public class HoodieCatalogFactory implements CatalogFactory {
   public Catalog createCatalog(Context context) {
     final FactoryUtil.CatalogFactoryHelper helper =
         FactoryUtil.createCatalogFactoryHelper(this, context);
-    helper.validate();
+    helper.validateExcept(HADOOP_PREFIX);
     String mode = helper.getOptions().get(CatalogOptions.MODE);
     switch (mode.toLowerCase(Locale.ROOT)) {
       case "hms":

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.catalog;
 
+import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.exception.HoodieCatalogException;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -40,7 +41,6 @@ public class HoodieCatalogFactory implements CatalogFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieCatalogFactory.class);
 
   public static final String IDENTIFIER = "hudi";
-  public static final String HADOOP_PREFIX = "hadoop.";
 
   @Override
   public String factoryIdentifier() {
@@ -51,7 +51,7 @@ public class HoodieCatalogFactory implements CatalogFactory {
   public Catalog createCatalog(Context context) {
     final FactoryUtil.CatalogFactoryHelper helper =
         FactoryUtil.createCatalogFactoryHelper(this, context);
-    helper.validateExcept(HADOOP_PREFIX);
+    helper.validateExcept(HadoopConfigurations.HADOOP_PREFIX);
     String mode = helper.getOptions().get(CatalogOptions.MODE);
     switch (mode.toLowerCase(Locale.ROOT)) {
       case "hms":

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
@@ -61,7 +61,7 @@ public class HoodieCatalogUtil {
    * @param hiveConfDir Hive conf directory path.
    * @return A HiveConf instance.
    */
-  public static HiveConf createHiveConf(@Nullable String hiveConfDir, @Nullable org.apache.flink.configuration.Configuration flinkConf) {
+  public static HiveConf createHiveConf(@Nullable String hiveConfDir, org.apache.flink.configuration.Configuration flinkConf) {
     // create HiveConf from hadoop configuration with hadoop conf directory configured.
     final org.apache.flink.configuration.Configuration flinkConfiguration = flinkConf == null ? new org.apache.flink.configuration.Configuration() : flinkConf;
     Configuration hadoopConf = HadoopConfigurations.getHadoopConf(flinkConfiguration);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
@@ -61,9 +61,10 @@ public class HoodieCatalogUtil {
    * @param hiveConfDir Hive conf directory path.
    * @return A HiveConf instance.
    */
-  public static HiveConf createHiveConf(@Nullable String hiveConfDir) {
+  public static HiveConf createHiveConf(@Nullable String hiveConfDir, @Nullable org.apache.flink.configuration.Configuration flinkConf) {
     // create HiveConf from hadoop configuration with hadoop conf directory configured.
-    Configuration hadoopConf = HadoopConfigurations.getHadoopConf(new org.apache.flink.configuration.Configuration());
+    final org.apache.flink.configuration.Configuration flinkConfiguration = flinkConf == null ? new org.apache.flink.configuration.Configuration() : flinkConf;
+    Configuration hadoopConf = HadoopConfigurations.getHadoopConf(flinkConfiguration);
 
     // ignore all the static conf file URLs that HiveConf may have set
     HiveConf.setHiveSiteLocation(null);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
@@ -63,8 +63,7 @@ public class HoodieCatalogUtil {
    */
   public static HiveConf createHiveConf(@Nullable String hiveConfDir, org.apache.flink.configuration.Configuration flinkConf) {
     // create HiveConf from hadoop configuration with hadoop conf directory configured.
-    final org.apache.flink.configuration.Configuration flinkConfiguration = flinkConf == null ? new org.apache.flink.configuration.Configuration() : flinkConf;
-    Configuration hadoopConf = HadoopConfigurations.getHadoopConf(flinkConfiguration);
+    Configuration hadoopConf = HadoopConfigurations.getHadoopConf(flinkConf);
 
     // ignore all the static conf file URLs that HiveConf may have set
     HiveConf.setHiveSiteLocation(null);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -130,7 +130,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
   private final boolean external;
 
   public HoodieHiveCatalog(String catalogName, Configuration options) {
-    this(catalogName, options, HoodieCatalogUtil.createHiveConf(options.getString(CatalogOptions.HIVE_CONF_DIR)), false);
+    this(catalogName, options, HoodieCatalogUtil.createHiveConf(options.getString(CatalogOptions.HIVE_CONF_DIR), options), false);
   }
 
   public HoodieHiveCatalog(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/HoodieCatalogTestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/HoodieCatalogTestUtils.java
@@ -48,6 +48,7 @@ public class HoodieCatalogTestUtils {
 
   public static HoodieHiveCatalog createHiveCatalog(String name, boolean external) {
     Configuration options = new Configuration();
+    options.setString("hadoop.dfs.client.block.write.replace-datanode-on-failure.enable", "true");
     options.setBoolean(CatalogOptions.TABLE_EXTERNAL, external);
     return new HoodieHiveCatalog(
         name,


### PR DESCRIPTION
### Change Logs

Flink HoodieHiveCatalog supports hadoop parameters

### Impact

Flink HoodieHiveCatalog supports hadoop parameters

### Risk level (write none, low medium or high below)

low

### Documentation Update
Flink HoodieHiveCatalog supports hadoop parameters
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
