### PR TITLE
[HUDI-7064] Recheck should use batch when cached result is true

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/NewHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/NewHoodieParquetFileFormat.scala
@@ -72,7 +72,7 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
   private var supportBatchCalled = false
   private var supportBatchResult = false
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
-    if (!supportBatchCalled) {
+    if (!supportBatchCalled || supportBatchResult) {
       supportBatchCalled = true
       supportBatchResult = !isIncremental && !isMOR && super.supportBatch(sparkSession, schema)
     }


### PR DESCRIPTION
### Change Logs

supports batch result is cached so the different file readers used are consistent for a query. File format can be used multiple times, so we don't want support batch to be true for the next query

### Impact

Remove failure point

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
