### PR TITLE
[MINOR] Disable failed test on master

### DIFF
--- a/hudi-aws/src/test/java/org/apache/hudi/aws/TestHoodieAWSCredentialsProviderFactory.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/TestHoodieAWSCredentialsProviderFactory.java
@@ -18,9 +18,10 @@
 
 package org.apache.hudi.aws;
 
-import org.apache.hudi.config.HoodieAWSConfig;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.config.HoodieAWSConfig;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
@@ -40,6 +41,7 @@ public class TestHoodieAWSCredentialsProviderFactory {
     assertEquals("random-session-token", credentials.sessionToken());
   }
 
+  @Disabled("HUDI-7114")
   @Test
   public void testGetAWSCredentialsWithInvalidAssumeRole() {
     // This test is to ensure that the AWS credentials provider factory fallbacks to default credentials


### PR DESCRIPTION
### Change Logs

As above, to disable a failed test introduced by #9260.  HUDI-7114 as a follow up to fix the test.

### Impact

Unblocks CI.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
