### PR TITLE
[HUDI-7105] support filesystem view configuable to avoid clean oom

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -139,6 +139,7 @@ public class EmbeddedTimelineService {
         .withRemoteTimelineInitialRetryIntervalMs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineInitialRetryIntervalMs())
         .withRemoteTimelineClientMaxRetryIntervalMs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientMaxRetryIntervalMs())
         .withRemoteTimelineClientRetryExceptions(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientRetryExceptions())
+        .withRemoteFileSystemViewFirst(writeConfig.getClientSpecifiedViewStorageConfig().isRemoteViewFirst())
         .build();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -388,6 +388,11 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
       return this;
     }
 
+    public Builder withRemoteFileSystemViewFirst(boolean enable) {
+      fileSystemViewStorageConfig.setValue(REMOTE_VIEW_FIRST, Boolean.toString(enable));
+      return this;
+    }
+
     public FileSystemViewStorageConfig build() {
       fileSystemViewStorageConfig.setDefaults(FileSystemViewStorageConfig.class.getName());
       // Validations

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -173,6 +173,12 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
       .withDocumentation("Config to control whether backup needs to be configured if clients were not able to reach"
           + " timeline service.");
 
+  public static final ConfigProperty<String> REMOTE_VIEW_FIRST = ConfigProperty
+      .key("hoodie.filesystem.view.remote.first")
+      .defaultValue("true")
+      .markAdvanced()
+      .withDocumentation("Controls whether or not the file system view is remote first or secondary first.");
+
   public static FileSystemViewStorageConfig.Builder newBuilder() {
     return new Builder();
   }
@@ -272,6 +278,10 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public String getRocksdbBasePath() {
     return getString(ROCKSDB_BASE_PATH);
+  }
+
+  public boolean isRemoteViewFirst() {
+    return getBoolean(REMOTE_VIEW_FIRST);
   }
 
   /**


### PR DESCRIPTION
### Change Logs

If there are many partitions and files When generating the clean plan, it's easy to throw oom exception even if configing a large memory. The default way is remote table view first, it can not fall back to secondary table view if remote view throws oom exception. Using secondary view first is more stable than remote view.

### Impact

N/A

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
