### PR TITLE
[HUDI-6961] Fixing DefaultHoodieRecordPayload to honor deletion based on meta field as well as custome delete marker

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * {@link HoodieRecordPayload} impl that honors ordering field in both preCombine and combineAndGetUpdateValue.
@@ -45,6 +46,8 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
   public static final String DELETE_KEY = "hoodie.payload.delete.field";
   public static final String DELETE_MARKER = "hoodie.payload.delete.marker";
   private Option<Object> eventTime = Option.empty();
+  private AtomicBoolean isDeleteComputed = new AtomicBoolean(false);
+  private boolean isDefaultRecordPayloadDeleted = false;
 
   public DefaultHoodieRecordPayload(GenericRecord record, Comparable orderingVal) {
     super(record, orderingVal);
@@ -73,10 +76,13 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
      */
     eventTime = updateEventTime(incomingRecord, properties);
 
+    if (!isDeleteComputed.getAndSet(true)) {
+      isDefaultRecordPayloadDeleted = isDeleteRecord(incomingRecord, properties);
+    }
     /*
      * Now check if the incoming record is a delete record.
      */
-    return isDeleteRecord(incomingRecord, properties) ? Option.empty() : Option.of(incomingRecord);
+    return isDefaultRecordPayloadDeleted ? Option.empty() : Option.of(incomingRecord);
   }
 
   @Override
@@ -87,7 +93,10 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
     eventTime = updateEventTime(incomingRecord, properties);
 
-    return isDeleteRecord(incomingRecord, properties) ? Option.empty() : Option.of(incomingRecord);
+    if (!isDeleteComputed.getAndSet(true)) {
+      isDefaultRecordPayloadDeleted = isDeleteRecord(incomingRecord, properties);
+    }
+    return isDefaultRecordPayloadDeleted ? Option.empty() : Option.of(incomingRecord);
   }
 
   public boolean isDeleted(Schema schema, Properties props) {
@@ -95,8 +104,11 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
       return true;
     }
     try {
-      GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
-      return isDeleteRecord(incomingRecord, props);
+      if (!isDeleteComputed.getAndSet(true)) {
+        GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
+        isDefaultRecordPayloadDeleted = isDeleteRecord(incomingRecord, props);
+      }
+      return isDefaultRecordPayloadDeleted;
     } catch (IOException e) {
       throw new HoodieIOException("Deserializing bytes to avro failed ", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -76,7 +76,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     /*
      * Now check if the incoming record is a delete record.
      */
-    return isDeleteRecord(incomingRecord, properties, schema) ? Option.empty() : Option.of(incomingRecord);
+    return isDeleteRecord(incomingRecord, properties) ? Option.empty() : Option.of(incomingRecord);
   }
 
   @Override
@@ -87,7 +87,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
     eventTime = updateEventTime(incomingRecord, properties);
 
-    return isDeleteRecord(incomingRecord, properties, schema) ? Option.empty() : Option.of(incomingRecord);
+    return isDeleteRecord(incomingRecord, properties) ? Option.empty() : Option.of(incomingRecord);
   }
 
   public boolean isDeleted(Schema schema, Properties props) {
@@ -96,7 +96,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     }
     try {
       GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
-      return isDeleteRecord(incomingRecord, props, schema);
+      return isDeleteRecord(incomingRecord, props);
     } catch (IOException e) {
       throw new HoodieIOException("Deserializing bytes to avro failed ", e);
     }
@@ -105,11 +105,9 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
   /**
    * @param genericRecord instance of {@link GenericRecord} of interest.
    * @param properties payload related properties
-   * @param schema schema of interest.
    * @returns {@code true} if record represents a delete record. {@code false} otherwise.
    */
