### PR TITLE
[HUDI-7210] In CleanFunction#open, triggers the cleaning under option 'clean.async.enabled'

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/CleanFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/CleanFunction.java
@@ -63,14 +63,16 @@ public class CleanFunction<T> extends AbstractRichFunction
     this.executor = NonThrownExecutor.builder(LOG).waitForTasksFinish(true).build();
     String instantTime = writeClient.createNewInstantTime();
     LOG.info(String.format("exec clean with instant time %s...", instantTime));
-    executor.execute(() -> {
-      this.isCleaning = true;
-      try {
-        this.writeClient.clean(instantTime);
-      } finally {
-        this.isCleaning = false;
-      }
-    }, "wait for cleaning finish");
+    if (conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED)) {
+      executor.execute(() -> {
+        this.isCleaning = true;
+        try {
+          this.writeClient.clean(instantTime);
+        } finally {
+          this.isCleaning = false;
+        }
+      }, "wait for cleaning finish");
+    }
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

The cleaning can happens concurrently in rare cases but it's actually unnecessary.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
