### PR TITLE
[HUDI-7086] Scaling gcs event source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -53,7 +53,17 @@ public class CloudSourceConfig extends HoodieConfig {
       .defaultValue(10)
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.meta.batch.size")
       .markAdvanced()
-      .withDocumentation("Number of metadata messages to pull at a time");
+      .withDocumentation("Number of metadata messages to pull in one API call to the cloud events queue. "
+          + "Multiple API calls with this batch size are sent to cloud events queue, until we consume hoodie.streamer.source.cloud.meta.max.num.messages.per.sync"
+          + "from the queue or hoodie.streamer.source.cloud.meta.max.fetch.time.per.sync.ms amount of time has passed or queue is empty. ");
+
+  public static final ConfigProperty<Integer> MAX_NUM_MESSAGES_PER_SYNC = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.meta.max.num.messages.per.sync")
+      .defaultValue(1000)
+      .markAdvanced()
+      .sinceVersion("0.14.1")
+      .withDocumentation("Maximum number of messages to consume per sync round. Multiple rounds of "
+          + BATCH_SIZE_CONF.key() + " could be invoked to reach max messages as configured by this config");
 
   public static final ConfigProperty<Boolean> ACK_MESSAGES = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.meta.ack")
@@ -137,4 +147,12 @@ public class CloudSourceConfig extends HoodieConfig {
       .sinceVersion("0.14.1")
       .withDocumentation("specify this value in bytes, to coalesce partitions of source dataset not greater than specified limit");
 
+  public static final ConfigProperty<Integer> MAX_FETCH_TIME_PER_SYNC_MS = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.meta.max.fetch.time.per.sync.ms")
+      .defaultValue(1)
+      .markAdvanced()
+      .sinceVersion("0.14.1")
+      .withDocumentation("Max time in millis to consume " + MAX_NUM_MESSAGES_PER_SYNC.key() + " messages from cloud queue. Cloud event queues like SQS, "
+          + "PubSub can return empty responses even when messages are available the queue, this config ensures we don't wait forever "
+          + "to consume MAX_MESSAGES_CONF messages, but time out and move on further.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsSource.java
@@ -49,6 +49,8 @@ import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.ACK_MESSAGES;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.BATCH_SIZE_CONF;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.MAX_FETCH_TIME_PER_SYNC_MS;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.MAX_NUM_MESSAGES_PER_SYNC;
 import static org.apache.hudi.utilities.config.GCSEventsSourceConfig.GOOGLE_PROJECT_ID;
 import static org.apache.hudi.utilities.config.GCSEventsSourceConfig.PUBSUB_SUBSCRIPTION_ID;
 import static org.apache.hudi.utilities.sources.helpers.gcs.MessageValidity.ProcessingDecision.DO_SKIP;
@@ -117,8 +119,9 @@ public class GcsEventsSource extends RowSource {
             new PubsubMessagesFetcher(
                 getStringWithAltKeys(props, GOOGLE_PROJECT_ID),
                 getStringWithAltKeys(props, PUBSUB_SUBSCRIPTION_ID),
-                getIntWithAltKeys(props, BATCH_SIZE_CONF)
-            )
+                getIntWithAltKeys(props, BATCH_SIZE_CONF),
+                getIntWithAltKeys(props, MAX_NUM_MESSAGES_PER_SYNC),
+                getIntWithAltKeys(props, MAX_FETCH_TIME_PER_SYNC_MS))
     );
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubMessagesFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubMessagesFetcher.java
@@ -59,8 +59,9 @@ public class PubsubMessagesFetcher {
 
   private static final int DEFAULT_BATCH_SIZE_ACK_API = 10;
   private static final long MAX_WAIT_TIME_TO_ACK_MESSAGES = TimeUnit.MINUTES.toMillis(1);
+  private static final int ACK_PRODUCER_THREAD_POOL_SIZE = 3;
 
-  private final ExecutorService threadPool = Executors.newFixedThreadPool(3);
+  private final ExecutorService threadPool = Executors.newFixedThreadPool(ACK_PRODUCER_THREAD_POOL_SIZE);
   private final String googleProjectId;
   private final String pubsubSubscriptionId;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubMessagesFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubMessagesFetcher.java
@@ -20,26 +20,15 @@ package org.apache.hudi.utilities.sources.helpers.gcs;
 
 import org.apache.hudi.exception.HoodieException;
 
-import com.google.cloud.ServiceOptions;
-import com.google.cloud.monitoring.v3.MetricServiceClient;
-import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
-import com.google.monitoring.v3.ListTimeSeriesRequest;
-import com.google.monitoring.v3.Point;
-import com.google.monitoring.v3.ProjectName;
-import com.google.monitoring.v3.TimeInterval;
-import com.google.protobuf.util.Timestamps;
-import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
-import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -151,48 +140,6 @@ public class PubsubMessagesFetcher {
     String subscriptionName = ProjectSubscriptionName.format(googleProjectId, pubsubSubscriptionId);
     List<String> messages = messagesToAck.subList(batchIndex, Math.min(batchIndex + DEFAULT_BATCH_SIZE_ACK_API, messagesToAck.size()));
     return CompletableFuture.runAsync(() -> pubsubQueueClient.makeAckRequest(subscriber, subscriptionName, messages), threadPool);
-  }
-
-  static class PubsubQueueClient {
-    private static final String METRIC_FILTER_PATTERN = "metric.type=\"pubsub.googleapis.com/subscription/%s\" AND resource.label.subscription_id=\"%s\"";
-    private static final String NUM_UNDELIVERED_MESSAGES = "num_undelivered_messages";
-
-    public SubscriberStub getSubscriber(SubscriberStubSettings subscriberStubSettings) throws IOException {
-      return GrpcSubscriberStub.create(subscriberStubSettings);
-    }
-
-    public PullResponse makePullRequest(SubscriberStub subscriber, String subscriptionName, int batchSize) throws IOException {
-      PullRequest pullRequest = PullRequest.newBuilder()
-          .setMaxMessages(batchSize)
-          .setSubscription(subscriptionName)
-          .build();
-      return subscriber.pullCallable().call(pullRequest);
-    }
-
-    public void makeAckRequest(SubscriberStub subscriber, String subscriptionName, List<String> messages) {
-      AcknowledgeRequest acknowledgeRequest = AcknowledgeRequest.newBuilder()
-          .setSubscription(subscriptionName)
-          .addAllAckIds(messages)
-          .build();
-      subscriber.acknowledgeCallable().call(acknowledgeRequest);
-    }
-
-    public long getNumUnAckedMessages(String subscriptionId) throws IOException {
-      try (MetricServiceClient metricServiceClient = MetricServiceClient.create()) {
-        MetricServiceClient.ListTimeSeriesPagedResponse response = metricServiceClient.listTimeSeries(
-            ListTimeSeriesRequest.newBuilder()
-                .setName(ProjectName.of(ServiceOptions.getDefaultProjectId()).toString())
-                .setFilter(String.format(METRIC_FILTER_PATTERN, NUM_UNDELIVERED_MESSAGES, subscriptionId))
-                .setInterval(TimeInterval.newBuilder()
-                    .setStartTime(Timestamps.fromSeconds(Instant.now().getEpochSecond() - TimeUnit.MINUTES.toSeconds(2)))
-                    .setEndTime(Timestamps.fromSeconds(Instant.now().getEpochSecond()))
-                    .build())
-                .build());
-        // use the latest value from the window
-        List<Point> pointList = response.getPage().getValues().iterator().next().getPointsList();
-        return pointList.stream().findFirst().map(point -> point.getValue().getInt64Value()).orElse(Long.MAX_VALUE);
-      }
-    }
   }
 }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubQueueClient.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/PubsubQueueClient.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.gcs;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.monitoring.v3.ListTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.protobuf.util.Timestamps;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class PubsubQueueClient {
+  private static final String METRIC_FILTER_PATTERN = "metric.type=\"pubsub.googleapis.com/subscription/%s\" AND resource.label.subscription_id=\"%s\"";
+  private static final String NUM_UNDELIVERED_MESSAGES = "num_undelivered_messages";
+
+  public SubscriberStub getSubscriber(SubscriberStubSettings subscriberStubSettings) throws IOException {
+    return GrpcSubscriberStub.create(subscriberStubSettings);
+  }
+
+  public PullResponse makePullRequest(SubscriberStub subscriber, String subscriptionName, int batchSize) throws IOException {
+    PullRequest pullRequest = PullRequest.newBuilder()
+        .setMaxMessages(batchSize)
+        .setSubscription(subscriptionName)
+        .build();
+    return subscriber.pullCallable().call(pullRequest);
+  }
+
+  public void makeAckRequest(SubscriberStub subscriber, String subscriptionName, List<String> messages) {
+    AcknowledgeRequest acknowledgeRequest = AcknowledgeRequest.newBuilder()
+        .setSubscription(subscriptionName)
+        .addAllAckIds(messages)
+        .build();
+    subscriber.acknowledgeCallable().call(acknowledgeRequest);
+  }
+
+  public long getNumUnAckedMessages(String subscriptionId) throws IOException {
+    try (MetricServiceClient metricServiceClient = MetricServiceClient.create()) {
+      MetricServiceClient.ListTimeSeriesPagedResponse response = metricServiceClient.listTimeSeries(
+          ListTimeSeriesRequest.newBuilder()
+              .setName(ProjectName.of(ServiceOptions.getDefaultProjectId()).toString())
+              .setFilter(String.format(METRIC_FILTER_PATTERN, NUM_UNDELIVERED_MESSAGES, subscriptionId))
+              .setInterval(TimeInterval.newBuilder()
+                  .setStartTime(Timestamps.fromSeconds(Instant.now().getEpochSecond() - TimeUnit.MINUTES.toSeconds(2)))
+                  .setEndTime(Timestamps.fromSeconds(Instant.now().getEpochSecond()))
+                  .build())
+              .build());
+      // use the latest value from the window
+      List<Point> pointList = response.getPage().getValues().iterator().next().getPointsList();
+      return pointList.stream().findFirst().map(point -> point.getValue().getInt64Value()).orElse(Long.MAX_VALUE);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/gcs/TestPubsubMessagesFetcher.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/gcs/TestPubsubMessagesFetcher.java
@@ -49,7 +49,7 @@ public class TestPubsubMessagesFetcher {
   private static final long MAX_WAIT_TIME_IN_REQUEST = TimeUnit.SECONDS.toMillis(1);
 
   private final SubscriberStub mockSubscriber = Mockito.mock(SubscriberStub.class);
-  private final PubsubMessagesFetcher.PubsubQueueClient mockPubsubQueueClient = Mockito.mock(PubsubMessagesFetcher.PubsubQueueClient.class);
+  private final PubsubQueueClient mockPubsubQueueClient = Mockito.mock(PubsubQueueClient.class);
 
   @Test
   public void testFetchMessages() throws IOException {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/gcs/TestPubsubMessagesFetcher.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/gcs/TestPubsubMessagesFetcher.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.gcs;
+
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestPubsubMessagesFetcher {
+  private static final String PROJECT_ID = "test-project";
+  private static final String SUBSCRIPTION_ID = "test-subscription";
+  private static final String SUBSCRIPTION_NAME = ProjectSubscriptionName.format(PROJECT_ID, SUBSCRIPTION_ID);
+  private static final int SMALL_BATCH_SIZE = 1;
+  private static final int MAX_MESSAGES_IN_REQUEST = 1000;
+  private static final long MAX_WAIT_TIME_IN_REQUEST = TimeUnit.SECONDS.toMillis(1);
+
+  private final SubscriberStub mockSubscriber = Mockito.mock(SubscriberStub.class);
+  private final PubsubMessagesFetcher.PubsubQueueClient mockPubsubQueueClient = Mockito.mock(PubsubMessagesFetcher.PubsubQueueClient.class);
+
+  @Test
+  public void testFetchMessages() throws IOException {
+    doNothing().when(mockSubscriber).close();
+    when(mockPubsubQueueClient.getSubscriber(any())).thenReturn(mockSubscriber);
+    when(mockPubsubQueueClient.getNumUnAckedMessages(SUBSCRIPTION_ID)).thenReturn(3L);
+    doNothing().when(mockSubscriber).close();
+    ReceivedMessage message1 = ReceivedMessage.newBuilder().setAckId("1").setMessage(PubsubMessage.newBuilder().setMessageId("msgId1").build()).build();
+    ReceivedMessage message2 = ReceivedMessage.newBuilder().setAckId("2").setMessage(PubsubMessage.newBuilder().setMessageId("msgId2").build()).build();
+    ReceivedMessage message3 = ReceivedMessage.newBuilder().setAckId("3").setMessage(PubsubMessage.newBuilder().setMessageId("msgId3").build()).build();
+    when(mockPubsubQueueClient.makePullRequest(mockSubscriber, SUBSCRIPTION_NAME, SMALL_BATCH_SIZE))
+        .thenReturn(PullResponse.newBuilder().addReceivedMessages(message1).build())
+        .thenReturn(PullResponse.newBuilder().addReceivedMessages(message2).build())
+        .thenReturn(PullResponse.newBuilder().addReceivedMessages(message3).build());
+
+    PubsubMessagesFetcher fetcher = new PubsubMessagesFetcher(
+        PROJECT_ID, SUBSCRIPTION_ID, SMALL_BATCH_SIZE,
+        MAX_MESSAGES_IN_REQUEST, MAX_WAIT_TIME_IN_REQUEST, mockPubsubQueueClient
+    );
+    List<ReceivedMessage> messages = fetcher.fetchMessages();
+
+    assertEquals(3, messages.size());
+    assertEquals("1", messages.get(0).getAckId());
+    assertEquals("2", messages.get(1).getAckId());
+    assertEquals("3", messages.get(2).getAckId());
+    verify(mockPubsubQueueClient, times(3)).makePullRequest(mockSubscriber, SUBSCRIPTION_NAME, SMALL_BATCH_SIZE);
+  }
+
+  @Test
+  public void testFetchMessagesZeroTimeout() throws IOException {
+    doNothing().when(mockSubscriber).close();
+    when(mockPubsubQueueClient.getSubscriber(any())).thenReturn(mockSubscriber);
+    when(mockPubsubQueueClient.getNumUnAckedMessages(SUBSCRIPTION_ID)).thenReturn(100L);
+    PubsubMessagesFetcher fetcher = new PubsubMessagesFetcher(
+        PROJECT_ID, SUBSCRIPTION_ID, SMALL_BATCH_SIZE,
+        MAX_MESSAGES_IN_REQUEST, 0, mockPubsubQueueClient
+    );
+
+    List<ReceivedMessage> messages = fetcher.fetchMessages();
+    assertEquals(0, messages.size());
+  }
+
+  @Test
+  public void testSendAcks() throws IOException {
+    doNothing().when(mockSubscriber).close();
+    when(mockPubsubQueueClient.getSubscriber(any())).thenReturn(mockSubscriber);
+    List<String> messageAcks = IntStream.range(0, 20).mapToObj(i -> "msg_" + i).collect(Collectors.toList());
+    doNothing().when(mockPubsubQueueClient).makeAckRequest(eq(mockSubscriber), eq(SUBSCRIPTION_NAME), any());
+    PubsubMessagesFetcher fetcher = new PubsubMessagesFetcher(
+        PROJECT_ID, SUBSCRIPTION_ID, SMALL_BATCH_SIZE,
+        MAX_MESSAGES_IN_REQUEST, MAX_WAIT_TIME_IN_REQUEST, mockPubsubQueueClient
+    );
+
+    fetcher.sendAcks(messageAcks);
+    verify(mockPubsubQueueClient, times(2)).makeAckRequest(eq(mockSubscriber), eq(SUBSCRIPTION_NAME), any());
+  }
+
+}


### PR DESCRIPTION
### Change Logs

Scaling gcs event source to support consuming 1000 messages or more per round of ingestion to hudi. 

### Impact

Scaling gcs event source to support consuming 1000 messages or more per round of ingestion to hudi. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
