### PR TITLE
[HUDI-7118] set conf 'spark.sql.parquet.enableVectorizedReader' to true automatically only if the value is not explicitly set

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
@@ -81,7 +81,9 @@ case class BaseFileOnlyRelation(override val sqlContext: SQLContext,
     super.imbueConfigs(sqlContext)
     // TODO Issue with setting this to true in spark 332
     if (HoodieSparkUtils.gteqSpark3_4 || !HoodieSparkUtils.gteqSpark3_3_2) {
-      sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
+      if (!sqlContext.sparkSession.sessionState.conf.contains("spark.sql.parquet.enableVectorizedReader")) {
+        sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
@@ -77,16 +77,6 @@ case class BaseFileOnlyRelation(override val sqlContext: SQLContext,
   override def updatePrunedDataSchema(prunedSchema: StructType): Relation =
     this.copy(prunedDataSchema = Some(prunedSchema))
 
-  override def imbueConfigs(sqlContext: SQLContext): Unit = {
-    super.imbueConfigs(sqlContext)
-    // TODO Issue with setting this to true in spark 332
-    if (HoodieSparkUtils.gteqSpark3_4 || !HoodieSparkUtils.gteqSpark3_3_2) {
-      if (!sqlContext.sparkSession.sessionState.conf.contains("spark.sql.parquet.enableVectorizedReader")) {
-        sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
-      }
-    }
-  }
-
   protected override def composeRDD(fileSplits: Seq[HoodieBaseFileSplit],
                                     tableSchema: HoodieTableSchema,
                                     requiredSchema: HoodieTableSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
@@ -67,13 +67,6 @@ case class HoodieBootstrapMORRelation(override val sqlContext: SQLContext,
 
   override lazy val mandatoryFields: Seq[String] = mandatoryFieldsForMerging
 
-  override def imbueConfigs(sqlContext: SQLContext): Unit = {
-    super.imbueConfigs(sqlContext)
-    if (!sqlContext.sparkSession.sessionState.conf.contains("spark.sql.parquet.enableVectorizedReader")) {
-      sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
-    }
-  }
-
   protected override def getFileSlices(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[FileSlice] = {
     if (globPaths.isEmpty) {
       fileIndex.listFileSlices(HoodieFileIndex.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
@@ -69,9 +69,10 @@ case class HoodieBootstrapMORRelation(override val sqlContext: SQLContext,
 
   override def imbueConfigs(sqlContext: SQLContext): Unit = {
     super.imbueConfigs(sqlContext)
-    sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
+    if (!sqlContext.sparkSession.sessionState.conf.contains("spark.sql.parquet.enableVectorizedReader")) {
+      sqlContext.sparkSession.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", "true")
+    }
   }
-
 
   protected override def getFileSlices(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[FileSlice] = {
     if (globPaths.isEmpty) {


### PR DESCRIPTION
### Change Logs

Currently, conf 'spark.sql.parquet.enableVectorizedReader' does not work properly. See complete discussion in [issue-9129](https://github.com/apache/hudi/issues/9129).
The pr aims to fix it.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
