### PR TITLE
[HUDI-7112] Reuse existing timeline server and performance improvements

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -120,7 +120,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
     if (timelineServer.isPresent() && shouldStopTimelineServer) {
       // Stop only if owner
       LOG.info("Stopping Timeline service !!");
-      timelineServer.get().stop();
+      timelineServer.get().stopForBasePath(basePath);
     }
 
     timelineServer = Option.empty();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
@@ -23,19 +23,12 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 
 /**
  * Helper class to instantiate embedded timeline service.
  */
 public class EmbeddedTimelineServerHelper {
-
-  private static final Logger LOG = LoggerFactory.getLogger(EmbeddedTimelineService.class);
-
-  private static Option<EmbeddedTimelineService> TIMELINE_SERVER = Option.empty();
 
   /**
    * Instantiate Embedded Timeline Server.
@@ -44,33 +37,16 @@ public class EmbeddedTimelineServerHelper {
    * @return TimelineServer if configured to run
    * @throws IOException
    */
-  public static synchronized Option<EmbeddedTimelineService> createEmbeddedTimelineService(
+  public static Option<EmbeddedTimelineService> createEmbeddedTimelineService(
       HoodieEngineContext context, HoodieWriteConfig config) throws IOException {
-    if (config.isEmbeddedTimelineServerReuseEnabled()) {
-      if (!TIMELINE_SERVER.isPresent() || !TIMELINE_SERVER.get().canReuseFor(config.getBasePath())) {
-        TIMELINE_SERVER = Option.of(startTimelineService(context, config));
-      } else {
-        updateWriteConfigWithTimelineServer(TIMELINE_SERVER.get(), config);
-      }
-      return TIMELINE_SERVER;
-    }
     if (config.isEmbeddedTimelineServerEnabled()) {
-      return Option.of(startTimelineService(context, config));
+      Option<String> hostAddr = context.getProperty(EngineProperty.EMBEDDED_SERVER_HOST);
+      EmbeddedTimelineService timelineService = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(context, hostAddr.orElse(null), config);
+      updateWriteConfigWithTimelineServer(timelineService, config);
+      return Option.of(timelineService);
     } else {
       return Option.empty();
     }
-  }
-
-  private static EmbeddedTimelineService startTimelineService(
-      HoodieEngineContext context, HoodieWriteConfig config) throws IOException {
-    // Run Embedded Timeline Server
-    LOG.info("Starting Timeline service !!");
-    Option<String> hostAddr = context.getProperty(EngineProperty.EMBEDDED_SERVER_HOST);
-    EmbeddedTimelineService timelineService = new EmbeddedTimelineService(
-        context, hostAddr.orElse(null), config);
-    timelineService.startServer();
-    updateWriteConfigWithTimelineServer(timelineService, config);
-    return timelineService;
   }
 
   /**
@@ -79,7 +55,7 @@ public class EmbeddedTimelineServerHelper {
    * @param config  Hoodie Write Config
    */
   public static void updateWriteConfigWithTimelineServer(EmbeddedTimelineService timelineServer,
-      HoodieWriteConfig config) {
+                                                         HoodieWriteConfig config) {
     // Allow executor to find this newly instantiated timeline service
     if (config.isEmbeddedTimelineServerEnabled()) {
       config.setViewStorageConfig(timelineServer.getRemoteFileSystemViewConfig());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -148,6 +148,24 @@ public class EmbeddedTimelineService {
           .markerBatchIntervalMs(writeConfig.getMarkersTimelineServerBasedBatchIntervalMs())
           .markerParallelism(writeConfig.getMarkersDeleteParallelism());
     }
+
+    if (writeConfig.isEarlyConflictDetectionEnable()) {
+      timelineServiceConfBuilder.earlyConflictDetectionEnable(true)
+          .earlyConflictDetectionStrategy(writeConfig.getEarlyConflictDetectionStrategyClassName())
+          .earlyConflictDetectionCheckCommitConflict(writeConfig.earlyConflictDetectionCheckCommitConflict())
+          .asyncConflictDetectorInitialDelayMs(writeConfig.getAsyncConflictDetectorInitialDelayMs())
+          .asyncConflictDetectorPeriodMs(writeConfig.getAsyncConflictDetectorPeriodMs())
+          .earlyConflictDetectionMaxAllowableHeartbeatIntervalInMs(
+              writeConfig.getHoodieClientHeartbeatIntervalInMs()
+                  * writeConfig.getHoodieClientHeartbeatTolerableMisses());
+    }
+
+    if (writeConfig.isTimelineServerBasedInstantStateEnabled()) {
+      timelineServiceConfBuilder
+          .instantStateForceRefreshRequestNumber(writeConfig.getTimelineServerBasedInstantStateForceRefreshRequestNumber())
+          .enableInstantStateRequests(true);
+    }
+
     this.serviceConfig = timelineServiceConfBuilder.build();
 
     server = timelineServiceCreator.create(context, hadoopConf.newCopy(), serviceConfig,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -123,6 +123,16 @@ public class EmbeddedTimelineService {
     return service;
   }
 
+  public static void shutdownAllTimelineServers() {
+    RUNNING_SERVICES.entrySet().forEach(entry -> {
+      LOG.info("Closing Timeline server");
+      entry.getValue().server.close();
+      METRICS_REGISTRY.set(NUM_EMBEDDED_TIMELINE_SERVERS, NUM_SERVERS_RUNNING.decrementAndGet());
+      LOG.info("Closed Timeline server");
+    });
+    RUNNING_SERVICES.clear();
+  }
+
   private FileSystemViewManager createViewManager() {
     // Using passed-in configs to build view storage configs
     FileSystemViewStorageConfig.Builder builder =

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -98,12 +98,10 @@ public class EmbeddedTimelineService {
     // if reuse is enabled, check if any existing instances are compatible
     if (writeConfig.isEmbeddedTimelineServerReuseEnabled()) {
       synchronized (SERVICE_LOCK) {
-        for (Map.Entry<TimelineServiceIdentifier, EmbeddedTimelineService> entry: RUNNING_SERVICES.entrySet()) {
-          if (entry.getKey().equals(timelineServiceIdentifier)) {
-            entry.getValue().addBasePath(writeConfig.getBasePath());
-            LOG.info("Reusing existing embedded timeline server with configuration: " + entry.getValue().serviceConfig);
-            return entry.getValue();
-          }
+        if (RUNNING_SERVICES.containsKey(timelineServiceIdentifier)) {
+          RUNNING_SERVICES.get(timelineServiceIdentifier).addBasePath(writeConfig.getBasePath());
+          LOG.info("Reusing existing embedded timeline server with configuration: " + RUNNING_SERVICES.get(timelineServiceIdentifier).serviceConfig);
+          return RUNNING_SERVICES.get(timelineServiceIdentifier);
         }
         // if no compatible instance is found, create a new one
         EmbeddedTimelineService service = createAndStartService(context, embeddedTimelineServiceHostAddr, writeConfig,
@@ -282,8 +280,12 @@ public class EmbeddedTimelineService {
         return false;
       }
       TimelineServiceIdentifier that = (TimelineServiceIdentifier) o;
-      return isMetadataEnabled == that.isMetadataEnabled && isEarlyConflictDetectionEnable == that.isEarlyConflictDetectionEnable
-          && isTimelineServerBasedInstantStateEnabled == that.isTimelineServerBasedInstantStateEnabled && hostAddr.equals(that.hostAddr) && markerType == that.markerType;
+      if (this.hostAddr != null && that.hostAddr != null) {
+        return isMetadataEnabled == that.isMetadataEnabled && isEarlyConflictDetectionEnable == that.isEarlyConflictDetectionEnable
+            && isTimelineServerBasedInstantStateEnabled == that.isTimelineServerBasedInstantStateEnabled && hostAddr.equals(that.hostAddr) && markerType == that.markerType;
+      } else {
+        return (hostAddr == null && that.hostAddr == null);
+      }
     }
 
     @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -476,8 +476,8 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.embed.timeline.server.reuse.enabled")
       .defaultValue(false)
       .markAdvanced()
-      .withDocumentation("Controls whether the timeline server instance should be cached and reused across the JVM (across task lifecycles)"
-          + "to avoid startup costs. This should rarely be changed.");
+      .withDocumentation("Controls whether the timeline server instance should be cached and reused across the tables"
+          + "to avoid startup costs and server overhead. This should only be used if you are running multiple writers in the same JVM.");
 
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_PORT_NUM = ConfigProperty
       .key("hoodie.embed.timeline.server.port")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/TimelineServerBasedWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/TimelineServerBasedWriteMarkers.java
@@ -62,6 +62,8 @@ import static org.apache.hudi.common.table.marker.MarkerOperation.MARKER_NAME_PA
  */
 public class TimelineServerBasedWriteMarkers extends WriteMarkers {
   private static final Logger LOG = LoggerFactory.getLogger(TimelineServerBasedWriteMarkers.class);
+  private static final TypeReference<Boolean> BOOLEAN_TYPE_REFERENCE = new TypeReference<Boolean>() {};
+  private static final TypeReference<Set<String>> STRING_TYPE_REFERENCE = new TypeReference<Set<String>>() {};
 
   private final HttpRequestClient httpRequestClient;
 
@@ -84,7 +86,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
     Map<String, String> paramsMap = Collections.singletonMap(MARKER_DIR_PATH_PARAM, markerDirPath.toString());
     try {
       return httpRequestClient.executeRequest(
-          DELETE_MARKER_DIR_URL, paramsMap, new TypeReference<Boolean>() {}, RequestMethod.POST);
+          DELETE_MARKER_DIR_URL, paramsMap, BOOLEAN_TYPE_REFERENCE, RequestMethod.POST);
     } catch (IOException e) {
       throw new HoodieRemoteException("Failed to delete marker directory " + markerDirPath.toString(), e);
     }
@@ -95,7 +97,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
     Map<String, String> paramsMap = Collections.singletonMap(MARKER_DIR_PATH_PARAM, markerDirPath.toString());
     try {
       return httpRequestClient.executeRequest(
-          MARKERS_DIR_EXISTS_URL, paramsMap, new TypeReference<Boolean>() {}, RequestMethod.GET);
+          MARKERS_DIR_EXISTS_URL, paramsMap, BOOLEAN_TYPE_REFERENCE, RequestMethod.GET);
     } catch (IOException e) {
       throw new HoodieRemoteException("Failed to check marker directory " + markerDirPath.toString(), e);
     }
@@ -106,7 +108,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
     Map<String, String> paramsMap = Collections.singletonMap(MARKER_DIR_PATH_PARAM, markerDirPath.toString());
     try {
       Set<String> markerPaths = httpRequestClient.executeRequest(
-          CREATE_AND_MERGE_MARKERS_URL, paramsMap, new TypeReference<Set<String>>() {}, RequestMethod.GET);
+          CREATE_AND_MERGE_MARKERS_URL, paramsMap, STRING_TYPE_REFERENCE, RequestMethod.GET);
       return markerPaths.stream().map(WriteMarkers::stripMarkerSuffix).collect(Collectors.toSet());
     } catch (IOException e) {
       throw new HoodieRemoteException("Failed to get CREATE and MERGE data file paths in "
@@ -119,7 +121,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
     Map<String, String> paramsMap = Collections.singletonMap(MARKER_DIR_PATH_PARAM, markerDirPath.toString());
     try {
       return httpRequestClient.executeRequest(
-          ALL_MARKERS_URL, paramsMap, new TypeReference<Set<String>>() {}, RequestMethod.GET);
+          ALL_MARKERS_URL, paramsMap, STRING_TYPE_REFERENCE, RequestMethod.GET);
     } catch (IOException e) {
       throw new HoodieRemoteException("Failed to get all markers in " + markerDirPath.toString(), e);
     }
@@ -173,8 +175,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
     boolean success;
     try {
       success = httpRequestClient.executeRequest(
-          CREATE_MARKER_URL, paramsMap, new TypeReference<Boolean>() {
-          }, HttpRequestClient.RequestMethod.POST);
+          CREATE_MARKER_URL, paramsMap, BOOLEAN_TYPE_REFERENCE, HttpRequestClient.RequestMethod.POST);
     } catch (IOException e) {
       throw new HoodieRemoteException("Failed to create marker file " + partitionPath + "/" + markerFileName, e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class HttpRequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(HttpRequestClient.class);
-  private final ObjectMapper mapper;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   private final String serverHost;
   private final int serverPort;
   private final int timeoutSecs;
@@ -51,7 +51,6 @@ public class HttpRequestClient {
   }
 
   public HttpRequestClient(String serverHost, int serverPort, int timeoutSecs, int maxRetry) {
-    this.mapper = new ObjectMapper();
     this.serverHost = serverHost;
     this.serverPort = serverPort;
     this.timeoutSecs = timeoutSecs;
@@ -59,7 +58,7 @@ public class HttpRequestClient {
   }
 
   public <T> T executeRequestWithRetry(String requestPath, Map<String, String> queryParameters,
-                                       TypeReference reference, RequestMethod method) {
+                                       TypeReference<T> reference, RequestMethod method) {
     int retry = maxRetry;
     while (--retry >= 0) {
       try {
@@ -72,14 +71,14 @@ public class HttpRequestClient {
   }
 
   public <T> T executeRequest(String requestPath, Map<String, String> queryParameters,
-                              TypeReference reference, RequestMethod method) throws IOException {
+                              TypeReference<T> reference, RequestMethod method) throws IOException {
     URIBuilder builder =
         new URIBuilder().setHost(serverHost).setPort(serverPort).setPath(requestPath).setScheme("http");
 
     queryParameters.forEach(builder::addParameter);
 
     String url = builder.toString();
-    LOG.debug("Sending request : (" + url + ")");
+    LOG.debug("Sending request : ( {} )", url);
     Response response;
     int timeout = this.timeoutSecs * 1000; // msec
     switch (method) {
@@ -92,7 +91,7 @@ public class HttpRequestClient {
         break;
     }
     String content = response.returnContent().asString();
-    return (T) mapper.readValue(content, reference);
+    return MAPPER.readValue(content, reference);
   }
 
   public enum RequestMethod {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
@@ -23,6 +23,7 @@ import org.apache.hudi.exception.HoodieException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.fluent.Response;
 import org.apache.http.client.utils.URIBuilder;
@@ -37,7 +38,7 @@ import java.util.Map;
  */
 public class HttpRequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(HttpRequestClient.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
   private final String serverHost;
   private final int serverPort;
   private final int timeoutSecs;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
@@ -1,0 +1,189 @@
+package org.apache.hudi.client.embedded;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.timeline.service.TimelineService;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * These tests are mainly focused on testing the creation and reuse of the embedded timeline server.
+ */
+public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
+
+  @Test
+  public void embeddedTimelineServiceReused() throws Exception {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new Configuration());
+    HoodieWriteConfig writeConfig1 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table1").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService = Mockito.mock(TimelineService.class);
+    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockService.startService()).thenReturn(123);
+    EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
+
+    HoodieWriteConfig writeConfig2 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table2").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    // do not mock the create method since that should never be called
+    EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
+    assertSame(service1, service2);
+
+    // test shutdown happens after the last path is removed
+    service1.stopForBasePath(writeConfig2.getBasePath());
+    verify(mockService, never()).close();
+    verify(mockService, times(1)).unregisterBasePath(writeConfig2.getBasePath());
+
+    service2.stopForBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).unregisterBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).close();
+  }
+
+  @Test
+  public void embeddedTimelineServiceCreatedForDifferentMetadataConfig() throws Exception {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new Configuration());
+    HoodieWriteConfig writeConfig1 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table1").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService = Mockito.mock(TimelineService.class);
+    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockService.startService()).thenReturn(321);
+    EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
+
+    HoodieWriteConfig writeConfig2 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table2").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(false)
+            .build())
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService2 = Mockito.mock(TimelineService.class);
+    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockService2.startService()).thenReturn(456);
+    EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
+    assertNotSame(service1, service2);
+
+    // test shutdown happens immediately since each server has only one path associated with it
+    service1.stopForBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).close();
+
+    service2.stopForBasePath(writeConfig2.getBasePath());
+    verify(mockService2, times(1)).close();
+  }
+
+  @Test
+  public void embeddedTimelineServerNotReusedIfReuseDisabled() throws Exception {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new Configuration());
+    HoodieWriteConfig writeConfig1 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table1").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService = Mockito.mock(TimelineService.class);
+    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockService.startService()).thenReturn(789);
+    EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
+
+    HoodieWriteConfig writeConfig2 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table2").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(false)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService2 = Mockito.mock(TimelineService.class);
+    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockService2.startService()).thenReturn(987);
+    EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
+    assertNotSame(service1, service2);
+
+    // test shutdown happens immediately since each server has only one path associated with it
+    service1.stopForBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).unregisterBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).close();
+
+    service2.stopForBasePath(writeConfig2.getBasePath());
+    verify(mockService2, times(1)).unregisterBasePath(writeConfig2.getBasePath());
+    verify(mockService2, times(1)).close();
+  }
+
+  @Test
+  public void embeddedTimelineServerIsNotReusedAfterStopped() throws Exception {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new Configuration());
+    HoodieWriteConfig writeConfig1 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table1").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService = Mockito.mock(TimelineService.class);
+    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockService.startService()).thenReturn(555);
+    EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
+
+    service1.stopForBasePath(writeConfig1.getBasePath());
+
+    HoodieWriteConfig writeConfig2 = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.resolve("table2").toString())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withEmbeddedTimelineServerReuseEnabled(true)
+        .build();
+    EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
+    TimelineService mockService2 = Mockito.mock(TimelineService.class);
+    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockService2.startService()).thenReturn(111);
+    EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
+    // a new service will be started since the original was shutdown already
+    assertNotSame(service1, service2);
+
+    // test shutdown happens immediately since each server has only one path associated with it
+    service1.stopForBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).unregisterBasePath(writeConfig1.getBasePath());
+    verify(mockService, times(1)).close();
+
+    service2.stopForBasePath(writeConfig2.getBasePath());
+    verify(mockService2, times(1)).unregisterBasePath(writeConfig2.getBasePath());
+    verify(mockService2, times(1)).close();
+  }
+}

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
@@ -116,9 +116,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
 
     HoodieJavaWriteClient writeClient;
     if (passInTimelineServer) {
-      EmbeddedTimelineService timelineService =
-          new EmbeddedTimelineService(context, null, writeConfig);
-      timelineService.startServer();
+      EmbeddedTimelineService timelineService = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(context, null, writeConfig);
       writeConfig.setViewStorageConfig(timelineService.getRemoteFileSystemViewConfig());
       writeClient = new HoodieJavaWriteClient(context, writeConfig, true, Option.of(timelineService));
       // Both the write client and the table service client should use the same passed-in
@@ -127,7 +125,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
       assertEquals(timelineService, writeClient.getTableServiceClient().getTimelineServer().get());
       // Write config should not be changed
       assertEquals(writeConfig, writeClient.getConfig());
-      timelineService.stop();
+      timelineService.stopForBasePath(writeConfig.getBasePath());
     } else {
       writeClient = new HoodieJavaWriteClient(context, writeConfig);
       // Only one timeline server should be instantiated, and the same timeline server

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -164,6 +164,18 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     return opts;
   }
 
