### PR TITLE
[HUDI-7158] Expose event time config to record event time in commit file

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -116,6 +116,13 @@ public class FlinkOptions extends HoodieConfig {
           + "key value, we will pick the one with the largest value for the precombine field,\n"
           + "determined by Object.compareTo(..)");
 
+  public static final ConfigOption<String> EVENT_TIME_FIELD = ConfigOptions
+      .key("eventtime.field")
+      .stringType()
+      .defaultValue("ts")
+      .withDescription("Table column/field name to derive timestamp associated with the records. This can"
+          + "be useful for e.g, determining the freshness of the table.");
+
   @AdvancedConfig
   public static final ConfigOption<String> PAYLOAD_CLASS_NAME = ConfigOptions
       .key("payload.class")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -145,11 +145,15 @@ public class StreamerUtil {
    * Returns the payload config with given configuration.
    */
   public static HoodiePayloadConfig getPayloadConfig(Configuration conf) {
-    return HoodiePayloadConfig.newBuilder()
+    HoodiePayloadConfig.Builder builder = HoodiePayloadConfig.newBuilder()
         .withPayloadClass(conf.getString(FlinkOptions.PAYLOAD_CLASS_NAME))
-        .withPayloadOrderingField(conf.getString(FlinkOptions.PRECOMBINE_FIELD))
-        .withPayloadEventTimeField(conf.getString(FlinkOptions.PRECOMBINE_FIELD))
-        .build();
+        .withPayloadOrderingField(conf.getString(FlinkOptions.PRECOMBINE_FIELD));
+
+    if (StringUtils.isNullOrEmpty(conf.getString(FlinkOptions.EVENT_TIME_FIELD))) {
+      return builder.withPayloadEventTimeField(conf.getString(FlinkOptions.PRECOMBINE_FIELD)).build();
+    } else {
+      return builder.withPayloadEventTimeField(conf.getString(FlinkOptions.EVENT_TIME_FIELD)).build();
+    }
   }
 
   /**


### PR DESCRIPTION
### Change Logs
Currently, we use `precombine.field` as `eventtime.field`. 
Generally speaking, **precombine**, **ordering** and **event time** are all time fields.

But sometimes it is not different. For example, the user uses the site value as the percombine field and also wants to record the event time at the same time.

### Impact

No

### Risk level (write none, low medium or high below)
Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
