### PR TITLE
[HUDI-7074] Flink incremental query for non-blocking concurrency control

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
@@ -99,7 +99,7 @@ public class HoodieMergedReadHandle<T, I, K, O> extends HoodieReadHandle<T, I, K
         && hoodieTable.getMetaClient().getCommitsTimeline().filterCompletedInstants().lastInstant().isPresent()) {
       return Option.fromJavaOptional(hoodieTable
           .getHoodieView()
-          .getLatestMergedFileSlicesBeforeOrOn(partitionPathFileIDPair.getLeft(), instantTime)
+          .getLatestFileSlices(partitionPathFileIDPair.getLeft())
           .filter(fileSlice -> fileSlice.getFileId().equals(partitionPathFileIDPair.getRight()))
           .findFirst());
     }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -613,9 +613,16 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     doWriteOperation(testTable, "0000003", INSERT);
 
     HoodieTableMetadata tableMetadata = metadata(writeConfig, context);
-    assertTrue(tableMetadata.getLatestCompactionTime().isPresent());
+    Option<String> metadataCompactionInstant = tableMetadata.getLatestCompactionTime();
+    assertTrue(metadataCompactionInstant.isPresent());
 
     validateMetadata(testTable);
+    // Fetch compaction Commit file and rename to some other file. completed compaction meta file should have some serialized info that table interprets
+    // for future upserts. so, renaming the file here to some temp name and later renaming it back to same name.
+    java.nio.file.Path metaFilePath = Paths.get(HoodieTestUtils.getCompleteInstantPath(metaClient.getFs(),
+            new Path(metadataTableBasePath, METAFOLDER_NAME), metadataCompactionInstant.get(), HoodieTimeline.COMMIT_ACTION)
+        .toUri());
+    java.nio.file.Path tempFilePath = FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
 
     metaClient.reloadActiveTimeline();
     testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
@@ -626,6 +633,9 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     if (simulateFailedCompaction) {
       // this should retry the compaction in metadata table.
       doWriteOperation(testTable, "0000004", INSERT);
+    } else {
+      // let the compaction succeed in metadata and validation should succeed.
+      FileCreateUtils.renameTempToMetaFile(tempFilePath, metaFilePath);
     }
 
     validateMetadata(testTable);
@@ -638,7 +648,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     if (simulateFailedCompaction) {
       //trigger another compaction failure.
       tableMetadata = metadata(writeConfig, context);
-      assertTrue(tableMetadata.getLatestCompactionTime().isPresent());
+      metadataCompactionInstant = tableMetadata.getLatestCompactionTime();
+      assertTrue(metadataCompactionInstant.isPresent());
+
+      // Fetch compaction Commit file and rename to some other file. completed compaction meta file should have some serialized info that table interprets
+      // for future upserts. so, renaming the file here to some temp name and later renaming it back to same name.
+      metaFilePath = Paths.get(HoodieTestUtils.getCompleteInstantPath(metaClient.getFs(),
+          new Path(metadataTableBasePath, METAFOLDER_NAME), metadataCompactionInstant.get(), HoodieTimeline.COMMIT_ACTION).toUri());
+      FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
 
       validateMetadata(testTable);
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1000,7 +1000,9 @@ public class HoodieTableMetadataUtil {
     if (mergeFileSlices) {
       if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
         fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
-            partition, metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().get().getTimestamp());
+            // including pending compaction instant as the last instant so that the finished delta commits
+            // that start earlier than the compaction can be queried.
+            partition, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().getTimestamp());
       } else {
         return Collections.emptyList();
       }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
@@ -199,7 +199,7 @@ public class BootstrapOperator<I, O extends HoodieRecord<?>>
     if (!StringUtils.isNullOrEmpty(lastInstantTime)) {
       commitsTimeline = commitsTimeline.findInstantsAfter(lastInstantTime);
     }
-    Option<HoodieInstant> latestCommitTime = commitsTimeline.filterCompletedInstants().lastInstant();
+    Option<HoodieInstant> latestCommitTime = commitsTimeline.filterCompletedAndCompactionInstants().lastInstant();
 
     if (latestCommitTime.isPresent()) {
       BaseFileUtils fileUtils = BaseFileUtils.getInstance(this.hoodieTable.getBaseFileFormat());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -50,7 +50,7 @@ public class DeltaWriteProfile extends WriteProfile {
     List<SmallFile> smallFileLocations = new ArrayList<>();
 
     // Init here since this class (and member variables) might not have been initialized
-    HoodieTimeline commitTimeline = metaClient.getCommitsTimeline().filterCompletedInstants();
+    HoodieTimeline commitTimeline = metaClient.getCommitsTimeline().filterCompletedAndCompactionInstants();
 
     // Find out all eligible small file slices
     if (!commitTimeline.empty()) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -36,6 +36,9 @@ import org.apache.flink.core.fs.Path;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -132,5 +135,13 @@ public class TestUtils {
   public static void saveInstantAsComplete(HoodieTableMetaClient metaClient, HoodieInstant instant, HoodieCommitMetadata metadata) throws Exception {
     metaClient.getActiveTimeline().saveAsComplete(new HoodieInstant(true, instant.getAction(), instant.getTimestamp()),
         serializeCommitMetadata(metadata));
+  }
+
+  public static void amendCompletionTimeToLatest(HoodieTableMetaClient metaClient, java.nio.file.Path sourcePath, String instantTime) throws IOException {
+    String fileExt = sourcePath.getFileName().toString().split("\\.")[1];
+    String newFileName = instantTime + "_" + metaClient.createNewInstantTime() + "." + fileExt;
+
+    java.nio.file.Path newFilePath = sourcePath.getParent().resolve(newFileName);
+    Files.move(sourcePath, newFilePath);
   }
 }


### PR DESCRIPTION
### Change Logs

Flink incremental queries works with non-blocking concurrency control.
Also fix the test regression of MDT in https://github.com/apache/hudi/pull/9871.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