-  protected boolean isDeleteRecord(GenericRecord genericRecord, Properties properties, Schema schema) {
-    // check for deletion based on custom delete marker.
+  protected boolean isDeleteRecord(GenericRecord genericRecord, Properties properties) {
     final String deleteKey = properties.getProperty(DELETE_KEY);
     if (StringUtils.isNullOrEmpty(deleteKey)) {
       return isDeleteRecord(genericRecord);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -148,9 +148,12 @@ public class TestDefaultHoodieRecordPayload {
     DefaultHoodieRecordPayload defaultDeletePayload = new DefaultHoodieRecordPayload(defaultDeleteRecord, 2);
 
     assertFalse(payload.isDeleted(schema, props));
+    assertTrue(deletePayload.isDeleted(schema, props));
+    assertFalse(defaultDeletePayload.isDeleted(schema, props)); // if custom marker is present, should honor that irrespective of hoodie_is_deleted
+
     assertEquals(record, payload.getInsertValue(schema, props).get());
-    assertFalse(defaultDeletePayload.getInsertValue(schema, props).isPresent());
     assertFalse(deletePayload.getInsertValue(schema, props).isPresent());
+    assertTrue(defaultDeletePayload.getInsertValue(schema, props).isPresent()); // if custom marker is present, should honor that irrespective of hoodie_is_deleted
 
     assertEquals(delRecord, payload.combineAndGetUpdateValue(delRecord, schema, props).get());
     assertEquals(defaultDeleteRecord, payload.combineAndGetUpdateValue(defaultDeleteRecord, schema, props).get());

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -109,6 +109,8 @@ public class TestDefaultHoodieRecordPayload {
 
     DefaultHoodieRecordPayload payload1 = new DefaultHoodieRecordPayload(record1, 1);
     DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(delRecord1, 2);
+    assertFalse(payload1.isDeleted(schema, props));
+    assertTrue(payload2.isDeleted(schema, props));
     assertEquals(payload1.preCombine(payload2, props), payload2);
     assertEquals(payload2.preCombine(payload1, props), payload2);
 
@@ -145,8 +147,9 @@ public class TestDefaultHoodieRecordPayload {
     DefaultHoodieRecordPayload deletePayload = new DefaultHoodieRecordPayload(delRecord, 2);
     DefaultHoodieRecordPayload defaultDeletePayload = new DefaultHoodieRecordPayload(defaultDeleteRecord, 2);
 
+    assertFalse(payload.isDeleted(schema, props));
     assertEquals(record, payload.getInsertValue(schema, props).get());
-    assertEquals(defaultDeleteRecord, defaultDeletePayload.getInsertValue(schema, props).get());
+    assertFalse(defaultDeletePayload.getInsertValue(schema, props).isPresent());
     assertFalse(deletePayload.getInsertValue(schema, props).isPresent());
 
     assertEquals(delRecord, payload.combineAndGetUpdateValue(delRecord, schema, props).get());

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -180,6 +180,7 @@ public class TestDefaultHoodieRecordPayload {
     }
 
     try {
+      payload = new DefaultHoodieRecordPayload(record, 1);
       payload.combineAndGetUpdateValue(record, schema, props).get();
       fail("Should fail");
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
### Change Logs

This PR fixes the DefaultHoodieRecordPayload to allow the records with custom delete key (hoodie.payload.delete.field) and delete marker (hoodie.payload.delete.marker) to be properly ingested. Before this fix, the write fails with the following exception

Error for key:HoodieKey { recordKey=0 partitionPath=} is 
java.util.NoSuchElementException: No value present in Option
	at org.apache.hudi.common.util.Option.get(Option.java:89)
	at org.apache.hudi.common.model.HoodieAvroRecord.prependMetaFields(HoodieAvroRecord.java:132)
	at org.apache.hudi.io.HoodieCreateHandle.doWrite(HoodieCreateHandle.java:144)
	at org.apache.hudi.io.HoodieWriteHandle.write(HoodieWriteHandle.java:180)
	at org.apache.hudi.execution.CopyOnWriteInsertHandler.consume(CopyOnWriteInsertHandler.java:98)
	at org.apache.hudi.execution.CopyOnWriteInsertHandler.consume(CopyOnWriteInsertHandler.java:42)
	at org.apache.hudi.common.util.queue.SimpleExecutor.execute(SimpleExecutor.java:69)
The bug is introduced by the RFC-46 implementation and the refactoring on payload merging.

Fix is to override isDeleted(Schema schema, Properties props) to deserialize the bytes and call into isDeleteRecord(incomingRecord, props, schema). That way, we will not change any public apis nor constructor. DefaultHoodieRecordPayload might incur a slight perf hit, but comparing with changing 
 ~ 50 files (https://github.com/apache/hudi/pull/9892/), we are going with confined fix just in DefaultHoodieRecordPayload. 

### Impact

Fixing DefaultHoodieRecordPayload to honor deletion based on meta field as well as custom delete marker. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
