### PR TITLE
[HUDI-7016] Fix bundling of RoaringBitmap in hudi-utilities-bundle

### DIFF
--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -115,6 +115,7 @@
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
                   <include>org.apache.parquet:parquet-avro</include>
+                  <include>org.roaringbitmap:RoaringBitmap</include>
                   <!-- Bundle Jackson JSR310 library since it is not present in spark 2.x. For spark 3.x this will
                        bundle the same JSR310 version that is included in spark runtime -->
                   <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
@@ -224,6 +225,10 @@
                 <relocation>
                   <pattern>org.apache.httpcomponents.</pattern>
                   <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.roaringbitmap.</pattern>
+                  <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
                 </relocation>
               </relocations>
               <filters>


### PR DESCRIPTION
### Change Logs

This PR fixes the bundling of RoaringBitmap dependency in hudi-utilities-bundle. It was previously fixed for Spark bundle in https://github.com/apache/hudi/commit/8d2b664864bfb02311ff3bedbb937590203371d2 but we missed utilities bundle.

Without this fix, running deltastreamer with only hudi-utilities-bundle will throw below error.
```
java.lang.NoSuchMethodError: org.roaringbitmap.longlong.Roaring64NavigableMap.serializePortable(Ljava/io/DataOutput;)V
```

### Impact

Fix dependency issue and successfully run deltastreamer with just hudi-utilities-bundle.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
