### PR TITLE
[HUDI-7129] Fix bug when upgrade from table version three using UpgradeOrDowngradeProcedure

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
@@ -22,12 +22,14 @@ package org.apache.hudi.table.upgrade;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.MetadataPartitionType;
 
 import java.util.Hashtable;
 import java.util.Map;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_CHECKSUM;
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_METADATA_PARTITIONS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartitionExists;
@@ -40,6 +42,10 @@ public class ThreeToFourUpgradeHandler implements UpgradeHandler {
   @Override
   public Map<ConfigProperty, String> upgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
     Map<ConfigProperty, String> tablePropsToAdd = new Hashtable<>();
+    String database = config.getString(DATABASE_NAME);
+    if (StringUtils.nonEmpty(database)) {
+      tablePropsToAdd.put(DATABASE_NAME, database);
+    }
     tablePropsToAdd.put(TABLE_CHECKSUM, String.valueOf(HoodieTableConfig.generateChecksum(config.getProps())));
     // if metadata is enabled and files partition exist then update TABLE_METADATA_INDEX_COMPLETED
     // schema for the files partition is same between the two versions

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/UpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/UpgradeOrDowngradeProcedure.scala
@@ -20,16 +20,18 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion
-import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.util.Option
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig, HoodieCleanConfig}
 import org.apache.hudi.index.HoodieIndex
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
+import org.apache.hudi.HoodieCLIUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util.function.Supplier
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 class UpgradeOrDowngradeProcedure extends BaseProcedure with ProcedureBuilder with Logging {
@@ -51,9 +53,8 @@ class UpgradeOrDowngradeProcedure extends BaseProcedure with ProcedureBuilder wi
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val toVersion = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
-    val basePath = getBasePath(tableName)
-
-    val config = getWriteConfigWithTrue(basePath)
+    val config = getWriteConfigWithTrue(tableName)
+    val basePath = config.getBasePath
     val metaClient = HoodieTableMetaClient.builder
       .setConf(jsc.hadoopConfiguration)
       .setBasePath(config.getBasePath)
@@ -78,12 +79,16 @@ class UpgradeOrDowngradeProcedure extends BaseProcedure with ProcedureBuilder wi
     Seq(Row(result))
   }
 
-  private def getWriteConfigWithTrue(basePath: String) = {
+  private def getWriteConfigWithTrue(tableOpt: scala.Option[Any]) = {
+    val basePath = getBasePath(tableOpt)
+    val (tableName, database) = HoodieCLIUtils.getTableIdentifier(tableOpt.get.asInstanceOf[String])
     HoodieWriteConfig.newBuilder
+      .forTable(tableName)
       .withPath(basePath)
       .withRollbackUsingMarkers(true)
       .withCleanConfig(HoodieCleanConfig.newBuilder.withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER).build)
       .withIndexConfig(HoodieIndexConfig.newBuilder.withIndexType(HoodieIndex.IndexType.BLOOM).build)
+      .withProps(Map(HoodieTableConfig.DATABASE_NAME.key -> database.getOrElse(sparkSession.sessionState.catalog.getCurrentDatabase)).asJava)
       .build
   }
 


### PR DESCRIPTION
### Change Logs

When upgrade from table version 3 to table version 4 using UpgradeOrDowngradeProcedure, the following exception would be thrown out.

> java.lang.IllegalArgumentException: hoodie.table.name property needs to be specified
	at org.apache.hudi.common.table.HoodieTableConfig.generateChecksum(HoodieTableConfig.java:478) ~[classes/:?]
	at org.apache.hudi.table.upgrade.ThreeToFourUpgradeHandler.upgrade(ThreeToFourUpgradeHandler.java:43) ~[classes/:?]
	at org.apache.hudi.table.upgrade.UpgradeDowngrade.upgrade(UpgradeDowngrade.java:173) ~[classes/:?]
	at org.apache.hudi.table.upgrade.UpgradeDowngrade.run(UpgradeDowngrade.java:143) ~[classes/:?]
	at org.apache.spark.sql.hudi.command.procedures.UpgradeOrDowngradeProcedure.$anonfun$call$1(UpgradeOrDowngradeProcedure.scala:69) ~[classes/:?]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.10.jar:?]
	at scala.util.Try$.apply(Try.scala:213) ~[scala-library-2.12.10.jar:?]
	at org.apache.spark.sql.hudi.command.procedures.UpgradeOrDowngradeProcedure.call(UpgradeOrDowngradeProcedure.scala:69) ~[classes/:?]

This pr aims to fix the bug.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
