### PR TITLE
[HUDI-7164] Add start time query API in CompletionTimeQueryView

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.generic.GenericRecord;
@@ -27,9 +28,13 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieArchivedTimeline.COMPLETION_TIME_ARCHIVED_META_FIELD;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 
@@ -40,6 +45,8 @@ public class CompletionTimeQueryView implements AutoCloseable, Serializable {
   private static final long serialVersionUID = 1L;
 
   private static final long MILLI_SECONDS_IN_THREE_DAYS = 3 * 24 * 3600 * 1000;
+
+  private static final long MILLI_SECONDS_IN_ONE_DAY = 24 * 3600 * 1000;
 
   private final HoodieTableMetaClient metaClient;
 
@@ -159,20 +166,65 @@ public class CompletionTimeQueryView implements AutoCloseable, Serializable {
       // the instant is still pending
       return Option.empty();
     }
+    loadCompletionTimeIncrementally(startTime);
+    return Option.ofNullable(this.startToCompletionInstantTimeMap.get(startTime));
+  }
+
+  /**
+   * Queries the instant start time with given completion time range.
+   *
+   * <p>By default, assumes there is at most 1 day time of duration for an instant to accelerate the queries.
+   *
+   * @param startCompletionTime The start completion time.
+   * @param endCompletionTime   The end completion time.
+   *
+   * @return The instant time set.
+   */
+  public Set<String> getStartTimeSet(String startCompletionTime, String endCompletionTime) {
+    // assumes any instant/transaction lasts at most 1 day to optimize the query efficiency.
+    return getStartTimeSet(startCompletionTime, endCompletionTime, s -> HoodieInstantTimeGenerator.instantTimeMinusMillis(s, MILLI_SECONDS_IN_ONE_DAY));
+  }
+
+  /**
+   * Queries the instant start time with given completion time range.
+   *
+   * @param startCompletionTime   The start completion time.
+   * @param endCompletionTime     The end completion time.
+   * @param earliestStartTimeFunc The function to generate the earliest start time boundary
+   *                              with the minimum completion time {@code startCompletionTime}.
+   *
+   * @return The instant time set.
+   */
+  public Set<String> getStartTimeSet(String startCompletionTime, String endCompletionTime, Function<String, String> earliestStartTimeFunc) {
+    String startInstant = earliestStartTimeFunc.apply(startCompletionTime);
+    final InstantRange instantRange = InstantRange.builder()
+        .rangeType(InstantRange.RangeType.CLOSE_CLOSE)
+        .startInstant(startCompletionTime)
+        .endInstant(endCompletionTime)
+        .nullableBoundary(true)
+        .build();
+    if (HoodieTimeline.compareTimestamps(this.cursorInstant, GREATER_THAN, startInstant)) {
+      loadCompletionTimeIncrementally(startInstant);
+    }
+    return this.startToCompletionInstantTimeMap.entrySet().stream()
+        .filter(entry -> instantRange.isInRange(entry.getValue()))
+        .map(Map.Entry::getKey).collect(Collectors.toSet());
+  }
+
+  private void loadCompletionTimeIncrementally(String startTime) {
     // the 'startTime' should be out of the eager loading range, switch to a lazy loading.
     // This operation is resource costly.
     synchronized (this) {
       if (HoodieTimeline.compareTimestamps(startTime, LESSER_THAN, this.cursorInstant)) {
         HoodieArchivedTimeline.loadInstants(metaClient,
             new HoodieArchivedTimeline.ClosedOpenTimeRangeFilter(startTime, this.cursorInstant),
-            HoodieArchivedTimeline.LoadMode.SLIM,
+            HoodieArchivedTimeline.LoadMode.TIME,
             r -> true,
             this::readCompletionTime);
       }
       // refresh the start instant
       this.cursorInstant = startTime;
     }
-    return Option.ofNullable(this.startToCompletionInstantTimeMap.get(startTime));
   }
 
   /**
@@ -188,7 +240,7 @@ public class CompletionTimeQueryView implements AutoCloseable, Serializable {
     // then load the archived instants.
     HoodieArchivedTimeline.loadInstants(metaClient,
         new HoodieArchivedTimeline.StartTsFilter(this.cursorInstant),
-        HoodieArchivedTimeline.LoadMode.SLIM,
+        HoodieArchivedTimeline.LoadMode.TIME,
         r -> true,
         this::readCompletionTime);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -182,7 +182,7 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
   }
 
   private List<HoodieInstant> loadInstants() {
-    return loadInstants(null, LoadMode.SLIM);
+    return loadInstants(null, LoadMode.ACTION);
   }
 
   private List<HoodieInstant> loadInstants(String startTs, String endTs) {
@@ -275,15 +275,19 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
    */
   public enum LoadMode {
     /**
+     * Loads the instantTime, completionTime.
+     */
+    TIME,
+    /**
      * Loads the instantTime, completionTime, action.
      */
-    SLIM,
+    ACTION,
     /**
      * Loads the instantTime, completionTime, action, metadata.
      */
     METADATA,
     /**
-     * Loads the instantTime, completionTime, plan.
+     * Loads the instantTime, completionTime, action, plan.
      */
     PLAN
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -105,6 +105,17 @@ public class HoodieInstantTimeGenerator {
     }
   }
 
