### PR TITLE
[MINOR] Fix functional index for nonpartitioned table

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -84,13 +84,13 @@ public class SparkMetadataWriterUtils {
       HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
       String filename = baseFile.getFileName();
       long fileSize = baseFile.getFileSize();
-      Path baseFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      Path baseFilePath = filePath(basePath, partition, filename);
       buildColumnRangeMetadata(metaClient, readerSchema, functionalIndex, columnToIndex, sqlContext, columnRangeMetadataList, fileSize, baseFilePath);
     }
     // Handle log files
     fileSlice.getLogFiles().forEach(logFile -> {
       String fileName = logFile.getFileName();
-      Path logFilePath = new Path(basePath, partition + Path.SEPARATOR + fileName);
+      Path logFilePath = filePath(basePath, partition, fileName);
       long fileSize = logFile.getFileSize();
       buildColumnRangeMetadata(metaClient, readerSchema, functionalIndex, columnToIndex, sqlContext, columnRangeMetadataList, fileSize, logFilePath);
     });
@@ -113,7 +113,7 @@ public class SparkMetadataWriterUtils {
     if (fileSlice.getBaseFile().isPresent()) {
       HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
       String filename = baseFile.getFileName();
-      Path baseFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      Path baseFilePath = filePath(basePath, partition, filename);
       buildBloomFilterMetadata(
           metaClient,
           readerSchema,
@@ -129,7 +129,7 @@ public class SparkMetadataWriterUtils {
     // Handle log files
     fileSlice.getLogFiles().forEach(logFile -> {
       String fileName = logFile.getFileName();
-      Path logFilePath = new Path(basePath, partition + Path.SEPARATOR + fileName);
+      Path logFilePath = filePath(basePath, partition, fileName);
       buildBloomFilterMetadata(
           metaClient,
           readerSchema,
@@ -238,5 +238,13 @@ public class SparkMetadataWriterUtils {
         Arrays.stream(df.columns())
             .filter(c -> !HOODIE_META_COLUMNS.contains(c))
             .map(df::col).toArray(Column[]::new));
+  }
+
+  private static Path filePath(String basePath, String partition, String filename) {
+    if (partition.isEmpty()) {
+      return new Path(basePath, filename);
+    } else {
+      return new Path(basePath, partition + Path.SEPARATOR + filename);
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1761,7 +1761,7 @@ public class HoodieTableMetadataUtil {
       final String partition = partitionAndBaseFile.getKey();
       final HoodieBaseFile baseFile = partitionAndBaseFile.getValue();
       final String filename = baseFile.getFileName();
-      Path dataFilePath = new Path(basePath, StringUtils.isNullOrEmpty(partition) ? filename : (partition + Path.SEPARATOR) + filename);
+      Path dataFilePath = filePath(basePath, partition, filename);
 
       final String fileId = baseFile.getFileId();
       final String instantTime = baseFile.getCommitTime();
@@ -1854,7 +1854,7 @@ public class HoodieTableMetadataUtil {
       }
       final HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
       final String filename = baseFile.getFileName();
-      Path dataFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      Path dataFilePath = filePath(basePath, partition, filename);
 
       final String fileId = baseFile.getFileId();
       final String instantTime = baseFile.getCommitTime();
@@ -1886,5 +1886,13 @@ public class HoodieTableMetadataUtil {
     TableSchemaResolver schemaResolver = new TableSchemaResolver(metaClient);
     Schema tableSchema = schemaResolver.getTableAvroSchema();
     return HoodieAvroUtils.getSchemaForFields(tableSchema, indexDefinition.getSourceFields());
+  }
+
+  private static Path filePath(String basePath, String partition, String filename) {
+    if (partition.isEmpty()) {
+      return new Path(basePath, filename);
+    } else {
+      return new Path(basePath, partition + Path.SEPARATOR + filename);
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

functional index doesn't work with unpartitioned table due to usage `new Path(basePath, partition + Path.SEPARATOR + filename);` with empty `partition` string

### Impact

-

### Risk level (write none, low medium or high below)

-

### Documentation Update

-

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
