### PR TITLE
[HUDI-5973] Fixing refreshing of schemas in HoodieStreamer continuous mode

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -45,6 +45,11 @@ public class FilebasedSchemaProvider extends SchemaProvider {
 
   private final FileSystem fs;
 
+  private final String sourceFile;
+  private final String targetFile;
+  private final boolean shouldSanitize;
+  private final String invalidCharMask;
+
   protected Schema sourceSchema;
 
   protected Schema targetSchema;
@@ -52,16 +57,19 @@ public class FilebasedSchemaProvider extends SchemaProvider {
   public FilebasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
     super(props, jssc);
     checkRequiredConfigProperties(props, Collections.singletonList(FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE));
-    String sourceFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE);
-    boolean shouldSanitize = SanitizationUtils.shouldSanitize(props);
-    String invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
+    this.sourceFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE);
+    this.targetFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.TARGET_SCHEMA_FILE);
+    this.shouldSanitize = SanitizationUtils.shouldSanitize(props);
+    this.invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
-    this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
+    this.sourceSchema = parseSchema(this.sourceFile);
     if (containsConfigProperty(props, FilebasedSchemaProviderConfig.TARGET_SCHEMA_FILE)) {
-      this.targetSchema = readAvroSchemaFromFile(
-          getStringWithAltKeys(props, FilebasedSchemaProviderConfig.TARGET_SCHEMA_FILE),
-          this.fs, shouldSanitize, invalidCharMask);
+      this.targetSchema = parseSchema(this.targetFile);
     }
+  }
+
+  private Schema parseSchema(String schemaFile){
+    return readAvroSchemaFromFile(schemaFile, this.fs, shouldSanitize, invalidCharMask);
   }
 
   @Override
@@ -88,9 +96,10 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     return SanitizationUtils.parseAvroSchema(schemaStr, sanitizeSchema, invalidCharMask);
   }
 
-  // Per write batch, refresh the schema from the file
+  // Per write batch, refresh the schemas from the file
   @Override
   public void refresh() {
-    this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
+    this.sourceSchema = parseSchema(this.sourceFile);
+    this.targetSchema = parseSchema(this.targetFile);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -87,4 +87,10 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     }
     return SanitizationUtils.parseAvroSchema(schemaStr, sanitizeSchema, invalidCharMask);
   }
+
+  // Per write batch, refresh the schema from the file
+  @Override
+  public void refresh() {
+    this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -58,7 +58,7 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     super(props, jssc);
     checkRequiredConfigProperties(props, Collections.singletonList(FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE));
     this.sourceFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE);
-    this.targetFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.TARGET_SCHEMA_FILE);
+    this.targetFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.TARGET_SCHEMA_FILE, sourceFile);
     this.shouldSanitize = SanitizationUtils.shouldSanitize(props);
     this.invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
@@ -68,7 +68,7 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     }
   }
 
