### PR TITLE
[HUDI-7069] Optimize metaclient construction and include table config…

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -56,17 +56,17 @@ public class HoodieClusteringJob {
   private HoodieTableMetaClient metaClient;
 
   public HoodieClusteringJob(JavaSparkContext jsc, Config cfg) {
-    this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs));
+    this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs),
+        UtilHelpers.createMetaClient(jsc, cfg.basePath, true));
   }
 
-  public HoodieClusteringJob(JavaSparkContext jsc, Config cfg, TypedProperties props) {
+  public HoodieClusteringJob(JavaSparkContext jsc, Config cfg, TypedProperties props, HoodieTableMetaClient metaClient) {
     this.cfg = cfg;
     this.jsc = jsc;
     this.props = props;
-    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+    this.metaClient = metaClient;
     // Disable async cleaning, will trigger synchronous cleaning manually.
     this.props.put(HoodieCleanConfig.ASYNC_CLEAN.key(), false);
-    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
     if (this.metaClient.getTableConfig().isMetadataTableAvailable()) {
       // add default lock config options if MDT is enabled.
       UtilHelpers.addLockOptions(cfg.basePath, this.props);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -56,7 +56,7 @@ public class HoodieCompactor {
   private transient FileSystem fs;
   private TypedProperties props;
   private final JavaSparkContext jsc;
-  private final HoodieTableMetaClient metaClient;
+  private HoodieTableMetaClient metaClient;
 
   public HoodieCompactor(JavaSparkContext jsc, Config cfg) {
     this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs),
@@ -257,7 +257,7 @@ public class HoodieCompactor {
       // If no compaction instant is provided by --instant-time, find the earliest scheduled compaction
       // instant from the active timeline
       if (StringUtils.isNullOrEmpty(cfg.compactionInstantTime)) {
-        HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+        metaClient = HoodieTableMetaClient.reload(metaClient);
         Option<HoodieInstant> firstCompactionInstant = metaClient.getActiveTimeline().filterPendingCompactionTimeline().firstInstant();
         if (firstCompactionInstant.isPresent()) {
           cfg.compactionInstantTime = firstCompactionInstant.get().getTimestamp();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -59,14 +59,15 @@ public class HoodieCompactor {
   private final HoodieTableMetaClient metaClient;
 
   public HoodieCompactor(JavaSparkContext jsc, Config cfg) {
-    this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs));
+    this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs),
+        UtilHelpers.createMetaClient(jsc, cfg.basePath, true));
   }
 
-  public HoodieCompactor(JavaSparkContext jsc, Config cfg, TypedProperties props) {
+  public HoodieCompactor(JavaSparkContext jsc, Config cfg, TypedProperties props, HoodieTableMetaClient metaClient) {
     this.cfg = cfg;
     this.jsc = jsc;
     this.props = props;
-    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+    this.metaClient = metaClient;
     // Disable async cleaning, will trigger synchronous cleaning manually.
     this.props.put(HoodieCleanConfig.ASYNC_CLEAN.key(), false);
     if (this.metaClient.getTableConfig().isMetadataTableAvailable()) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.multitable;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.utilities.HoodieClusteringJob;
 
 import org.apache.spark.api.java.JavaSparkContext;
@@ -43,13 +44,18 @@ class ClusteringTask extends TableServiceTask {
    */
   private String clusteringMode;
 
+  /**
+   * Meta Client.
+   */
+  private HoodieTableMetaClient metaClient;
+
   @Override
   void run() {
     HoodieClusteringJob.Config clusteringConfig = new HoodieClusteringJob.Config();
     clusteringConfig.basePath = basePath;
     clusteringConfig.parallelism = parallelism;
     clusteringConfig.runningMode = clusteringMode;
-    new HoodieClusteringJob(jsc, clusteringConfig, props).cluster(retry);
+    new HoodieClusteringJob(jsc, clusteringConfig, props, metaClient).cluster(retry);
   }
 
   /**
@@ -98,6 +104,11 @@ class ClusteringTask extends TableServiceTask {
      */
     private int retry;
 
+    /**
+     * Meta Client.
+     */
+    private HoodieTableMetaClient metaClient;
+
     private Builder() {
     }
 
@@ -131,6 +142,11 @@ class ClusteringTask extends TableServiceTask {
       return this;
     }
 
+    public Builder withMetaclient(HoodieTableMetaClient metaClient) {
+      this.metaClient = metaClient;
+      return this;
+    }
+
     public ClusteringTask build() {
       ClusteringTask clusteringTask = new ClusteringTask();
       clusteringTask.jsc = this.jsc;
@@ -139,6 +155,7 @@ class ClusteringTask extends TableServiceTask {
       clusteringTask.retry = this.retry;
       clusteringTask.basePath = this.basePath;
       clusteringTask.props = this.props;
+      clusteringTask.metaClient = this.metaClient;
       return clusteringTask;
     }
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.multitable;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.utilities.HoodieCompactor;
 
 import org.apache.spark.api.java.JavaSparkContext;
@@ -48,6 +49,11 @@ class CompactionTask extends TableServiceTask {
    */
   private int parallelism;
 
+  /**
+   * Meta Client.
+   */
+  private HoodieTableMetaClient metaClient;
+
   @Override
   void run() {
     HoodieCompactor.Config compactionCfg = new HoodieCompactor.Config();
@@ -56,7 +62,7 @@ class CompactionTask extends TableServiceTask {
     compactionCfg.runningMode = compactionRunningMode;
     compactionCfg.parallelism = parallelism;
     compactionCfg.retry = retry;
-    new HoodieCompactor(jsc, compactionCfg, props).compact(retry);
+    new HoodieCompactor(jsc, compactionCfg, props, metaClient).compact(retry);
   }
 
   /**
@@ -109,6 +115,11 @@ class CompactionTask extends TableServiceTask {
      */
     private JavaSparkContext jsc;
 
+    /**
+     * Meta Client.
+     */
+    private HoodieTableMetaClient metaClient;
+
     public Builder withProps(TypedProperties props) {
       this.props = props;
       return this;
@@ -144,6 +155,11 @@ class CompactionTask extends TableServiceTask {
       return this;
     }
 
+    public Builder withMetaclient(HoodieTableMetaClient metaClient) {
+      this.metaClient = metaClient;
+      return this;
+    }
+
     public CompactionTask build() {
       CompactionTask compactionTask = new CompactionTask();
       compactionTask.basePath = this.basePath;
@@ -153,6 +169,7 @@ class CompactionTask extends TableServiceTask {
       compactionTask.compactionStrategyName = this.compactionStrategyName;
       compactionTask.retry = this.retry;
       compactionTask.props = this.props;
+      compactionTask.metaClient = this.metaClient;
       return compactionTask;
     }
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -23,7 +23,6 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.TableNotFoundException;
@@ -40,9 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -172,12 +169,8 @@ public class MultiTableServiceUtils {
                                                                TypedProperties props) {
     TableServicePipeline pipeline = new TableServicePipeline();
     HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, basePath, true);
-    TypedProperties propsWithTableConfig = new TypedProperties();
-    Map<String, String> tableConfigMap = new HashMap<>(metaClient.getTableConfig().propsMap());
-    propsWithTableConfig.putAll(tableConfigMap);
-    props.stringPropertyNames().stream()
-        .filter(key -> !tableConfigMap.containsKey(key) || StringUtils.isNullOrEmpty(tableConfigMap.get(key)))
-        .forEach(key -> propsWithTableConfig.put(key, props.get(key)));
+    TypedProperties propsWithTableConfig = new TypedProperties(metaClient.getTableConfig().getProps());
+    propsWithTableConfig.putAll(props);
 
     if (cfg.enableCompaction) {
       pipeline.add(CompactionTask.newBuilder()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -22,7 +22,6 @@ package org.apache.hudi.utilities.multitable;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -41,7 +40,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -172,9 +173,10 @@ public class MultiTableServiceUtils {
     TableServicePipeline pipeline = new TableServicePipeline();
     HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, basePath, true);
     TypedProperties propsWithTableConfig = new TypedProperties();
-    propsWithTableConfig.putAll(metaClient.getTableConfig().getProps());
+    Map<String, String> tableConfigMap = new HashMap<>(metaClient.getTableConfig().propsMap());
+    propsWithTableConfig.putAll(tableConfigMap);
     props.stringPropertyNames().stream()
-        .filter(key -> !propsWithTableConfig.containsKey(key) || StringUtils.isNullOrEmpty(propsWithTableConfig.get(key).toString()))
+        .filter(key -> !tableConfigMap.containsKey(key) || StringUtils.isNullOrEmpty(tableConfigMap.get(key)))
         .forEach(key -> propsWithTableConfig.put(key, props.get(key)));
 
     if (cfg.enableCompaction) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -169,6 +169,7 @@ public class MultiTableServiceUtils {
                                                                TypedProperties props) {
     TableServicePipeline pipeline = new TableServicePipeline();
     HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, basePath, true);
+    // Add the table config to the write config.
     props.putAll(metaClient.getTableConfig().getProps());
     if (cfg.enableCompaction) {
       pipeline.add(CompactionTask.newBuilder()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.multitable;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
@@ -163,14 +164,17 @@ public class MultiTableServiceUtils {
     }
   }
 
+  public static void addNecessaryTableConfigToWriteConfig(HoodieTableMetaClient metaClient, TypedProperties props) {
+    props.put(HoodieTableConfig.NAME.key(), metaClient.getTableConfig().getTableName());
+  }
+
   public static TableServicePipeline buildTableServicePipeline(JavaSparkContext jsc,
                                                                String basePath,
                                                                HoodieMultiTableServicesMain.Config cfg,
                                                                TypedProperties props) {
     TableServicePipeline pipeline = new TableServicePipeline();
     HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, basePath, true);
-    // Add the table config to the write config.
-    props.putAll(metaClient.getTableConfig().getProps());
+    addNecessaryTableConfigToWriteConfig(metaClient, props);
     if (cfg.enableCompaction) {
       pipeline.add(CompactionTask.newBuilder()
           .withJsc(jsc)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -22,9 +22,11 @@ package org.apache.hudi.utilities.multitable;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.utilities.UtilHelpers;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -166,6 +168,8 @@ public class MultiTableServiceUtils {
                                                                HoodieMultiTableServicesMain.Config cfg,
                                                                TypedProperties props) {
     TableServicePipeline pipeline = new TableServicePipeline();
+    HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, basePath, true);
+    props.putAll(metaClient.getTableConfig().getProps());
     if (cfg.enableCompaction) {
       pipeline.add(CompactionTask.newBuilder()
           .withJsc(jsc)
@@ -175,6 +179,7 @@ public class MultiTableServiceUtils {
           .withCompactionStrategyName(cfg.compactionStrategyClassName)
           .withProps(props)
           .withRetry(cfg.retry)
+          .withMetaclient(metaClient)
           .build());
     }
     if (cfg.enableClustering) {
@@ -185,6 +190,7 @@ public class MultiTableServiceUtils {
           .withClusteringRunningMode(cfg.clusteringRunningMode)
           .withProps(props)
           .withRetry(cfg.retry)
+          .withMetaclient(metaClient)
           .build());
     }
     if (cfg.enableClean) {


### PR DESCRIPTION
In the current implementation of run multi tables services, the clustering task and compaction task both build metaclient repeatedly for each table, causing additional overhead. To reduce this overhead, we extract the construction of metaclient and only construct it once for each table, passing it as a parameter to the corresponding task.

At the same time, when running multi tables services, the write config lacks some information from the table config, such as the table name. This leads to empty strings when retrieving the table name in certain situations. For example, when configuring the prefix for metrics, if not specified, the table name is used as the prefix. However, in the current situation, without the table config, it's impossible to differentiate the metrics of different tables, resulting in an empty prefix. By adding the table config to the write config beforehand, we can obtain all the configuration information in the subsequent write config step.
Taking a metrics example, it would be displayed as follows before the fix:
`".replacecommit.totalFilesInsert":"2"`
After the fix, it would be displayed as follows:
`"test_tb.replacecommit.totalFilesInsert":"2"`

Additionally, we made a small modification by removing the redundant construction of metaclient in the clusteringJob's constructor.

### Change Logs

We now construct metaclient only once per table and add table config to the write config to obtain all necessary information. Furthermore, unnecessary construction of metaclient in the clusteringJob's constructor has been removed.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
