### PR TITLE
[HUDI-7067] Add fallback to full update if all fields are updated in MERGE INTO statement

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -506,12 +506,10 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    *         {@code false} otherwise.
    */
   private def areAllFieldsUpdated(updatedFieldSet: Set[Attribute]): Boolean = {
-    mergeInto.targetTable.output
-      .filterNot(attr => isMetaField(attr.name))
-      .filter { tableAttr =>
-        !updatedFieldSet.exists(attr => attributeEquals(attr, tableAttr))
-      }
-      .isEmpty
+    !mergeInto.targetTable.output
+      .filterNot(attr => isMetaField(attr.name)).exists { tableAttr =>
+      !updatedFieldSet.exists(attr => attributeEquals(attr, tableAttr))
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestPartialUpdateForMergeInto.scala
@@ -35,7 +35,7 @@ import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.testutils.HoodieTestUtils.{getDefaultHadoopConf, getLogFileListFromFileSlice}
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.metadata.HoodieTableMetadata
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 
 import java.util.{Collections, List}
 import scala.collection.JavaConverters._
@@ -52,6 +52,55 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
 
   test("Test Partial Update with MOR and Parquet log format") {
     testPartialUpdate("mor", "parquet")
+  }
+
+  test("Test fallback to full update with MOR even if partial updates are enabled") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = tmp.getCanonicalPath + "/" + tableName
+      spark.sql(s"set ${MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key} = 0")
+      spark.sql(s"set ${ENABLE_MERGE_INTO_PARTIAL_UPDATES.key} = true")
+      spark.sql(s"set ${FILE_GROUP_READER_ENABLED.key} = true")
+      spark.sql(s"set ${USE_NEW_HUDI_PARQUET_FILE_FORMAT.key} = true")
+
+      // Create a table with five data fields
+      spark.sql(
+        s"""
+           |create table $tableName (
+           | id int,
+           | name string,
+           | price double,
+           | _ts long,
+           | description string
+           |) using hudi
+           |tblproperties(
+           | type ='mor',
+           | primaryKey = 'id',
+           | preCombineField = '_ts'
+           |)
+           |location '$basePath'
+        """.stripMargin)
+      spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, 'a1: desc1')," +
+        "(2, 'a2', 20, 1200, 'a2: desc2'), (3, 'a3', 30, 1250, 'a3: desc3')")
+
+      // Update all fields
+      spark.sql(
+        s"""
+           |merge into $tableName t0
+           |using ( select 1 as id, 'a1' as name, 12 as price, 1001 as _ts, 'a1: updated' as description
+           |union select 3 as id, 'a3' as name, 25 as price, 1260 as _ts, 'a3: updated' as description) s0
+           |on t0.id = s0.id
+           |when matched then update set *
+           |""".stripMargin)
+
+      checkAnswer(s"select id, name, price, _ts, description from $tableName")(
+        Seq(1, "a1", 12.0, 1001, "a1: updated"),
+        Seq(2, "a2", 20.0, 1200, "a2: desc2"),
+        Seq(3, "a3", 25.0, 1260, "a3: updated")
+      )
+
+      validateLogBlock(basePath, 1, Seq(Seq("id", "name", "price", "_ts", "description")), false)
+    }
   }
 
   def testPartialUpdate(tableType: String,
@@ -102,7 +151,7 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
       )
 
       if (tableType.equals("mor")) {
-        validateLogBlock(basePath, 1, Seq(Seq("price", "_ts")))
+        validateLogBlock(basePath, 1, Seq(Seq("price", "_ts")), true)
       }
 
       // Partial updates using MERGE INTO statement with changed fields: "description" and "_ts"
@@ -122,7 +171,7 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
       )
 
       if (tableType.equals("mor")) {
-        validateLogBlock(basePath, 2, Seq(Seq("price", "_ts"), Seq("_ts", "description")))
+        validateLogBlock(basePath, 2, Seq(Seq("price", "_ts"), Seq("_ts", "description")), true)
       }
 
       if (tableType.equals("cow")) {
@@ -206,7 +255,8 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
 
   def validateLogBlock(basePath: String,
                        expectedNumLogFile: Int,
-                       changedFields: Seq[Seq[String]]): Unit = {
+                       changedFields: Seq[Seq[String]],
+                       isPartial: Boolean): Unit = {
     val hadoopConf = getDefaultHadoopConf
     val metaClient: HoodieTableMetaClient =
       HoodieTableMetaClient.builder.setConf(hadoopConf).setBasePath(basePath).build
@@ -237,12 +287,16 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
       assertTrue(logReader.hasNext)
       val logBlockHeader = logReader.next().getLogBlockHeader
       assertTrue(logBlockHeader.containsKey(HeaderMetadataType.SCHEMA))
-      assertTrue(logBlockHeader.containsKey(HeaderMetadataType.IS_PARTIAL))
-      val partialSchema = new Schema.Parser().parse(logBlockHeader.get(HeaderMetadataType.SCHEMA))
-      val expectedPartialSchema = HoodieAvroUtils.addMetadataFields(HoodieAvroUtils.generateProjectionSchema(
+      if (isPartial) {
+        assertTrue(logBlockHeader.containsKey(HeaderMetadataType.IS_PARTIAL))
+        assertTrue(logBlockHeader.get(HeaderMetadataType.IS_PARTIAL).toBoolean)
+      } else {
+        assertFalse(logBlockHeader.containsKey(HeaderMetadataType.IS_PARTIAL))
+      }
+      val actualSchema = new Schema.Parser().parse(logBlockHeader.get(HeaderMetadataType.SCHEMA))
+      val expectedSchema = HoodieAvroUtils.addMetadataFields(HoodieAvroUtils.generateProjectionSchema(
         avroSchema, changedFields(i).asJava), false)
-      assertEquals(expectedPartialSchema, partialSchema)
-      assertTrue(logBlockHeader.get(HeaderMetadataType.IS_PARTIAL).toBoolean)
+      assertEquals(expectedSchema, actualSchema)
     }
   }
 }


### PR DESCRIPTION
### Change Logs

This PR improves the partial update logic in Spark SQL MERGE INTO statement so that the partial updates are not enabled if all fields corresponding to the table schema are updated (e.g., `UPDATE SET *`), since if all fields are updated, there is no point marking the updates as partial and existing merging logic based on full updates can still be applied.  A new test is added to validate the improvement from this PR.

### Impact

Improves the case where all fields are updated and there is no need to go through partial update logic.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
