### PR TITLE
[HUDI-7142] Support Custom partitioner in append mode

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -129,8 +129,9 @@ public class FlinkOptions extends HoodieConfig {
       .key("write.insert.partitioner.class.name")
       .stringType()
       .defaultValue("")
-      .withDescription("Insert partitioner to use in append mode aiming to re-balance records and reducing small file number."
-          + "Currently support  org.apache.hudi.sink.partitioner.DefaultInsertPartitioner");
+      .withDescription("Insert partitioner to use aiming to re-balance records and reducing small file number "
+          + "in the scenario of multi-level partitioning. For example dt/hour/eventID"
+          + "Currently support org.apache.hudi.sink.partitioner.DefaultInsertPartitioner");
 
   public static final ConfigOption<Integer> DEFAULT_PARALLELISM_PER_PARTITION = ConfigOptions
       .key("write.insert.partitioner.parallelism.per.partition")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -125,7 +125,19 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Payload class used. Override this, if you like to roll your own merge logic, when upserting/inserting.\n"
           + "This will render any value set for the option in-effective");
 
-  @AdvancedConfig
+  public static final ConfigOption<String> INSERT_PARTITIONER_CLASS_NAME = ConfigOptions
+      .key("write.insert.partitioner.class.name")
+      .stringType()
+      .defaultValue("")
+      .withDescription("Insert partitioner to use in append mode aiming to re-balance records and reducing small file number."
+          + "Currently support  org.apache.hudi.sink.partitioner.DefaultInsertPartitioner");
+
+  public static final ConfigOption<Integer> DEFAULT_PARALLELISM_PER_PARTITION = ConfigOptions
+      .key("write.insert.partitioner.parallelism.per.partition")
+      .intType()
+      .defaultValue(30)
+      .withDescription("The parallelism to use in each partition when using DefaultInsertPartitioner.");
+
   public static final ConfigOption<String> RECORD_MERGER_IMPLS = ConfigOptions
       .key("record.merger.impls")
       .stringType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DefaultInsertPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DefaultInsertPartitioner.java
@@ -34,6 +34,15 @@ import java.util.Random;
  * 期望每一个数据partition下对应10个task写数据(控制文件数)
  * 则 1,2,3,4,..,100 ==> group1-[1,2,3,..,10], group2-[11,12,13,...,20],...,group10-[91,92,..,100]
  * partition1 使用 group1
+ *
+ * groupLength must be lower than numPartitions ==> groupLength < numPartitions
+ * groupNumber = [0,]
+ * groupIndex = [0, groupNumber-1]
+ * index = [0, groupLength -1]
+ *
+ * Be careful :
+ * If numPartitions is not divisible by groupLength, then the partition corresponding to the remainder will be wasted.
+ *
  */
 public class DefaultInsertPartitioner<T extends HoodieKey> implements Partitioner<T> {
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DefaultInsertPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DefaultInsertPartitioner.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.Random;
+
+/**
+ * Insert input partitioner.
+ * 假设：
+ * Flink并行度为 100
+ * 期望每一个数据partition下对应10个task写数据(控制文件数)
+ * 则 1,2,3,4,..,100 ==> group1-[1,2,3,..,10], group2-[11,12,13,...,20],...,group10-[91,92,..,100]
+ * partition1 使用 group1
+ */
+public class DefaultInsertPartitioner<T extends HoodieKey> implements Partitioner<T> {
+
+  private final int groupLength;
+  private final Random random;
+
+  public DefaultInsertPartitioner(Configuration conf) {
+    this.groupLength = conf.get(FlinkOptions.DEFAULT_PARALLELISM_PER_PARTITION); // default 30 ==> parallelism per partition
+    this.random = new Random();
+  }
+
+  @Override
+  public int partition(HoodieKey hoodieKey, int numPartitions) {
+    String partitionPath = hoodieKey.getPartitionPath();
+    int groupNumber = numPartitions / groupLength;
+    ValidationUtils.checkArgument(groupNumber != 0,
+        String.format("write.insert.partitioner.default_parallelism_per_partition are greater than numPartitions %d.", numPartitions));
+
+    int groupIndex = (partitionPath.hashCode() & Integer.MAX_VALUE) % groupNumber;
+    int index = random.nextInt(groupLength);
+    return groupIndex * groupLength + index;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestDefaultInsertPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestDefaultInsertPartitioner.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestDefaultInsertPartitioner {
+
+  @Test
+  void testPartitioner() {
+    Configuration conf = new Configuration();
+    int para = 30;
+    conf.set(FlinkOptions.DEFAULT_PARALLELISM_PER_PARTITION, para);
+    DefaultInsertPartitioner partitioner = new DefaultInsertPartitioner(conf);
+    int numberFlinkPartitions = 2023;
+    int numberDataPartition = 1030;
+    int recordsPerPartition = 20;
+    HashMap<Integer, Integer> res = new HashMap<>();
+    String partitionPath = "dt=2023-11-27/hour=01/index=";
+    for(int partitionIndex = 0 ; partitionIndex < numberDataPartition; partitionIndex ++) {
+      for(int recordIndex = 0 ; recordIndex < recordsPerPartition; recordIndex ++) {
+        int id = partitioner.partition(new HoodieKey("id" + recordIndex, partitionPath + partitionIndex), numberFlinkPartitions);
+        if (res.containsKey(id)) {
+          Integer value = res.get(id);
+          res.put(id, value + 1);
+        } else {
+          res.put(id, 1);
+        }
+      }
+    }
+
+    // make sure all partitions can be used.
+    assertTrue(res.size() <= numberFlinkPartitions
+        && res.size() >= (numberFlinkPartitions - numberFlinkPartitions % para));
+  }
+
+}


### PR DESCRIPTION
### Change Logs

Support Custom partitioner in append mode.
For example default `DefaultInsertPartitioner` can be use to re-balance input records aiming to reduce small files.

Before using DefaultInsertPartitioner
<img width="840" alt="截屏2023-11-24 19 26 44" src="https://github.com/apache/hudi/assets/69956021/4aba3610-1a16-406f-b650-f8b7407ab2f5">

![image](https://github.com/apache/hudi/assets/69956021/6098575f-7965-41f8-8fb6-83f186e6f5a8)

`hdfs dfs -count hdfs://ns/xxx/xxx ==> 4801 `

After using DefaultInsertPartitioner
<img width="756" alt="截屏2023-11-24 19 26 49" src="https://github.com/apache/hudi/assets/69956021/5331fb03-4e2f-4667-836c-ecec35c70fae">


<img width="239" alt="截屏2023-11-24 19 18 22" src="https://github.com/apache/hudi/assets/69956021/16197a19-a126-4b56-8336-431d7daf7066">

`hdfs dfs -count dfs://ns/xxx/xxx  ==> 1950`

**_Reduce 59.38%_**


### Impact

Flink streaming append mode

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
