### PR TITLE
[HUDI-7160] Copy over schema properties when adding Hudi Metadata fields

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -294,13 +294,17 @@ public class HoodieAvroUtils {
     for (Schema.Field field : schema.getFields()) {
       if (!isMetadataField(field.name())) {
         Schema.Field newField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
-        newField.putAll(field);
+        for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
+          newField.addProp(prop.getKey(), prop.getValue());
+        }
         parentFields.add(newField);
       }
     }
 
     Schema mergedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
-    mergedSchema.putAll(schema);
+    for (Map.Entry<String, Object> prop : schema.getObjectProps().entrySet()) {
+      mergedSchema.addProp(prop.getKey(), prop.getValue());
+    }
     mergedSchema.setFields(parentFields);
     return mergedSchema;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -294,14 +294,13 @@ public class HoodieAvroUtils {
     for (Schema.Field field : schema.getFields()) {
       if (!isMetadataField(field.name())) {
         Schema.Field newField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
-        for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
-          newField.addProp(prop.getKey(), prop.getValue());
-        }
+        newField.putAll(field);
         parentFields.add(newField);
       }
     }
 
     Schema mergedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
+    mergedSchema.putAll(schema);
     mergedSchema.setFields(parentFields);
     return mergedSchema;
   }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -613,7 +613,7 @@ public class TestHoodieAvroUtils {
 
   @Test
   public void testAddMetadataFields() {
-    Schema baseSchema = new Schema.Parser().parse(EXAMPLE_SCHEMA);
+    Schema baseSchema = new Schema.Parser().parse(EXAMPLE_SCHEMA_WITH_PROPS);
     Schema schemaWithMetadata = HoodieAvroUtils.addMetadataFields(baseSchema);
     List<Schema.Field> updatedFields = schemaWithMetadata.getFields();
     // assert fields added in expected order


### PR DESCRIPTION
### Change Logs

Copies over the properties of the original schema when adding metadata fields. Adds test to assert this behavior.

### Impact

Allows user defined properties to be carried through to the commit metadata

### Risk level (write none, low medium or high below)

None, this is just metadata on the schema. We already had this behavior at the field level but also want it at the record level.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
