### PR TITLE
[HUDI-7054][FOLLOW_UP] HoodieCatalogTable should ignore lazily deleted partitions

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.AvroSchemaUtils
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, TypedProperties}
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING
+import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
@@ -169,9 +170,14 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
   lazy val partitionSchema: StructType = StructType(tableSchema.filter(f => partitionFields.contains(f.name)))
 
   /**
-   * All the partition paths
+   * All the partition paths, excludes lazily deleted partitions.
    */
-  def getPartitionPaths: Seq[String] = getAllPartitionPaths(spark, table)
+  def getPartitionPaths: Seq[String] = {
+    val droppedPartitions = TimelineUtils.getDroppedPartitions(metaClient.getActiveTimeline)
+
+    getAllPartitionPaths(spark, table)
+      .filter(!droppedPartitions.contains(_))
+  }
 
   /**
    * Check if table is a partitioned table

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/ShowHoodieTablePartitionsCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/ShowHoodieTablePartitionsCommand.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.hudi.command
 
-import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
+
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -55,7 +55,6 @@ case class ShowHoodieTablePartitionsCommand(
         }
       }
         .getOrElse(hoodieCatalogTable.getPartitionPaths)
-        .filter(!TimelineUtils.getDroppedPartitions(hoodieCatalogTable.metaClient.getActiveTimeline).contains(_))
         .map(Row(_))
     } else {
       Seq.empty[Row]


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
Thinking it might be better to directly let `HoodieCatalogTable` to filter deleted partitions, it shouldn't show deleted partitions when calling `getPartitionPaths`.

This can also fix `RepairHoodieTableCommand` to not repair deleted partitions.

### Impact

_Describe any public API or user-facing feature change or any performance impact._
None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
None
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
