### PR TITLE
[HUDI-7116] Add docker image for flink 1.14 and spark 2.4.8

### DIFF
--- a/packaging/bundle-validation/base/build_flink1146hive239spark248.sh
+++ b/packaging/bundle-validation/base/build_flink1146hive239spark248.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+docker build \
+ --build-arg HIVE_VERSION=2.3.9 \
+ --build-arg FLINK_VERSION=1.14.6 \
+ --build-arg SPARK_VERSION=2.4.8 \
+ --build-arg SPARK_HADOOP_VERSION=2.7 \
+ -t hudi-ci-bundle-validation-base:flink1146hive239spark248 .
+docker image tag hudi-ci-bundle-validation-base:flink1146hive239spark248 apachehudi/hudi-ci-bundle-validation-base:flink1146hive239spark248


### PR DESCRIPTION
### Change Logs

Add the build image for flink 1.14 and spark 2.4.8.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
