### PR TITLE
[MINOR] Modified description to include missing trigger strategy

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -673,7 +673,9 @@ public class FlinkOptions extends HoodieConfig {
       .key("compaction.trigger.strategy")
       .stringType()
       .defaultValue(NUM_COMMITS) // default true for MOR write
-      .withDescription("Strategy to trigger compaction, options are 'num_commits': trigger compaction when reach N delta commits;\n"
+      .withDescription("Strategy to trigger compaction, options are "
+          + "'num_commits': trigger compaction when there are at least N delta commits after last completed compaction;\n"
+          + "'num_commits_after_last_request': trigger compaction when there are at least N delta commits after last completed/requested compaction;\n"
           + "'time_elapsed': trigger compaction when time elapsed > N seconds since last compaction;\n"
           + "'num_and_time': trigger compaction when both NUM_COMMITS and TIME_ELAPSED are satisfied;\n"
           + "'num_or_time': trigger compaction when NUM_COMMITS or TIME_ELAPSED is satisfied.\n"


### PR DESCRIPTION
### Change Logs

In https://github.com/apache/hudi/pull/6144, a new compaction trigger strategy was added named `NUM_COMMITS_AFTER_LAST_REQUEST`, org.apache.hudi.table.action.compact.CompactionTriggerStrategy.

However, the FlinkOptions description was not updated to include this new trigger strategy. Adding it in so that configs page on doc-site will reflect this trigger strategy for completeness.

**TODO:** 
Might need to do some refactoring to centralise these common config so that we do not have to worry about these de-sync in the future. Might also make it easier for testing.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
