### PR TITLE
[MINOR] disable reader in schema evo test

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -20,9 +20,11 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
@@ -58,8 +60,10 @@ import org.junit.jupiter.api.BeforeEach;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -89,6 +93,13 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   protected boolean useKafkaSource;
   protected boolean useTransformer;
   protected boolean userProvidedSchema;
+
+  protected Map<String, String> readOpts = new HashMap<String, String>() {
+    {
+      put(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT().key(), "false");
+      put(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false");
+    }
+  };
 
   @BeforeAll
   public static void initKafka() {
@@ -135,6 +146,8 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
 
   protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(String[] transformerClasses, boolean nullForDeletedCols,
                                                               TypedProperties extraProps) throws IOException {
+    extraProps.setProperty(DataSourceReadOptions.USE_NEW_HUDI_PARQUET_FILE_FORMAT().key(), "false");
+    extraProps.setProperty(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false");
     extraProps.setProperty("hoodie.datasource.write.table.type", tableType);
     extraProps.setProperty("hoodie.datasource.write.row.writer.enable", rowWriterEnable.toString());
     extraProps.setProperty(DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS().key(), Boolean.toString(nullForDeletedCols));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
@@ -154,7 +154,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
     }
     assertRecordCount(numRecords);
 
-    Dataset<Row> df = sparkSession.read().format("hudi").load(tableBasePath);
+    Dataset<Row> df = sparkSession.read().format("hudi").options(readOpts).load(tableBasePath);
     df.show(9,false);
     df.select(updateColumn).show(9);
     for (String condition : conditions.keySet()) {
@@ -353,7 +353,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
   protected String typePromoUpdates;
 
   protected void assertDataType(String colName, DataType expectedType) {
-    assertEquals(expectedType, sparkSession.read().format("hudi").load(tableBasePath).select(colName).schema().fields()[0].dataType());
+    assertEquals(expectedType, sparkSession.read().format("hudi").options(readOpts).load(tableBasePath).select(colName).schema().fields()[0].dataType());
   }
 
   protected void testTypePromotionBase(String colName, DataType startType, DataType updateType) throws Exception {
@@ -409,7 +409,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
       assertFileNumber(numFiles, false);
     }
     assertRecordCount(numRecords);
-    sparkSession.read().format("hudi").load(tableBasePath).select(colName).show(9);
+    sparkSession.read().format("hudi").options(readOpts).load(tableBasePath).select(colName).show(9);
     assertDataType(colName, endType);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -219,7 +219,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
     }
     assertRecordCount(numRecords);
 
-    df = sparkSession.read().format("hudi").load(tableBasePath);
+    df = sparkSession.read().format("hudi").options(readOpts).load(tableBasePath);
     df.show(100,false);
     df.cache();
     assertDataType(df, "tip_history", DataTypes.createArrayType(DataTypes.LongType));


### PR DESCRIPTION
### Change Logs

disable new reader explicitly 

### Impact

not supported currently so will pass even if reader is enabled by default

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