+  @ParameterizedTest
+  @MethodSource("configParamsDirectBased")
+  public void testHoodieClientBasicMultiWriterWithEarlyConflictDetectionDirect(String tableType, String earlyConflictDetectionStrategy) throws Exception {
+    testHoodieClientBasicMultiWriterWithEarlyConflictDetection(tableType, MarkerType.DIRECT.name(), earlyConflictDetectionStrategy);
+  }
+
+  @ParameterizedTest
+  @MethodSource("configParamsTimelineServerBased")
+  public void testHoodieClientBasicMultiWriterWithEarlyConflictDetectionTimelineServerBased(String tableType, String earlyConflictDetectionStrategy) throws Exception {
+    testHoodieClientBasicMultiWriterWithEarlyConflictDetection(tableType, MarkerType.TIMELINE_SERVER_BASED.name(), earlyConflictDetectionStrategy);
+  }
+
   /**
    * Test multi-writers with early conflict detect enable, including
    * 1. MOR + Direct marker
@@ -184,9 +196,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
    * @param markerType
    * @throws Exception
    */
-  @ParameterizedTest
-  @MethodSource("configParams")
-  public void testHoodieClientBasicMultiWriterWithEarlyConflictDetection(String tableType, String markerType, String earlyConflictDetectionStrategy) throws Exception {
+  private void testHoodieClientBasicMultiWriterWithEarlyConflictDetection(String tableType, String markerType, String earlyConflictDetectionStrategy) throws Exception {
     if (tableType.equalsIgnoreCase(HoodieTableType.MERGE_ON_READ.name())) {
       setUpMORTestTable();
     }
@@ -955,14 +965,21 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     return result;
   }
 
-  public static Stream<Arguments> configParams() {
+  public static Stream<Arguments> configParamsTimelineServerBased() {
     Object[][] data =
         new Object[][] {
-            {"COPY_ON_WRITE", MarkerType.TIMELINE_SERVER_BASED.name(), AsyncTimelineServerBasedDetectionStrategy.class.getName()},
-            {"MERGE_ON_READ", MarkerType.TIMELINE_SERVER_BASED.name(), AsyncTimelineServerBasedDetectionStrategy.class.getName()},
-            {"MERGE_ON_READ", MarkerType.DIRECT.name(), SimpleDirectMarkerBasedDetectionStrategy.class.getName()},
-            {"COPY_ON_WRITE", MarkerType.DIRECT.name(), SimpleDirectMarkerBasedDetectionStrategy.class.getName()},
-            {"COPY_ON_WRITE", MarkerType.DIRECT.name(), SimpleTransactionDirectMarkerBasedDetectionStrategy.class.getName()}
+            {"COPY_ON_WRITE", AsyncTimelineServerBasedDetectionStrategy.class.getName()},
+            {"MERGE_ON_READ", AsyncTimelineServerBasedDetectionStrategy.class.getName()}
+        };
+    return Stream.of(data).map(Arguments::of);
+  }
+
+  public static Stream<Arguments> configParamsDirectBased() {
+    Object[][] data =
+        new Object[][] {
+            {"MERGE_ON_READ", SimpleDirectMarkerBasedDetectionStrategy.class.getName()},
+            {"COPY_ON_WRITE", SimpleDirectMarkerBasedDetectionStrategy.class.getName()},
+            {"COPY_ON_WRITE", SimpleTransactionDirectMarkerBasedDetectionStrategy.class.getName()}
         };
     return Stream.of(data).map(Arguments::of);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
@@ -84,9 +84,7 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
 
     SparkRDDWriteClient writeClient;
     if (passInTimelineServer) {
-      EmbeddedTimelineService timelineService =
-          new EmbeddedTimelineService(context(), null, writeConfig);
-      timelineService.startServer();
+      EmbeddedTimelineService timelineService = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(context(), null, writeConfig);
       writeConfig.setViewStorageConfig(timelineService.getRemoteFileSystemViewConfig());
       writeClient = new SparkRDDWriteClient(context(), writeConfig, Option.of(timelineService));
       // Both the write client and the table service client should use the same passed-in
@@ -95,7 +93,7 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
       assertEquals(timelineService, writeClient.getTableServiceClient().getTimelineServer().get());
       // Write config should not be changed
       assertEquals(writeConfig, writeClient.getConfig());
-      timelineService.stop();
+      timelineService.stopForBasePath(writeConfig.getBasePath());
     } else {
       writeClient = new SparkRDDWriteClient(context(), writeConfig);
       // Only one timeline server should be instantiated, and the same timeline server

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -53,7 +53,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,6 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
     initPath();
     initSparkContexts();
     initFileSystem();
-    initTimelineService();
     dataGen = new HoodieTestDataGenerator(0x1f86);
   }
 
@@ -129,30 +128,46 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
     }
   }
 
+  private enum TestCase {
+    USE_EXISTING_TIMELINE_SERVER(true, false),
+    EMBEDDED_TIMELINE_SERVER_PER_TABLE(false, false),
+    SINGLE_EMBEDDED_TIMELINE_SERVER(false, true);
+
+    private final boolean useExistingTimelineServer;
+    private final boolean reuseTimelineServer;
+
+    TestCase(boolean useExistingTimelineServer, boolean reuseTimelineServer) {
+      this.useExistingTimelineServer = useExistingTimelineServer;
+      this.reuseTimelineServer = reuseTimelineServer;
+    }
+  }
+
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testMORGetLatestFileSliceWithMetadataTable(boolean useExistingTimelineServer) throws IOException {
+  @EnumSource(value = TestCase.class)
+  public void testMORGetLatestFileSliceWithMetadataTable(TestCase testCase) throws IOException {
+    if (testCase.useExistingTimelineServer) {
+      initTimelineService();
+    }
     // This test utilizes the `HoodieBackedTestDelayedTableMetadata` to make sure the
     // synced file system view is always served.
 
     // Create two tables to guarantee the timeline server can properly handle multiple base paths with metadata table enabled
     String basePathStr1 = initializeTable("dataset1");
     String basePathStr2 = initializeTable("dataset2");
-    try (SparkRDDWriteClient writeClient1 = createWriteClient(basePathStr1, "test_mor_table1",
-        useExistingTimelineServer ? Option.of(timelineService) : Option.empty());
-         SparkRDDWriteClient writeClient2 = createWriteClient(basePathStr2, "test_mor_table2",
-             useExistingTimelineServer ? Option.of(timelineService) : Option.empty())) {
+    try (SparkRDDWriteClient writeClient1 = createWriteClient(basePathStr1, "test_mor_table1", testCase.reuseTimelineServer,
+        testCase.useExistingTimelineServer ? Option.of(timelineService) : Option.empty());
+         SparkRDDWriteClient writeClient2 = createWriteClient(basePathStr2, "test_mor_table2", testCase.reuseTimelineServer,
+             testCase.useExistingTimelineServer ? Option.of(timelineService) : Option.empty())) {
       for (int i = 0; i < 3; i++) {
         writeToTable(i, writeClient1);
       }
-
 
       for (int i = 0; i < 3; i++) {
         writeToTable(i, writeClient2);
       }
 
-      runAssertionsForBasePath(useExistingTimelineServer, basePathStr1, writeClient1);
-      runAssertionsForBasePath(useExistingTimelineServer, basePathStr2, writeClient2);
+      runAssertionsForBasePath(testCase.useExistingTimelineServer, basePathStr1, writeClient1);
+      runAssertionsForBasePath(testCase.useExistingTimelineServer, basePathStr2, writeClient2);
     }
   }
 
@@ -229,7 +244,7 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
     return HoodieTableType.MERGE_ON_READ;
   }
 
-  private SparkRDDWriteClient createWriteClient(String basePath, String tableName, Option<TimelineService> timelineService) {
+  private SparkRDDWriteClient createWriteClient(String basePath, String tableName, boolean reuseTimelineServer, Option<TimelineService> timelineService) {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withPath(basePath)
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
@@ -247,6 +262,7 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
             .withRemoteServerPort(timelineService.isPresent()
                 ? timelineService.get().getServerPort() : REMOTE_PORT_NUM.defaultValue())
             .build())
+        .withEmbeddedTimelineServerReuseEnabled(reuseTimelineServer)
         .withAutoCommit(false)
         .forTable(tableName)
         .build();

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -127,6 +127,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-afterburner</artifactId>
+    </dependency>
 
     <!-- Avro -->
     <dependency>

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
@@ -41,9 +41,9 @@ public class DTOUtils {
     } else if (fileGroups.size() == 1) {
       return Collections.singletonList(FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
     } else {
-      List<FileGroupDTO> fileGroupDTOS = new ArrayList<>();
+      List<FileGroupDTO> fileGroupDTOS = new ArrayList<>(fileGroups.size());
       fileGroupDTOS.add(FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
-      fileGroupDTOS.addAll(fileGroups.subList(1, fileGroups.size()).stream()
+      fileGroupDTOS.addAll(fileGroups.stream().skip(1)
           .map(fg -> FileGroupDTO.fromFileGroup(fg, false)).collect(Collectors.toList()));
       return fileGroupDTOS;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -43,6 +43,7 @@ import org.apache.hudi.exception.HoodieRemoteException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import org.apache.http.Consts;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.fluent.Response;
@@ -146,7 +147,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
   private static final TypeReference<List<BaseFileDTO>> BASE_FILE_DTOS_REFERENCE = new TypeReference<List<BaseFileDTO>>() {};
   private static final TypeReference<Map<String, List<BaseFileDTO>>> BASE_FILE_MAP_REFERENCE = new TypeReference<Map<String, List<BaseFileDTO>>>() {};
   private static final TypeReference<Map<String, List<FileSliceDTO>>> FILE_SLICE_MAP_REFERENCE = new TypeReference<Map<String, List<FileSliceDTO>>>() {};
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
 
   private final String serverHost;
   private final int serverPort;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -136,13 +136,23 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoteHoodieTableFileSystemView.class);
+  private static final TypeReference<List<FileSliceDTO>> FILE_SLICE_DTOS_REFERENCE = new TypeReference<List<FileSliceDTO>>() {};
+  private static final TypeReference<List<FileGroupDTO>> FILE_GROUP_DTOS_REFERENCE = new TypeReference<List<FileGroupDTO>>() {};
+  private static final TypeReference<Boolean> BOOLEAN_TYPE_REFERENCE = new TypeReference<Boolean>() {};
+  private static final TypeReference<List<CompactionOpDTO>> COMPACTION_OP_DTOS_REFERENCE = new TypeReference<List<CompactionOpDTO>>() {};
+  private static final TypeReference<List<ClusteringOpDTO>> CLUSTERING_OP_DTOS_REFERENCE = new TypeReference<List<ClusteringOpDTO>>() {};
+  private static final TypeReference<List<InstantDTO>> INSTANT_DTOS_REFERENCE = new TypeReference<List<InstantDTO>>() {};
+  private static final TypeReference<TimelineDTO> TIMELINE_DTO_REFERENCE = new TypeReference<TimelineDTO>() {};
+  private static final TypeReference<List<BaseFileDTO>> BASE_FILE_DTOS_REFERENCE = new TypeReference<List<BaseFileDTO>>() {};
+  private static final TypeReference<Map<String, List<BaseFileDTO>>> BASE_FILE_MAP_REFERENCE = new TypeReference<Map<String, List<BaseFileDTO>>>() {};
+  private static final TypeReference<Map<String, List<FileSliceDTO>>> FILE_SLICE_MAP_REFERENCE = new TypeReference<Map<String, List<FileSliceDTO>>>() {};
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final String serverHost;
   private final int serverPort;
   private final String basePath;
   private final HoodieTableMetaClient metaClient;
   private HoodieTimeline timeline;
-  private final ObjectMapper mapper;
   private final int timeoutMs;
 
   private boolean closed = false;
@@ -159,7 +169,6 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
   public RemoteHoodieTableFileSystemView(HoodieTableMetaClient metaClient, FileSystemViewStorageConfig viewConf) {
     this.basePath = metaClient.getBasePath();
-    this.mapper = new ObjectMapper();
     this.metaClient = metaClient;
     this.timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
     this.serverHost = viewConf.getRemoteViewServerHost();
@@ -175,7 +184,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     }
   }
 
-  private <T> T executeRequest(String requestPath, Map<String, String> queryParameters, TypeReference reference,
+  private <T> T executeRequest(String requestPath, Map<String, String> queryParameters, TypeReference<T> reference,
                                RequestMethod method) throws IOException {
     ValidationUtils.checkArgument(!closed, "View already closed");
 
@@ -192,7 +201,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     LOG.info("Sending request : (" + url + ")");
     Response response = retryHelper != null ? retryHelper.start(() -> get(timeoutMs, url, method)) : get(timeoutMs, url, method);
     String content = response.returnContent().asString(Consts.UTF_8);
-    return (T) mapper.readValue(content, reference);
+    return MAPPER.readValue(content, reference);
   }
 
   private Map<String, String> getParamsWithPartitionPath(String partitionPath) {
@@ -250,7 +259,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
   private Stream<HoodieBaseFile> getLatestBaseFilesFromParams(Map<String, String> paramsMap, String requestPath) {
     try {
       List<BaseFileDTO> dataFiles = executeRequest(requestPath, paramsMap,
-          new TypeReference<List<BaseFileDTO>>() {}, RequestMethod.GET);
+          BASE_FILE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(BaseFileDTO::toHoodieBaseFile);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -273,8 +282,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
       Map<String, List<BaseFileDTO>> dataFileMap = executeRequest(
           ALL_LATEST_BASE_FILES_BEFORE_ON_INSTANT_URL,
           paramsMap,
-          new TypeReference<Map<String, List<BaseFileDTO>>>() {
-          },
+          BASE_FILE_MAP_REFERENCE,
           RequestMethod.GET);
       return dataFileMap.entrySet().stream().collect(
           Collectors.toMap(
@@ -291,8 +299,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
         new String[] {INSTANT_PARAM, FILEID_PARAM}, new String[] {instantTime, fileId});
     try {
       List<BaseFileDTO> dataFiles = executeRequest(LATEST_DATA_FILE_ON_INSTANT_URL, paramsMap,
-          new TypeReference<List<BaseFileDTO>>() {
-          }, RequestMethod.GET);
+          BASE_FILE_DTOS_REFERENCE, RequestMethod.GET);
       return Option.fromJavaOptional(dataFiles.stream().map(BaseFileDTO::toHoodieBaseFile).findFirst());
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -317,7 +324,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
     try {
       List<FileSliceDTO> dataFiles = executeRequest(LATEST_PARTITION_SLICES_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -329,7 +336,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, FILEID_PARAM, fileId);
     try {
       List<FileSliceDTO> dataFiles = executeRequest(LATEST_PARTITION_SLICE_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return Option.fromJavaOptional(dataFiles.stream().map(FileSliceDTO::toFileSlice).findFirst());
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -341,7 +348,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
     try {
       List<FileSliceDTO> dataFiles = executeRequest(LATEST_PARTITION_UNCOMPACTED_SLICES_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -355,8 +362,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
         new String[] {MAX_INSTANT_PARAM, INCLUDE_FILES_IN_PENDING_COMPACTION_PARAM},
         new String[] {maxCommitTime, String.valueOf(includeFileSlicesInPendingCompaction)});
     try {
-      List<FileSliceDTO> dataFiles = executeRequest(LATEST_SLICES_BEFORE_ON_INSTANT_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+      List<FileSliceDTO> dataFiles = executeRequest(LATEST_SLICES_BEFORE_ON_INSTANT_URL, paramsMap, FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -371,7 +377,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
     try {
       Map<String, List<FileSliceDTO>> fileSliceMap = executeRequest(ALL_LATEST_SLICES_BEFORE_ON_INSTANT_URL, paramsMap,
-          new TypeReference<Map<String, List<FileSliceDTO>>>() {}, RequestMethod.GET);
+          FILE_SLICE_MAP_REFERENCE, RequestMethod.GET);
       return fileSliceMap.entrySet().stream().collect(
           Collectors.toMap(
               Map.Entry::getKey,
@@ -386,7 +392,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, MAX_INSTANT_PARAM, maxInstantTime);
     try {
       List<FileSliceDTO> dataFiles = executeRequest(LATEST_SLICES_MERGED_BEFORE_ON_INSTANT_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -399,7 +405,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
         getParams(INSTANTS_PARAM, StringUtils.join(commitsToReturn.toArray(new String[0]), ","));
     try {
       List<FileSliceDTO> dataFiles = executeRequest(LATEST_SLICES_RANGE_INSTANT_URL, paramsMap,
-          new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -411,7 +417,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
     try {
       List<FileSliceDTO> dataFiles =
-          executeRequest(ALL_SLICES_URL, paramsMap, new TypeReference<List<FileSliceDTO>>() {}, RequestMethod.GET);
+          executeRequest(ALL_SLICES_URL, paramsMap, FILE_SLICE_DTOS_REFERENCE, RequestMethod.GET);
       return dataFiles.stream().map(FileSliceDTO::toFileSlice);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -423,7 +429,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_FILEGROUPS_FOR_PARTITION_URL, paramsMap,
-          new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
+          FILE_GROUP_DTOS_REFERENCE, RequestMethod.GET);
       return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -435,7 +441,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, MAX_INSTANT_PARAM, maxCommitTime);
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE_OR_ON, paramsMap,
-          new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
+          FILE_GROUP_DTOS_REFERENCE, RequestMethod.GET);
       return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -447,7 +453,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, MAX_INSTANT_PARAM, maxCommitTime);
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE, paramsMap,
-          new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
+          FILE_GROUP_DTOS_REFERENCE, RequestMethod.GET);
       return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -459,7 +465,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, MIN_INSTANT_PARAM, minCommitTime);
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_AFTER_OR_ON, paramsMap,
-              new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
+              FILE_GROUP_DTOS_REFERENCE, RequestMethod.GET);
       return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -471,7 +477,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_PARTITION, paramsMap,
-          new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
+          FILE_GROUP_DTOS_REFERENCE, RequestMethod.GET);
       return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -483,7 +489,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       // refresh the local timeline first.
       this.timeline = metaClient.reloadActiveTimeline().filterCompletedAndCompactionInstants();
-      return executeRequest(REFRESH_TABLE, paramsMap, new TypeReference<Boolean>() {}, RequestMethod.POST);
+      return executeRequest(REFRESH_TABLE, paramsMap, BOOLEAN_TYPE_REFERENCE, RequestMethod.POST);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -493,7 +499,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
   public Void loadAllPartitions() {
     Map<String, String> paramsMap = getParams();
     try {
-      executeRequest(LOAD_ALL_PARTITIONS_URL, paramsMap, new TypeReference<Boolean>() {}, RequestMethod.POST);
+      executeRequest(LOAD_ALL_PARTITIONS_URL, paramsMap, BOOLEAN_TYPE_REFERENCE, RequestMethod.POST);
       return null;
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -505,7 +511,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParams();
     try {
       List<CompactionOpDTO> dtos = executeRequest(PENDING_COMPACTION_OPS, paramsMap,
-          new TypeReference<List<CompactionOpDTO>>() {}, RequestMethod.GET);
+          COMPACTION_OP_DTOS_REFERENCE, RequestMethod.GET);
       return dtos.stream().map(CompactionOpDTO::toCompactionOperation);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -517,7 +523,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParams();
     try {
       List<CompactionOpDTO> dtos = executeRequest(PENDING_LOG_COMPACTION_OPS, paramsMap,
-          new TypeReference<List<CompactionOpDTO>>() {}, RequestMethod.GET);
+          COMPACTION_OP_DTOS_REFERENCE, RequestMethod.GET);
       return dtos.stream().map(CompactionOpDTO::toCompactionOperation);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -529,7 +535,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParams();
     try {
       List<ClusteringOpDTO> dtos = executeRequest(PENDING_CLUSTERING_FILEGROUPS, paramsMap,
-          new TypeReference<List<ClusteringOpDTO>>() {}, RequestMethod.GET);
+          CLUSTERING_OP_DTOS_REFERENCE, RequestMethod.GET);
       return dtos.stream().map(ClusteringOpDTO::toClusteringOperation);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -551,7 +557,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParams();
     try {
       List<InstantDTO> instants =
-          executeRequest(LAST_INSTANT, paramsMap, new TypeReference<List<InstantDTO>>() {}, RequestMethod.GET);
+          executeRequest(LAST_INSTANT, paramsMap, INSTANT_DTOS_REFERENCE, RequestMethod.GET);
       return Option.fromJavaOptional(instants.stream().map(InstantDTO::toInstant).findFirst());
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -563,7 +569,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParams();
     try {
       TimelineDTO timeline =
-          executeRequest(TIMELINE, paramsMap, new TypeReference<TimelineDTO>() {}, RequestMethod.GET);
+          executeRequest(TIMELINE, paramsMap, TIMELINE_DTO_REFERENCE, RequestMethod.GET);
       return TimelineDTO.toTimeline(timeline, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
@@ -580,8 +586,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     Map<String, String> paramsMap = getParamsWithAdditionalParam(partitionPath, FILEID_PARAM, fileId);
     try {
       List<BaseFileDTO> dataFiles = executeRequest(LATEST_PARTITION_DATA_FILE_URL, paramsMap,
-          new TypeReference<List<BaseFileDTO>>() {
-          }, RequestMethod.GET);
+          BASE_FILE_DTOS_REFERENCE, RequestMethod.GET);
       return Option.fromJavaOptional(dataFiles.stream().map(BaseFileDTO::toHoodieBaseFile).findFirst());
     } catch (IOException e) {
       throw new HoodieRemoteException(e);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.sink;
 
 import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -73,6 +74,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   @AfterEach
   public void after() {
     conf = null;
+    EmbeddedTimelineService.shutdownAllTimelineServers();
   }
 
   /**
@@ -617,6 +619,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   @Test
   public void testReuseEmbeddedServer() throws IOException {
     conf.setInteger("hoodie.filesystem.view.remote.timeout.secs", 500);
+    conf.setString("hoodie.metadata.enable","true");
     HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf);
     FileSystemViewStorageConfig viewStorageConfig = writeClient.getConfig().getViewStorageConfig();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -545,9 +545,11 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
           .checkpoint(1)
           .assertNextEvent()
           .checkpointComplete(1)
-          .checkWrittenData(EXPECTED3, 1);
+          .checkWrittenData(EXPECTED3, 1)
+          .end();
       // step to commit the 2nd txn
       validateConcurrentCommit(pipeline1);
+      pipeline1.end();
     }
   }
 
@@ -607,6 +609,8 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
       // should success for concurrent modification of same fileGroups if using non-blocking concurrency control
       // should throw exception otherwise
       validateConcurrentCommit(pipeline2);
+      pipeline1.end();
+      pipeline2.end();
     }
   }
 
@@ -619,11 +623,12 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
     assertSame(viewStorageConfig.getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
 
     // get another write client
-    writeClient = FlinkWriteClients.createWriteClient(conf);
-    assertSame(writeClient.getConfig().getViewStorageConfig().getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
-    assertEquals(viewStorageConfig.getRemoteViewServerPort(), writeClient.getConfig().getViewStorageConfig().getRemoteViewServerPort());
+    HoodieFlinkWriteClient writeClient2 = FlinkWriteClients.createWriteClient(conf);
+    assertSame(writeClient2.getConfig().getViewStorageConfig().getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
+    assertEquals(viewStorageConfig.getRemoteViewServerPort(), writeClient2.getConfig().getViewStorageConfig().getRemoteViewServerPort());
     assertEquals(viewStorageConfig.getRemoteTimelineClientTimeoutSecs(), 500);
     writeClient.close();
+    writeClient2.close();
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -159,6 +159,8 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // because the data files belongs 3rd commit is not included in the last compaction.
     Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
     TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
+    pipeline1.end();
+    pipeline2.end();
   }
 
   @Test
@@ -227,6 +229,8 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // the data files belongs 3rd commit is not included in the last compaction.
     Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,1,par1]");
     TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
+    pipeline1.end();
+    pipeline2.end();
   }
 
   // case1: txn1 is upsert writer, txn2 is bulk_insert writer.
@@ -269,6 +273,8 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
 
     // step to commit the 2nd txn, should throw exception
     pipeline2.endInputThrows(HoodieWriteConflictException.class, "Cannot resolve conflicts");
+    pipeline1.end();
+    pipeline2.end();
   }
 
   // case1: txn1 is upsert writer, txn2 is bulk_insert writer.
@@ -342,6 +348,8 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // because the data files belongs 3rd commit is not included in the last compaction.
     Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
     TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
+    pipeline1.end();
+    pipeline2.end();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -522,6 +522,7 @@ public class TestWriteBase {
 
     public void end() throws Exception {
       this.pipeline.close();
+      this.pipeline = null;
     }
 
     private String lastPendingInstant() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -18,8 +18,8 @@
 
 package org.apache.hudi.sink.utils;
 
+import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
-import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -268,7 +268,8 @@ public class TestWriteBase {
      * Stop the timeline server.
      */
     public TestHarness stopTimelineServer() {
-      pipeline.getCoordinator().getWriteClient().getTimelineServer().ifPresent(EmbeddedTimelineService::stop);
+      HoodieFlinkWriteClient<?> client = pipeline.getCoordinator().getWriteClient();
+      client.getTimelineServer().ifPresent(embeddedTimelineService -> embeddedTimelineService.stopForBasePath(client.getConfig().getBasePath()));
       return this;
     }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -822,7 +822,6 @@ class HoodieSparkSqlWriterInternal {
         log.info("Closing write client")
         writeClient.close()
       }
-      EmbeddedTimelineService.shutdownAllTimelineServers()
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -33,6 +33,7 @@ import org.apache.hudi.avro.AvroSchemaUtils.{isCompatibleProjectionOf, isSchemaC
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.removeMetadataFields
 import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.client.embedded.EmbeddedTimelineService
 import org.apache.hudi.client.{HoodieWriteResult, SparkRDDWriteClient}
 import org.apache.hudi.commit.{DatasetBulkInsertCommitActionExecutor, DatasetBulkInsertOverwriteCommitActionExecutor, DatasetBulkInsertOverwriteTableCommitActionExecutor}
 import org.apache.hudi.common.config._
@@ -821,6 +822,7 @@ class HoodieSparkSqlWriterInternal {
         log.info("Closing write client")
         writeClient.close()
       }
+      EmbeddedTimelineService.shutdownAllTimelineServers()
     }
   }
 

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -24,12 +24,12 @@ import org.apache.hudi.common.table.marker.MarkerOperation;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.dto.BaseFileDTO;
-import org.apache.hudi.common.table.timeline.dto.InstantStateDTO;
 import org.apache.hudi.common.table.timeline.dto.ClusteringOpDTO;
 import org.apache.hudi.common.table.timeline.dto.CompactionOpDTO;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
 import org.apache.hudi.common.table.timeline.dto.InstantDTO;
+import org.apache.hudi.common.table.timeline.dto.InstantStateDTO;
 import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView;
@@ -45,6 +45,7 @@ import org.apache.hudi.timeline.service.handlers.TimelineHandler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import io.javalin.Javalin;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
@@ -69,7 +70,7 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public class RequestHandler {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
   private static final Logger LOG = LoggerFactory.getLogger(RequestHandler.class);
 
   private final TimelineService.Config timelineServiceConfig;

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -52,8 +52,8 @@ public class TimelineService {
   private static final int DEFAULT_NUM_THREADS = 250;
 
   private int serverPort;
-  private Config timelineServerConf;
-  private Configuration conf;
+  private final Config timelineServerConf;
+  private final Configuration conf;
   private transient HoodieEngineContext context;
   private transient FileSystem fs;
   private transient Javalin app = null;
@@ -432,6 +432,10 @@ public class TimelineService {
     }
     this.fsViewsManager.close();
     LOG.info("Closed Timeline Service");
+  }
+
+  public void unregisterBasePath(String basePath) {
+    fsViewsManager.clearFileSystemView(basePath);
   }
 
   public Configuration getConf() {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/BaseFileHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/BaseFileHandler.java
@@ -26,8 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -49,7 +48,7 @@ public class BaseFileHandler extends Handler {
 
   public List<BaseFileDTO> getLatestDataFile(String basePath, String partitionPath, String fileId) {
     return viewManager.getFileSystemView(basePath).getLatestBaseFile(partitionPath, fileId)
-        .map(BaseFileDTO::fromHoodieBaseFile).map(Arrays::asList).orElse(new ArrayList<>());
+        .map(BaseFileDTO::fromHoodieBaseFile).map(Collections::singletonList).orElse(Collections.emptyList());
   }
 
   public List<BaseFileDTO> getLatestDataFiles(String basePath) {
@@ -74,10 +73,8 @@ public class BaseFileHandler extends Handler {
 
   public List<BaseFileDTO> getLatestDataFileOn(String basePath, String partitionPath, String instantTime,
                                                String fileId) {
-    List<BaseFileDTO> result = new ArrayList<>();
-    viewManager.getFileSystemView(basePath).getBaseFileOn(partitionPath, instantTime, fileId)
-        .map(BaseFileDTO::fromHoodieBaseFile).ifPresent(result::add);
-    return result;
+    return viewManager.getFileSystemView(basePath).getBaseFileOn(partitionPath, instantTime, fileId)
+        .map(BaseFileDTO::fromHoodieBaseFile).map(Collections::singletonList).orElse(Collections.emptyList());
   }
 
   public List<BaseFileDTO> getLatestDataFilesInRange(String basePath, List<String> instants) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerDirState.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerDirState.java
@@ -32,6 +32,7 @@ import org.apache.hudi.exception.HoodieIOException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -64,7 +65,7 @@ import static org.apache.hudi.timeline.service.RequestHandler.jsonifyResult;
  */
 public class MarkerDirState implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(MarkerDirState.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
   // Marker directory
   private final String markerDirPath;
   private final FileSystem fileSystem;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1208,6 +1208,7 @@ public class StreamSync implements Serializable, Closeable {
    * Close all resources.
    */
   public void close() {
+    String basePath = writeClient.getConfig().getBasePath();
     if (writeClient != null) {
       writeClient.close();
       writeClient = null;
@@ -1219,7 +1220,7 @@ public class StreamSync implements Serializable, Closeable {
 
     LOG.info("Shutting down embedded timeline server");
     if (embeddedTimelineService.isPresent()) {
-      embeddedTimelineService.get().stop();
+      embeddedTimelineService.get().stopForBasePath(basePath);
     }
 
     if (metrics != null) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1208,7 +1208,6 @@ public class StreamSync implements Serializable, Closeable {
    * Close all resources.
    */
   public void close() {
-    String basePath = writeClient.getConfig().getBasePath();
     if (writeClient != null) {
       writeClient.close();
       writeClient = null;
@@ -1220,7 +1219,7 @@ public class StreamSync implements Serializable, Closeable {
 
     LOG.info("Shutting down embedded timeline server");
     if (embeddedTimelineService.isPresent()) {
-      embeddedTimelineService.get().stopForBasePath(basePath);
+      embeddedTimelineService.get().stopForBasePath(cfg.targetBasePath);
     }
 
     if (metrics != null) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -531,7 +531,6 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     List<Row> counts = countsPerCommit(tableBasePath, sqlContext);
     assertEquals(1000, counts.stream().mapToLong(entry -> entry.getLong(1)).sum());
 
-
     //perform the upsert and now with the original config, the commit should go through
     HoodieDeltaStreamer.Config newCfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.BULK_INSERT);
     newCfg.sourceLimit = 2000;

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-afterburner</artifactId>
-        <version>${fasterxml.jackson.databind.version}</version>
+        <version>${fasterxml.version}</version>
       </dependency>
 
       <!-- Glassfish -->

--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,8 @@
               <include>org.apache.hbase.thirdparty:hbase-shaded-netty</include>
               <include>org.apache.hbase.thirdparty:hbase-shaded-protobuf</include>
               <include>org.apache.htrace:htrace-core4</include>
+              <!-- afterburner module for jackson performance -->
+              <include>com.fasterxml.jackson.module:jackson-module-afterburner</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -871,6 +873,12 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         <version>${fasterxml.jackson.module.scala.version}</version>
+      </dependency>
+      <!-- Provides performance improvements with json serialization/deserialization -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-afterburner</artifactId>
+        <version>${fasterxml.jackson.databind.version}</version>
       </dependency>
 
       <!-- Glassfish -->


### PR DESCRIPTION
### Change Logs

- Allows users to reuse a running timeline server for other tables
- Minor performance improvements around object reuse and creation
- Use of AfterburnerModule where we saw a 22% increase in throughput for to/from json on the base file DTOs used in the timeline server

### Impact

- Allows users to lower overhead when running multiple writers in the same JVM by reusing the underlying server instance
- Performance improvement in the json (de)serialization

### Risk level (write none, low medium or high below)

low - feature for reusing the server is off by default

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
