### PR TITLE
[HUDI-7183] Fix static insert overwrite partitions issue

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteCommitActionExecutor.java
@@ -36,7 +36,7 @@ import org.apache.hudi.table.action.HoodieWriteMetadata;
 
 import org.apache.spark.Partitioner;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -81,14 +81,15 @@ public class SparkInsertOverwriteCommitActionExecutor<T>
 
   @Override
   protected Map<String, List<String>> getPartitionToReplacedFileIds(HoodieWriteMetadata<HoodieData<WriteStatus>> writeMetadata) {
-    if (writeMetadata.getWriteStatuses().isEmpty()) {
-      String staticOverwritePartition = config.getStringOrDefault(HoodieInternalConfig.STATIC_OVERWRITE_PARTITION_PATHS);
-      if (StringUtils.isNullOrEmpty(staticOverwritePartition)) {
-        return Collections.emptyMap();
-      } else {
-        return Collections.singletonMap(staticOverwritePartition, getAllExistingFileIds(staticOverwritePartition));
-      }
+    String staticOverwritePartition = config.getStringOrDefault(HoodieInternalConfig.STATIC_OVERWRITE_PARTITION_PATHS);
+    if (StringUtils.nonEmpty(staticOverwritePartition)) {
+      // static insert overwrite partitions
+      List<String> partitionPaths = Arrays.asList(staticOverwritePartition.split(","));
+      context.setJobStatus(this.getClass().getSimpleName(), "Getting ExistingFileIds of matching static partitions");
+      return HoodieJavaPairRDD.getJavaPairRDD(context.parallelize(partitionPaths, partitionPaths.size()).mapToPair(
+          partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
     } else {
+      // dynamic insert overwrite partitions
       return HoodieJavaPairRDD.getJavaPairRDD(writeMetadata.getWriteStatuses().map(status -> status.getStat().getPartitionPath()).distinct().mapToPair(partitionPath ->
           Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteCommitActionExecutor.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieInternalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -33,7 +34,7 @@ import org.apache.hudi.data.HoodieJavaPairRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,14 +61,15 @@ public class DatasetBulkInsertOverwriteCommitActionExecutor extends BaseDatasetB
 
   @Override
   protected Map<String, List<String>> getPartitionToReplacedFileIds(HoodieData<WriteStatus> writeStatuses) {
-    if (writeStatuses.isEmpty()) {
-      String staticOverwritePartition = writeConfig.getStringOrDefault(HoodieInternalConfig.STATIC_OVERWRITE_PARTITION_PATHS);
-      if (staticOverwritePartition == null || staticOverwritePartition.isEmpty()) {
-        return Collections.emptyMap();
-      } else {
-        return Collections.singletonMap(staticOverwritePartition, getAllExistingFileIds(staticOverwritePartition));
-      }
+    String staticOverwritePartition = writeConfig.getStringOrDefault(HoodieInternalConfig.STATIC_OVERWRITE_PARTITION_PATHS);
+    if (StringUtils.nonEmpty(staticOverwritePartition)) {
+      // static insert overwrite partitions
+      List<String> partitionPaths = Arrays.asList(staticOverwritePartition.split(","));
+      table.getContext().setJobStatus(this.getClass().getSimpleName(), "Getting ExistingFileIds of matching static partitions");
+      return HoodieJavaPairRDD.getJavaPairRDD(table.getContext().parallelize(partitionPaths, partitionPaths.size()).mapToPair(
+          partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
     } else {
+      // dynamic insert overwrite partitions
       return HoodieJavaPairRDD.getJavaPairRDD(writeStatuses.map(status -> status.getStat().getPartitionPath()).distinct().mapToPair(partitionPath ->
           Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -339,7 +339,12 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
           nullableField
         }
       }.partition(f => partitionFields.contains(f.name))
-      StructType(dataFields ++ partFields)
+      // insert_overwrite operation with partial partition values will mix up the order
+      // of partition columns, so we also need reorder partition fields here.
+      val nameToField = partFields.map(field => (field.name, field)).toMap
+      val orderedPartFields = partitionFields.map(nameToField(_)).toSeq
+
+      StructType(dataFields ++ orderedPartFields)
     })
     catch {
       case cause: Throwable =>

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -110,22 +110,6 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
     success
   }
 
-  private def getStaticOverwritePartitionPath(hoodieCatalogTable: HoodieCatalogTable,
-                                              partitionsSpec: Map[String, Option[String]],
-                                              isOverWritePartition: Boolean): Option[String] = {
-    if (isOverWritePartition) {
-      val staticPartitionValues = filterStaticPartitionValues(partitionsSpec)
-      val isStaticOverwritePartition = staticPartitionValues.keys.size == hoodieCatalogTable.partitionFields.length
-      if (isStaticOverwritePartition) {
-        Option.apply(makePartitionPath(hoodieCatalogTable, staticPartitionValues))
-      } else {
-        Option.empty
-      }
-    } else {
-      Option.empty
-    }
-  }
-
   /**
    * Align provided [[query]]'s output with the expected [[catalogTable]] schema by
    *

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -88,19 +88,11 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
           extraOptions: Map[String, String] = Map.empty): Boolean = {
     val catalogTable = new HoodieCatalogTable(sparkSession, table)
 
-    var mode = SaveMode.Append
-    var isOverWriteTable = false
-    var isOverWritePartition = false
-
-    if (overwrite) {
-      if (deduceIsOverwriteTable(sparkSession, catalogTable, partitionSpec, extraOptions)) {
-        isOverWriteTable = true
-        mode = SaveMode.Overwrite
-      } else {
-        isOverWritePartition = true
-      }
+    val (mode, isOverWriteTable, isOverWritePartition, staticOverwritePartitionPathOpt) = if (overwrite) {
+      deduceOverwriteConfig(sparkSession, catalogTable, partitionSpec, extraOptions)
+    } else {
+      (SaveMode.Append, false, false, Option.empty)
     }
-    val staticOverwritePartitionPathOpt = getStaticOverwritePartitionPath(catalogTable, partitionSpec, isOverWritePartition)
     val config = buildHoodieInsertConfig(catalogTable, sparkSession, isOverWritePartition, isOverWriteTable, partitionSpec, extraOptions, staticOverwritePartitionPathOpt)
 
     val alignedQuery = alignQueryOutput(query, catalogTable, partitionSpec, sparkSession.sessionState.conf)


### PR DESCRIPTION
### Change Logs

1. Refactor overwrite config deduce:
 Record matching static partitions for static insert_overwrite operation;
 Read replaced partition fileIds through write status for dynamic insert overwrite.
2. Reorder partition fields in hoodie table schema.
3. Add test cases for insert overwrite multiple partitioned table.

### Impact
Fix the issue that static insert overwrite not work for multiple partitioned table.

### Risk level (write none, low medium or high below)

low.

### Documentation Update
none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
