### PR TITLE
[HUDI-7099] Providing metrics for archive and defining some string constants

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/HoodieTimelineArchiver.java
@@ -43,7 +43,6 @@ import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.marker.WriteMarkers;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
 
-import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -55,7 +55,11 @@ public class HoodieMetrics {
   public static final String TOTAL_ROLLBACK_LOG_BLOCKS_STR = "totalRollbackLogBlocks";
   public static final String DURATION_STR = "duration";
   public static final String DELETE_FILES_NUM_STR = "numFilesDeleted";
-
+  public static final String FINALIZED_FILES_NUM_STR = "numFilesFinalized";
+  public static final String CONFLICT_RESOLUTION_STR = "conflict_resolution";
+  public static final String COMMIT_LATENCY_STR = "commitLatencyInMs";
+  public static final String COMMIT_FRESHNESS_STR = "commitFreshnessInMs";
+  public static final String COMMIT_TIME_STR = "commitTime";
   public static final String TIMER_ACTION = "timer";
   public static final String COUNTER_ACTION = "counter";
   public static final String ARCHIVE_ACTION = "archive";
@@ -112,11 +116,11 @@ public class HoodieMetrics {
       this.compactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.COMPACTION_ACTION);
       this.logCompactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION);
       this.indexTimerName = getMetricsName(TIMER_ACTION, INDEX_ACTION);
-      this.conflictResolutionTimerName = getMetricsName(TIMER_ACTION, "conflict_resolution");
-      this.conflictResolutionSuccessCounterName = getMetricsName(COUNTER_ACTION, "conflict_resolution.success");
-      this.conflictResolutionFailureCounterName = getMetricsName(COUNTER_ACTION, "conflict_resolution.failure");
-      this.compactionRequestedCounterName = getMetricsName(COUNTER_ACTION, "compaction.requested");
-      this.compactionCompletedCounterName = getMetricsName(COUNTER_ACTION, "compaction.completed");
+      this.conflictResolutionTimerName = getMetricsName(TIMER_ACTION, CONFLICT_RESOLUTION_STR);
+      this.conflictResolutionSuccessCounterName = getMetricsName(COUNTER_ACTION, CONFLICT_RESOLUTION_STR + ".success");
+      this.conflictResolutionFailureCounterName = getMetricsName(COUNTER_ACTION, CONFLICT_RESOLUTION_STR + ".failure");
+      this.compactionRequestedCounterName = getMetricsName(COUNTER_ACTION, HoodieTimeline.COMPACTION_ACTION + ".requested");
+      this.compactionCompletedCounterName = getMetricsName(COUNTER_ACTION, HoodieTimeline.COMPACTION_ACTION + ".completed");
     }
   }
 
@@ -273,13 +277,13 @@ public class HoodieMetrics {
       Pair<Option<Long>, Option<Long>> eventTimePairMinMax = metadata.getMinAndMaxEventTime();
       if (eventTimePairMinMax.getLeft().isPresent()) {
         long commitLatencyInMs = commitEpochTimeInMs + durationInMs - eventTimePairMinMax.getLeft().get();
-        metrics.registerGauge(getMetricsName(actionType, "commitLatencyInMs"), commitLatencyInMs);
+        metrics.registerGauge(getMetricsName(actionType, COMMIT_LATENCY_STR), commitLatencyInMs);
       }
       if (eventTimePairMinMax.getRight().isPresent()) {
         long commitFreshnessInMs = commitEpochTimeInMs + durationInMs - eventTimePairMinMax.getRight().get();
-        metrics.registerGauge(getMetricsName(actionType, "commitFreshnessInMs"), commitFreshnessInMs);
+        metrics.registerGauge(getMetricsName(actionType, COMMIT_FRESHNESS_STR), commitFreshnessInMs);
       }
-      metrics.registerGauge(getMetricsName(actionType, "commitTime"), commitEpochTimeInMs);
+      metrics.registerGauge(getMetricsName(actionType, COMMIT_TIME_STR), commitEpochTimeInMs);
       metrics.registerGauge(getMetricsName(actionType, DURATION_STR), durationInMs);
     }
   }
