### PR TITLE
[HUDI-7206] Fixing auto deletion of mdt

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -1014,8 +1014,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     // Only execute metadata table deletion when all the following conditions are met
     // (1) This is data table
     // (2) Metadata table is disabled in HoodieWriteConfig for the writer
+    // (3) if mdt is already enabled.
     return !metaClient.isMetadataTable()
-        && !config.isMetadataTableEnabled();
+        && !config.isMetadataTableEnabled()
+        && !metaClient.getTableConfig().getMetadataPartitions().isEmpty();
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Fixing auto deletion of metadata table. Due to a bug, we are triggering deletion of mdt and updating hoodie.properties even if its already disabled and not present. Fixing it to trigger deletion only if its already enabled and new write config disables metadata table. There is no correctness issue, but a sub optimal code. 

### Impact

Fixing auto deletion of metadata table.

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
