### PR TITLE
[MINOR][DOCS] updated notes for spark-hive integrated local environments

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -220,6 +220,13 @@ CREATE TABLE hudi_table (
 PARTITIONED BY (city);
 ```
 
+:::note NOTE:
+If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
+it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 For more options for creating Hudi tables, please refer to [SQL DDL](/docs/next/sql_ddl) reference guide.  
 
 </TabItem>

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -203,7 +203,10 @@ values={[
 </TabItem>
 <TabItem value="sparksql">
 
-
+:::note NOTE:
+For users who have Spark-Hive integration in their environment, this guide assumes that you have the appropriate
+settings configured to allow Spark to create tables and register in Hive Metastore.
+:::
 
 Here is an example of creating a Hudi table.
 
@@ -220,14 +223,7 @@ CREATE TABLE hudi_table (
 PARTITIONED BY (city);
 ```
 
-:::note NOTE:
-If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
-it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
-1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
-2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
-:::
-
-For more options for creating Hudi tables, please refer to [SQL DDL](/docs/next/sql_ddl) reference guide.  
+For more options for creating Hudi tables or if you're running into any issues, please refer to [SQL DDL](/docs/next/sql_ddl) reference guide.  
 
 </TabItem>
 

--- a/website/docs/sql_ddl.md
+++ b/website/docs/sql_ddl.md
@@ -40,6 +40,13 @@ CREATE TABLE IF NOT EXISTS hudi_table (
 ) USING hudi;
 ```
 
+:::note NOTE:
+If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
+it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 ### Create partitioned table
 A partitioned table can be created by adding a `partitioned by` clause. Partitioning helps to organize the data into multiple folders 
 based on the partition columns. It can also help speed up queries and index lookups by limiting the amount of metadata, index and data scanned.

--- a/website/docs/sql_ddl.md
+++ b/website/docs/sql_ddl.md
@@ -27,6 +27,15 @@ CREATE TABLE [IF NOT EXISTS] [db_name.]table_name
   [AS select_statement];
 ```
 
+:::note NOTE:
+For users running this tutorial locally and have a Spark-Hive(HMS) integration in their environment: If you use 
+`default` database or if you don't provide `[LOCATION path]` with the DDL statement, Spark will return 
+`java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` error. 
+To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 ### Create non-partitioned table
 
 Creating a non-partitioned table is as simple as creating a regular table.
@@ -39,13 +48,6 @@ CREATE TABLE IF NOT EXISTS hudi_table (
   price DOUBLE
 ) USING hudi;
 ```
-
-:::note NOTE:
-If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
-it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
-1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
-2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
-:::
 
 ### Create partitioned table
 A partitioned table can be created by adding a `partitioned by` clause. Partitioning helps to organize the data into multiple folders 

--- a/website/versioned_docs/version-0.14.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.14.0/quick-start-guide.md
@@ -203,7 +203,10 @@ values={[
 </TabItem>
 <TabItem value="sparksql">
 
-
+:::note NOTE:
+For users who have Spark-Hive integration in their environment, this guide assumes that you have the appropriate
+settings configured to allow Spark to create tables and register in Hive Metastore.
+:::
 
 Here is an example of creating a Hudi table.
 
@@ -220,14 +223,7 @@ CREATE TABLE hudi_table (
 PARTITIONED BY (city);
 ```
 
-:::note NOTE:
-If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
-it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
-1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
-2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
-:::
-
-For more options for creating Hudi tables, please refer to [SQL DDL](/docs/sql_ddl) reference guide.  
+For more options for creating Hudi tables or if you're running into any issues, please refer to [SQL DDL](/docs/sql_ddl) reference guide.
 
 </TabItem>
 

--- a/website/versioned_docs/version-0.14.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.14.0/quick-start-guide.md
@@ -220,6 +220,13 @@ CREATE TABLE hudi_table (
 PARTITIONED BY (city);
 ```
 
+:::note NOTE:
+If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
+it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 For more options for creating Hudi tables, please refer to [SQL DDL](/docs/sql_ddl) reference guide.  
 
 </TabItem>

--- a/website/versioned_docs/version-0.14.0/sql_ddl.md
+++ b/website/versioned_docs/version-0.14.0/sql_ddl.md
@@ -40,6 +40,13 @@ CREATE TABLE IF NOT EXISTS hudi_table (
 ) USING hudi;
 ```
 
+:::note NOTE:
+If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
+it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 ### Create partitioned table
 A partitioned table can be created by adding a `partitioned by` clause. Partitioning helps to organize the data into multiple folders 
 based on the partition columns. It can also help speed up queries and index lookups by limiting the amount of metadata, index and data scanned.

--- a/website/versioned_docs/version-0.14.0/sql_ddl.md
+++ b/website/versioned_docs/version-0.14.0/sql_ddl.md
@@ -27,6 +27,15 @@ CREATE TABLE [IF NOT EXISTS] [db_name.]table_name
   [AS select_statement];
 ```
 
+:::note NOTE:
+For users running this tutorial locally and have a Spark-Hive(HMS) integration in their environment: If you use
+`default` database or if you don't provide `[LOCATION path]` with the DDL statement, Spark will return
+`java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` error.
+To get around this, you can follow either of the two options mentioned below:
+1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
+2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
+:::
+
 ### Create non-partitioned table
 
 Creating a non-partitioned table is as simple as creating a regular table.
@@ -39,13 +48,6 @@ CREATE TABLE IF NOT EXISTS hudi_table (
   price DOUBLE
 ) USING hudi;
 ```
-
-:::note NOTE:
-If you're running this tutorial locally and if you are facing `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` issue,
-it's likely because of the spark-hive integration. To get around this, you can follow either of the two options mentioned below:
-1. Create a database i.e. `CREATE DATABASE hudidb;` and use it i.e. `USE hudidb;` before running the DDL statement.
-2. Or provide a path using `LOCATION` keyword to persist the data with the DDL statement.
-:::
 
 ### Create partitioned table
 A partitioned table can be created by adding a `partitioned by` clause. Partitioning helps to organize the data into multiple folders 


### PR DESCRIPTION
### Change Logs

Updated notes for SQL DDL and SQL Quickstart page to add more clarity.

If user is working on the tutorial locally and has a previous Spark-HMS integration and if they don't have a non-default database setup or if they don't provide `LOCATION` with DDL, they will face `java.io.IOException: Mkdirs failed to create file:/user/hive/warehouse/hudi_table/.hoodie` error.

### Impact

Updated notes for SQL DDL and SQL Quickstart page to add more clarity.

### Risk level (write none, low medium or high below)

MINOR

### Documentation Update

Update was to documentation.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable. `npm run build` and `npm run serve` passed.
- [NA] CI passed - CI runs after PR is raised.
