### PR TITLE
[HUDI-7226] Fix clean-by-hour policy for race condition

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -351,23 +351,14 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
             continue;
           }
 
-          if (policy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS) {
-            // Do not delete the latest commit and also the last commit before the earliest commit we
-            // are retaining
-            // The window of commit retain == max query run time. So a query could be running which
-            // still
-            // uses this file.
-            if (fileCommitTime.equals(lastVersion) || (fileCommitTime.equals(lastVersionBeforeEarliestCommitToRetain))) {
-              // move on to the next file
-              continue;
-            }
-          } else if (policy == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
-            // This block corresponds to KEEP_LATEST_BY_HOURS policy
-            // Do not delete the latest commit.
-            if (fileCommitTime.equals(lastVersion)) {
-              // move on to the next file
-              continue;
-            }
+          // Do not delete the latest commit and also the last commit before the earliest commit we
+          // are retaining
+          // The window of commit retain == max query run time. So a query could be running which
+          // still
+          // uses this file.
+          if (fileCommitTime.equals(lastVersion) || (fileCommitTime.equals(lastVersionBeforeEarliestCommitToRetain))) {
+            // move on to the next file
+            continue;
           }
 
           // Always keep the last commit


### PR DESCRIPTION
### Change Logs

`lastVersionBeforeEarliestCommitToRetain` is not honored by `KEEP_LATEST_BY_HOURS` policy. This essentially makes cleaner to remove an eligible file slice when it becomes non-latest. This could fail long-running queries in a race condition:

1. timeline contains a t0.deltacommit (not cleaned because it's latest)
2. a snapshot query starts and running
3. compaction runs and creates t1.commit
4. cleaner runs and remove t0 (because now t1.commit is the latest)
5. the query failed due to a log file belongs to t0.deltacommit is not found

### Impact

Make cleaner logic more robust when use clean by hour policy.

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
