### PR TITLE
[HUDI-7144] Infer partition logically and use index to prune

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -387,6 +387,12 @@ public class HoodieIndexUtils {
     }
   }
 
+  /**
+   * Get the partition name from the metadata partition type.
+   * NOTE: For certain types of metadata partition, such as functional index and secondary index,
+   * partition path defined enum is just the prefix to denote the type of metadata partition.
+   * The actual partition name is contained in the index definition.
+   */
   public static String getPartitionNameFromPartitionType(MetadataPartitionType partitionType, HoodieTableMetaClient metaClient, String indexName) {
     if (MetadataPartitionType.FUNCTIONAL_INDEX.equals(partitionType)) {
       checkArgument(metaClient.getFunctionalIndexMetadata().isPresent(), "Index definition is not present");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -34,18 +34,19 @@ import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.MetadataValues;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
-import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.io.HoodieMergedReadHandle;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.Schema;
@@ -64,6 +65,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.table.action.commit.HoodieDeleteHelper.createDeleteRecord;
 
 /**
@@ -177,7 +179,7 @@ public class HoodieIndexUtils {
    */
   public static List<Pair<String, Long>> filterKeysFromFile(Path filePath, List<String> candidateRecordKeys,
                                                             Configuration configuration) throws HoodieIndexException {
-    ValidationUtils.checkArgument(FSUtils.isBaseFile(filePath));
+    checkArgument(FSUtils.isBaseFile(filePath));
     List<Pair<String, Long>> foundRecordKeys = new ArrayList<>();
     try (HoodieFileReader fileReader = HoodieFileReaderFactory.getReaderFactory(HoodieRecordType.AVRO)
         .getFileReader(configuration, filePath)) {
@@ -383,5 +385,13 @@ public class HoodieIndexUtils {
       default:
         throw new HoodieIndexException("Unsupported record type: " + recordType);
     }
+  }
+
+  public static String getPartitionNameFromPartitionType(MetadataPartitionType partitionType, HoodieTableMetaClient metaClient, String indexName) {
+    if (MetadataPartitionType.FUNCTIONAL_INDEX.equals(partitionType)) {
+      checkArgument(metaClient.getFunctionalIndexMetadata().isPresent(), "Index definition is not present");
+      return metaClient.getFunctionalIndexMetadata().get().getIndexDefinitions().get(indexName).getIndexName();
+    }
+    return partitionType.getPartitionPath();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
@@ -96,10 +96,13 @@ public class HoodieCreateHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     this.path = makeNewPath(partitionPath);
 
     try {
-      HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(fs, instantTime,
-          new Path(config.getBasePath()), FSUtils.getPartitionPath(config.getBasePath(), partitionPath),
-          hoodieTable.getPartitionMetafileFormat());
-      partitionMetadata.trySave(getPartitionId());
+      // If logical partitioning is enabled, we need not save partition metadata
+      if (!hoodieTable.getMetaClient().getTableConfig().isLogicalPartitioningEnabled()) {
+        HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(fs, instantTime,
+            new Path(config.getBasePath()), FSUtils.getPartitionPath(config.getBasePath(), partitionPath),
+            hoodieTable.getPartitionMetafileFormat());
+        partitionMetadata.trySave(getPartitionId());
+      }
       createMarkerFile(partitionPath, FSUtils.makeBaseFileName(this.instantTime, this.writeToken, this.fileId, hoodieTable.getBaseFileExtension()));
       this.fileWriter = HoodieFileWriterFactory.getFileWriter(instantTime, path, hoodieTable.getHadoopConf(), config,
         writeSchemaWithMetaFields, this.taskContextSupplier, config.getRecordMerger().getRecordType());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/TestHoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/TestHoodieIndexUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index;
+
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
+import org.apache.hudi.common.model.HoodieFunctionalIndexMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.MetadataPartitionType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestHoodieIndexUtils {
+
+  @Test
+  public void testGetFunctionalIndexPath() {
+    MetadataPartitionType partitionType = MetadataPartitionType.FUNCTIONAL_INDEX;
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    String indexName = "testIndex";
+
+    Map<String, HoodieFunctionalIndexDefinition> indexDefinitions = new HashMap<>();
+    indexDefinitions.put(
+        indexName,
+        new HoodieFunctionalIndexDefinition("func_index_testIndex", "column_stats", "lower", Collections.singletonList("name"), null));
+    HoodieFunctionalIndexMetadata indexMetadata = new HoodieFunctionalIndexMetadata(indexDefinitions);
+    when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.of(indexMetadata));
+
+    String result = HoodieIndexUtils.getPartitionNameFromPartitionType(partitionType, metaClient, indexName);
+    assertEquals("func_index_testIndex", result);
+  }
+
+  @Test
+  public void testGetNonFunctionalIndexPath() {
+    MetadataPartitionType partitionType = MetadataPartitionType.COLUMN_STATS;
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    String result = HoodieIndexUtils.getPartitionNameFromPartitionType(partitionType, metaClient, null);
+    assertEquals(partitionType.getPartitionPath(), result);
+  }
+
+  @Test
+  public void testExceptionForMissingFunctionalIndexMetadata() {
+    MetadataPartitionType partitionType = MetadataPartitionType.FUNCTIONAL_INDEX;
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.empty());
+
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieIndexUtils.getPartitionNameFromPartitionType(partitionType, metaClient, "testIndex"));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -298,6 +298,12 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Absolute path where the index definitions are stored");
 
+  public static final ConfigProperty<Boolean> LOGICAL_PARTITIONING_ENABLE = ConfigProperty
+      .key("hoodie.table.logical.partitioning.enable")
+      .defaultValue(false)
+      .sinceVersion("1.0.0")
+      .withDocumentation("When set to true, the tables need not be physically partitioned. Index will be used to prune the partitions.");
+
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
   public HoodieTableConfig(FileSystem fs, String metaPath, String payloadClassName, String recordMergerStrategyId) {
@@ -468,6 +474,7 @@ public class HoodieTableConfig extends HoodieConfig {
         HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getString(TIMELINE_TIMEZONE)));
       }
       hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS);
+      hoodieConfig.setDefaultValue(LOGICAL_PARTITIONING_ENABLE);
 
       storeProperties(hoodieConfig.getProps(), outputStream);
     }
@@ -695,6 +702,10 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public Boolean shouldDropPartitionColumns() {
     return getBooleanOrDefault(DROP_PARTITION_COLUMNS);
+  }
+
+  public Boolean isLogicalPartitioningEnabled() {
+    return getBooleanOrDefault(LOGICAL_PARTITIONING_ENABLE);
   }
 
   public boolean isMultipleBaseFileFormatsEnabled() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -945,8 +945,8 @@ public class HoodieTableMetaClient implements Serializable {
     private String inflightMetadataPartitions;
     private String secondaryIndexesMetadata;
     private Boolean multipleBaseFileFormatsEnabled;
-
     private String indexDefinitionPath;
+    private Boolean isLogicalPartitioningEnabled;
 
     /**
      * Persist the configs that is written at the first time, and should not be changed.
@@ -1121,6 +1121,11 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
+    public PropertyBuilder setIsLogicalPartitioningEnabled(Boolean isLogicalPartitioningEnabled) {
+      this.isLogicalPartitioningEnabled = isLogicalPartitioningEnabled;
+      return this;
+    }
+
     public PropertyBuilder set(Map<String, Object> props) {
       for (ConfigProperty<String> configProperty : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
         if (containsConfigProperty(props, configProperty)) {
@@ -1251,6 +1256,9 @@ public class HoodieTableMetaClient implements Serializable {
       if (hoodieConfig.contains(HoodieTableConfig.INDEX_DEFINITION_PATH)) {
         setIndexDefinitionPath(hoodieConfig.getString(HoodieTableConfig.INDEX_DEFINITION_PATH));
       }
+      if (hoodieConfig.contains(HoodieTableConfig.LOGICAL_PARTITIONING_ENABLE)) {
+        setShouldDropPartitionColumns(hoodieConfig.getBoolean(HoodieTableConfig.LOGICAL_PARTITIONING_ENABLE));
+      }
       return this;
     }
 
@@ -1364,6 +1372,9 @@ public class HoodieTableMetaClient implements Serializable {
       }
       if (null != indexDefinitionPath) {
         tableConfig.setValue(HoodieTableConfig.INDEX_DEFINITION_PATH, indexDefinitionPath);
+      }
+      if (null != isLogicalPartitioningEnabled) {
+        tableConfig.setValue(HoodieTableConfig.LOGICAL_PARTITIONING_ENABLE, Boolean.toString(isLogicalPartitioningEnabled));
       }
       return tableConfig.getProps();
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -647,6 +647,8 @@ object DataSourceWriteOptions {
     .withDocumentation("Controls whether overwrite use dynamic or static mode, if not configured, " +
       "respect spark.sql.sources.partitionOverwriteMode")
 
+  val LOGICAL_PARTITION_ENABLE: ConfigProperty[java.lang.Boolean] = HoodieTableConfig.LOGICAL_PARTITIONING_ENABLE
+
   /** @deprecated Use {@link HIVE_USE_PRE_APACHE_INPUT_FORMAT} and its methods instead */
   @Deprecated
   val HIVE_USE_PRE_APACHE_INPUT_FORMAT_OPT_KEY = HiveSyncConfigHolder.HIVE_USE_PRE_APACHE_INPUT_FORMAT.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hudi.AutoRecordKeyGenerationUtils.mayBeValidateParamsForAutoGenerationOfRecordKeys
 import org.apache.hudi.AvroConversionUtils.{convertAvroSchemaToStructType, convertStructTypeToAvroSchema, getAvroRecordNameAndNamespace}
-import org.apache.hudi.DataSourceOptionsHelper.fetchMissingWriteConfigsFromTableConfig
+import org.apache.hudi.DataSourceOptionsHelper.{fetchMissingWriteConfigsFromTableConfig, mayBeDerivePartitionPath}
 import org.apache.hudi.DataSourceUtils.tryOverrideParquetWriteLegacyFormatProperty
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.{toProperties, toScalaOption}
@@ -32,7 +32,6 @@ import org.apache.hudi.HoodieWriterUtils._
 import org.apache.hudi.avro.AvroSchemaUtils.resolveNullableSchema
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.client.common.HoodieSparkEngineContext
-import org.apache.hudi.client.embedded.EmbeddedTimelineService
 import org.apache.hudi.client.{HoodieWriteResult, SparkRDDWriteClient}
 import org.apache.hudi.commit.{DatasetBulkInsertCommitActionExecutor, DatasetBulkInsertOverwriteCommitActionExecutor, DatasetBulkInsertOverwriteTableCommitActionExecutor}
 import org.apache.hudi.common.config._
@@ -56,7 +55,6 @@ import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter
 import org.apache.hudi.internal.schema.utils.SerDeHelper
 import org.apache.hudi.keygen.constant.KeyGeneratorType
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
-import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory.getKeyGeneratorClassName
 import org.apache.hudi.keygen.{BaseKeyGenerator, TimestampBasedAvroKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.metrics.Metrics
 import org.apache.hudi.sync.common.HoodieSyncConfig
@@ -1054,8 +1052,8 @@ class HoodieSparkSqlWriterInternal {
   private def mergeParamsAndGetHoodieConfig(optParams: Map[String, String],
                                             tableConfig: HoodieTableConfig, mode: SaveMode,
                                             isStreamingWrite: Boolean): (Map[String, String], HoodieConfig) = {
-    val translatedOptions = DataSourceWriteOptions.mayBeDerivePartitionPath(optParams)
-    var translatedOptsWithMappedTableConfig = mutable.Map.empty ++ translatedOptions.toMap
+    val translatedOptions = mayBeDerivePartitionPath(optParams)
+    var translatedOptsWithMappedTableConfig = mutable.Map.empty ++ translatedOptions
     if (tableConfig != null && mode != SaveMode.Overwrite) {
       // for missing write configs corresponding to table configs, fill them up.
       fetchMissingWriteConfigsFromTableConfig(tableConfig, optParams).foreach((kv) => translatedOptsWithMappedTableConfig += (kv._1 -> kv._2))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -86,6 +86,7 @@ object HoodieWriterUtils {
     hoodieConfig.setDefaultValue(MAKE_NEW_COLUMNS_NULLABLE)
     hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS)
     hoodieConfig.setDefaultValue(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED)
+    hoodieConfig.setDefaultValue(LOGICAL_PARTITION_ENABLE)
     Map() ++ hoodieConfig.getProps.asScala ++ globalProps ++ DataSourceOptionsHelper.translateConfigurations(parameters)
   }
 

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -400,6 +400,14 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hive-sync</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -22,12 +22,12 @@ package org.apache.spark.sql.hudi.command.index
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.Option
 import org.apache.hudi.hive.HiveSyncConfigHolder._
-import org.apache.hudi.hive.{HiveSyncTool, SlashEncodedDayPartitionValueExtractor}
+import org.apache.hudi.hive.HiveSyncTool
 import org.apache.hudi.hive.testutils.HiveTestUtil
-import org.apache.hudi.hive.testutils.HiveTestUtil.{hiveSyncProps, hiveTestService}
-import org.apache.hudi.sync.common.HoodieSyncConfig.{META_SYNC_BASE_PATH, META_SYNC_DATABASE_NAME, META_SYNC_PARTITION_EXTRACTOR_CLASS, META_SYNC_TABLE_NAME}
+import org.apache.hudi.sync.common.HoodieSyncConfig.{META_SYNC_BASE_PATH, META_SYNC_DATABASE_NAME, META_SYNC_TABLE_NAME}
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.parser.ParserInterface
@@ -148,7 +148,10 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
   }
 
   test("Test Functional Index With Hive Sync Non Partitioned Table") {
-    if (HoodieSparkUtils.gteqSpark3_2) {
+    // There is a big difference between Java class loader architecture of versions 1.8 and 17.
+    // Hive 2.3.7 is compiled with Java 1.8, and the class loader used there throws error when Hive APIs are run on Java 17.
+    // So we special case this test only for Java 8.
+    if (HoodieSparkUtils.gteqSpark3_2 && HoodieTestUtils.getJavaVersion == 8) {
       withTempDir { tmp =>
         Seq("mor").foreach { tableType =>
           val databaseName = "default"

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -19,6 +19,10 @@
 package org.apache.spark.sql.hudi.catalog
 
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.view.FileSystemViewManager
 import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.sql.InsertMode
@@ -34,6 +38,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.hudi.analysis.HoodieSpark32PlusAnalysis.HoodieV1OrV2Table
+import org.apache.spark.sql.hudi.catalog.HoodieCatalog.buildPartitionTransforms
 import org.apache.spark.sql.hudi.command._
 import org.apache.spark.sql.hudi.{HoodieSqlCommonUtils, ProvidesHoodieConfig}
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -41,7 +46,7 @@ import org.apache.spark.sql.{Dataset, SaveMode, SparkSession, _}
 
 import java.net.URI
 import java.util
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter}
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 class HoodieCatalog extends DelegatingCatalogExtension
@@ -54,7 +59,8 @@ class HoodieCatalog extends DelegatingCatalogExtension
   override def stageCreate(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): StagedTable = {
     if (sparkAdapter.isHoodieTable(properties)) {
       val locUriAndTableType = deduceTableLocationURIAndTableType(ident, properties)
-      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitions,
+      val partitionTransforms = if (partitions.isEmpty) buildPartitionTransforms(spark, locUriAndTableType._1.getPath) else partitions
+      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitionTransforms,
         properties, TableCreationMode.STAGE_CREATE)
     } else {
       BasicStagedTable(
@@ -67,7 +73,8 @@ class HoodieCatalog extends DelegatingCatalogExtension
   override def stageReplace(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): StagedTable = {
     if (sparkAdapter.isHoodieTable(properties)) {
       val locUriAndTableType = deduceTableLocationURIAndTableType(ident, properties)
-      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitions,
+      val partitionTransforms = if (partitions.isEmpty) buildPartitionTransforms(spark, locUriAndTableType._1.getPath) else partitions
+      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitionTransforms,
         properties, TableCreationMode.STAGE_REPLACE)
     } else {
       super.dropTable(ident)
@@ -84,7 +91,8 @@ class HoodieCatalog extends DelegatingCatalogExtension
                                     properties: util.Map[String, String]): StagedTable = {
     if (sparkAdapter.isHoodieTable(properties)) {
       val locUriAndTableType = deduceTableLocationURIAndTableType(ident, properties)
-      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitions,
+      val partitionTransforms = if (partitions.isEmpty) buildPartitionTransforms(spark, locUriAndTableType._1.getPath) else partitions
+      HoodieStagedTable(ident, locUriAndTableType, this, schema, partitionTransforms,
         properties, TableCreationMode.CREATE_OR_REPLACE)
     } else {
       try super.dropTable(ident) catch {
@@ -140,7 +148,8 @@ class HoodieCatalog extends DelegatingCatalogExtension
                            properties: util.Map[String, String]): Table = {
     if (sparkAdapter.isHoodieTable(properties)) {
       val locUriAndTableType = deduceTableLocationURIAndTableType(ident, properties)
-      createHoodieTable(ident, schema, locUriAndTableType, partitions, properties,
+      val partitionTransforms = if (partitions.isEmpty) buildPartitionTransforms(spark, locUriAndTableType._1.getPath) else partitions
+      createHoodieTable(ident, schema, locUriAndTableType, partitionTransforms, properties,
         Map.empty, Option.empty, TableCreationMode.CREATE)
     } else {
       super.createTable(ident, schema, partitions, properties)
@@ -368,5 +377,29 @@ object HoodieCatalog {
     }
 
     (identityCols, bucketSpec)
+  }
+
+  def buildPartitionTransforms(spark: SparkSession,
+                               basePath: String): Array[Transform] = {
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(spark.sessionState.newHadoopConf())
+      .setBasePath(basePath)
+      .build()
+    val metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build()
+    val metadataFileSystemView = FileSystemViewManager.createInMemoryFileSystemView(
+      new HoodieSparkEngineContext(spark.sparkContext), metaClient, metadataConfig)
+    val partitions: List[Path] = metadataFileSystemView.getPartitionPaths.asScala.toList
+    val transforms = mutable.Set[Transform]()
+    partitions.foreach { path =>
+      path.toString.split("/").foreach { part =>
+        // TODO: make it work for non-hive style partitioning
+        part.split("=") match {
+          case Array(key, value) =>
+            transforms += new IdentityTransform(new FieldReference(Seq(key)))
+          case _ => // Not a partition path part
+        }
+      }
+    }
+    transforms.toArray
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -191,7 +191,7 @@ public class TestHiveSyncTool {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp();
+    HiveTestUtil.setUp(Option.empty());
   }
 
   @AfterEach

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -191,7 +191,7 @@ public class TestHiveSyncTool {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp(Option.empty());
+    HiveTestUtil.setUp(Option.empty(), true);
   }
 
   @AfterEach

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -132,7 +132,7 @@ public class HiveTestUtil {
   private static DateTimeFormatter dtfOut;
   private static Set<String> createdTablesSet = new HashSet<>();
 
-  public static void setUp() throws IOException, InterruptedException, HiveException, MetaException {
+  public static void setUp(Option<TypedProperties> hiveSyncProperties) throws IOException, InterruptedException, HiveException, MetaException {
     configuration = new Configuration();
     if (zkServer == null) {
       zkService = new ZookeeperTestService(configuration);
@@ -143,20 +143,24 @@ public class HiveTestUtil {
       hiveServer = hiveTestService.start();
     }
 
-    basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
+    if (hiveSyncProperties.isPresent()) {
+      hiveSyncProps = hiveSyncProperties.get();
+      basePath = Files.createTempDirectory(hiveSyncProps.getProperty(META_SYNC_BASE_PATH.key())).toUri().toString();
+    } else {
+      basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
 
-    hiveSyncProps = new TypedProperties();
-    hiveSyncProps.setProperty(HIVE_URL.key(), hiveTestService.getJdbcHive2Url());
-    hiveSyncProps.setProperty(HIVE_USER.key(), "");
-    hiveSyncProps.setProperty(HIVE_PASS.key(), "");
-    hiveSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), DB_NAME);
-    hiveSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), TABLE_NAME);
-    hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
-    hiveSyncProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key(), "false");
-    hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
-    hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
-    hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
-
+      hiveSyncProps = new TypedProperties();
+      hiveSyncProps.setProperty(HIVE_URL.key(), hiveTestService.getJdbcHive2Url());
+      hiveSyncProps.setProperty(HIVE_USER.key(), "");
+      hiveSyncProps.setProperty(HIVE_PASS.key(), "");
+      hiveSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), DB_NAME);
+      hiveSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), TABLE_NAME);
+      hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
+      hiveSyncProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key(), "false");
+      hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
+      hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
+      hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
+    }
     hiveSyncConfig = new HiveSyncConfig(hiveSyncProps, hiveTestService.getHiveConf());
     fileSystem = hiveSyncConfig.getHadoopFileSystem();
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -132,7 +132,7 @@ public class HiveTestUtil {
   private static DateTimeFormatter dtfOut;
   private static Set<String> createdTablesSet = new HashSet<>();
 
-  public static void setUp(Option<TypedProperties> hiveSyncProperties) throws IOException, InterruptedException, HiveException, MetaException {
+  public static void setUp(Option<TypedProperties> hiveSyncProperties, boolean shouldClearBasePathAndTables) throws IOException, InterruptedException, HiveException, MetaException {
     configuration = new Configuration();
     if (zkServer == null) {
       zkService = new ZookeeperTestService(configuration);
@@ -145,7 +145,8 @@ public class HiveTestUtil {
 
     if (hiveSyncProperties.isPresent()) {
       hiveSyncProps = hiveSyncProperties.get();
-      basePath = Files.createTempDirectory(hiveSyncProps.getProperty(META_SYNC_BASE_PATH.key())).toUri().toString();
+      hiveSyncProps.setProperty(HIVE_URL.key(), hiveTestService.getJdbcHive2Url());
+      basePath = hiveSyncProps.getProperty(META_SYNC_BASE_PATH.key());
     } else {
       basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
 
@@ -167,7 +168,9 @@ public class HiveTestUtil {
     dtfOut = DateTimeFormatter.ofPattern("yyyy/MM/dd");
     ddlExecutor = new HiveQueryDDLExecutor(hiveSyncConfig, IMetaStoreClientUtil.getMSC(hiveSyncConfig.getHiveConf()));
 
-    clear();
+    if (shouldClearBasePathAndTables) {
+      clear();
+    }
   }
 
   public static void clear() throws IOException, HiveException, MetaException {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HiveSyncTool;
 import org.apache.hudi.hive.HoodieHiveSyncClient;
@@ -64,7 +65,7 @@ public class TestHiveIncrementalPuller {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp();
+    HiveTestUtil.setUp(Option.empty());
   }
 
   @AfterEach

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -65,7 +65,7 @@ public class TestHiveIncrementalPuller {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp(Option.empty());
+    HiveTestUtil.setUp(Option.empty(), true);
   }
 
   @AfterEach


### PR DESCRIPTION
### Change Logs

Supports logical partitioning.

* When using `spark.write.partitionBy(partitionCol).format("hudi").options(...).save(basePath)`, write as a non-partitioned table.
* Use index to prune the partitions.
* Introduced a new table config and data source write options for the behavior change. It is false by default. We should turn it on by default in a future release.

### Impact

Usability and storage.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
