### PR TITLE
[HUDI-7110] Add call procedure for show column stats information

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -309,7 +309,7 @@ class ColumnStatsIndexSupport(spark: SparkSession,
     colStatsDF.select(targetColumnStatsIndexColumns.map(col): _*)
   }
 
-  private def loadColumnStatsIndexRecords(targetColumns: Seq[String], shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
+  def loadColumnStatsIndexRecords(targetColumns: Seq[String], shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
     // Read Metadata Table's Column Stats Index records into [[HoodieData]] container by
     //    - Fetching the records from CSI by key-prefixes (encoded column names)
     //    - Extracting [[HoodieMetadataColumnStats]] records

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -66,6 +66,7 @@ object HoodieProcedures {
       ,(ShowBootstrapPartitionsProcedure.NAME, ShowBootstrapPartitionsProcedure.builder)
       ,(UpgradeTableProcedure.NAME, UpgradeTableProcedure.builder)
       ,(DowngradeTableProcedure.NAME, DowngradeTableProcedure.builder)
+      ,(ShowMetadataTableColumnStatsProcedure.NAME, ShowMetadataTableColumnStatsProcedure.builder)
       ,(ShowMetadataTableFilesProcedure.NAME, ShowMetadataTableFilesProcedure.builder)
       ,(ShowMetadataTablePartitionsProcedure.NAME, ShowMetadataTablePartitionsProcedure.builder)
       ,(CreateMetadataTableProcedure.NAME, CreateMetadataTableProcedure.builder)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.avro.generic.IndexedRecord
+import org.apache.hudi.avro.model.{BooleanWrapper, BytesWrapper, DateWrapper, DecimalWrapper, DoubleWrapper, FloatWrapper, HoodieMetadataColumnStats, IntWrapper, LongWrapper, StringWrapper, TimeMicrosWrapper, TimestampMicrosWrapper}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.data.HoodieData
+import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.{AvroConversionUtils, ColumnStatsIndexSupport}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util
+import java.util.function.Supplier
+
+
+class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with ProcedureBuilder with Logging {
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "targetColumns", DataTypes.StringType)
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("file_name", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("column_name", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("min_value", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("max_value", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("null_num", DataTypes.LongType, nullable = true, Metadata.empty)
+  ))
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val table = getArgValueOrDefault(args, PARAMETERS(0))
+    val targetColumns = getArgValueOrDefault(args, PARAMETERS(1)).getOrElse("").toString
+    val targetColumnsSeq = targetColumns.split(",").toSeq
+    val basePath = getBasePath(table)
+    val metadataConfig = HoodieMetadataConfig.newBuilder
+      .enable(true)
+      .build
+    val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
+    val schemaUtil = new TableSchemaResolver(metaClient)
+    var schema = AvroConversionUtils.convertAvroSchemaToStructType(schemaUtil.getTableAvroSchema)
+    val columnStatsIndex = new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
+    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = columnStatsIndex.loadColumnStatsIndexRecords(targetColumnsSeq, false)
+
+    val rows = new util.ArrayList[Row]
+    colStatsRecords.collectAsList()
+      .stream()
+      .forEach(c => {
+        rows.add(Row(c.getFileName, c.getColumnName, getColumnStatsValue(c.getMinValue), getColumnStatsValue(c.getMaxValue), c.getNullCount.longValue()))
+      })
+    rows.stream().toArray().map(r => r.asInstanceOf[Row]).toList
+  }
+
+  def getColumnStatsValue(stats_value: Any): String = {
+    stats_value match {
+      case _: IntWrapper |
+           _: BooleanWrapper |
+           _: BytesWrapper |
+           _: DateWrapper |
+           _: DecimalWrapper |
+           _: DoubleWrapper |
+           _: FloatWrapper |
+           _: LongWrapper |
+           _: StringWrapper |
+           _: TimeMicrosWrapper |
+           _: TimestampMicrosWrapper =>
+        String.valueOf(stats_value.asInstanceOf[IndexedRecord].get(0))
+      case _ => throw new Exception("Unsupported type.")
+    }
+  }
+
+  override def build: Procedure = new ShowMetadataTableColumnStatsProcedure()
+}
+
+object ShowMetadataTableColumnStatsProcedure {
+  val NAME = "show_metadata_table_column_stats"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get() = new ShowMetadataTableColumnStatsProcedure()
+  }
+}
+

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -76,9 +76,9 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
       .build
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
     val schemaUtil = new TableSchemaResolver(metaClient)
-    var schema = AvroConversionUtils.convertAvroSchemaToStructType(schemaUtil.getTableAvroSchema)
+    val schema = AvroConversionUtils.convertAvroSchemaToStructType(schemaUtil.getTableAvroSchema)
     val columnStatsIndex = new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
-    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = columnStatsIndex.loadColumnStatsIndexRecords(targetColumnsSeq, false)
+    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = columnStatsIndex.loadColumnStatsIndexRecords(targetColumnsSeq, shouldReadInMemory = false)
     val fsView = buildFileSystemView(table)
     val allFileSlices: Set[FileSlice] = {
       if (partitionsSeq.isEmpty) {
@@ -108,7 +108,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     rows.toList
   }
 
-  def getColumnStatsValue(stats_value: Any): String = {
+  private def getColumnStatsValue(stats_value: Any): String = {
     stats_value match {
       case _: IntWrapper |
            _: BooleanWrapper |

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -78,9 +78,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     stats_value match {
       case _: IntWrapper |
            _: BooleanWrapper |
-           _: BytesWrapper |
            _: DateWrapper |
-           _: DecimalWrapper |
            _: DoubleWrapper |
            _: FloatWrapper |
            _: LongWrapper |
@@ -88,6 +86,12 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
            _: TimeMicrosWrapper |
            _: TimestampMicrosWrapper =>
         String.valueOf(stats_value.asInstanceOf[IndexedRecord].get(0))
+      case _: BytesWrapper =>
+        var bytes_value = stats_value.asInstanceOf[BytesWrapper].getValue
+        util.Arrays.toString(bytes_value.array())
+      case _: DecimalWrapper =>
+        var decimal_value = stats_value.asInstanceOf[DecimalWrapper].getValue
+        util.Arrays.toString(decimal_value.array())
       case _ => throw new Exception("Unsupported type.")
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
@@ -131,7 +131,7 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
            |""".stripMargin)
 
       // collect column stats for table
-      for (i <- 3 to 3) {
+      for (i <- 1 to 10) {
         val columnName = s"c$i"
         val metadataStats = spark.sql(s"""call show_metadata_table_column_stats(table => '$tableName', targetColumns => '$columnName')""").collect()
         assertResult(2) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
@@ -102,7 +102,7 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
            |  c2 boolean,
            |  c3 binary,
            |  c4 date,
-           |  c5 decimal,
+           |  c5 decimal(10,1),
            |  c6 double,
            |  c7 float,
            |  c8 long,
@@ -122,12 +122,12 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
       spark.sql(
         s"""
            |insert into table $tableName
-           |values (1, true, CAST('binary data' AS BINARY), CAST('2021-01-01' AS DATE), 10.5, 3.14, 2.5, 1000, 'example string', CAST('2021-01-01 00:00:00' AS TIMESTAMP))
+           |values (1, true, CAST('binary data' AS BINARY), CAST('2021-01-01' AS DATE), CAST(10.5 AS DECIMAL(10,1)), CAST(3.14 AS DOUBLE), CAST(2.5 AS FLOAT), 1000, 'example string', CAST('2021-01-01 00:00:00' AS TIMESTAMP))
            |""".stripMargin)
       spark.sql(
         s"""
            |insert into table $tableName
-           |values (10, false, CAST('binary data' AS BINARY), CAST('2022-02-02' AS DATE), 20.5, 6.28, 3.14, 2000, 'another string', CAST('2022-02-02 00:00:00' AS TIMESTAMP))
+           |values (10, false, CAST('binary data' AS BINARY), CAST('2022-02-02' AS DATE),  CAST(20.5 AS DECIMAL(10,1)), CAST(6.28 AS DOUBLE), CAST(3.14 AS FLOAT), 2000, 'another string', CAST('2022-02-02 00:00:00' AS TIMESTAMP))
            |""".stripMargin)
 
       // Only numerical and string types are compared for clarity on min/max values.


### PR DESCRIPTION
### Change Logs

This feature introduces a call procedure that allows users to specify the table name and column names to retrieve column stats information from the metadata table. This functionality facilitates the observation of data distribution status and assists in data skipping.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

A procedure for show column stats information.
An example:

`call show_metadata_table_column_stats(table => 'tableName', targetColumns => 'column1,column2');`

Supports querying multiple columns simultaneously, separated by commas.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
