### PR TITLE
[HUDI-7148] Add an additional fix to the potential thread insecurity problem of heartbeat client.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -266,6 +266,11 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
       heartbeat.setLastHeartbeatTime(newHeartbeatTime);
       heartbeat.setNumHeartbeats(heartbeat.getNumHeartbeats() + 1);
     } catch (IOException io) {
+      Boolean isHeartbeatStopped = instantToHeartbeatMap.get(instantTime).isHeartbeatStopped;
+      if (isHeartbeatStopped) {
+        LOG.warn(String.format("update heart beat failed, because the instant time %s was stopped ? : %s", instantTime, isHeartbeatStopped));
+        return;
+      }
       throw new HoodieHeartbeatException("Unable to generate heartbeat for instant " + instantTime, io);
     }
   }


### PR DESCRIPTION
### Change Logs

A potential problem: 
If the heartbeat client is updating the heartbeat time for the instant t1, then the write client completes the commit of the instant t1 and stops the heartbeat of the instant t1. 
At this time, the try-catch that updates the heartbeat will catch an exception: `File does not exist`. 
When handling this exception, we should check again whether the heartbeat of t1 instant has been stopped by the writing client. 
If it has been stopped, we should not throw this exception, but skip the update of this heartbeat directly. 
But if has not been stopped, we should throw an exception at this time.

### Impact

NONE

### Risk level (write none, low medium or high below)

NONE

### Documentation Update

NONE

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
