### PR TITLE
[HUDI-7165] Flink multi writer not close the failed instant heartbeat

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -420,6 +420,10 @@ public class StreamWriteOperatorCoordinator
       }
       commitInstant(instant);
     }
+    // stop the heartbeat for old instant
+    if (writeClient.getConfig().getFailedWritesCleanPolicy().isLazy() && !WriteMetadataEvent.BOOTSTRAP_INSTANT.equals(this.instant)) {
+      writeClient.getHeartbeatClient().stop(this.instant);
+    }
     // starts a new instant
     startInstant();
     // upgrade downgrade


### PR DESCRIPTION
### Change Logs

When using multi-writer, flink job may not close the failed instant's heartbeat that causing the lazy clean not process the corresponding commit.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
