### PR TITLE
[HUDI-7006] Reduce unnecessary is_empty rdd calls in StreamSync

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -87,7 +87,7 @@ public class HoodieDeltaStreamerWrapper extends HoodieDeltaStreamer {
         .setBasePath(service.getCfg().targetBasePath)
         .build();
     String instantTime = InProcessTimeGenerator.createNewInstantTime();
-    InputBatch inputBatch = service.readFromSource(instantTime, metaClient).getLeft();
+    InputBatch inputBatch = service.readFromSource(instantTime, metaClient);
     return Pair.of(inputBatch.getSchemaProvider(), Pair.of(inputBatch.getCheckpointForNextBatch(), (JavaRDD<HoodieRecord>) inputBatch.getBatch().get()));
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -64,7 +64,7 @@ public class SparkSampleWritesUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkSampleWritesUtils.class);
 
-  public static Option<HoodieWriteConfig> getWriteConfigWithRecordSizeEstimate(JavaSparkContext jsc, JavaRDD<HoodieRecord> records, HoodieWriteConfig writeConfig) {
+  public static Option<HoodieWriteConfig> getWriteConfigWithRecordSizeEstimate(JavaSparkContext jsc, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieWriteConfig writeConfig) {
     if (!writeConfig.getBoolean(SAMPLE_WRITES_ENABLED)) {
       LOG.debug("Skip overwriting record size estimate as it's disabled.");
       return Option.empty();
@@ -76,7 +76,7 @@ public class SparkSampleWritesUtils {
     }
     try {
       String instantTime = getInstantFromTemporalAccessor(Instant.now().atZone(ZoneId.systemDefault()));
-      Pair<Boolean, String> result = doSampleWrites(jsc, records, writeConfig, instantTime);
+      Pair<Boolean, String> result = doSampleWrites(jsc, recordsOpt, writeConfig, instantTime);
       if (result.getLeft()) {
         long avgSize = getAvgSizeFromSampleWrites(jsc, result.getRight());
         LOG.info("Overwriting record size estimate to " + avgSize);
@@ -90,7 +90,7 @@ public class SparkSampleWritesUtils {
     return Option.empty();
   }
 
-  private static Pair<Boolean, String> doSampleWrites(JavaSparkContext jsc, JavaRDD<HoodieRecord> records, HoodieWriteConfig writeConfig, String instantTime)
+  private static Pair<Boolean, String> doSampleWrites(JavaSparkContext jsc, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieWriteConfig writeConfig, String instantTime)
       throws IOException {
     final String sampleWritesBasePath = getSampleWritesBasePath(jsc, writeConfig, instantTime);
     HoodieTableMetaClient.withPropertyBuilder()
@@ -109,25 +109,31 @@ public class SparkSampleWritesUtils {
         .withAutoCommit(true)
         .withPath(sampleWritesBasePath)
         .build();
+    Pair<Boolean, String> emptyRes = Pair.of(false, null);
     try (SparkRDDWriteClient sampleWriteClient = new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), sampleWriteConfig, Option.empty())) {
       int size = writeConfig.getIntOrDefault(SAMPLE_WRITES_SIZE);
-      List<HoodieRecord> samples = records.coalesce(1).take(size);
-      sampleWriteClient.startCommitWithTime(instantTime);
-      JavaRDD<WriteStatus> writeStatusRDD = sampleWriteClient.bulkInsert(jsc.parallelize(samples, 1), instantTime);
-      if (writeStatusRDD.filter(WriteStatus::hasErrors).count() > 0) {
-        LOG.error(String.format("sample writes for table %s failed with errors.", writeConfig.getTableName()));
-        if (LOG.isTraceEnabled()) {
-          LOG.trace("Printing out the top 100 errors");
-          writeStatusRDD.filter(WriteStatus::hasErrors).take(100).forEach(ws -> {
-            LOG.trace("Global error :", ws.getGlobalError());
-            ws.getErrors().forEach((key, throwable) ->
-                LOG.trace(String.format("Error for key: %s", key), throwable));
-          });
+      return recordsOpt.map(records -> {
+        List<HoodieRecord> samples = records.coalesce(1).take(size);
+        if (samples.isEmpty()) {
+          return emptyRes;
         }
-        return Pair.of(false, null);
-      } else {
-        return Pair.of(true, sampleWritesBasePath);
-      }
+        sampleWriteClient.startCommitWithTime(instantTime);
+        JavaRDD<WriteStatus> writeStatusRDD = sampleWriteClient.bulkInsert(jsc.parallelize(samples, 1), instantTime);
+        if (writeStatusRDD.filter(WriteStatus::hasErrors).count() > 0) {
+          LOG.error(String.format("sample writes for table %s failed with errors.", writeConfig.getTableName()));
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Printing out the top 100 errors");
+            writeStatusRDD.filter(WriteStatus::hasErrors).take(100).forEach(ws -> {
+              LOG.trace("Global error :", ws.getGlobalError());
+              ws.getErrors().forEach((key, throwable) ->
+                  LOG.trace(String.format("Error for key: %s", key), throwable));
+            });
+          }
+          return emptyRes;
+        } else {
+          return Pair.of(true, sampleWritesBasePath);
+        }
+      }).orElse(emptyRes);
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -543,9 +543,9 @@ public class StreamSync implements Serializable, Closeable {
     if (useRowWriter) { // no additional processing required for row writer.
       return inputBatch;
     } else {
-      JavaRDD<HoodieRecord> records = HoodieStreamerUtils.createHoodieRecords(cfg, props, inputBatch.getBatch(), schemaProvider,
+      Option<JavaRDD<HoodieRecord>> recordsOpt = HoodieStreamerUtils.createHoodieRecords(cfg, props, inputBatch.getBatch(), schemaProvider,
           recordType, autoGenerateRecordKeys, instantTime);
-      return new InputBatch(Option.of(records), checkpointStr, schemaProvider);
+      return new InputBatch(recordsOpt, checkpointStr, schemaProvider);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -466,8 +466,8 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
           .stream().anyMatch(t -> t.getType().equals(Schema.Type.STRING)));
       assertTrue(metaClient.reloadActiveTimeline().lastInstant().get().compareTo(lastInstant) > 0);
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("java.lang.NullPointerException")
-          || e.getMessage().contains("Incoming batch schema is not compatible with the table's one"));
+      assertTrue(containsErrorMessage(e, "java.lang.NullPointerException",
+          "Incoming batch schema is not compatible with the table's one"));
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -80,7 +80,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
         .withPath(basePath())
         .build();
     JavaRDD<HoodieRecord> records = jsc().parallelize(dataGen.generateInserts(commitTime, 1), 1);
-    Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), records, originalWriteConfig);
+    Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), Option.of(records), originalWriteConfig);
     assertFalse(writeConfigOpt.isPresent());
     assertEquals(originalRecordSize, originalWriteConfig.getCopyOnWriteRecordSizeEstimate(), "Original record size estimate should not be changed.");
   }
@@ -100,7 +100,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
 
     String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);
     JavaRDD<HoodieRecord> records = jsc().parallelize(dataGen.generateInserts(commitTime, 2000), 2);
-    Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), records, originalWriteConfig);
+    Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), Option.of(records), originalWriteConfig);
     assertTrue(writeConfigOpt.isPresent());
     assertEquals(779.0, writeConfigOpt.get().getCopyOnWriteRecordSizeEstimate(), 10.0);
   }


### PR DESCRIPTION
### Change Logs

We are doing multiple isEmpty calls , which can impact perf for non-empty but filtered rdds .
The way isEmpty is implemented ->
it checks in each job [1, 5, 25 , ...] partitions for non-empty untill it finds first non empty partition .

If there is filter applied in transformers/incremental sources then after filtering
we can have some partitions empty which can impact perf to find first non empty partition. 
### Impact

perf improvement for filtered datasets .
### Risk level (write none, low medium or high below)
low

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
