### PR TITLE
[HUDI-7200] Fix bugs of Avro record merger for event time merging

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.testutils.MetadataMergeWriteStatus;
@@ -158,6 +159,7 @@ public class HoodieWriterClientTestHarness extends HoodieCommonTestHarness {
         .withStorageConfig(HoodieStorageConfig.newBuilder().hfileMaxFileSize(1024 * 1024).parquetMaxFileSize(1024 * 1024).orcMaxFileSize(1024 * 1024).build())
         .forTable(RAW_TRIPS_TEST_NAME)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType).build())
+        .withPayloadConfig(HoodiePayloadConfig.newBuilder().withPayloadOrderingField("timestamp").build())
         .withEmbeddedTimelineServerEnabled(true).withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withEnableBackupForRemoteFileSystemView(false) // Fail test if problem connecting to timeline-server
             .withRemoteServerPort(timelineServicePort)

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
@@ -59,6 +59,13 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger, OperationMode
       return Option.empty();
     }
 
+    if (newer.isDelete(schema, props)) {
+      if (newer.getOrderingValue(schema, props).compareTo(older.getOrderingValue(schema, props)) >= 0) {
+        return Option.empty();
+      }
+      return previousAvroData;
+    }
+
     return ((HoodieAvroRecord) newer).getData().combineAndGetUpdateValue(previousAvroData.get(), schema, props);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
@@ -137,6 +137,6 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
   @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
   default Comparable<?> getOrderingValue() {
     // default natural order
-    return 0;
+    return 0L;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -164,7 +164,8 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
       HoodieRecord<T> combinedRecord = combinedRecordAndSchema.getLeft();
 
       // If pre-combine returns existing record, no need to update it
-      if (combinedRecord.getData() != existingRecordMetadataPair.getLeft().get()) {
+      if ((!existingRecordMetadataPair.getLeft().isPresent())
+          || combinedRecord.getData() != existingRecordMetadataPair.getLeft().get()) {
         return Option.of(Pair.of(
             combinedRecord.getData(),
             enablePartialMerging


### PR DESCRIPTION
### Change Logs

Support operation patterns like insert/delete/update. In more details,

Assume we have a record R in base file; we do two operations after the initial insert: delete and then update or insert.
For MOR table, when we merge these updates, we will merge a delete record and insert/update record.

Since delete happens before update/insert, we have to compare their ordering field if we want to support event time merging.

### Impact

Fix the broken logic.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
