### PR TITLE
[MINOR] Fixing config naming for OOB schema evol support to handle missing cols and data type demotion

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -81,13 +81,15 @@ public class HoodieCommonConfig extends HoodieConfig {
           + " operation will fail schema compatibility check. Set this option to true will make the newly added "
           + " column nullable to successfully complete the write operation.");
 
-  public static final ConfigProperty<String> SET_NULL_FOR_MISSING_COLUMNS = ConfigProperty
-      .key("hoodie.write.set.null.for.missing.columns")
+  public static final ConfigProperty<String> HANDLE_MISSING_COLS_AND_DATATYPE_DEMOTION = ConfigProperty
+      .key("hoodie.write.handle.missing.cols.and.datatype.demotion")
       .defaultValue("false")
       .markAdvanced()
       .withDocumentation("When a non-nullable column is missing from incoming batch during a write operation, the write "
           + " operation will fail schema compatibility check. Set this option to true will make the missing "
-          + " column be filled with null values to successfully complete the write operation.");
+          + " column be filled with null values to successfully complete the write operation. Similarly, when a column's data type " +
+          "is demoted (from long to int), enabling this config will succeed the batch of writes keeping the final table schema in long. " +
+          "If not for this config, the write may fail since long to int is not backwards compatible evolution.");
 
   public static final ConfigProperty<ExternalSpillableMap.DiskMapType> SPILLABLE_DISK_MAP_TYPE = ConfigProperty
       .key("hoodie.common.spillable.diskmap.type")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -539,7 +539,7 @@ object DataSourceWriteOptions {
   @Deprecated
   val RECONCILE_SCHEMA: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.RECONCILE_SCHEMA
 
-  val SET_NULL_FOR_MISSING_COLUMNS: ConfigProperty[String] = HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS
+  val SET_NULL_FOR_MISSING_COLUMNS: ConfigProperty[String] = HoodieCommonConfig.HANDLE_MISSING_COLS_AND_DATATYPE_DEMOTION
 
   val MAKE_NEW_COLUMNS_NULLABLE: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.MAKE_NEW_COLUMNS_NULLABLE
 


### PR DESCRIPTION
### Change Logs

Fixing config naming for OOB schema evol support to handle missing cols and data type demotion. Config is named as "hoodie.write.handle.missing.cols.and.datatype.demotion". Intention of this config is as follows:
```
When a non-nullable column is missing from incoming batch during a write operation, the write operation will fail schema compatibility check. Set this option to true will make the missing column be filled with null values to successfully complete the write operation. Similarly, when a column's data type is demoted (from long to int), enabling this config will succeed the batch of writes keeping the final table schema in long. If not for this config, the write may fail since long to int is not backwards compatible evolution.
```

### Impact

Improves usability.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
