### PR TITLE
[HUDI-7201] Schema Evolution: use target schema if source is empty

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
@@ -140,8 +140,12 @@ public class AvroSchemaEvolutionUtils {
    * @return schema (based off {@code source} one) that has nullability constraints and datatypes reconciled
    */
   public static Schema reconcileSchemaRequirements(Schema sourceSchema, Schema targetSchema, Map<String, String> opts) {
-    if (sourceSchema.getType() == Schema.Type.NULL || sourceSchema.getFields().isEmpty() || targetSchema.getFields().isEmpty()) {
+    if (targetSchema.getFields().isEmpty()) {
       return sourceSchema;
+    }
+
+    if (sourceSchema.getType() == Schema.Type.NULL || sourceSchema.getFields().isEmpty()) {
+      return targetSchema;
     }
 
     InternalSchema sourceInternalSchema = convert(sourceSchema);

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
@@ -140,7 +140,7 @@ public class AvroSchemaEvolutionUtils {
    * @return schema (based off {@code source} one) that has nullability constraints and datatypes reconciled
    */
   public static Schema reconcileSchemaRequirements(Schema sourceSchema, Schema targetSchema, Map<String, String> opts) {
-    if (targetSchema.getFields().isEmpty()) {
+    if (targetSchema.getType() == Schema.Type.NULL || targetSchema.getFields().isEmpty()) {
       return sourceSchema;
     }
 


### PR DESCRIPTION
### Change Logs

If the incoming df is empty, the commit schema will be empty. Now, it will be the current table schema.

### Impact

Currently if a user does an empty commit, we won't be able to detect invalid schema evolution in the next commit

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
