### PR TITLE
[HUDI-7057] Support CopyToTableProcedure with patitial column copy

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCopyToTableProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCopyToTableProcedure.scala
@@ -93,6 +93,14 @@ class TestCopyToTableProcedure extends HoodieSparkProcedureTestBase {
       val copyTableCount = spark.sql(s"""select count(1) from $copyTableName""").collectAsList()
       assert(copyTableCount.size() == 1 && copyTableCount.get(0).get(0) == 4)
 
+      val patitialTable = generateTableName
+      spark.sql(s"""call copy_to_table(table=>'$tableName',new_table=>'$patitialTable',columns=>'id,name')""").collectAsList()
+      checkAnswer(s"select * from $patitialTable")(
+        Seq(1, "a1"),
+        Seq(2, "a2"),
+        Seq(3, "a3"),
+        Seq(4, "a4")
+      )
 
     }
   }
@@ -153,14 +161,6 @@ class TestCopyToTableProcedure extends HoodieSparkProcedureTestBase {
       val ids: util.List[Row] = df.selectExpr("id").collectAsList()
       assert(ids.containsAll(util.Arrays.asList(Row(1), Row(2), Row(3), Row(4), Row(5))))
 
-      val patitialTable = generateTableName
-      spark.sql(s"""call copy_to_table(table=>'$tableName',new_table=>'$patitialTable',columns=>'id,name')""").collectAsList()
-      checkAnswer(s"select * from $patitialTable")(
-        Seq(1, "a1"),
-        Seq(2, "a2"),
-        Seq(3, "a3"),
-        Seq(4, "a4")
-      )
     }
   }
 


### PR DESCRIPTION
### Change Logs

currently CopyToTableProcedure only support all schema copy to a new table，but many sences user need a part columns from table schema，for example user don't need metadata column due to storage cost

### Impact

none

### Risk level (write none, low medium or high below)

lower

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