@@ -316,14 +320,14 @@ public class HoodieMetrics {
       LOG.info(String.format("Sending finalize write metrics (duration=%d, numFilesFinalized=%d)", durationInMs,
           numFilesFinalized));
       metrics.registerGauge(getMetricsName(FINALIZE_ACTION, DURATION_STR), durationInMs);
-      metrics.registerGauge(getMetricsName(FINALIZE_ACTION, "numFilesFinalized"), numFilesFinalized);
+      metrics.registerGauge(getMetricsName(FINALIZE_ACTION, FINALIZED_FILES_NUM_STR), numFilesFinalized);
     }
   }
 
   public void updateIndexMetrics(final String action, final long durationInMs) {
     if (config.isMetricsOn()) {
       LOG.info(String.format("Sending index metrics (%s.duration, %d)", action, durationInMs));
-      metrics.registerGauge(getMetricsName(INDEX_ACTION, String.format("%s.duration", action)), durationInMs);
+      metrics.registerGauge(getMetricsName(INDEX_ACTION, String.format("%s.%s", action, DURATION_STR)), durationInMs);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -53,11 +53,20 @@ public class HoodieMetrics {
   public static final String TOTAL_RECORDS_DELETED = "totalRecordsDeleted";
   public static final String TOTAL_CORRUPTED_LOG_BLOCKS_STR = "totalCorruptedLogBlocks";
   public static final String TOTAL_ROLLBACK_LOG_BLOCKS_STR = "totalRollbackLogBlocks";
+  public static final String DURATION_STR = "duration";
+  public static final String DELETE_FILES_NUM_STR = "numFilesDeleted";
 
+  public static final String TIMER_ACTION = "timer";
+  public static final String COUNTER_ACTION = "counter";
+  public static final String ARCHIVE_ACTION = "archive";
+  public static final String FINALIZE_ACTION = "finalize";
+  public static final String INDEX_ACTION = "index";
+  
   private Metrics metrics;
   // Some timers
   public String rollbackTimerName = null;
   public String cleanTimerName = null;
+  public String archiveTimerName = null;
   public String commitTimerName = null;
   public String logCompactionTimerName = null;
   public String deltaCommitTimerName = null;
@@ -74,6 +83,7 @@ public class HoodieMetrics {
   private String tableName;
   private Timer rollbackTimer = null;
   private Timer cleanTimer = null;
+  private Timer archiveTimer = null;
   private Timer commitTimer = null;
   private Timer deltaCommitTimer = null;
   private Timer finalizeTimer = null;
@@ -92,20 +102,21 @@ public class HoodieMetrics {
     this.tableName = config.getTableName();
     if (config.isMetricsOn()) {
       metrics = Metrics.getInstance(config);
-      this.rollbackTimerName = getMetricsName("timer", HoodieTimeline.ROLLBACK_ACTION);
-      this.cleanTimerName = getMetricsName("timer", HoodieTimeline.CLEAN_ACTION);
-      this.commitTimerName = getMetricsName("timer", HoodieTimeline.COMMIT_ACTION);
-      this.deltaCommitTimerName = getMetricsName("timer", HoodieTimeline.DELTA_COMMIT_ACTION);
-      this.replaceCommitTimerName = getMetricsName("timer", HoodieTimeline.REPLACE_COMMIT_ACTION);
-      this.finalizeTimerName = getMetricsName("timer", "finalize");
-      this.compactionTimerName = getMetricsName("timer", HoodieTimeline.COMPACTION_ACTION);
-      this.logCompactionTimerName = getMetricsName("timer", HoodieTimeline.LOG_COMPACTION_ACTION);
-      this.indexTimerName = getMetricsName("timer", "index");
-      this.conflictResolutionTimerName = getMetricsName("timer", "conflict_resolution");
-      this.conflictResolutionSuccessCounterName = getMetricsName("counter", "conflict_resolution.success");
-      this.conflictResolutionFailureCounterName = getMetricsName("counter", "conflict_resolution.failure");
-      this.compactionRequestedCounterName = getMetricsName("counter", "compaction.requested");
-      this.compactionCompletedCounterName = getMetricsName("counter", "compaction.completed");
+      this.rollbackTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.ROLLBACK_ACTION);
+      this.cleanTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.CLEAN_ACTION);
+      this.archiveTimerName = getMetricsName(TIMER_ACTION, ARCHIVE_ACTION);
+      this.commitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.COMMIT_ACTION);
+      this.deltaCommitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION);
+      this.replaceCommitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION);
+      this.finalizeTimerName = getMetricsName(TIMER_ACTION, FINALIZE_ACTION);
+      this.compactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.COMPACTION_ACTION);
+      this.logCompactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION);
+      this.indexTimerName = getMetricsName(TIMER_ACTION, INDEX_ACTION);
+      this.conflictResolutionTimerName = getMetricsName(TIMER_ACTION, "conflict_resolution");
+      this.conflictResolutionSuccessCounterName = getMetricsName(COUNTER_ACTION, "conflict_resolution.success");
+      this.conflictResolutionFailureCounterName = getMetricsName(COUNTER_ACTION, "conflict_resolution.failure");
+      this.compactionRequestedCounterName = getMetricsName(COUNTER_ACTION, "compaction.requested");
+      this.compactionCompletedCounterName = getMetricsName(COUNTER_ACTION, "compaction.completed");
     }
   }
 
