### PR TITLE
[HUDI-7107] Reused MetricsReporter fails to publish metrics in Spark streaming job

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -86,6 +86,8 @@ public class Metrics {
 
   public static synchronized void shutdownAllMetrics() {
     METRICS_INSTANCE_PER_BASEPATH.values().forEach(Metrics::shutdown);
+    // to avoid reusing already stopped metrics
+    METRICS_INSTANCE_PER_BASEPATH.clear();
   }
 
   private List<MetricsReporter> addAdditionalMetricsExporters(HoodieWriteConfig metricConfig) {


### PR DESCRIPTION
### Change Logs

When shutdown all the metrics, clear the metric cache to avoid reusing already stopped MetricsReporter

### Impact

No public API change.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
