### PR TITLE
[HUDI-7171] Fix 'show partitions' not display rewritten partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -164,4 +164,8 @@ public enum WriteOperationType {
   public static boolean isDelete(WriteOperationType operation) {
     return operation == DELETE || operation == DELETE_PREPPED;
   }
+
+  public static boolean isDeletePartition(WriteOperationType operation) {
+    return operation == DELETE_PARTITION || operation == INSERT_OVERWRITE_TABLE;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -164,8 +164,4 @@ public enum WriteOperationType {
   public static boolean isDelete(WriteOperationType operation) {
     return operation == DELETE || operation == DELETE_PREPPED;
   }
-
-  public static boolean isDeletePartition(WriteOperationType operation) {
-    return operation == DELETE_PARTITION || operation == INSERT_OVERWRITE_TABLE;
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieTimeTravelException;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -82,22 +84,41 @@ public class TimelineUtils {
    * Does not include internal operations such as clean in the timeline.
    */
   public static List<String> getDroppedPartitions(HoodieTimeline timeline) {
-    HoodieTimeline replaceCommitTimeline = timeline.getWriteTimeline().filterCompletedInstants().getCompletedReplaceTimeline();
+    HoodieTimeline completedTimeline = timeline.getWriteTimeline().filterCompletedInstants();
+    HoodieTimeline replaceCommitTimeline = completedTimeline.getCompletedReplaceTimeline();
 
-    return replaceCommitTimeline.getInstantsAsStream().flatMap(instant -> {
-      try {
-        HoodieReplaceCommitMetadata commitMetadata = HoodieReplaceCommitMetadata.fromBytes(
-            replaceCommitTimeline.getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
-        if (WriteOperationType.DELETE_PARTITION.equals(commitMetadata.getOperationType())) {
-          Map<String, List<String>> partitionToReplaceFileIds = commitMetadata.getPartitionToReplaceFileIds();
-          return partitionToReplaceFileIds.keySet().stream();
-        } else {
-          return Stream.empty();
-        }
-      } catch (IOException e) {
-        throw new HoodieIOException("Failed to get partitions modified at " + instant, e);
-      }
-    }).distinct().filter(partition -> !partition.isEmpty()).collect(Collectors.toList());
+    Map<String, String> partitionToLatestDeleteTimestamp = replaceCommitTimeline.getInstants().stream()
+        .map(instant -> {
+          try {
+            HoodieReplaceCommitMetadata commitMetadata = HoodieReplaceCommitMetadata.fromBytes(
+                replaceCommitTimeline.getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
+            return Pair.of(instant, commitMetadata);
+          } catch (IOException e) {
+            throw new HoodieIOException("Failed to get partitions modified at " + instant, e);
+          }
+        })
+        .filter(pair -> WriteOperationType.isDeletePartition(pair.getRight().getOperationType()))
+        .flatMap(pair -> pair.getRight().getPartitionToReplaceFileIds().keySet().stream()
+            .map(partition -> new AbstractMap.SimpleEntry<>(partition, pair.getLeft().getTimestamp()))
+        ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replace) -> replace));
+
+    Map<String, String> partitionToLatestWriteTimestamp = completedTimeline.getInstants().stream()
+        .flatMap(instant -> {
+          try {
+            HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+                completedTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+            return commitMetadata.getWritePartitionPaths().stream()
+                .map(partition -> new AbstractMap.SimpleEntry<>(partition, instant.getTimestamp()));
+          } catch (IOException e) {
+            throw new HoodieIOException("Failed to get partitions writes at " + instant, e);
+          }
+        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replace) -> replace));
+
+    return partitionToLatestDeleteTimestamp.entrySet().stream()
+        .filter(entry -> !partitionToLatestWriteTimestamp.containsKey(entry.getKey())
+            || HoodieTimeline.compareTimestamps(entry.getValue(), HoodieTimeline.GREATER_THAN,
+            partitionToLatestWriteTimestamp.get(entry.getKey()))
+        ).map(Map.Entry::getKey).filter(partition -> !partition.isEmpty()).collect(Collectors.toList());
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
@@ -250,7 +250,7 @@ class TestShowPartitions extends HoodieSparkSqlTestBase {
       // Insert overwrite table
       spark.sql(
         s"""
-           | insert overwrite $tableName
+           | insert overwrite table $tableName
            | values
            |   (4, 'a4', 10, 1000, '2023', '12', '01'),
            |   (2, 'a2', 10, 1000, '2023', '12', '04')

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
@@ -202,8 +202,63 @@ class TestShowPartitions extends HoodieSparkSqlTestBase {
           // Lazily drop that partition
           spark.sql(s"alter table $tableName drop partition(year='2023', month='06', day='06')")
           checkAnswer(s"show partitions $tableName")(Seq.empty: _*)
+          // rewrite data to the dropped partition
+          spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, '2023', '06', '06')")
+          checkAnswer(s"show partitions $tableName")(
+            Seq("year=2023/month=06/day=06")
+          )
         }
       }
+    }
+  }
+
+  test("Test show partitions after table being overwritten") {
+    withTable(generateTableName) { tableName =>
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |   id int,
+           |   name string,
+           |   price double,
+           |   ts long,
+           |   year string,
+           |   month string,
+           |   day string
+           | ) using hudi
+           | partitioned by (year, month, day)
+           | tblproperties (
+           |   primaryKey = 'id',
+           |   preCombineField = 'ts'
+           | )
+         """.stripMargin)
+
+      // Insert into dynamic partition
+      spark.sql(
+        s"""
+           | insert into $tableName
+           | values
+           |   (1, 'a1', 10, 1000, '2023', '12', '01'),
+           |   (2, 'a2', 10, 1000, '2023', '12', '02'),
+           |   (3, 'a3', 10, 1000, '2023', '12', '03')
+        """.stripMargin)
+      checkAnswer(s"show partitions $tableName")(
+        Seq("year=2023/month=12/day=01"),
+        Seq("year=2023/month=12/day=02"),
+        Seq("year=2023/month=12/day=03")
+      )
+
+      // Insert overwrite table
+      spark.sql(
+        s"""
+           | insert overwrite $tableName
+           | values
+           |   (4, 'a4', 10, 1000, '2023', '12', '01'),
+           |   (2, 'a2', 10, 1000, '2023', '12', '04')
+        """.stripMargin)
+      checkAnswer(s"show partitions $tableName")(
+        Seq("year=2023/month=12/day=01"),
+        Seq("year=2023/month=12/day=04")
+      )
     }
   }
 }


### PR DESCRIPTION
### Change Logs
`show partitions` sql can not return correct result in following two cases:
1. the dropped partitions should be displayed after they were recreated.
2. after `insert overwrite` a partitioned table, the partitions should be marked as `dropped`

### Impact

bug fix.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