-  private Schema parseSchema(String schemaFile){
+  private Schema parseSchema(String schemaFile) {
     return readAvroSchemaFromFile(schemaFile, this.fs, shouldSanitize, invalidCharMask);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -59,7 +59,8 @@ public abstract class SchemaProvider implements Serializable {
     return getSourceSchema();
   }
 
-  public void clearCaches() {
-    cachedSchema = null;
+  //every schema provider has the ability to refresh itself, which will mean something different per provider.
+  public void refresh() {
+
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -39,6 +39,8 @@ public abstract class SchemaProvider implements Serializable {
 
   protected JavaSparkContext jssc;
 
+  protected Schema cachedSchema;
+
   public SchemaProvider(TypedProperties props) {
     this(props, null);
   }
@@ -55,5 +57,9 @@ public abstract class SchemaProvider implements Serializable {
   public Schema getTargetSchema() {
     // by default, use source schema as target for hoodie table as well
     return getSourceSchema();
+  }
+
+  public void clearCaches() {
+    cachedSchema = null;
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -39,8 +39,6 @@ public abstract class SchemaProvider implements Serializable {
 
   protected JavaSparkContext jssc;
 
-  protected Schema cachedSchema;
-
   public SchemaProvider(TypedProperties props) {
     this(props, null);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -82,6 +82,8 @@ public class SchemaRegistryProvider extends SchemaProvider {
     public static final String SSL_KEY_PASSWORD_PROP = "schema.registry.ssl.key.password";
   }
 
+  protected Schema cachedSchema;
+
   @FunctionalInterface
   public interface SchemaConverter {
     /**
@@ -219,5 +221,12 @@ public class SchemaRegistryProvider extends SchemaProvider {
           Config.TARGET_SCHEMA_REGISTRY_URL_PROP,
           StringUtils.truncate(targetRegistryUrl, 10, 10)), e);
     }
+  }
+  // Per SyncOnce call, the cachedschema for the provider is dropped and SourceSchema re-attained
+  // Subsequent calls to getSourceSchema within the write batch should be cached.
+  @Override
+  public void refresh() {
+    cachedSchema = null;
+    getSourceSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -88,7 +88,6 @@ public class SchemaRegistryProvider extends SchemaProvider {
   private final String srcSchemaRegistryUrl;
   private final String targetSchemaRegistryUrl;
 
-
   @FunctionalInterface
   public interface SchemaConverter {
     /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -82,7 +82,12 @@ public class SchemaRegistryProvider extends SchemaProvider {
     public static final String SSL_KEY_PASSWORD_PROP = "schema.registry.ssl.key.password";
   }
 
-  protected Schema cachedSchema;
+  protected Schema cachedSourceSchema;
+  protected Schema cachedTargetSchema;
+
+  private final String srcSchemaRegistryUrl;
+  private final String targetSchemaRegistryUrl;
+
 
   @FunctionalInterface
   public interface SchemaConverter {
@@ -162,6 +167,8 @@ public class SchemaRegistryProvider extends SchemaProvider {
   public SchemaRegistryProvider(TypedProperties props, JavaSparkContext jssc) {
     super(props, jssc);
     checkRequiredConfigProperties(props, Collections.singletonList(HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
+    this.srcSchemaRegistryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
+    this.targetSchemaRegistryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.TARGET_SCHEMA_REGISTRY_URL, srcSchemaRegistryUrl);
     if (config.containsKey(Config.SSL_KEYSTORE_LOCATION_PROP)
         || config.containsKey(Config.SSL_TRUSTSTORE_LOCATION_PROP)) {
       setUpSSLStores();
@@ -193,40 +200,42 @@ public class SchemaRegistryProvider extends SchemaProvider {
 
   @Override
   public Schema getSourceSchema() {
-    String registryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
     try {
-      if (cachedSchema == null) {
-        cachedSchema = parseSchemaFromRegistry(registryUrl);
+      if (cachedSourceSchema == null) {
+        cachedSourceSchema = parseSchemaFromRegistry(this.srcSchemaRegistryUrl);
       }
       return cachedSchema;
     } catch (Exception e) {
       throw new HoodieSchemaFetchException(String.format(
           "Error reading source schema from registry. Please check %s is configured correctly. Truncated URL: %s",
           Config.SRC_SCHEMA_REGISTRY_URL_PROP,
-          StringUtils.truncate(registryUrl, 10, 10)), e);
+          StringUtils.truncate(srcSchemaRegistryUrl, 10, 10)), e);
     }
   }
 
   @Override
   public Schema getTargetSchema() {
-    String registryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
-    String targetRegistryUrl =
-        getStringWithAltKeys(config, HoodieSchemaProviderConfig.TARGET_SCHEMA_REGISTRY_URL, registryUrl);
     try {
-      return parseSchemaFromRegistry(targetRegistryUrl);
+      if (cachedTargetSchema == null) {
+        cachedTargetSchema = parseSchemaFromRegistry(this.targetSchemaRegistryUrl);
+      }
+      return cachedTargetSchema;
     } catch (Exception e) {
       throw new HoodieSchemaFetchException(String.format(
           "Error reading target schema from registry. Please check %s is configured correctly. If that is not configured then check %s. Truncated URL: %s",
           Config.SRC_SCHEMA_REGISTRY_URL_PROP,
           Config.TARGET_SCHEMA_REGISTRY_URL_PROP,
-          StringUtils.truncate(targetRegistryUrl, 10, 10)), e);
+          StringUtils.truncate(targetSchemaRegistryUrl, 10, 10)), e);
     }
   }
+
   // Per SyncOnce call, the cachedschema for the provider is dropped and SourceSchema re-attained
   // Subsequent calls to getSourceSchema within the write batch should be cached.
   @Override
   public void refresh() {
-    cachedSchema = null;
+    cachedSourceSchema = null;
+    cachedTargetSchema = null;
     getSourceSchema();
+    getTargetSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -193,7 +193,10 @@ public class SchemaRegistryProvider extends SchemaProvider {
   public Schema getSourceSchema() {
     String registryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
     try {
-      return parseSchemaFromRegistry(registryUrl);
+      if (cachedSchema == null) {
+        cachedSchema = parseSchemaFromRegistry(registryUrl);
+      }
+      return cachedSchema;
     } catch (Exception e) {
       throw new HoodieSchemaFetchException(String.format(
           "Error reading source schema from registry. Please check %s is configured correctly. Truncated URL: %s",

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -203,7 +203,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
       if (cachedSourceSchema == null) {
         cachedSourceSchema = parseSchemaFromRegistry(this.srcSchemaRegistryUrl);
       }
-      return cachedSchema;
+      return cachedSourceSchema;
     } catch (Exception e) {
       throw new HoodieSchemaFetchException(String.format(
           "Error reading source schema from registry. Please check %s is configured correctly. Truncated URL: %s",

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -59,7 +59,6 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
 
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
-    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -59,6 +59,10 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
 
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
+    
+    //Clear any cached Schemas if using a SchemaProvider, currently only SchemaRegistryProvider.
+    this.schemaProvider.clearCaches();
+    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -60,9 +60,6 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
     
-    //Clear any cached Schemas if using a SchemaProvider, currently only SchemaRegistryProvider.
-    this.schemaProvider.clearCaches();
-    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -450,7 +450,8 @@ public class StreamSync implements Serializable, Closeable {
 
       result = writeToSinkAndDoMetaSync(instantTime, inputBatch, metrics, overallTimerContext);
     }
-
+    // refresh schemas if need be before next batch
+    schemaProvider.refresh();
     metrics.updateStreamerSyncMetrics(System.currentTimeMillis());
     return result;
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -451,7 +451,9 @@ public class StreamSync implements Serializable, Closeable {
       result = writeToSinkAndDoMetaSync(instantTime, inputBatch, metrics, overallTimerContext);
     }
     // refresh schemas if need be before next batch
-    schemaProvider.refresh();
+    if (schemaProvider != null) {
+      schemaProvider.refresh();
+    }
     metrics.updateStreamerSyncMetrics(System.currentTimeMillis());
     return result;
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -145,7 +145,7 @@ class TestSchemaRegistryProvider {
     assertNotNull(actual);
     verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
 
-    assert spyUnderTest.cachedSchema != null;
+    assert spyUnderTest.cachedSourceSchema != null;
 
     Schema actualTwo = spyUnderTest.getSourceSchema();
     

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -133,4 +133,24 @@ class TestSchemaRegistryProvider {
           .toString();
     }
   }
+
+  // The SR is checked when cachedSchema is empty, when not empty, the cachedSchema is used.
+  @Test
+  public void testGetSourceSchemaUsesCachedSchema() throws IOException {
+    TypedProperties props = getProps();
+    SchemaRegistryProvider spyUnderTest = getUnderTest(props);
+
+    // Call when cachedSchema is empty
+    Schema actual = spyUnderTest.getSourceSchema();
+    assertNotNull(actual);
+    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+
+    assert spyUnderTest.cachedSchema != null;
+
+    Schema actualTwo = spyUnderTest.getSourceSchema();
+    
+    // cachedSchema should now be set, a subsequent call should not call parseSchemaFromRegistry
+    // Assuming this verify() has the scope of the whole test? so it should still be 1 from previous call?
+    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+  }
 }


### PR DESCRIPTION
### Change Logs

Fixing refreshing of schemas in HoodieStreamer continuous mode.

### Impact

Fixing refreshing of schemas in HoodieStreamer continuous mode. 
With FileBased schema provide one has to shutdown and restart deltstreamer if schema is changed. So we are fixing this as part of this patch. 
Wrt Schema registry based schema provider, everytime we call getSourceSchema, we make remote calls and fetch real time schema. If a pipeline has N transformers, chances are that each transformer could be operating w/ a diff schema. So, with caching and explicit refresh calls, we are ensuring for an entire write, only one source and target schema will be in play. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
