### PR TITLE
[HUDI-7062] Implement Caching Iterator for new filegroup reader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -84,9 +84,18 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
     this.baseFileIterator = baseFileIterator;
   }
 
+  protected abstract boolean doHasNext() throws IOException;
+
   @Override
-  public T next() {
-    return nextRecord;
+  public final boolean hasNext() throws IOException {
+    return nextRecord != null || doHasNext();
+  }
+
+  @Override
+  public final T next() {
+    T record = nextRecord;
+    nextRecord = null;
+    return record;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -84,6 +84,11 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
     this.baseFileIterator = baseFileIterator;
   }
 
+  /**
+   * This allows hasNext() to be called multiple times without incrementing the iterator by more than 1
+   * record. It does come with the caveat that hasNext() must be called every time before next(). But
+   * that is pretty expected behavior and every user should be doing that anyway.
+   */
   protected abstract boolean doHasNext() throws IOException;
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
@@ -121,7 +121,7 @@ public class HoodieKeyBasedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  protected boolean doHasNext() throws IOException {
     ValidationUtils.checkState(baseFileIterator != null, "Base file iterator has not been set yet");
 
     // Handle merging.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
@@ -163,7 +163,7 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieBaseFileG
   }
 
   @Override
-  public boolean hasNext() throws IOException {
+  protected boolean doHasNext() throws IOException {
     ValidationUtils.checkState(baseFileIterator != null, "Base file iterator has not been set yet");
 
     // Handle merging.


### PR DESCRIPTION
### Change Logs

Sometimes df.count() ends up calling hasnext multiple times before calling next() so we need to use caching iterator style

### Impact

fix issue that was causing tests to fail

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