@@ -150,6 +161,13 @@ public class HoodieMetrics {
       cleanTimer = createTimer(cleanTimerName);
     }
     return cleanTimer == null ? null : cleanTimer.time();
+  }
+
+  public Timer.Context getArchiveCtx() {
+    if (config.isMetricsOn() && archiveTimer == null) {
+      archiveTimer = createTimer(archiveTimerName);
+    }
+    return archiveTimer == null ? null : archiveTimer.time();
   }
 
   public Timer.Context getCommitCtx() {
@@ -262,7 +280,7 @@ public class HoodieMetrics {
         metrics.registerGauge(getMetricsName(actionType, "commitFreshnessInMs"), commitFreshnessInMs);
       }
       metrics.registerGauge(getMetricsName(actionType, "commitTime"), commitEpochTimeInMs);
-      metrics.registerGauge(getMetricsName(actionType, "duration"), durationInMs);
+      metrics.registerGauge(getMetricsName(actionType, DURATION_STR), durationInMs);
     }
   }
 
@@ -270,8 +288,8 @@ public class HoodieMetrics {
     if (config.isMetricsOn()) {
       LOG.info(
           String.format("Sending rollback metrics (duration=%d, numFilesDeleted=%d)", durationInMs, numFilesDeleted));
-      metrics.registerGauge(getMetricsName("rollback", "duration"), durationInMs);
-      metrics.registerGauge(getMetricsName("rollback", "numFilesDeleted"), numFilesDeleted);
+      metrics.registerGauge(getMetricsName(HoodieTimeline.ROLLBACK_ACTION, DURATION_STR), durationInMs);
+      metrics.registerGauge(getMetricsName(HoodieTimeline.ROLLBACK_ACTION, DELETE_FILES_NUM_STR), numFilesDeleted);
     }
   }
 
@@ -279,8 +297,17 @@ public class HoodieMetrics {
     if (config.isMetricsOn()) {
       LOG.info(
           String.format("Sending clean metrics (duration=%d, numFilesDeleted=%d)", durationInMs, numFilesDeleted));
-      metrics.registerGauge(getMetricsName("clean", "duration"), durationInMs);
-      metrics.registerGauge(getMetricsName("clean", "numFilesDeleted"), numFilesDeleted);
+      metrics.registerGauge(getMetricsName(HoodieTimeline.CLEAN_ACTION, DURATION_STR), durationInMs);
+      metrics.registerGauge(getMetricsName(HoodieTimeline.CLEAN_ACTION, DELETE_FILES_NUM_STR), numFilesDeleted);
+    }
+  }
+
+  public void updateArchiveMetrics(long durationInMs, int numFilesDeleted) {
+    if (config.isMetricsOn()) {
+      LOG.info(
+          String.format("Sending archive metrics (duration=%d, numFilesDeleted=%d)", durationInMs, numFilesDeleted));
+      metrics.registerGauge(getMetricsName(ARCHIVE_ACTION, DURATION_STR), durationInMs);
+      metrics.registerGauge(getMetricsName(ARCHIVE_ACTION, DELETE_FILES_NUM_STR), numFilesDeleted);
     }
   }
 
