### PR TITLE
[MINOR] NPE fix while adding projection field & added its test cases

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
@@ -86,7 +86,7 @@ public class HoodieRealtimeInputFormatUtils extends HoodieInputFormatUtils {
 
   public static void addProjectionField(Configuration conf, String[] fieldName) {
     if (fieldName.length > 0) {
-      List<String> columnNameList = Arrays.stream(conf.get(serdeConstants.LIST_COLUMNS).split(",")).collect(Collectors.toList());
+      List<String> columnNameList = Arrays.stream(conf.get(serdeConstants.LIST_COLUMNS, "").split(",")).collect(Collectors.toList());
       Arrays.stream(fieldName).forEach(field -> {
         int index = columnNameList.indexOf(field);
         if (index != -1) {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
@@ -1,0 +1,28 @@
+package org.apache.hudi.hadoop.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestHoodieRealtimeInputFormatUtils {
+    private Configuration hadoopConf;
+
+    @TempDir
+    public java.nio.file.Path basePath;
+
+    @BeforeEach
+    public void setUp() {
+        hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
+        hadoopConf.set("fs.defaultFS", "file:///");
+        hadoopConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+    }
+
+    @Test
+    public void testAddProjectionField() {
+        hadoopConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
+        HoodieRealtimeInputFormatUtils.addProjectionField(hadoopConf, hadoopConf.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
+    }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
@@ -20,27 +20,30 @@ package org.apache.hudi.hadoop.utils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestHoodieRealtimeInputFormatUtils {
-    private Configuration hadoopConf;
 
-    @TempDir
-    public java.nio.file.Path basePath;
+  private Configuration hadoopConf;
 
-    @BeforeEach
-    public void setUp() {
-        hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
-        hadoopConf.set("fs.defaultFS", "file:///");
-        hadoopConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
-    }
+  @TempDir
+  public java.nio.file.Path basePath;
 
-    @Test
-    public void testAddProjectionField() {
-        hadoopConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
-        HoodieRealtimeInputFormatUtils.addProjectionField(hadoopConf, hadoopConf.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
-    }
+  @BeforeEach
+  public void setUp() {
+    hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
+    hadoopConf.set("fs.defaultFS", "file:///");
+    hadoopConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+  }
+
+  @Test
+  public void testAddProjectionField() {
+    hadoopConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
+    HoodieRealtimeInputFormatUtils.addProjectionField(hadoopConf, hadoopConf.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
+  }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.hadoop.utils;
 
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
### Change Logs

Describe context and summary for this change :

While using `HoodieParquetInputFormat` to read a partitioned hudi table from Flink we encountered below exception

```
java.lang.NullPointerException
	at org.apache.hudi.hadoop.utils.HoodieRealtimeInputFormatUtils.addProjectionField(HoodieRealtimeInputFormatUtils.java:88)
	at org.apache.hudi.hadoop.HoodieParquetInputFormat.getRecordReader(HoodieParquetInputFormat.java:90)
	at org.apache.flink.api.java.hadoop.mapred.HadoopInputFormatBase.open(HadoopInputFormatBase.java:176)
	at org.apache.flink.api.java.hadoop.mapred.HadoopInputFormatBase.open(HadoopInputFormatBase.java:58)
	at org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction.run(InputFormatSourceFunction.java:84)
	at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:110)
	at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:67)
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.run(SourceStreamTask.java:333)
```

Table type : cow & insert_overwrite 
Hudi version : 0.13.1 
Flink version : 1.16.0 

This PR fixes the NPE & Also adds a simple test case for any further testing in `HoodieRealtimeInputFormatUtils` 

### Impact

Describe any public API or user-facing feature change or any performance impact._ : NA

### Risk level (write none, low medium or high below)

If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
