### PR TITLE
Incoming batch schema is not compatible with the table's one #9980

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -1092,6 +1092,10 @@ class HoodieSparkSqlWriterInternal {
       && mergedParams.getOrElse(DataSourceWriteOptions.TABLE_TYPE.key, COPY_ON_WRITE.name) == MERGE_ON_READ.name) {
       mergedParams.put(HoodieTableConfig.DROP_PARTITION_COLUMNS.key, "false")
     }
+    // use meta sync database to fill hoodie.table.name if it not sets
+    if (!mergedParams.contains(HoodieTableConfig.DATABASE_NAME.key()) && mergedParams.contains(HoodieSyncConfig.META_SYNC_DATABASE_NAME.key())) {
+      mergedParams.put(HoodieTableConfig.DATABASE_NAME.key(),mergedParams(HoodieSyncConfig.META_SYNC_DATABASE_NAME.key()))
+    }
 
     val params = mergedParams.toMap
     (params, HoodieWriterUtils.convertMapToHoodieConfig(params))


### PR DESCRIPTION
### Change Logs

 Use meta sync database to fill hoodie.table.name if it not sets
 

### Impact

Fix issue that if there are same table name under hive 'default' schema than will case Incoming batch schema is not compatible with the table's one.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
