### PR TITLE
[HUDI-7235] Fix checkpoint bug for S3/GCS Incremental Source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -177,7 +177,7 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
         IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
             filteredSourceData, sourceLimit, queryInfo, cloudObjectIncrCheckpoint);
     if (!checkPointAndDataset.getRight().isPresent()) {
-      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft().toString());
+      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft());
       return Pair.of(Option.empty(), checkPointAndDataset.getLeft().toString());
     }
     LOG.info("Adjusted end checkpoint :" + checkPointAndDataset.getLeft());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -177,8 +177,8 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
         IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
             filteredSourceData, sourceLimit, queryInfo, cloudObjectIncrCheckpoint);
     if (!checkPointAndDataset.getRight().isPresent()) {
-      LOG.info("Empty source, returning endpoint:" + queryInfo.getEndInstant());
-      return Pair.of(Option.empty(), queryInfo.getEndInstant());
+      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft().toString());
+      return Pair.of(Option.empty(), checkPointAndDataset.getLeft().toString());
     }
     LOG.info("Adjusted end checkpoint :" + checkPointAndDataset.getLeft());
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -152,7 +152,7 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
         IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
             filteredSourceData, sourceLimit, queryInfo, cloudObjectIncrCheckpoint);
     if (!checkPointAndDataset.getRight().isPresent()) {
-      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft().toString());
+      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft());
       return Pair.of(Option.empty(), checkPointAndDataset.getLeft().toString());
     }
     LOG.info("Adjusted end checkpoint :" + checkPointAndDataset.getLeft());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -152,8 +152,8 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
         IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
             filteredSourceData, sourceLimit, queryInfo, cloudObjectIncrCheckpoint);
     if (!checkPointAndDataset.getRight().isPresent()) {
-      LOG.info("Empty source, returning endpoint:" + queryInfo.getEndInstant());
-      return Pair.of(Option.empty(), queryInfo.getEndInstant());
+      LOG.info("Empty source, returning endpoint:" + checkPointAndDataset.getLeft().toString());
+      return Pair.of(Option.empty(), checkPointAndDataset.getLeft().toString());
     }
     LOG.info("Adjusted end checkpoint :" + checkPointAndDataset.getLeft());
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -207,7 +207,10 @@ public class IncrSourceHelper {
         // queryInfo.getEndInstant() represents source table's last completed instant
         // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c1, return c1#abc.
         // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c2, return c2.
-        CloudObjectIncrCheckpoint updatedCheckpoint = queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit() ? cloudObjectIncrCheckpoint : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
+        CloudObjectIncrCheckpoint updatedCheckpoint =
+            queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit()
+                ? cloudObjectIncrCheckpoint
+                : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
         return Pair.of(updatedCheckpoint, Option.empty());
       }
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -185,7 +185,7 @@ public class IncrSourceHelper {
     if (sourceData.isEmpty()) {
       // There is no file matching the prefix.
       CloudObjectIncrCheckpoint updatedCheckpoint =
-              queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit()
+              queryInfo.getEndInstant().equals(cloudObjectIncrCheckpoint.getCommit())
                       ? cloudObjectIncrCheckpoint
                       : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
       return Pair.of(updatedCheckpoint, Option.empty());
@@ -212,7 +212,7 @@ public class IncrSourceHelper {
         // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c1, return c1#abc.
         // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c2, return c2.
         CloudObjectIncrCheckpoint updatedCheckpoint =
-            queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit()
+            queryInfo.getEndInstant().equals(cloudObjectIncrCheckpoint.getCommit())
                 ? cloudObjectIncrCheckpoint
                 : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
         return Pair.of(updatedCheckpoint, Option.empty());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -183,7 +183,7 @@ public class IncrSourceHelper {
                                                                                                                     long sourceLimit, QueryInfo queryInfo,
                                                                                                                     CloudObjectIncrCheckpoint cloudObjectIncrCheckpoint) {
     if (sourceData.isEmpty()) {
-      return Pair.of(cloudObjectIncrCheckpoint, Option.empty());
+      return Pair.of(new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null), Option.empty());
     }
     // Let's persist the dataset to avoid triggering the dag repeatedly
     sourceData.persist(StorageLevel.MEMORY_AND_DISK());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -183,6 +183,7 @@ public class IncrSourceHelper {
                                                                                                                     long sourceLimit, QueryInfo queryInfo,
                                                                                                                     CloudObjectIncrCheckpoint cloudObjectIncrCheckpoint) {
     if (sourceData.isEmpty()) {
+      // There is no file matching the prefix.
       return Pair.of(new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null), Option.empty());
     }
     // Let's persist the dataset to avoid triggering the dag repeatedly
@@ -199,11 +200,15 @@ public class IncrSourceHelper {
           functions.concat(functions.col(queryInfo.getOrderColumn()), functions.col(queryInfo.getKeyColumn())));
       // Apply incremental filter
       orderedDf = orderedDf.filter(functions.col("commit_key").gt(concatenatedKey.get())).drop("commit_key");
-      // We could be just at the end of the commit, so return empty
+      // If there are no more files where commit_key is greater than lastCheckpointCommit#lastCheckpointKey
       if (orderedDf.isEmpty()) {
         LOG.info("Empty ordered source, returning endpoint:" + queryInfo.getEndInstant());
         sourceData.unpersist();
-        return Pair.of(new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), lastCheckpointKey.get()), Option.empty());
+        // queryInfo.getEndInstant() represents source table's last completed instant
+        // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c1, return c1#abc.
+        // If current checkpoint is c1#abc and queryInfo.getEndInstant() is c2, return c2.
+        CloudObjectIncrCheckpoint updatedCheckpoint = queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit() ? cloudObjectIncrCheckpoint : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
+        return Pair.of(updatedCheckpoint, Option.empty());
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -184,7 +184,11 @@ public class IncrSourceHelper {
                                                                                                                     CloudObjectIncrCheckpoint cloudObjectIncrCheckpoint) {
     if (sourceData.isEmpty()) {
       // There is no file matching the prefix.
-      return Pair.of(new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null), Option.empty());
+      CloudObjectIncrCheckpoint updatedCheckpoint =
+              queryInfo.getEndInstant() == cloudObjectIncrCheckpoint.getCommit()
+                      ? cloudObjectIncrCheckpoint
+                      : new CloudObjectIncrCheckpoint(queryInfo.getEndInstant(), null);
+      return Pair.of(updatedCheckpoint, Option.empty());
     }
     // Let's persist the dataset to avoid triggering the dag repeatedly
     sourceData.persist(StorageLevel.MEMORY_AND_DISK());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -242,7 +242,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
   @CsvSource({
       "1,1#path/to/file2.json,3#path/to/file4.json,1#path/to/file1.json,1",
       "2,1#path/to/file2.json,3#path/to/file4.json,1#path/to/file1.json,2",
-      "3,3#path/to/file5.json,3,1#path/to/file1.json,3"
+      "3,3#path/to/file5.json,3#path/to/file5.json,1#path/to/file1.json,3"
   })
   public void testSplitSnapshotLoad(String snapshotCheckPoint, String exptected1, String exptected2, String exptected3, String exptected4) throws IOException {
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -434,7 +434,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
   @CsvSource({
       "1,1#path/to/file2.json,3#path/to/file4.json,1#path/to/file1.json,1",
       "2,1#path/to/file2.json,3#path/to/file4.json,1#path/to/file1.json,2",
-      "3,3#path/to/file5.json,3,1#path/to/file1.json,3"
+      "3,3#path/to/file5.json,3#path/to/file5.json,1#path/to/file1.json,3"
   })
   public void testSplitSnapshotLoad(String snapshotCheckPoint, String exptected1, String exptected2, String exptected3, String exptected4) throws IOException {
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -358,8 +358,8 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("1"), 1000L, "2", typedProperties);
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("1#path/to/file3.json"), 1000L, "2", typedProperties);
-    readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("2#path/to/skip4.json"), 1000L, "2", typedProperties);
-    readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("2#path/to/skip5.json"), 1000L, "2", typedProperties);
+    readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("2#path/to/skip4.json"), 1000L, "2#path/to/skip4.json", typedProperties);
+    readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("2#path/to/skip5.json"), 1000L, "2#path/to/skip5.json", typedProperties);
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("2"), 1000L, "2", typedProperties);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL;
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.INIT_INSTANT_TS;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
@@ -261,6 +261,7 @@ class TestIncrSourceHelper extends SparkClientFunctionalTestHarness {
     filePathSizeAndCommitTime.add(Triple.of("path/to/file8.json", 100L, "commit3"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file6.json", 250L, "commit3"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file7.json", 50L, "commit3"));
+    filePathSizeAndCommitTime.add(Triple.of("path/to/file8.json", 50L, "commit3"));
     Dataset<Row> inputDs = generateDataset(filePathSizeAndCommitTime);
 
     QueryInfo queryInfo = new QueryInfo(

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
@@ -122,7 +122,7 @@ class TestIncrSourceHelper extends SparkClientFunctionalTestHarness {
         "s3.object.key", "s3.object.size");
     Pair<CloudObjectIncrCheckpoint, Option<Dataset<Row>>> result = IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
         emptyDataset, 50L, queryInfo, new CloudObjectIncrCheckpoint(null, null));
-    assertEquals(INIT_INSTANT_TS, result.getKey().toString());
+    assertEquals("commit2", result.getKey().toString());
     assertTrue(!result.getRight().isPresent());
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
@@ -264,6 +264,7 @@ class TestIncrSourceHelper extends SparkClientFunctionalTestHarness {
     filePathSizeAndCommitTime.add(Triple.of("path/to/file8.json", 50L, "commit3"));
     Dataset<Row> inputDs = generateDataset(filePathSizeAndCommitTime);
 
+    // Test case 1 when queryInfo.endInstant() is equal to lastCheckpointCommit
     QueryInfo queryInfo = new QueryInfo(
         QUERY_TYPE_INCREMENTAL_OPT_VAL(), "commit1", "commit1",
         "commit3", "_hoodie_commit_time",
@@ -271,6 +272,15 @@ class TestIncrSourceHelper extends SparkClientFunctionalTestHarness {
     Pair<CloudObjectIncrCheckpoint, Option<Dataset<Row>>> result = IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
         inputDs, 1500L, queryInfo, new CloudObjectIncrCheckpoint("commit3", "path/to/file8.json"));
     assertEquals("commit3#path/to/file8.json", result.getKey().toString());
+    assertTrue(!result.getRight().isPresent());
+    // Test case 2 when queryInfo.endInstant() is greater than lastCheckpointCommit
+    queryInfo = new QueryInfo(
+        QUERY_TYPE_INCREMENTAL_OPT_VAL(), "commit1", "commit1",
+        "commit4", "_hoodie_commit_time",
+        "s3.object.key", "s3.object.size");
+    result = IncrSourceHelper.filterAndGenerateCheckpointBasedOnSourceLimit(
+        inputDs, 1500L, queryInfo, new CloudObjectIncrCheckpoint("commit3","path/to/file8.json"));
+    assertEquals("commit4", result.getKey().toString());
     assertTrue(!result.getRight().isPresent());
   }
 


### PR DESCRIPTION
### Change Logs

Fix bug in checkpointing logic for S3/GCS in empty dataset use-case. The reason for the bug was following. 

1st  delta commit's checkpoint, processed 3 files.
```
23/12/06 16:55:26 INFO S3EventsHoodieIncrSource  : Querying S3 with:00000000000000, queryInfo:Query information for Incremental Source queryType: snapshot, previousInstant: 00000000000000, startInstant: 00000000000000, endInstant: 20231206150423946, orderColumn: _hoodie_commit_time, keyColumn: s3.object.key, limitColumn: s3.object.size, orderByColumns: [_hoodie_commit_time, s3.object.key]
	

23/12/06 16:55:42 INFO S3EventsHoodieIncrSource  : Adjusting end checkpoint:20231206150423946 based on sourceLimit :300000000
	
23/12/06 16:55:46 INFO S3EventsHoodieIncrSource  : Adjusted end checkpoint :20231206150423946#ee-facts/0012_part_00.parquet
	

23/12/06 16:55:49 INFO S3EventsHoodieIncrSource  : Total number of files to process :3
```

2nd delta commit was an empty one and the checkpoint returned was 20231206150423946 which is not a valid checkpoint progression because it should either be equal or increase monotonically (based on lexicographical order)
```
23/12/06 16:59:52 INFO S3EventsHoodieIncrSource  : Querying S3 with:20231206150423946#ee-facts/0012_part_00.parquet, queryInfo:Query information for Incremental Source queryType: incremental, previousInstant: 00000000000000, startInstant: 20231206150423946, endInstant: 20231206150423946, orderColumn: _hoodie_commit_time, keyColumn: s3.object.key, limitColumn: s3.object.size, orderByColumns: [_hoodie_commit_time, s3.object.key]
	
23/12/06 16:59:53 INFO S3EventsHoodieIncrSource  : Adjusting end checkpoint:20231206150423946 based on sourceLimit :300000000
	
23/12/06 16:59:55 INFO S3EventsHoodieIncrSource  : Empty source, returning endpoint:20231206150423946
```

As the previous commits' checkpoint was a faulty one, the 3rd commit read the same set of files again and wrote duplicate data.

### Impact

Bug Fix

### Risk level (write none, low medium or high below)
Medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

None, this is a bug fix for an existing feature.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
