### PR TITLE
[HUDI-7209] Add configuration to skip not exists file in streaming read

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -329,6 +329,12 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Whether to skip clustering instants to avoid reading base files of clustering operations for streaming read "
           + "to improve read performance.");
 
+  public static final ConfigOption<Boolean> READ_STREAMING_SKIP_NOT_EXIST_FILE = ConfigOptions
+          .key("read.streaming.skip_not_exist_file")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to skip not exist file when read streaming");
+
   public static final String START_COMMIT_EARLIEST = "earliest";
   public static final ConfigOption<String> READ_START_COMMIT = ConfigOptions
       .key("read.start-commit")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
@@ -84,30 +84,11 @@ public class WriteProfiles {
 
   /**
    * Returns all the incremental write file statuses with the given commits metadata.
-   * Only existing files are included.
    *
    * @param basePath           Table base path
    * @param hadoopConf         The hadoop conf
    * @param metadataList       The commit metadata list (should in ascending order)
    * @param tableType          The table type
-   * @return the file status array
-   */
-  public static FileStatus[] getFilesFromMetadata(
-      Path basePath,
-      Configuration hadoopConf,
-      List<HoodieCommitMetadata> metadataList,
-      HoodieTableType tableType) {
-    return getFilesFromMetadata(basePath, hadoopConf, metadataList, tableType, true);
-  }
-
-  /**
-   * Returns all the incremental write file statuses with the given commits metadata.
-   *
-   * @param basePath           Table base path
-   * @param hadoopConf         The hadoop conf
-   * @param metadataList       The commit metadata list (should in ascending order)
-   * @param tableType          The table type
-   * @param ignoreMissingFiles Whether to ignore the missing files from filesystem
    * @return the file status array or null if any file is missing with ignoreMissingFiles as false
    */
   @Nullable
@@ -115,8 +96,7 @@ public class WriteProfiles {
       Path basePath,
       Configuration hadoopConf,
       List<HoodieCommitMetadata> metadataList,
-      HoodieTableType tableType,
-      boolean ignoreMissingFiles) {
+      HoodieTableType tableType) {
     FileSystem fs = FSUtils.getFs(basePath.toString(), hadoopConf);
     Map<String, FileStatus> uniqueIdToFileStatus = new HashMap<>();
     // If a file has been touched multiple times in the given commits, the return value should keep the one
@@ -126,8 +106,6 @@ public class WriteProfiles {
         if (StreamerUtil.isValidFile(entry.getValue()) && !uniqueIdToFileStatus.containsKey(entry.getKey())) {
           if (StreamerUtil.fileExists(fs, entry.getValue().getPath())) {
             uniqueIdToFileStatus.put(entry.getKey(), entry.getValue());
-          } else if (!ignoreMissingFiles) {
-            return null;
           }
         }
       }


### PR DESCRIPTION
### Change Logs
In `streaming reading`, if there are a large number of files in metada, especially archive files that are very old, then it is IO-intensive to determine whether the file exists during the file traversal process. In extreme cases, flink checkpoint may not be completed.
<img width="1074" alt="image" src="https://github.com/apache/hudi/assets/13013780/f25cda8d-e75c-4380-b660-8ad347c4a6ca">

Another potential problem is that if deleted files are skipped by default, is there a problem of missing data and the user is not aware of it?

The purpose of this PR is to add a configuration to control whether to skip files that have been deleted but exist in metada. If it is true then fall back to full table scan, otherwise the logic of whether the file exists will be executed.

### Impact

Describe any public API or user-facing feature change or any performance impact.

### Risk level (write none, low medium or high below)

If medium or high, explain what verification was done to mitigate the risks.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
