### PR TITLE
[HUDI-7060] Disable new file group reader or new parquet file format for CDC, time travel, and incremental query types

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -22,6 +22,7 @@ import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.JobConf
+import org.apache.hudi.DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT
 import org.apache.hudi.HoodieBaseRelation.{convertToAvroSchema, isSchemaEvolutionEnabledOnRead}
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.HoodieFileIndex.getConfigProperties
@@ -244,10 +245,12 @@ class HoodieMergeOnReadSnapshotHadoopFsRelationFactory(override val sqlContext: 
     sparkSession.sparkContext.broadcast(HoodieTableSchema(tableStructSchema, tableAvroSchema.toString, internalSchemaOpt)),
     metaClient.getTableConfig.getTableName, mergeType, mandatoryFields, true, false, Seq.empty)
 
+  private val isTimeTravelQuery: Boolean = options.contains(TIME_TRAVEL_AS_OF_INSTANT.key())
+
   override def buildFileIndex(): FileIndex = fileIndex
 
   override def buildFileFormat(): FileFormat = {
-    if (fileGroupReaderEnabled) {
+    if (fileGroupReaderEnabled && !isTimeTravelQuery & !isBootstrap) {
       fileGroupReaderBasedFileFormat
     } else if (metaClient.getTableConfig.isMultipleBaseFileFormatsEnabled && !isBootstrap) {
       multipleBaseFileFormat


### PR DESCRIPTION


### Change Logs

Due to the bug fixing status, we decide to use the following rules to turn on/off new_spark_file_format and file_group_reader_file_format. Rules are as follows:

1. For CDC queries, we should not use either of the two file formats. Then we keep using the existing relation.
2. For time_travel queries and bootstrap queries, we use new_spark_file_format but not use file_group_reader_file_format.
3. For Incremental queries, we use the existing relations, e.g., IncrementalRelation or MergeOnReadIncrementalRelation to handle.

### Impact

Low.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