@@ -288,15 +315,15 @@ public class HoodieMetrics {
     if (config.isMetricsOn()) {
       LOG.info(String.format("Sending finalize write metrics (duration=%d, numFilesFinalized=%d)", durationInMs,
           numFilesFinalized));
-      metrics.registerGauge(getMetricsName("finalize", "duration"), durationInMs);
-      metrics.registerGauge(getMetricsName("finalize", "numFilesFinalized"), numFilesFinalized);
+      metrics.registerGauge(getMetricsName(FINALIZE_ACTION, DURATION_STR), durationInMs);
+      metrics.registerGauge(getMetricsName(FINALIZE_ACTION, "numFilesFinalized"), numFilesFinalized);
     }
   }
 
   public void updateIndexMetrics(final String action, final long durationInMs) {
     if (config.isMetricsOn()) {
       LOG.info(String.format("Sending index metrics (%s.duration, %d)", action, durationInMs));
-      metrics.registerGauge(getMetricsName("index", String.format("%s.duration", action)), durationInMs);
+      metrics.registerGauge(getMetricsName(INDEX_ACTION, String.format("%s.duration", action)), durationInMs);
     }
   }
 
@@ -306,7 +333,7 @@ public class HoodieMetrics {
   }
 
   public void updateClusteringFileCreationMetrics(long durationInMs) {
-    reportMetrics("replacecommit", "fileCreationTime", durationInMs);
+    reportMetrics(HoodieTimeline.REPLACE_COMMIT_ACTION, "fileCreationTime", durationInMs);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -257,8 +257,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   public void testArchiveEmptyTable() throws Exception {
     init();
     HoodieWriteConfig cfg =
-        HoodieWriteConfig.newBuilder().withPath(basePath)
-            .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
             .withParallelism(2, 2).forTable("test-trip-table").build();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -256,8 +256,8 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     HoodieTimelineArchiver archiver = new HoodieTimelineArchiver(cfg, table);
-    boolean result = archiver.archiveIfRequired(context);
-    assertTrue(result);
+    int result = archiver.archiveIfRequired(context);
+    assertEquals(0, result);
   }
 
   @ParameterizedTest
@@ -767,7 +767,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
     assertEquals(6, timeline.countInstants(), "Loaded 6 commits and the count should match");
-    assertTrue(archiver.archiveIfRequired(context));
+    archiver.archiveIfRequired(context);
     timeline = metaClient.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants();
     if (archiveBeyondSavepoint) {
       // commits in active timeline = 101 and 105.
@@ -953,8 +953,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     HoodieTimelineArchiver archiver = new HoodieTimelineArchiver(cfg, table);
-    boolean result = archiver.archiveIfRequired(context);
-    assertTrue(result);
+    archiver.archiveIfRequired(context);
     HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
     List<HoodieInstant> archivedInstants = Arrays.asList(instant1, instant2, instant3);
     assertEquals(new HashSet<>(archivedInstants),
@@ -1360,10 +1359,9 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     // Run archival
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     HoodieTimelineArchiver archiver = new HoodieTimelineArchiver(cfg, table);
-    boolean result = archiver.archiveIfRequired(context);
+    archiver.archiveIfRequired(context);
     expectedInstants.remove("1000");
     expectedInstants.remove("1001");
-    assertTrue(result);
     timeline = metaClient.reloadActiveTimeline().getWriteTimeline();
 
     // Check the count of instants after archive it should have 2 less instants
@@ -1383,7 +1381,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     metaClient.reloadActiveTimeline();
 
     // Run archival
-    assertTrue(archiver.archiveIfRequired(context));
+    archiver.archiveIfRequired(context);
     timeline = metaClient.reloadActiveTimeline().getWriteTimeline();
     expectedInstants.removeAll(Arrays.asList("1002", "1003", "1004", "1005"));
 
@@ -1417,8 +1415,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
     HoodieTimeline timeline = metaClient.reloadActiveTimeline();
     assertEquals(9, timeline.countInstants(), "Loaded 9 commits and the count should match");
-    boolean result = archiver.archiveIfRequired(context);
-    assertTrue(result);
+    archiver.archiveIfRequired(context);
     timeline = metaClient.reloadActiveTimeline();
     assertEquals(9, timeline.countInstants(),
         "Since we have a pending replacecommit at 1001, we should never archive any commit after 1001");


### PR DESCRIPTION
In the existing table service, `HoodieMetrics` registers the duration and other relevant information for compaction, clustering, and clean operations. However, there are no corresponding metrics for the archive operation. Therefore, we have implemented the necessary metrics for the archive operation.

Additionally, we have defined string constants in the field to extract string literal in `HoodieMetrics`.
 

### Change Logs

Providing metrics for archive.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
