### PR TITLE
[HUDI-7034] Refresh index fix - remove cached file slices within part…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -428,6 +428,8 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     // Reset it to null to trigger re-loading of all partition path
     this.cachedAllPartitionPaths = null;
+    // Reset to force reload file slices inside partitions
+    this.cachedAllInputFileSlices = new HashMap<>();
     if (!shouldListLazily) {
       ensurePreloadedPartitions(getAllQueryPartitionPaths());
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -267,7 +267,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
 
     val readOpts = queryOpts ++ Map(
       HoodieMetadataConfig.ENABLE.key -> useMetadataTable.toString,
-      DataSourceReadOptions.FILE_INDEX_LISTING_MODE_OVERRIDE.key -> listingModeOverride,
+      DataSourceReadOptions.FILE_INDEX_LISTING_MODE_OVERRIDE.key -> listingModeOverride
     )
 
     metaClient = HoodieTableMetaClient.reload(metaClient)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -246,7 +246,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
   def testIndexRefreshesFileSlices(listingModeOverride: String,
                                    useMetadataTable: Boolean): Unit = {
     def getDistinctCommitTimeFromAllFilesInIndex(files: Seq[PartitionDirectory]): Seq[String] = {
-      files.flatMap(_.files).map(new HoodieBaseFile(_)).map(_.getCommitTime).distinct
+      files.flatMap(_.files).map(fileStatus => new HoodieBaseFile(fileStatus.getPath.toString)).map(_.getCommitTime).distinct
     }
 
     val r = new Random(0xDEED)


### PR DESCRIPTION
### Change Logs

This is a fix for the issue [10088](https://github.com/apache/hudi/issues/10088)/[Hudi-7034](https://issues.apache.org/jira/browse/HUDI-7034).
The issue is reproducible - the reproduction [here](https://github.com/VitoMakarevich/hudi-incremental-issue/blob/master/src/main/scala/com/example/hudi/HudiRefreshBug.scala).
The issue impact is that once loaded partition file slices are never changing(filenames). Therefore - partitions are not receiving updates and later we start receiving `FileNotFoundException` - due to the fact that some files to which index is stuck, were cleaned.
The way I fixed it is basically invalidated list of files in partitions, so the subsequent call to `getAllQueryPartitionPaths` will refresh the list of partitions and then this code will not see any cached file for any partition and refresh the list of files
```
    List<PartitionPath> missingPartitions = partitionPaths.stream()
        .filter(p -> !cachedAllInputFileSlices.containsKey(p))
        .collect(Collectors.toList());
```

There is no test created for this yet, I will try to add a unit test as well as direct `refresh view` test.

### Impact

There's no user-facing change, but I don't know all code-paths this code is used.

### Risk level (write none, low medium or high below)

Hard to assess

### Documentation Update

 No need.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
