### PR TITLE
[MINOR] Turn off filegroup reader for type promotion tests

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
@@ -18,7 +18,7 @@
  */
 package org.apache.hudi
 
-import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.SchemaCompatibilityException
@@ -145,7 +145,12 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
           upsertData(upsertDf, tempRecordPath, isCow)
 
           // read out the table
-          val readDf = spark.read.format("hudi").load(tempRecordPath)
+          val readDf = spark.read.format("hudi")
+            // NOTE: type promotion is not supported for the custom file format and the filegroup reader
+            //       HUDI-7045 and PR#10007 in progress to fix the issue
+            .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false")
+            .option(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT.key(), "false")
+            .load(tempRecordPath)
           readDf.printSchema()
           readDf.show(false)
           readDf.foreach(_ => {})
@@ -383,7 +388,12 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
     upsertData(df2, tempRecordPath, isCow)
 
     // read out the table
-    val readDf = spark.read.format("hudi").load(tempRecordPath)
+    val readDf = spark.read.format("hudi")
+      // NOTE: long to int type change is not supported for the custom file format and the filegroup reader
+      //       HUDI-7045 and PR#10007 in progress to fix the issue
+      .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false")
+      .option(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT.key(), "false")
+      .load(tempRecordPath)
     readDf.printSchema()
     readDf.show(false)
     readDf.foreach(_ => {})
@@ -475,7 +485,12 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
     upsertData(df2, tempRecordPath, isCow)
 
     // read out the table
-    val readDf = spark.read.format("hudi").load(tempRecordPath)
+    val readDf = spark.read.format("hudi")
+      // NOTE: type promotion is not supported for the custom file format and the filegroup reader
+      //       HUDI-7045 and PR#10007 in progress to fix the issue
+      .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false")
+      .option(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT.key(), "false")
+      .load(tempRecordPath)
     readDf.printSchema()
     readDf.show(false)
     readDf.foreach(_ => {})
@@ -537,7 +552,12 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
     upsertData(df2, tempRecordPath, isCow)
 
     // read out the table
-    val readDf = spark.read.format("hudi").load(tempRecordPath)
+    val readDf = spark.read.format("hudi")
+      // NOTE: type promotion is not supported for the custom file format and the filegroup reader
+      //       HUDI-7045 and PR#10007 in progress to fix the issue
+      .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false")
+      .option(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT.key(), "false")
+      .load(tempRecordPath)
     readDf.printSchema()
     readDf.show(false)
     readDf.foreach(_ => {})
@@ -803,7 +823,12 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
     upsertData(df7, tempRecordPath)
 
     // read out the table
-    val readDf = spark.read.format("hudi").load(tempRecordPath)
+    val readDf = spark.read.format("hudi")
+      // NOTE: type promotion is not supported for the custom file format and the filegroup reader
+      //       HUDI-7045 and PR#10007 in progress to fix the issue
+      .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false")
+      .option(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT.key(), "false")
+      .load(tempRecordPath)
     readDf.printSchema()
     readDf.show(false)
     readDf.foreach(_ => {})


### PR DESCRIPTION
### Change Logs

Currently, type change is not supported with new file format and file group reader. This PR turns them off for such tests. 
Should probaby be fixed by #10007 

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
