### PR TITLE
[HUDI-7150] ExternalSpillableMap support values method

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -284,7 +284,7 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
     }
     List<R> result = new ArrayList<>(inMemoryMap.size() + diskBasedMap.size());
     result.addAll(inMemoryMap.values());
-    Iterator<R> iterator = getDiskBasedMap().iterator();
+    Iterator<R> iterator = diskBasedMap.iterator();
     while (iterator.hasNext()) {
       result.add(iterator.next());
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -284,7 +284,10 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
     }
     List<R> result = new ArrayList<>(inMemoryMap.size() + diskBasedMap.size());
     result.addAll(inMemoryMap.values());
-    result.addAll(diskBasedMap.values());
+    Iterator<R> iterator = getDiskBasedMap().iterator();
+    while (iterator.hasNext()) {
+      result.add(iterator.next());
+    }
     return result;
   }
 


### PR DESCRIPTION
### Change Logs

getDiskBasedMap return both RocksDbDiskMap and BitCaskDiskMap not support values method，but other modules would call the method. we should support it

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
