### PR TITLE
[HUDI-7151] Modify the "fs.delete" to prioritize moving paths and files under distributed file systems to the trash instead of directly deleting them

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -574,7 +575,7 @@ public class FSUtils {
       if (recovered) {
         break;
       }
-      // Sleep for 1 second before trying again. Typically it takes about 2-3 seconds to recover
+      // Sleep for 1 second before trying again. Typically, it takes about 2-3 seconds to recover
       // under default settings
       Thread.sleep(1000);
     }
@@ -697,7 +698,7 @@ public class FSUtils {
    * @param fs file system
    * @param dirPath directory path
    * @param parallelism parallelism to use for sub-paths
-   * @return {@code true} if the directory is delete; {@code false} otherwise.
+   * @return {@code true} if the directory is deleted; {@code false} otherwise.
    */
   public static boolean deleteDir(
       HoodieEngineContext hoodieEngineContext, FileSystem fs, Path dirPath, int parallelism) {
@@ -707,7 +708,7 @@ public class FSUtils {
             pairOfSubPathAndConf -> deleteSubPath(
                 pairOfSubPathAndConf.getKey(), pairOfSubPathAndConf.getValue(), true)
         );
-        boolean result = fs.delete(dirPath, true);
+        boolean result = handleFileSystemDeletion(fs, dirPath, true);
         LOG.info("Removed directory at " + dirPath);
         return result;
       }
@@ -779,7 +780,7 @@ public class FSUtils {
     try {
       Path subPath = new Path(subPathStr);
       FileSystem fileSystem = subPath.getFileSystem(conf.get());
-      return fileSystem.delete(subPath, recursive);
+      return handleFileSystemDeletion(fileSystem, subPath, recursive);
     } catch (IOException e) {
       throw new HoodieIOException(e.getMessage(), e);
     }
@@ -860,7 +861,7 @@ public class FSUtils {
           try {
             FileSystem fs = metaClient.getFs();
             if (fs.exists(file)) {
-              return fs.delete(file, false);
+              return handleFileSystemDeletion(fs, file, false);
             }
             return true;
           } catch (IOException e) {
@@ -887,4 +888,28 @@ public class FSUtils {
   private static Option<HoodieLogFile> getLatestLogFile(Stream<HoodieLogFile> logFiles) {
     return Option.fromJavaOptional(logFiles.min(HoodieLogFile.getReverseLogFileComparator()));
   }
+
+  /**
+   * Delete a file or move the file and path to the trash when on the distributed file system.
+   *
+   * @param fs                  {@link FileSystem} instance.
+   * @param relativeFilePath    Path to delete.
+   * @param recursive           If path is a directory and set to true, the directory is deleted else throws an exception. In case of a file the recursive can be set to either true or false.
+   * @return true if delete is successful else false.
+   */
+  public static boolean handleFileSystemDeletion(FileSystem fs, Path relativeFilePath, Boolean recursive) throws IOException {
+    boolean success;
+    try {
+      if (fs instanceof DistributedFileSystem) {
+        success = Trash.moveToAppropriateTrash(fs, relativeFilePath, fs.getConf());
+      } else {
+        success = fs.delete(relativeFilePath, recursive);
+      }
+    } catch (IOException e) {
+      LOG.error("An error occurred while handling the file system deletion", e);
+      throw new IOException("Failed to handle the file system deletion", e);
+    }
+    return success;
+  }
+
 }


### PR DESCRIPTION
### Change Logs

Calling the "fs.delete" method will cause the path and file to be deleted directly instead of moving to the trash. This will cause the path, data and other information to be lost directly and cannot be recovered.

This modification introduces a new method "handleFileSystemDeletion". When FileSystem is a Distributed File System, the file and path will be moved to Trash, which is consistent with online deletion logic. 

The methods involved are: deleteDir, deleteSubPath and deleteFilesParallelize.

### Impact

Theoretically no impact.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
