### PR TITLE
[HUDI-7125] Fix bugs for CDC queries

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodiePartitionCDCFileGroupMapping.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodiePartitionCDCFileGroupMapping.scala
@@ -24,11 +24,10 @@ import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 import org.apache.spark.sql.catalyst.InternalRow
 
 class HoodiePartitionCDCFileGroupMapping(partitionValues: InternalRow,
-                                         fileGroups: Map[HoodieFileGroupId, List[HoodieCDCFileSplit]]
-                                        )
+                                         fileSplits: List[HoodieCDCFileSplit])
   extends HoodiePartitionValues(partitionValues) {
 
-  def getFileSplitsFor(fileGroupId: HoodieFileGroupId): Option[List[HoodieCDCFileSplit]] = {
-    fileGroups.get(fileGroupId)
+  def getFileSplits(): List[HoodieCDCFileSplit] = {
+    fileSplits
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.HoodieBaseRelation.BaseFileReader
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.HoodieDataSourceHelper.AvroDeserializerSupport
 import org.apache.hudi.avro.HoodieAvroUtils
+import org.apache.hudi.cdc.CDCRelation.FULL_CDC_SPARK_SCHEMA
 import org.apache.hudi.{AvroConversionUtils, AvroProjection, HoodieFileIndex, HoodieMergeOnReadFileSplit, HoodieTableSchema, HoodieTableState, LogFileIterator, RecordMergingFileIterator, SparkAdapterSupport}
 import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
 import org.apache.hudi.common.model.{FileSlice, HoodieAvroRecordMerger, HoodieLogFile, HoodieRecord, HoodieRecordMerger, HoodieRecordPayload}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieTableValuedFunction.scala
@@ -255,7 +255,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
             col("after.name"),
             col("after.price"),
             col("after.ts")
-          ).orderBy("after.id").collect()
+          ).orderBy("after.id").take(10)
           checkAnswer(change1)(
             Seq("i", null, 1, "a1", 10.0, 1000),
             Seq("i", null, 2, "a2", 20.0, 1000),
@@ -296,7 +296,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
             col("after.name"),
             col("after.price"),
             col("after.ts")
-          ).orderBy("after.id").collect()
+          ).orderBy("after.id").take(10)
           checkAnswer(change2)(
             Seq("u", 1, "a1", 10.0, 1000, 1, "a1_1", 10.0, 1100),
             Seq("u", 2, "a2", 20.0, 1000, 2, "a2_2", 20.0, 1100),
@@ -338,7 +338,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
             col("after.name"),
             col("after.price"),
             col("after.ts")
-          ).orderBy("after.id").collect()
+          ).orderBy("after.id").take(10)
           checkAnswer(change3)(
             Seq("u", 1, "a1", 10.0, 1000, 1, "a1_1", 10.0, 1100),
             Seq("u", 2, "a2", 20.0, 1000, 2, "a2_2", 20.0, 1100),


### PR DESCRIPTION
### Change Logs

By using HadoopFsRelation.

Solved a bunch of bugs for CDC queries, including:

1. For non-partitioned tables, added virtual partition path;
2. Store data schema of underlying parquet files into the query options.
3. Fixed the way to initialize the meta client in the file format. 
4. Fixed the NULL file index problem by removing the file format initialization.
5. Fixed the ordering of CDCFileSplit returned from the CDCFileIndex.
6. Fixed the mapping between cdcSchema and requiredSchema.

### Impact

Enables CDC queries to utilize HadoopFsRelation.

### Risk level (write none, low medium or high below)

Low since we can turn it off.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
