### PR TITLE
[HUDI-7110][FOLLOW-UP] Improve call procedure for show column stats information

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -103,7 +103,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
           getColumnStatsValue(c.getMaxValue), c.getNullCount.longValue())
       }
 
-    rows.toList
+    rows.toList.sortBy(r => r.getString(1))
   }
 
   private def getColumnStatsValue(stats_value: Any): String = {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -22,13 +22,15 @@ import org.apache.hadoop.fs.FileStatus
 import org.apache.hudi.avro.model._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.data.HoodieData
+import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.timeline.{HoodieDefaultTimeline, HoodieInstant}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
-import org.apache.hudi.common.util.collection.{Pair => HPair}
+import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.metadata.HoodieTableMetadata
+import org.apache.hudi.{AvroConversionUtils, ColumnStatsIndexSupport}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
@@ -36,7 +38,7 @@ import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 import java.util
 import java.util.function.{Function, Supplier}
 import scala.collection.{JavaConversions, mutable}
-import scala.jdk.CollectionConverters.{asScalaBufferConverter, asScalaIteratorConverter, collectionAsScalaIterableConverter}
+import scala.jdk.CollectionConverters.{asScalaBufferConverter, asScalaIteratorConverter}
 
 class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
@@ -70,31 +72,36 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     val metadataConfig = HoodieMetadataConfig.newBuilder
       .enable(true)
       .build
-    val engineCtx = new HoodieSparkEngineContext(jsc)
-    val metaTable = HoodieTableMetadata.create(engineCtx, metadataConfig, basePath)
+    val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
+    val schemaUtil = new TableSchemaResolver(metaClient)
+    val schema = AvroConversionUtils.convertAvroSchemaToStructType(schemaUtil.getTableAvroSchema)
+    val columnStatsIndex = new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
+    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = columnStatsIndex.loadColumnStatsIndexRecords(targetColumnsSeq, shouldReadInMemory = false)
     val fsView = buildFileSystemView(table)
-    val partitionFileNameList: util.List[HPair[String, String]] = new util.ArrayList[HPair[String, String]]()
+    val allFileSlices: Set[FileSlice] = {
+      if (partitionsSeq.isEmpty) {
+        val engineCtx = new HoodieSparkEngineContext(jsc)
+        val metaTable = HoodieTableMetadata.create(engineCtx, metadataConfig, basePath)
+        metaTable.getAllPartitionPaths
+          .asScala
+          .flatMap(path => fsView.getLatestFileSlices(path).iterator().asScala)
+          .toSet
+      } else {
+        partitionsSeq
+          .flatMap(partition => fsView.getLatestFileSlices(partition).iterator().asScala)
+          .toSet
+      }
+    }
 
-    metaTable.getAllPartitionPaths
-      .asScala
-      .filter(path => partitionsSeq.isEmpty || partitionsSeq.exists(prefix => path.startsWith(prefix)))
-      .foreach(path => {
-        val fsViews = fsView.getLatestFileSlices(path).iterator().asScala
-        fsViews.toStream.foreach(fs => {
-          partitionFileNameList.add(HPair.of(path, fs.getBaseFile.get().getFileName))
-        })
-      })
+    val allFileNames: Set[String] = allFileSlices.map(_.getBaseFile.get().getFileName)
 
     val rows = mutable.ListBuffer[Row]()
-    targetColumnsSeq.toStream.foreach(targetColumn => {
-      val colStatsRecords: util.Collection[HoodieMetadataColumnStats] = metaTable.getColumnStats(partitionFileNameList, targetColumn).values()
-
-      colStatsRecords.asScala
-        .foreach { c =>
-          rows += Row(c.getFileName, c.getColumnName, getColumnStatsValue(c.getMinValue),
-            getColumnStatsValue(c.getMaxValue), c.getNullCount.longValue())
-        }
-    })
+    colStatsRecords.collectAsList().asScala
+      .filter(c => allFileNames.contains(c.getFileName))
+      .foreach { c =>
+        rows += Row(c.getFileName, c.getColumnName, getColumnStatsValue(c.getMinValue),
+          getColumnStatsValue(c.getMaxValue), c.getNullCount.longValue())
+      }
 
     rows.toList
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -48,11 +48,11 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
-    StructField("File Name", DataTypes.StringType, nullable = true, Metadata.empty),
-    StructField("Column Name", DataTypes.StringType, nullable = true, Metadata.empty),
-    StructField("Min Value", DataTypes.StringType, nullable = true, Metadata.empty),
-    StructField("Max Value", DataTypes.StringType, nullable = true, Metadata.empty),
-    StructField("Null Number", DataTypes.LongType, nullable = true, Metadata.empty)
+    StructField("file_name", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("column_name", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("min_value", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("max_value", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("null_number", DataTypes.LongType, nullable = true, Metadata.empty)
   ))
 
   def parameters: Array[ProcedureParameter] = PARAMETERS

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
@@ -144,8 +144,8 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
         val columnName = s"c$i"
         val metadataStats = spark.sql(s"""call show_metadata_table_column_stats(table => '$tableName', targetColumns => '$columnName')""").collect()
         assertResult(1)(metadataStats.length)
-        val minVal: String = metadataStats(0).getAs[String]("Min Value")
-        val maxVal: String = metadataStats(0).getAs[String]("Max Value")
+        val minVal: String = metadataStats(0).getAs[String]("min_value")
+        val maxVal: String = metadataStats(0).getAs[String]("max_value")
 
         expectedValues.get(i) match {
           case Some((expectedMin, expectedMax)) =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
@@ -144,8 +144,8 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
         val columnName = s"c$i"
         val metadataStats = spark.sql(s"""call show_metadata_table_column_stats(table => '$tableName', targetColumns => '$columnName')""").collect()
         assertResult(1)(metadataStats.length)
-        val minVal: String = metadataStats(0).getAs[String]("min_value")
-        val maxVal: String = metadataStats(0).getAs[String]("max_value")
+        val minVal: String = metadataStats(0).getAs[String]("Min Value")
+        val maxVal: String = metadataStats(0).getAs[String]("Max Value")
 
         expectedValues.get(i) match {
           case Some((expectedMin, expectedMax)) =>


### PR DESCRIPTION
### Change Logs
https://github.com/apache/hudi/pull/10120
Improvement content:

1. Use the public method of obtaining column stats in the metadata table to acquire relevant content.
2. Simplify the implementation of some codes and remove meaningless and redundant codes.
3. Add handling of null values in type judgment to prevent the occurrence of NPE (NullPointerException).
4. Results can now be output in the order of column names.
5. The partition path can be matched with a prefix now.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
