### PR TITLE
[MINOR] Throw exceptions when cleaner/compactor fail

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 
@@ -168,18 +169,20 @@ public class HoodieCompactor {
     JCommander cmd = new JCommander(cfg, null, args);
     if (cfg.help || args.length == 0) {
       cmd.usage();
-      System.exit(1);
+      throw new HoodieException("Fail to run compaction for " + cfg.tableName + ", return code: " + 1);
     }
     final JavaSparkContext jsc = UtilHelpers.buildSparkContext("compactor-" + cfg.tableName, cfg.sparkMaster, cfg.sparkMemory);
     int ret = 0;
     try {
-      HoodieCompactor compactor = new HoodieCompactor(jsc, cfg);
-      ret = compactor.compact(cfg.retry);
+      ret = new HoodieCompactor(jsc, cfg).compact(cfg.retry);
     } catch (Throwable throwable) {
-      LOG.error("Fail to run compaction for " + cfg.tableName, throwable);
+      throw new HoodieException("Fail to run compaction for " + cfg.tableName + ", return code: " + ret, throwable);
     } finally {
       jsc.stop();
-      System.exit(ret);
+    }
+
+    if (ret != 0) {
+      throw new HoodieException("Fail to run compaction for " + cfg.tableName + ", return code: " + ret);
     }
   }
 


### PR DESCRIPTION
### Change Logs

Issue: #10035 
Spark applications should not use `System.exit` to terminate itself, see [SPARK-1446](https://issues.apache.org/jira/browse/SPARK-1446)

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
