### PR TITLE
[HUDI-7097] Fixing instantiation of Hms Uri with HiveSync tool

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -46,7 +46,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getInputFormatClassName;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getOutputFormatClassName;
@@ -104,22 +103,12 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
   public HiveSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf);
     String configuredMetastoreUris = props.getProperty(METASTORE_URIS.key());
-    String existingHadoopConfMetastoreUris = hadoopConf.get(HiveConf.ConfVars.METASTOREURIS.varname);
 
     final Configuration hadoopConfForSync; // the configuration to use for this instance of the sync tool
     if (nonEmpty(configuredMetastoreUris)) {
-      // if the metastore uris from the provided hadoop configuration exist and are equal to the user provided URIs, then we can use the provided configuration
-      if (configuredMetastoreUris.equals(existingHadoopConfMetastoreUris)) {
-        hadoopConfForSync = hadoopConf;
-      } else if (isNullOrEmpty(existingHadoopConfMetastoreUris)) {
-        // if there is no value already set in the provided configuration, update the existing configuration to avoid making copies of the configuration per instance of this tool
-        hadoopConf.set(HiveConf.ConfVars.METASTOREURIS.varname, configuredMetastoreUris);
-        hadoopConfForSync = hadoopConf;
-      } else {
-        // if the metastore uris exist in the provided hadoop configuration but differ from the user provided URIs, then we need to create a new configuration with the value set
-        hadoopConfForSync = new Configuration(hadoopConf);
-        hadoopConfForSync.set(HiveConf.ConfVars.METASTOREURIS.varname, configuredMetastoreUris);
-      }
+      // if metastore uri is configured, we can create a new configuration with the value set
+      hadoopConfForSync = new Configuration(hadoopConf);
+      hadoopConfForSync.set(HiveConf.ConfVars.METASTOREURIS.varname, configuredMetastoreUris);
     } else {
       // if the user did not provide any URIs, then we can use the provided configuration
       hadoopConfForSync = hadoopConf;


### PR DESCRIPTION
### Change Logs

Fixing instantiation of Hms Uri with HiveSync tool.
Updates how we handle HMS URIs so that we are able to handle multiple targets in the same multi-deltastreamer. We're currently setting the URIs in the hadoop configuration once and assuming that all HMS targets are the same. This change updates these assumptions so that we can handle a case where the user provides multiple targets by creating a copy of the configuration when there is a value already present in the hadoop configuration.

### Impact

Fixes bug customer is experiencing when there are multiple HMS instances

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
