### PR TITLE
[HUDI-7106] Fix sqs deletes, deltasync service close and error table default configs.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
@@ -200,9 +200,12 @@ public class CloudObjectsSelector {
    * Delete batch of messages from queue.
    */
   protected void deleteBatchOfMessages(SqsClient sqs, String queueUrl, List<Message> messagesToBeDeleted) {
-    DeleteMessageBatchRequest deleteBatchReq =
-        DeleteMessageBatchRequest.builder().queueUrl(queueUrl).build();
-    List<DeleteMessageBatchRequestEntry> deleteEntries = new ArrayList<>(deleteBatchReq.entries());
+    if (messagesToBeDeleted.isEmpty()) {
+      return;
+    }
+    DeleteMessageBatchRequest.Builder builder = DeleteMessageBatchRequest.builder().queueUrl(queueUrl);
+    List<DeleteMessageBatchRequestEntry> deleteEntries = new ArrayList<>();
+
     for (Message message : messagesToBeDeleted) {
       deleteEntries.add(
           DeleteMessageBatchRequestEntry.builder()
@@ -210,7 +213,8 @@ public class CloudObjectsSelector {
                   .receiptHandle(message.receiptHandle())
                   .build());
     }
-    DeleteMessageBatchResponse deleteResponse = sqs.deleteMessageBatch(deleteBatchReq);
+    builder.entries(deleteEntries);
+    DeleteMessageBatchResponse deleteResponse = sqs.deleteMessageBatch(builder.build());
     List<String> deleteFailures =
         deleteResponse.failed().stream()
             .map(BatchResultErrorEntry::id)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
@@ -64,7 +64,7 @@ public final class ErrorTableUtils {
 
   public static HoodieErrorTableConfig.ErrorWriteFailureStrategy getErrorWriteFailureStrategy(
       TypedProperties props) {
-    String writeFailureStrategy = props.getString(ERROR_TABLE_WRITE_FAILURE_STRATEGY.key());
+    String writeFailureStrategy = props.getString(ERROR_TABLE_WRITE_FAILURE_STRATEGY.key(), ERROR_TABLE_WRITE_FAILURE_STRATEGY.defaultValue());
     return HoodieErrorTableConfig.ErrorWriteFailureStrategy.valueOf(writeFailureStrategy);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -844,6 +844,8 @@ public class HoodieStreamer implements Serializable {
         streamSync.syncOnce();
       } catch (IOException e) {
         throw new HoodieIngestionException(String.format("Ingestion via %s failed with exception.", this.getClass()), e);
+      } finally {
+        close();
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -844,8 +844,6 @@ public class HoodieStreamer implements Serializable {
         streamSync.syncOnce();
       } catch (IOException e) {
         throw new HoodieIngestionException(String.format("Ingestion via %s failed with exception.", this.getClass()), e);
-      } finally {
-        close();
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -119,12 +119,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import scala.Tuple2;
 import scala.collection.JavaConversions;
@@ -975,7 +974,7 @@ public class StreamSync implements Serializable, Closeable {
   }
 
   public void runMetaSync() {
-    Set<String> syncClientToolClasses = new HashSet<>(Arrays.asList(cfg.syncClientToolClassNames.split(",")));
+    List<String> syncClientToolClasses = Arrays.stream(cfg.syncClientToolClassNames.split(",")).distinct().collect(Collectors.toList());
     // for backward compatibility
     if (cfg.enableHiveSync) {
       cfg.enableMetaSync = true;


### PR DESCRIPTION
### Change Logs

PR fixes a few things:
SQS source should send delete API if no delete messages.
Ensure the same catalog sync class is not called twice
Error table failure strategy has default value set

### Impact

Minor bug fixes.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