+  public static String instantTimeMinusMillis(String timestamp, long milliseconds) {
+    try {
+      String timestampInMillis = fixInstantTimeCompatibility(timestamp);
+      LocalDateTime dt = LocalDateTime.parse(timestampInMillis, MILLIS_INSTANT_TIME_FORMATTER);
+      ZoneId zoneId = HoodieTimelineTimeZone.UTC.equals(commitTimeZone) ? ZoneId.of("UTC") : ZoneId.systemDefault();
+      return MILLIS_INSTANT_TIME_FORMATTER.format(dt.atZone(zoneId).toInstant().minusMillis(milliseconds).atZone(zoneId).toLocalDateTime());
+    } catch (DateTimeParseException e) {
+      throw new HoodieException(e);
+    }
+  }
+
   private static String fixInstantTimeCompatibility(String instantTime) {
     // Enables backwards compatibility with non-millisecond granularity instants
     if (isSecondGranularity(instantTime)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -119,8 +119,10 @@ public class LSMTimeline {
   // -------------------------------------------------------------------------
   public static Schema getReadSchema(HoodieArchivedTimeline.LoadMode loadMode) {
     switch (loadMode) {
-      case SLIM:
-        return ArchivedInstantReadSchemas.TIMELINE_LSM_SLIM_READ_SCHEMA;
+      case TIME:
+        return ArchivedInstantReadSchemas.TIMELINE_LSM_READ_SCHEMA_WITH_TIME;
+      case ACTION:
+        return ArchivedInstantReadSchemas.TIMELINE_LSM_READ_SCHEMA_WITH_ACTION;
       case METADATA:
         return ArchivedInstantReadSchemas.TIMELINE_LSM_READ_SCHEMA_WITH_METADATA;
       case PLAN:

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ArchivedInstantReadSchemas.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ArchivedInstantReadSchemas.java
@@ -24,7 +24,25 @@ import org.apache.avro.Schema;
  * Avro schema for different archived instant read cases.
  */
 public abstract class ArchivedInstantReadSchemas {
-  public static final Schema TIMELINE_LSM_SLIM_READ_SCHEMA = new Schema.Parser().parse("{\n"
+  public static final Schema TIMELINE_LSM_READ_SCHEMA_WITH_TIME = new Schema.Parser().parse("{\n"
+      + "   \"type\":\"record\",\n"
+      + "   \"name\":\"HoodieArchivedMetaEntryV2\",\n"
+      + "   \"namespace\":\"org.apache.hudi.avro.model\",\n"
+      + "   \"fields\":[\n"
+      + "      {\n"
+      + "         \"name\":\"instantTime\",\n"
+      + "         \"type\":[\"null\",\"string\"],\n"
+      + "         \"default\": null\n"
+      + "      },\n"
+      + "      {\n"
+      + "         \"name\":\"completionTime\",\n"
+      + "         \"type\":[\"null\",\"string\"],\n"
+      + "         \"default\": null\n"
+      + "      }\n"
+      + "   ]\n"
+      + "}");
+
+  public static final Schema TIMELINE_LSM_READ_SCHEMA_WITH_ACTION = new Schema.Parser().parse("{\n"
       + "   \"type\":\"record\",\n"
       + "   \"name\":\"HoodieArchivedMetaEntryV2\",\n"
       + "   \"namespace\":\"org.apache.hudi.avro.model\",\n"

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -219,9 +219,13 @@ public class HoodieTestTable {
   }
 
   public HoodieTestTable addCommit(String instantTime, Option<HoodieCommitMetadata> metadata) throws Exception {
+    return addCommit(instantTime, Option.empty(), metadata);
+  }
+
+  public HoodieTestTable addCommit(String instantTime, Option<String> completionTime, Option<HoodieCommitMetadata> metadata) throws Exception {
     createRequestedCommit(basePath, instantTime);
     createInflightCommit(basePath, instantTime);
-    createCommit(basePath, instantTime, metadata);
+    createCommit(basePath, instantTime, completionTime, metadata);
     currentInstantTime = instantTime;
     return this;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.client.common.HoodieJavaEngineContext
 import org.apache.hudi.client.timeline.LSMTimelineWriter
 import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieCommitMetadata, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata
-import org.apache.hudi.common.table.timeline.{ActiveAction, HoodieArchivedTimeline, HoodieInstant, LSMTimeline}
+import org.apache.hudi.common.table.timeline.{ActiveAction, CompletionTimeQueryView, HoodieArchivedTimeline, HoodieInstant, LSMTimeline}
 import org.apache.hudi.common.testutils.{HoodieTestTable, HoodieTestUtils}
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.index.HoodieIndex.IndexType
@@ -42,8 +42,9 @@ object LSMTimelineReadBenchmark extends HoodieBenchmarkBase {
    * Apple M2
    * pref load archived instants:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
    * ------------------------------------------------------------------------------------------------------------------------
-   * read shim instants                                   18             32          15          0.1       17914.8       1.0X
-   * read instants with commit metadata                   19             25           5          0.1       19403.1       0.9X
+   * read slim instants                                  494            521          27          0.5        1899.6       1.0X
+   * read instants with commit metadata                 2544           2625         116          0.1        9785.9       0.2X
+   * read start time                                     156            177          26          1.7         601.1       3.2X
    */
   private def readArchivedInstantsBenchmark(): Unit = {
     withTempDir(f => {
@@ -60,13 +61,14 @@ object LSMTimelineReadBenchmark extends HoodieBenchmarkBase {
 
       val startTs = System.currentTimeMillis()
       val startInstant = startTs + 1 + ""
-      val commitsNum = 10000000
-      val batchSize = 2000
+      val commitsNum = 260000
+      val batchSize = 10
       val instantBuffer = new util.ArrayList[ActiveAction]()
       for (i <- 1 to commitsNum) {
         val instantTime = startTs + i + ""
+        val completionTime = startTs + i + 1000 + ""
         val action = if (i % 2 == 0) "delta_commit" else "commit"
-        val instant = new HoodieInstant(HoodieInstant.State.COMPLETED, action, instantTime, instantTime + 1000)
+        val instant = new HoodieInstant(HoodieInstant.State.COMPLETED, action, instantTime, completionTime)
         val metadata: HoodieCommitMetadata = HoodieTestTable.of(metaClient).createCommitMetadata(instantTime, WriteOperationType.INSERT, util.Arrays.asList("par1", "par2"), 10, false)
         val serializedMetadata = serializeCommitMetadata(metadata).get()
         instantBuffer.add(new DummyActiveAction(instant, serializedMetadata))
@@ -84,6 +86,15 @@ object LSMTimelineReadBenchmark extends HoodieBenchmarkBase {
       }
       benchmark.addCase("read instants with commit metadata") { _ =>
         new HoodieArchivedTimeline(metaClient, startInstant)
+      }
+      // for scala compatibility
+      val earliestStartTimeFunc: java.util.function.Function[String, String] = new java.util.function.Function[String, String] {
+        override def apply(s: String): String = {
+          (s.toLong - 1000) + ""
+        }
+      }
+      benchmark.addCase("read start time") { _ =>
+        new CompletionTimeQueryView(metaClient).getStartTimeSet(startTs + 1 + 1000 + "", startTs + commitsNum + 1000 + "", earliestStartTimeFunc)
       }
       benchmark.run()
       val totalSize = LSMTimeline.latestSnapshotManifest(metaClient).getFiles.asScala


### PR DESCRIPTION
### Change Logs

Add API for start time queries which will serve the completion time based incremental queries.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
