### PR TITLE
[MINOR] Add log to print wrong number of instant metadata files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/ActiveAction.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/ActiveAction.java
@@ -48,7 +48,8 @@ public class ActiveAction implements Serializable, Comparable<ActiveAction> {
   }
 
   public static ActiveAction fromInstants(List<HoodieInstant> instants) {
-    ValidationUtils.checkArgument(instants.size() <= 3);
+    ValidationUtils.checkArgument(instants.size() <= 3,
+        "Number of instant metadata files should be <= 3: " + instants);
     HoodieInstant requested = null;
     HoodieInstant inflight = null;
     HoodieInstant completed = null;


### PR DESCRIPTION
### Change Logs

Before modification:
![image](https://github.com/apache/hudi/assets/34104400/03e60654-5a63-47b1-8301-230f41a215fc)
Unable to directly determine the instant issue from the logs.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
