### PR TITLE
[HUDI-7144] Build storage partition stats index and use it for data skipping

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2001,6 +2001,14 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getMetadataConfig().getColumnsEnabledForColumnStatsIndex();
   }
 
+  public boolean isPartitionStatsIndexEnabled() {
+    return isMetadataTableEnabled() && getMetadataConfig().isPartitionStatsIndexEnabled();
+  }
+
+  public int getPartitionStatsIndexParallelism() {
+    return metadataConfig.getPartitionStatsIndexParallelism();
+  }
+
   public List<String> getColumnsEnabledForBloomFilterIndex() {
     return getMetadataConfig().getColumnsEnabledForBloomFilterIndex();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -71,8 +71,7 @@ public class HoodieMetadataWriteUtils {
   private static final long MDT_MAX_HFILE_SIZE_BYTES = 10 * 1024 * 1024 * 1024L; // 10GB
 
   /**
-   * Create a {@code HoodieWriteConfig} to use for the Metadata Table.  This is used by async
-   * indexer only.
+   * Create a {@code HoodieWriteConfig} to use for the Metadata Table.
    *
    * @param writeConfig                {@code HoodieWriteConfig} of the main dataset writer
    * @param failedWritesCleaningPolicy Cleaning policy on failed writes

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -334,7 +334,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".index.partition.stats.enable")
       .defaultValue(true)
       .sinceVersion("1.0.0")
-      .withDocumentation("Enable aggregating stats for each column at the storage partition level. ");
+      .withDocumentation("Enable aggregating stats for each column at the storage partition level.");
 
   public static final ConfigProperty<Integer> METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.file.group.count")

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -330,6 +330,27 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Parallelism to use, when generating functional index.");
 
+  public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty
+      .key(METADATA_PREFIX + ".index.partition.stats.enable")
+      .defaultValue(true)
+      .sinceVersion("1.0.0")
+      .withDocumentation("Enable aggregating stats for each column at the storage partition level. ");
+
+  public static final ConfigProperty<Integer> METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT = ConfigProperty
+      .key(METADATA_PREFIX + ".index.partition.stats.file.group.count")
+      .defaultValue(1)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Metadata partition stats file group count. This controls the size of the base and "
+          + "log files and read parallelism in the partition stats index.");
+
+  public static final ConfigProperty<Integer> PARTITION_STATS_INDEX_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".index.partition.stats.parallelism")
+      .defaultValue(200)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Parallelism to use, when generating partition stats index.");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -460,6 +481,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public int getFunctionalIndexParallelism() {
     return getInt(FUNCTIONAL_INDEX_PARALLELISM);
+  }
+
+  public boolean isPartitionStatsIndexEnabled() {
+    return getBooleanOrDefault(ENABLE_METADATA_INDEX_PARTITION_STATS);
+  }
+
+  public int getPartitionStatsIndexFileGroupCount() {
+    return getInt(METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT);
+  }
+
+  public int getPartitionStatsIndexParallelism() {
+    return getInt(PARTITION_STATS_INDEX_PARALLELISM);
   }
 
   public static class Builder {
@@ -642,6 +675,21 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withFunctionalIndexParallelism(int parallelism) {
       metadataConfig.setValue(FUNCTIONAL_INDEX_PARALLELISM, String.valueOf(parallelism));
+      return this;
+    }
+
+    public Builder withMetadataIndexPartitionStats(boolean enable) {
+      metadataConfig.setValue(ENABLE_METADATA_INDEX_PARTITION_STATS, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetadataIndexPartitionStatsFileGroupCount(int fileGroupCount) {
+      metadataConfig.setValue(METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT, String.valueOf(fileGroupCount));
+      return this;
+    }
+
+    public Builder withPartitionStatsIndexParallelism(int parallelism) {
+      metadataConfig.setValue(PARTITION_STATS_INDEX_PARALLELISM, String.valueOf(parallelism));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
@@ -76,14 +76,10 @@ public abstract class BaseFileUtils {
    * @param fileColumnRanges List of column range statistics for each file in a partition
    */
   public static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> getColumnRangeInPartition(@Nonnull List<HoodieColumnRangeMetadata<T>> fileColumnRanges) {
-    if (fileColumnRanges.size() == 1) {
-      // Only one parquet file, we can just return that range.
-      return fileColumnRanges.get(0);
-    }
+    ValidationUtils.checkArgument(!fileColumnRanges.isEmpty(), "fileColumnRanges should not be empty.");
     // There are multiple files. Compute min(file_mins) and max(file_maxs)
     return fileColumnRanges.stream()
-        .sequential()
-        .reduce(BaseFileUtils::mergeRanges).get();
+        .reduce(BaseFileUtils::mergeRanges).orElseThrow(() -> new HoodieException("MergingColumnRanges failed."));
   }
 
   private static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> mergeRanges(HoodieColumnRangeMetadata<T> one,

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
@@ -73,21 +73,23 @@ public abstract class BaseFileUtils {
   /**
    * Aggregate column range statistics across files in a partition.
    *
-   * @param fileRanges List of column range statistics for each file in a partition
+   * @param fileColumnRanges List of column range statistics for each file in a partition
    */
-  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> getColumnRangeInPartition(@Nonnull List<HoodieColumnRangeMetadata<T>> fileRanges) {
-    if (fileRanges.size() == 1) {
+  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> getColumnRangeInPartition(@Nonnull List<HoodieColumnRangeMetadata<T>> fileColumnRanges) {
+    if (fileColumnRanges.size() == 1) {
       // Only one parquet file, we can just return that range.
-      return fileRanges.get(0);
+      return fileColumnRanges.get(0);
     }
     // There are multiple files. Compute min(file_mins) and max(file_maxs)
-    return fileRanges.stream()
+    return fileColumnRanges.stream()
         .sequential()
         .reduce(BaseFileUtils::mergeRanges).get();
   }
 
   private static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> mergeRanges(HoodieColumnRangeMetadata<T> one,
                                                                                     HoodieColumnRangeMetadata<T> another) {
+    ValidationUtils.checkArgument(one.getColumnName().equals(another.getColumnName()),
+        "Column names should be the same for merging column ranges");
     final T minValue = getMinValueForColumnRanges(one, another);
     final T maxValue = getMaxValueForColumnRanges(one, another);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
@@ -86,25 +86,10 @@ public abstract class BaseFileUtils {
         .reduce(BaseFileUtils::mergeRanges).get();
   }
 
-  private static  <T extends Comparable<T>> HoodieColumnRangeMetadata<T> mergeRanges(HoodieColumnRangeMetadata<T> one,
-                                                                                     HoodieColumnRangeMetadata<T> another) {
-    final T minValue;
-    final T maxValue;
-    if (one.getMinValue() != null && another.getMinValue() != null) {
-      minValue = one.getMinValue().compareTo(another.getMinValue()) < 0 ? one.getMinValue() : another.getMinValue();
-    } else if (one.getMinValue() == null) {
-      minValue = another.getMinValue();
-    } else {
-      minValue = one.getMinValue();
-    }
-
-    if (one.getMaxValue() != null && another.getMaxValue() != null) {
-      maxValue = one.getMaxValue().compareTo(another.getMaxValue()) < 0 ? another.getMaxValue() : one.getMaxValue();
-    } else if (one.getMaxValue() == null) {
-      maxValue = another.getMaxValue();
-    } else {
-      maxValue = one.getMaxValue();
-    }
+  private static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> mergeRanges(HoodieColumnRangeMetadata<T> one,
+                                                                                    HoodieColumnRangeMetadata<T> another) {
+    final T minValue = getMinValueForColumnRanges(one, another);
+    final T maxValue = getMaxValueForColumnRanges(one, another);
 
     return HoodieColumnRangeMetadata.create(
         null, one.getColumnName(), minValue, maxValue,
@@ -112,6 +97,30 @@ public abstract class BaseFileUtils {
         one.getValueCount() + another.getValueCount(),
         one.getTotalSize() + another.getTotalSize(),
         one.getTotalUncompressedSize() + another.getTotalUncompressedSize());
+  }
+
+  public static <T extends Comparable<T>> T getMaxValueForColumnRanges(HoodieColumnRangeMetadata<T> one, HoodieColumnRangeMetadata<T> another) {
+    final T maxValue;
+    if (one.getMaxValue() != null && another.getMaxValue() != null) {
+      maxValue = one.getMaxValue().compareTo(another.getMaxValue()) < 0 ? another.getMaxValue() : one.getMaxValue();
+    } else if (one.getMaxValue() == null) {
+      maxValue = another.getMaxValue();
+    } else {
+      maxValue = one.getMaxValue();
+    }
+    return maxValue;
+  }
+
+  public static <T extends Comparable<T>> T getMinValueForColumnRanges(HoodieColumnRangeMetadata<T> one, HoodieColumnRangeMetadata<T> another) {
+    final T minValue;
+    if (one.getMinValue() != null && another.getMinValue() != null) {
+      minValue = one.getMinValue().compareTo(another.getMinValue()) < 0 ? one.getMinValue() : another.getMinValue();
+    } else if (one.getMinValue() == null) {
+      minValue = another.getMinValue();
+    } else {
+      minValue = one.getMinValue();
+    }
+    return minValue;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -401,23 +401,8 @@ public class ParquetUtils extends BaseFileUtils {
       HoodieColumnRangeMetadata<T> one,
       HoodieColumnRangeMetadata<T> another
   ) {
-    final T minValue;
-    final T maxValue;
-    if (one.getMinValue() != null && another.getMinValue() != null) {
-      minValue = one.getMinValue().compareTo(another.getMinValue()) < 0 ? one.getMinValue() : another.getMinValue();
-    } else if (one.getMinValue() == null) {
-      minValue = another.getMinValue();
-    } else {
-      minValue = one.getMinValue();
-    }
-
-    if (one.getMaxValue() != null && another.getMaxValue() != null) {
-      maxValue = one.getMaxValue().compareTo(another.getMaxValue()) < 0 ? another.getMaxValue() : one.getMaxValue();
-    } else if (one.getMaxValue() == null) {
-      maxValue = another.getMaxValue();
-    } else {
-      maxValue = one.getMaxValue();
-    }
+    final T minValue = getMinValueForColumnRanges(one, another);
+    final T maxValue = getMaxValueForColumnRanges(one, another);
 
     return HoodieColumnRangeMetadata.create(
         one.getFilePath(),

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -654,7 +654,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
                                                                  Collection<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList,
                                                                  boolean isDeleted) {
     return columnRangeMetadataList.stream().map(columnRangeMetadata -> {
-      HoodieKey key = new HoodieKey(getPartitionStatsIndexKey(partitionPath, columnRangeMetadata),
+      HoodieKey key = new HoodieKey(getPartitionStatsIndexKey(partitionPath, columnRangeMetadata.getColumnName()),
           MetadataPartitionType.PARTITION_STATS.getPartitionPath());
 
       HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(),
@@ -674,9 +674,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     });
   }
 
-  public static String getPartitionStatsIndexKey(String partitionPath, HoodieColumnRangeMetadata<Comparable> columnRangeMetadata) {
+  public static String getPartitionStatsIndexKey(String partitionPath, String columnName) {
     final PartitionIndexID partitionIndexID = new PartitionIndexID(HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionPath));
-    final ColumnIndexID columnIndexID = new ColumnIndexID(columnRangeMetadata.getColumnName());
+    final ColumnIndexID columnIndexID = new ColumnIndexID(columnName);
     return columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -102,13 +102,14 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMetadataPayload.class);
   /**
    * Type of the record. This can be an enum in the schema but Avro1.8
-   * has a bug - https://issues.apache.org/jira/browse/AVRO-1810
+   * has a bug - <a href="https://issues.apache.org/jira/browse/AVRO-1810">...</a>
    */
-  protected static final int METADATA_TYPE_PARTITION_LIST = 1;
-  protected static final int METADATA_TYPE_FILE_LIST = 2;
-  protected static final int METADATA_TYPE_COLUMN_STATS = 3;
-  protected static final int METADATA_TYPE_BLOOM_FILTER = 4;
+  private static final int METADATA_TYPE_PARTITION_LIST = 1;
+  private static final int METADATA_TYPE_FILE_LIST = 2;
+  private static final int METADATA_TYPE_COLUMN_STATS = 3;
+  private static final int METADATA_TYPE_BLOOM_FILTER = 4;
   private static final int METADATA_TYPE_RECORD_INDEX = 5;
+  private static final int METADATA_TYPE_PARTITION_STATS = 6;
 
   /**
    * HoodieMetadata schema field ids
@@ -226,7 +227,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               (Boolean) bloomFilterRecord.get(BLOOM_FILTER_FIELD_IS_DELETED)
           );
         }
-      } else if (type == METADATA_TYPE_COLUMN_STATS) {
+      } else if (type == METADATA_TYPE_COLUMN_STATS || type == METADATA_TYPE_PARTITION_STATS) {
         GenericRecord columnStatsRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_COLUMN_STATS);
         // NOTE: Only legitimate reason for {@code ColumnStatsMetadata} to not be present is when
         //       it's not been read from the storage (ie it's not been a part of projected schema).
@@ -647,6 +648,36 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
 
       return new HoodieAvroRecord<>(key, payload);
     });
+  }
+
+  public static Stream<HoodieRecord> createPartitionStatsRecords(String partitionPath,
+                                                                 Collection<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList,
+                                                                 boolean isDeleted) {
+    return columnRangeMetadataList.stream().map(columnRangeMetadata -> {
+      HoodieKey key = new HoodieKey(getPartitionStatsIndexKey(partitionPath, columnRangeMetadata),
+          MetadataPartitionType.PARTITION_STATS.getPartitionPath());
+
+      HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(),
+          HoodieMetadataColumnStats.newBuilder()
+              .setFileName(null)
+              .setColumnName(columnRangeMetadata.getColumnName())
+              .setMinValue(wrapValueIntoAvro(columnRangeMetadata.getMinValue()))
+              .setMaxValue(wrapValueIntoAvro(columnRangeMetadata.getMaxValue()))
+              .setNullCount(columnRangeMetadata.getNullCount())
+              .setValueCount(columnRangeMetadata.getValueCount())
+              .setTotalSize(columnRangeMetadata.getTotalSize())
+              .setTotalUncompressedSize(columnRangeMetadata.getTotalUncompressedSize())
+              .setIsDeleted(isDeleted)
+              .build());
+
+      return new HoodieAvroRecord<>(key, payload);
+    });
+  }
+
+  public static String getPartitionStatsIndexKey(String partitionPath, HoodieColumnRangeMetadata<Comparable> columnRangeMetadata) {
+    final PartitionIndexID partitionIndexID = new PartitionIndexID(HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionPath));
+    final ColumnIndexID columnIndexID = new ColumnIndexID(columnRangeMetadata.getColumnName());
+    return columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString());
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -674,7 +674,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     });
   }
 
-  public static String getPartitionStatsIndexKey(String partitionPath, String columnName) {
+  private static String getPartitionStatsIndexKey(String partitionPath, String columnName) {
     final PartitionIndexID partitionIndexID = new PartitionIndexID(HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionPath));
     final ColumnIndexID columnIndexID = new ColumnIndexID(columnName);
     return columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1898,13 +1898,13 @@ public class HoodieTableMetadataUtil {
     int parallelism = Math.max(Math.min(partitionInfoList.size(), metadataConfig.getPartitionStatsIndexParallelism()), 1);
     return engineContext.parallelize(partitionInfoList, parallelism).flatMap(partitionInfo -> {
       final String partitionPath = partitionInfo.getRelativePath();
-      // Step 1: Collect Column Metadata for Each File (Your existing code does this)
+      // Step 1: Collect Column Metadata for Each File
       List<List<HoodieColumnRangeMetadata<Comparable>>> fileColumnMetadata = partitionInfo.getFileNameToSizeMap().keySet().stream()
           .map(fileName -> getFileStatsRangeMetadata(partitionPath, partitionPath + "/" + fileName, dataTableMetaClient, columnsToIndex, false))
           .collect(toList());
       // Step 2: Flatten and Group by Column Name
       Map<String, List<HoodieColumnRangeMetadata<Comparable>>> columnMetadataMap = fileColumnMetadata.stream()
-          .flatMap(List::stream) // Flatten the list
+          .flatMap(List::stream)
           .collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, toList())); // Group by column name
       // Step 3: Aggregate Column Ranges
       Stream<HoodieColumnRangeMetadata<Comparable>> partitionStatsRangeMetadata = columnMetadataMap.entrySet().stream()
@@ -1962,13 +1962,13 @@ public class HoodieTableMetadataUtil {
       int parallelism = Math.max(Math.min(partitionedWriteStats.size(), metadataConfig.getPartitionStatsIndexParallelism()), 1);
       return engineContext.parallelize(partitionedWriteStats, parallelism).flatMap(partitionedWriteStat -> {
         final String partitionName = partitionedWriteStat.get(0).getPartitionPath();
-        // Step 1: Collect Column Metadata for Each File (Your existing code does this)
+        // Step 1: Collect Column Metadata for Each File
         List<List<HoodieColumnRangeMetadata<Comparable>>> fileColumnMetadata = partitionedWriteStat.stream()
             .map(writeStat -> translateWriteStatToFileStats(writeStat, dataMetaClient, columnsToIndex))
             .collect(toList());
         // Step 2: Flatten and Group by Column Name
         Map<String, List<HoodieColumnRangeMetadata<Comparable>>> columnMetadataMap = fileColumnMetadata.stream()
-            .flatMap(List::stream) // Flatten the list
+            .flatMap(List::stream)
             .collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, toList())); // Group by column name
         // Step 3: Aggregate Column Ranges
         Stream<HoodieColumnRangeMetadata<Comparable>> partitionStatsRangeMetadata = columnMetadataMap.entrySet().stream()

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -20,7 +20,6 @@ package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,6 +35,8 @@ import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA
 import static org.apache.hudi.common.config.HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.common.util.StringUtils.EMPTY_STRING;
+import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 
 /**
  * Partition types for metadata table.
@@ -81,7 +82,7 @@ public enum MetadataPartitionType {
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-") {
     @Override
     public boolean isMetadataPartitionEnabled(TypedProperties writeConfig) {
-      return getBooleanWithAltKeys(writeConfig, ENABLE_METADATA_INDEX_PARTITION_STATS) && StringUtils.nonEmpty(getStringWithAltKeys(writeConfig, COLUMN_STATS_INDEX_FOR_COLUMNS));
+      return getBooleanWithAltKeys(writeConfig, ENABLE_METADATA_INDEX_PARTITION_STATS) && nonEmpty(getStringWithAltKeys(writeConfig, COLUMN_STATS_INDEX_FOR_COLUMNS, EMPTY_STRING));
     }
   };
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -20,6 +20,7 @@ package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,11 +28,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS;
+import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 
 /**
  * Partition types for metadata table.
@@ -72,6 +76,12 @@ public enum MetadataPartitionType {
     @Override
     public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
       return metaClient.getFunctionalIndexMetadata().isPresent();
+    }
+  },
+  PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-") {
+    @Override
+    public boolean isMetadataPartitionEnabled(TypedProperties writeConfig) {
+      return getBooleanWithAltKeys(writeConfig, ENABLE_METADATA_INDEX_PARTITION_STATS) && StringUtils.nonEmpty(getStringWithAltKeys(writeConfig, COLUMN_STATS_INDEX_FOR_COLUMNS));
     }
   };
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestBaseFileUtils {
+
+  @Test
+  public void testGetColumnRangeInPartition() {
+    // Step 1: Set Up Test Data
+    HoodieColumnRangeMetadata<Comparable> fileRange1 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file1", "columnName", 1, 5, 0, 10, 100, 200);
+    HoodieColumnRangeMetadata<Comparable> fileRange2 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file2", "columnName", 3, 8, 1, 15, 120, 250);
+
+    List<HoodieColumnRangeMetadata<Comparable>> fileRanges = Arrays.asList(fileRange1, fileRange2);
+
+    // Step 2: Call the Method
+    HoodieColumnRangeMetadata<Comparable> result = BaseFileUtils.getColumnRangeInPartition(fileRanges);
+
+    // Step 3: Assertions
+    assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
+    assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
+    assertEquals(1, result.getNullCount());
+    assertEquals(25, result.getValueCount());
+    assertEquals(220, result.getTotalSize());
+    assertEquals(450, result.getTotalUncompressedSize());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
@@ -27,22 +27,20 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestBaseFileUtils {
 
   @Test
   public void testGetColumnRangeInPartition() {
     // Step 1: Set Up Test Data
-    HoodieColumnRangeMetadata<Comparable> fileRange1 = HoodieColumnRangeMetadata.<Comparable>create(
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file1", "columnName", 1, 5, 0, 10, 100, 200);
-    HoodieColumnRangeMetadata<Comparable> fileRange2 = HoodieColumnRangeMetadata.<Comparable>create(
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file2", "columnName", 3, 8, 1, 15, 120, 250);
-
-    List<HoodieColumnRangeMetadata<Comparable>> fileRanges = Arrays.asList(fileRange1, fileRange2);
-
+    List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
     // Step 2: Call the Method
-    HoodieColumnRangeMetadata<Comparable> result = BaseFileUtils.getColumnRangeInPartition(fileRanges);
-
+    HoodieColumnRangeMetadata<Comparable> result = BaseFileUtils.getColumnRangeInPartition(fileColumnRanges);
     // Step 3: Assertions
     assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
     assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
@@ -50,5 +48,37 @@ public class TestBaseFileUtils {
     assertEquals(25, result.getValueCount());
     assertEquals(220, result.getTotalSize());
     assertEquals(450, result.getTotalUncompressedSize());
+  }
+
+  @Test
+  public void testGetColumnRangeInPartitionWithNullMinMax() {
+    // Step 1: Set Up Test Data
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file1", "columnName", 1, null, 0, 10, 100, 200);
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file2", "columnName", null, 8, 1, 15, 120, 250);
+
+    List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
+    // Step 2: Call the Method
+    HoodieColumnRangeMetadata<Comparable> result = BaseFileUtils.getColumnRangeInPartition(fileColumnRanges);
+    // Step 3: Assertions
+    assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
+    assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
+    assertEquals(1, result.getNullCount());
+    assertEquals(25, result.getValueCount());
+    assertEquals(220, result.getTotalSize());
+    assertEquals(450, result.getTotalUncompressedSize());
+  }
+
+  @Test
+  public void testGetColumnRangeInPartitionWithDifferentColumnNameThrowsException() {
+    // Step 1: Set Up Test Data
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file1", "columnName1", 1, null, 0, 10, 100, 200);
+    HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file2", "columnName2", null, 8, 1, 15, 120, 250);
+    List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
+    // Step 2: Call the Method
+    assertThrows(IllegalArgumentException.class, () -> BaseFileUtils.getColumnRangeInPartition(fileColumnRanges));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -89,7 +89,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
 
   @Test
   public void testConvertFilesToPartitionStatsRecords() throws Exception {
-    HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
+    HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
     String instant1 = "20230918120000000";
     hoodieTestTable = hoodieTestTable.addCommit(instant1);
     String instant2 = "20230918121110000";

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
@@ -84,6 +85,79 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         EngineType.SPARK
     );
     assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testConvertFilesToPartitionStatsRecords() throws Exception {
+    HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
+    String instant1 = "20230918120000000";
+    hoodieTestTable = hoodieTestTable.addCommit(instant1);
+    String instant2 = "20230918121110000";
+    hoodieTestTable = hoodieTestTable.addCommit(instant2);
+    List<HoodieTableMetadataUtil.DirectoryInfo> partitionInfoList = new ArrayList<>();
+    // Generate 10 inserts for each partition and populate partitionBaseFilePairs and recordKeys.
+    DATE_PARTITIONS.forEach(p -> {
+      try {
+        String fileId1 = UUID.randomUUID().toString();
+        FileSlice fileSlice1 = new FileSlice(p, instant1, fileId1);
+        StoragePath storagePath1 = new StoragePath(hoodieTestTable.getBaseFilePath(p, fileId1).toUri());
+        writeParquetFile(
+            instant1,
+            storagePath1,
+            dataGen.generateInsertsForPartition(instant1, 10, p),
+            metaClient,
+            engineContext);
+        HoodieBaseFile baseFile1 = new HoodieBaseFile(hoodieTestTable.getBaseFilePath(p, fileId1).toString());
+        fileSlice1.setBaseFile(baseFile1);
+        String fileId2 = UUID.randomUUID().toString();
+        FileSlice fileSlice2 = new FileSlice(p, instant2, fileId2);
+        StoragePath storagePath2 = new StoragePath(hoodieTestTable.getBaseFilePath(p, fileId2).toUri());
+        writeParquetFile(
+            instant2,
+            storagePath2,
+            dataGen.generateInsertsForPartition(instant2, 10, p),
+            metaClient,
+            engineContext);
+        HoodieBaseFile baseFile2 = new HoodieBaseFile(hoodieTestTable.getBaseFilePath(p, fileId2).toString());
+        fileSlice2.setBaseFile(baseFile2);
+        partitionInfoList.add(new HoodieTableMetadataUtil.DirectoryInfo(
+            p,
+            metaClient.getStorage().listDirectEntries(Arrays.asList(storagePath1, storagePath2)),
+            instant2));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    List<String> columnsToIndex = Arrays.asList("rider", "driver");
+    HoodieData<HoodieRecord> result = HoodieTableMetadataUtil.convertFilesToPartitionStatsRecords(
+        engineContext,
+        partitionInfoList,
+        HoodieMetadataConfig.newBuilder().enable(true)
+            .withMetadataIndexColumnStats(true)
+            .withMetadataIndexPartitionStats(true)
+            .withColumnStatsIndexForColumns("rider,driver")
+            .withPartitionStatsIndexParallelism(1)
+            .build(),
+        metaClient);
+    // Validate the result.
+    List<HoodieRecord> records = result.collectAsList();
+    // 3 partitions * 2 columns = 6 partition stats records
+    assertEquals(6, records.size());
+    assertEquals(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), records.get(0).getPartitionPath());
+    ((HoodieMetadataPayload) result.collectAsList().get(0).getData()).getColumnStatMetadata().get().getColumnName();
+    records.forEach(r -> {
+      HoodieMetadataPayload payload = (HoodieMetadataPayload) r.getData();
+      assertTrue(payload.getColumnStatMetadata().isPresent());
+      // instant1 < instant2 so instant1 should be in the min value and instant2 should be in the max value.
+      if (payload.getColumnStatMetadata().get().getColumnName().equals("rider")) {
+        assertEquals(String.format("{\"value\": \"rider-%s\"}", instant1), String.valueOf(payload.getColumnStatMetadata().get().getMinValue()));
+        assertEquals(String.format("{\"value\": \"rider-%s\"}", instant2), String.valueOf(payload.getColumnStatMetadata().get().getMaxValue()));
+      } else if (payload.getColumnStatMetadata().get().getColumnName().equals("driver")) {
+        assertEquals(String.format("{\"value\": \"driver-%s\"}", instant1), String.valueOf(payload.getColumnStatMetadata().get().getMinValue()));
+        assertEquals(String.format("{\"value\": \"driver-%s\"}", instant2), String.valueOf(payload.getColumnStatMetadata().get().getMaxValue()));
+      }
+    });
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -70,6 +70,10 @@ public class TestMetadataPartitionType {
         metadataConfigBuilder.enable(true).withEnableRecordIndex(true);
         expectedEnabledPartitions = 2;
         break;
+      case PARTITION_STATS:
+        metadataConfigBuilder.enable(true).withMetadataIndexPartitionStats(true).withColumnStatsIndexForColumns("partitionCol");
+        expectedEnabledPartitions = 2;
+        break;
       default:
         throw new IllegalArgumentException("Unknown partition type: " + partitionType);
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -101,6 +101,7 @@ case class HoodieFileIndex(spark: SparkSession,
    */
   @transient private lazy val indicesSupport: List[SparkBaseIndexSupport] = List(
     new RecordLevelIndexSupport(spark, metadataConfig, metaClient),
+    new PartitionStatsIndexSupport(spark, schema, metadataConfig, metaClient),
     new FunctionalIndexSupport(spark, metadataConfig, metaClient),
     new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
   )

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.HoodieConversionUtils.toScalaOption
+import org.apache.hudi.avro.model.{HoodieMetadataColumnStats, HoodieMetadataRecord}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.data.HoodieData
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.ValidationUtils.checkState
+import org.apache.hudi.common.util.hash.ColumnIndexID
+import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
+import org.apache.hudi.util.JFunction
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
+
+import scala.collection.JavaConverters._
+
+class PartitionStatsIndexSupport(spark: SparkSession,
+                                 tableSchema: StructType,
+                                 @transient metadataConfig: HoodieMetadataConfig,
+                                 @transient metaClient: HoodieTableMetaClient,
+                                 allowCaching: Boolean = false)
+  extends ColumnStatsIndexSupport(spark, tableSchema, metadataConfig, metaClient, allowCaching) {
+
+  override def isIndexAvailable: Boolean = {
+    checkState(metadataConfig.isEnabled, "Metadata Table support has to be enabled")
+    metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS)
+  }
+
+  override def loadColumnStatsIndexRecords(targetColumns: Seq[String], shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
+    checkState(targetColumns.nonEmpty)
+    val encodedTargetColumnNames = targetColumns.map(colName => new ColumnIndexID(colName).asBase64EncodedString())
+    val metadataRecords: HoodieData[HoodieRecord[HoodieMetadataPayload]] =
+      metadataTable.getRecordsByKeyPrefixes(encodedTargetColumnNames.asJava, HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, shouldReadInMemory)
+    val columnStatsRecords: HoodieData[HoodieMetadataColumnStats] =
+      // NOTE: Explicit conversion is required for Scala 2.11
+      metadataRecords.map(JFunction.toJavaSerializableFunction(record => {
+          toScalaOption(record.getData.getInsertValue(null, null))
+            .map(metadataRecord => metadataRecord.asInstanceOf[HoodieMetadataRecord].getColumnStatsMetadata)
+            .orNull
+        }))
+        .filter(JFunction.toJavaSerializableFunction(columnStatsRecord => columnStatsRecord != null))
+
+    columnStatsRecords
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
@@ -46,12 +46,12 @@ case class HoodiePruneFileSourcePartitions(spark: SparkSession) extends Rule[Log
       val deterministicFilters = filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f))
       val normalizedFilters = exprUtils.normalizeExprs(deterministicFilters, lr.output)
 
-      val (partitionPruningFilters, _) =
+      val (partitionPruningFilters, dataFilters) =
         getPartitionFiltersAndDataFilters(fileIndex.partitionSchema, normalizedFilters)
 
       // [[HudiFileIndex]] is a caching one, therefore we don't need to reconstruct new relation,
       // instead we simply just refresh the index and update the stats
-      fileIndex.listFiles(partitionPruningFilters, Seq())
+      fileIndex.listFiles(partitionPruningFilters, dataFilters)
 
       if (partitionPruningFilters.nonEmpty) {
         // Change table stats based on the sizeInBytes of pruned files

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
@@ -318,6 +318,7 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
     options.put(HoodieMetadataConfig.ENABLE.key(), "true");
     options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     options.put(HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key(), "trip_type");
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     options.put(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true");
     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL());
     options.put(HoodieWriteConfig.TBL_NAME.key(), "testTable");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
@@ -109,6 +109,7 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
    */
   @Test
   public void testBaseFileOnly() {
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     Dataset<Row> inserts = makeInsertDf("000", 100);
     Dataset<Row> batch1 = inserts.where(matchCond);
     Dataset<Row> batch2 = inserts.where(nonMatchCond);
@@ -179,6 +180,7 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
    */
   @Test
   public void testBaseFileAndLogFileUpdateMatchesDeleteBlockCompact() {
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     testBaseFileAndLogFileUpdateMatchesHelper(false, true,true, false);
   }
 
@@ -192,6 +194,7 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
    */
   @Test
   public void testBaseFileAndLogFileUpdateMatchesAndRollBack() {
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     testBaseFileAndLogFileUpdateMatchesHelper(false, false,false, true);
   }
 
@@ -318,7 +321,7 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
     options.put(HoodieMetadataConfig.ENABLE.key(), "true");
     options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     options.put(HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key(), "trip_type");
-    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
+    // options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     options.put(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true");
     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL());
     options.put(HoodieWriteConfig.TBL_NAME.key(), "testTable");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
@@ -321,7 +321,6 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
     options.put(HoodieMetadataConfig.ENABLE.key(), "true");
     options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     options.put(HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key(), "trip_type");
-    // options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
     options.put(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true");
     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL());
     options.put(HoodieWriteConfig.TBL_NAME.key(), "testTable");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkUtils.scala
@@ -19,6 +19,7 @@
 package org.apache.hudi
 
 import org.apache.avro.generic.GenericRecord
+import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.getSparkConfForTest
 import org.apache.spark.sql.types.{ArrayType, StructField, StructType}
@@ -232,5 +233,14 @@ object TestHoodieSparkUtils {
     val newSchema = setNullableRec(schema, columnName.split('.'), 0)
     // apply new schema
     df.sqlContext.createDataFrame(df.rdd, newSchema)
+  }
+
+  /**
+   * Utility method for dropping all hoodie meta related columns.
+   */
+  def dropMetaFields(df: DataFrame): DataFrame = {
+    df.drop(HoodieRecord.HOODIE_META_COLUMNS.get(0)).drop(HoodieRecord.HOODIE_META_COLUMNS.get(1))
+      .drop(HoodieRecord.HOODIE_META_COLUMNS.get(2)).drop(HoodieRecord.HOODIE_META_COLUMNS.get(3))
+      .drop(HoodieRecord.HOODIE_META_COLUMNS.get(4))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.PartitionStatsIndexSupport
+import org.apache.hudi.TestHoodieSparkUtils.dropMetaFields
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
+import org.apache.hudi.common.model.{ActionType, HoodieCommitMetadata, WriteOperationType}
+import org.apache.hudi.common.table.timeline.{HoodieInstant, MetadataConversionUtils}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.metadata.HoodieBackedTableMetadata
+import org.apache.hudi.storage.StoragePath
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.util.JavaConversions
+import org.apache.spark.sql.functions.{col, not}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.Collectors
+import scala.collection.JavaConverters._
+import scala.collection.{JavaConverters, mutable}
+import scala.util.matching.Regex
+
+/**
+ * Common test setup and validation methods for partition stats index testing.
+ */
+class PartitionStatsIndexTestBase extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = _
+  var instantTime: AtomicInteger = _
+  val targetColumnsToIndex: Seq[String] = Seq("rider", "driver")
+  val metadataOpts: Map[String, String] = Map(
+    HoodieMetadataConfig.ENABLE.key -> "true",
+    HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key -> "true",
+    HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> targetColumnsToIndex.mkString(",")
+  )
+  val commonOpts: Map[String, String] = Map(
+    "hoodie.insert.shuffle.parallelism" -> "4",
+    "hoodie.upsert.shuffle.parallelism" -> "4",
+    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+    RECORDKEY_FIELD.key -> "_row_key",
+    PARTITIONPATH_FIELD.key -> "partition,trip_type",
+    HIVE_STYLE_PARTITIONING.key -> "true",
+    PRECOMBINE_FIELD.key -> "timestamp"
+  ) ++ metadataOpts
+  var mergedDfList: List[DataFrame] = List.empty
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    initPath()
+    initSparkContexts()
+    initHoodieStorage()
+    initTestDataGenerator()
+
+    setTableName("hoodie_test")
+    initMetaClient()
+
+    instantTime = new AtomicInteger(1)
+
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    cleanupResources()
+  }
+
+  protected def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
+    val lastInstant = String.format("%03d", new Integer(instantTime.incrementAndGet()))
+    if (enforce || metaClient.getActiveTimeline.lastInstant().get().getTimestamp.compareTo(lastInstant) < 0) {
+      println("Reloaded timeline")
+      metaClient.reloadActiveTimeline()
+      metaClient
+    }
+    metaClient
+  }
+
+  protected def rollbackLastInstant(hudiOpts: Map[String, String]): HoodieInstant = {
+    val lastInstant = getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
+      .lastInstant().get()
+    if (getLatestCompactionInstant != getLatestMetaClient(false).getActiveTimeline.lastInstant()
+      && lastInstant.getAction != ActionType.replacecommit.name()
+      && lastInstant.getAction != ActionType.clean.name()) {
+      mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+    }
+    val writeConfig = getWriteConfig(hudiOpts)
+    new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), writeConfig)
+      .rollback(lastInstant.getTimestamp)
+
+    if (lastInstant.getAction != ActionType.clean.name()) {
+      assertEquals(ActionType.rollback.name(), getLatestMetaClient(true).getActiveTimeline.lastInstant().get().getAction)
+    }
+    lastInstant
+  }
+
+  protected def executeFunctionNTimes[T](function0: Function0[T], n: Int): Unit = {
+    for (_ <- 1 to n) {
+      function0.apply()
+    }
+  }
+
+  protected def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
+    assertTrue(storage.deleteFile(new StoragePath(metaClient.getMetaPath, lastInstant.getFileName)))
+    assertTrue(storage.deleteFile(new StoragePath(metadataTableMetaClient.getMetaPath, metadataTableLastInstant.getFileName)))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  protected def deleteLastCompletedCommitFromTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    assertTrue(storage.deleteFile(new StoragePath(metaClient.getMetaPath, lastInstant.getFileName)))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  protected def getMetadataMetaClient(hudiOpts: Map[String, String]): HoodieTableMetaClient = {
+    getHoodieTable(metaClient, getWriteConfig(hudiOpts)).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+  }
+
+  protected def getLatestCompactionInstant: org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(s => Option(
+        try {
+          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
+            .orElse(new HoodieCommitMetadata())
+          commitMetadata
+        } catch {
+          case _: Exception => new HoodieCommitMetadata()
+        })
+        .map(c => c.getOperationType == WriteOperationType.COMPACT)
+        .get))
+      .lastInstant()
+  }
+
+  protected def getLatestClusteringInstant: org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
+  }
+
+  protected def doWriteAndValidateDataAndPartitionStats(hudiOpts: Map[String, String],
+                                                        operation: String,
+                                                        saveMode: SaveMode,
+                                                        validate: Boolean = true): DataFrame = {
+    var latestBatch: mutable.Buffer[String] = null
+    if (operation == UPSERT_OPERATION_OPT_VAL) {
+      val instantTime = getInstantTime
+      val records = recordsToStrings(dataGen.generateUniqueUpdates(instantTime, 20))
+      records.addAll(recordsToStrings(dataGen.generateInserts(instantTime, 20)))
+      latestBatch = records.asScala
+    } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
+      latestBatch = recordsToStrings(dataGen.generateInsertsForPartition(
+        getInstantTime, 20, dataGen.getPartitionPaths.last)).asScala
+    } else {
+      latestBatch = recordsToStrings(dataGen.generateInserts(getInstantTime, 20)).asScala
+    }
+    val latestBatchDf = spark.read.json(spark.sparkContext.parallelize(latestBatch, 2))
+    latestBatchDf.cache()
+    latestBatchDf.write.format("org.apache.hudi")
+      .options(hudiOpts)
+      .option(OPERATION.key, operation)
+      .mode(saveMode)
+      .save(basePath)
+    val deletedDf = calculateMergedDf(latestBatchDf, operation)
+    deletedDf.cache()
+    if (validate) {
+      validateDataAndPartitionStats(deletedDf)
+    }
+    deletedDf.unpersist()
+    latestBatchDf
+  }
+
+  /**
+   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
+   */
+  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = {
+    val prevDfOpt = mergedDfList.lastOption
+    if (prevDfOpt.isEmpty) {
+      mergedDfList = mergedDfList :+ latestBatchDf
+      sparkSession.emptyDataFrame
+    } else {
+      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
+        mergedDfList = mergedDfList :+ latestBatchDf
+        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
+        prevDfOpt.get
+      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
+        val overwrittenPartitions = latestBatchDf.select("partition")
+          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
+        val prevDf = prevDfOpt.get
+        val latestSnapshot = prevDf
+          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
+          .union(latestBatchDf)
+        mergedDfList = mergedDfList :+ latestSnapshot
+
+        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
+        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
+      } else {
+        val prevDf = prevDfOpt.get
+        val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
+          && prevDf("partition") === latestBatchDf("partition") && prevDf("trip_type") === latestBatchDf("trip_type"), "leftanti")
+        val latestSnapshot = prevDfOld.union(latestBatchDf)
+        mergedDfList = mergedDfList :+ latestSnapshot
+        sparkSession.emptyDataFrame
+      }
+    }
+  }
+
+  private def getInstantTime: String = {
+    String.format("%03d", new Integer(instantTime.incrementAndGet()))
+  }
+
+  protected def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
+    val props = TypedProperties.fromMap(JavaConverters.mapAsJavaMapConverter(hudiOpts).asJava)
+    HoodieWriteConfig.newBuilder()
+      .withProps(props)
+      .withPath(basePath)
+      .build()
+  }
+
+  protected def validateDataAndPartitionStats(inputDf: DataFrame = sparkSession.emptyDataFrame): Unit = {
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val readDf = spark.read.format("hudi").load(basePath)
+    val partitionStatsIndex = new PartitionStatsIndexSupport(
+      spark,
+      inputDf.schema,
+      HoodieMetadataConfig.newBuilder().enable(true).withMetadataIndexPartitionStats(true).build(),
+      metaClient)
+    val partitionStats = partitionStatsIndex.loadColumnStatsIndexRecords(List("partition", "trip_type"), shouldReadInMemory = true).collectAsList()
+    assertEquals(0, partitionStats.size())
+    val prevDf = mergedDfList.last.drop("tip_history")
+    val nonMatchingRecords = dropMetaFields(readDf).drop("tip_history")
+      .join(prevDf, prevDf.columns, "leftanti")
+    assertEquals(0, nonMatchingRecords.count())
+  }
+
+  def checkPartitionFilters(sparkPlan: String, partitionFilter: String): Boolean = {
+    val partitionFilterPattern: Regex = """PartitionFilters: \[(.*?)\]""".r
+    val tsPattern: Regex = (partitionFilter).r
+
+    val partitionFilterMatch = partitionFilterPattern.findFirstMatchIn(sparkPlan)
+
+    partitionFilterMatch match {
+      case Some(m) =>
+        val filters = m.group(1)
+        tsPattern.findFirstIn(filters).isDefined
+      case None =>
+        false
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -45,6 +45,9 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
 
   val sqlTempTable = "hudi_tbl"
 
+  /**
+   * Test case to do a write (no updates) and validate the partition stats index initialization.
+   */
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testIndexInitialization(tableType: HoodieTableType): Unit = {
@@ -55,6 +58,9 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       saveMode = SaveMode.Overwrite)
   }
 
+  /**
+   * Test case to do a write with updates and validate the partition stats index.
+   */
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testIndexWithUpsert(tableType: HoodieTableType): Unit = {
@@ -68,6 +74,9 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       saveMode = SaveMode.Append)
   }
 
+  /**
+   * Test case to do a write with updates for non-partitioned table and validate the partition stats index.
+   */
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testIndexWithUpsertNonPartitioned(tableType: HoodieTableType): Unit = {
@@ -82,28 +91,39 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       saveMode = SaveMode.Append)
   }
 
+  /**
+   * Test case to do a write with updates and rollback the last instant and validate the partition stats index.
+   */
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testIndexUpsertAndRollback(tableType: HoodieTableType): Unit = {
     val hudiOpts = commonOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name())
+    // Insert Operation
     doWriteAndValidateDataAndPartitionStats(
       hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Overwrite)
+    // Upsert Operation
     doWriteAndValidateDataAndPartitionStats(
       hudiOpts,
       operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Append)
+    // Another Upsert
     doWriteAndValidateDataAndPartitionStats(
       hudiOpts,
       operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Append)
+    // Rollback
     rollbackLastInstant(hudiOpts)
+    // Validate
     validateDataAndPartitionStats()
   }
 
+  /**
+   * Test case to do a write with updates and then validate file pruning using partition stats.
+   */
   @Test
-  def testPartitionStatsIndexWithSQL(): Unit = {
+  def testPartitionStatsIndexFilePruning(): Unit = {
     var hudiOpts = commonOpts
     hudiOpts = hudiOpts + (
       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
@@ -123,6 +143,9 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
     verifyQueryPredicate(hudiOpts)
   }
 
+  /**
+   * Test case to do a write with updates using partitionBy and validation partition filters pushed down to physical plan.
+   */
   @Test
   def testPartitionStatsWithPartitionBy(): Unit = {
     val hudiOpts = commonOpts.-(PARTITIONPATH_FIELD.key)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions.PARTITIONPATH_FIELD
+import org.apache.hudi.common.model.{FileSlice, HoodieTableType}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+import org.apache.hudi.metadata.HoodieMetadataFileSystemView
+import org.apache.hudi.util.JFunction
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieFileIndex}
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
+import org.apache.spark.sql.types.StringType
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{Tag, Test}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+import scala.collection.JavaConversions._
+
+/**
+ * Test cases on partition stats index with Spark datasource.
+ */
+@Tag("functional")
+class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
+
+  val sqlTempTable = "hudi_tbl"
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testIndexInitialization(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name())
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testIndexWithUpsert(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name())
+    doWriteAndValidateDataAndPartitionStats(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testIndexWithUpsertNonPartitioned(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts - PARTITIONPATH_FIELD.key + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name())
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testIndexUpsertAndRollback(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name())
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+    rollbackLastInstant(hudiOpts)
+    validateDataAndPartitionStats()
+  }
+
+  @Test
+  def testPartitionStatsIndexWithSQL(): Unit = {
+    var hudiOpts = commonOpts
+    hudiOpts = hudiOpts + (
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
+
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      validate = false)
+    doWriteAndValidateDataAndPartitionStats(
+      hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      validate = false)
+
+    createTempTable(hudiOpts)
+    verifyQueryPredicate(hudiOpts)
+  }
+
+  @Test
+  def testPartitionStatsWithPartitionBy(): Unit = {
+    val hudiOpts = commonOpts.-(PARTITIONPATH_FIELD.key)
+    // Insert Operation
+    val records = recordsToStrings(dataGen.generateInserts("000", 100)).toList
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+
+    inputDF.write.partitionBy("partition").format("hudi")
+      .options(hudiOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(KeyGeneratorOptions.URL_ENCODE_PARTITIONING.key, "true")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val snapshot0 = spark.read.format("org.apache.hudi").options(hudiOpts).load(basePath).where("partition > '2015/03/16'")
+    snapshot0.cache()
+    assertTrue(checkPartitionFilters(snapshot0.queryExecution.executedPlan.toString, "partition.* > 2015/03/16"))
+    assertEquals(67, snapshot0.count())
+  }
+
+  def verifyQueryPredicate(hudiOpts: Map[String, String]): Unit = {
+    val reckey = mergedDfList.last.limit(1).collect().map(row => row.getAs("_row_key").toString)
+    val dataFilter = EqualTo(attribute("_row_key"), Literal(reckey(0)))
+    assertEquals(2, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
+    verifyFilePruning(hudiOpts, dataFilter)
+  }
+
+  private def attribute(partition: String): AttributeReference = {
+    AttributeReference(partition, StringType, true)()
+  }
+
+  private def createTempTable(hudiOpts: Map[String, String]): Unit = {
+    val readDf = spark.read.format("hudi").options(hudiOpts).load(basePath)
+    readDf.createOrReplaceTempView(sqlTempTable)
+  }
+
+  private def verifyFilePruning(opts: Map[String, String], dataFilter: Expression): Unit = {
+    // with data skipping
+    val commonOpts = opts + ("path" -> basePath)
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    var fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts, includeLogFiles = true)
+    val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
+    val filteredFilesCount = filteredPartitionDirectories.flatMap(s => s.files).size
+    assertTrue(filteredFilesCount <= getLatestDataFilesCount(opts))
+
+    // with no data skipping
+    fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false"), includeLogFiles = true)
+    val filesCountWithNoSkipping = fileIndex.listFiles(Seq(), Seq(dataFilter)).flatMap(s => s.files).size
+    assertTrue(filteredFilesCount <= filesCountWithNoSkipping)
+  }
+
+  private def getLatestDataFilesCount(opts: Map[String, String], includeLogFiles: Boolean = true) = {
+    var totalLatestDataFiles = 0L
+    getTableFileSystemView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
+      .values()
+      .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
+        (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
+          slice => totalLatestDataFiles += (if (includeLogFiles) slice.getLogFiles.count() else 0)
+            + (if (slice.getBaseFile.isPresent) 1 else 0)))))
+    totalLatestDataFiles
+  }
+
+  private def getTableFileSystemView(opts: Map[String, String]): HoodieMetadataFileSystemView = {
+    new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline, metadataWriter(getWriteConfig(opts)).getTableMetadata)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
@@ -21,6 +21,7 @@ package org.apache.hudi.functional
 
 import org.apache.hudi.common.model.WriteOperationType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.junit.jupiter.api.Tag
 
@@ -63,7 +64,7 @@ class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
       // Check the missing properties for spark sql
       val metaClient = HoodieTableMetaClient.builder()
         .setBasePath(tablePath)
-        .setConf(spark.sessionState.newHadoopConf())
+        .setConf(HoodieTestUtils.getDefaultStorageConf)
         .build()
       val properties = metaClient.getTableConfig.getProps.asScala.toMap
       assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
@@ -31,7 +31,7 @@ class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
 
   val sqlTempTable = "hudi_tbl"
 
-  test("Test Create Table As Select") {
+  test("Test partition stats index following insert, merge into, update and delete") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.common.model.WriteOperationType
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.junit.jupiter.api.Tag
+
+import scala.collection.JavaConverters._
+
+@Tag("functional")
+class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
+
+  val sqlTempTable = "hudi_tbl"
+
+  test("Test Create Table As Select") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      // Create table with date type partition
+      spark.sql(
+        s"""
+           | create table $tableName using hudi
+           | partitioned by (dt)
+           | tblproperties(
+           |    primaryKey = 'id',
+           |    preCombineField = 'ts',
+           |    'hoodie.metadata.index.partition.stats.enable' = 'true'
+           | )
+           | location '$tablePath'
+           | AS
+           | select 1 as id, 'a1' as name, 10 as price, 1000 as ts, cast('2021-05-06' as date) as dt
+         """.stripMargin
+      )
+
+      assertResult(WriteOperationType.BULK_INSERT) {
+        HoodieSparkSqlTestBase.getLastCommitMetadata(spark, tablePath).getOperationType
+      }
+      checkAnswer(s"select id, name, price, ts, cast(dt as string) from $tableName")(
+        Seq(1, "a1", 10, 1000, "2021-05-06")
+      )
+
+      val partitionValue = "2021-05-06"
+
+      // Check the missing properties for spark sql
+      val metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(tablePath)
+        .setConf(spark.sessionState.newHadoopConf())
+        .build()
+      val properties = metaClient.getTableConfig.getProps.asScala.toMap
+      assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+      assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+      assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELD.key))
+      assertResult(tableName)(metaClient.getTableConfig.getTableName)
+
+      // Test insert into
+      spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, cast('$partitionValue' as date))")
+      checkAnswer(s"select _hoodie_record_key, _hoodie_partition_path, id, name, price, ts, cast(dt as string) from $tableName order by id")(
+        Seq("1", s"dt=$partitionValue", 1, "a1", 10, 1000, partitionValue),
+        Seq("2", s"dt=$partitionValue", 2, "a2", 10, 1000, partitionValue)
+      )
+      // Test merge into
+      spark.sql(
+        s"""
+           |merge into $tableName h0
+           |using (select 1 as id, 'a1' as name, 11 as price, 1001 as ts, '$partitionValue' as dt) s0
+           |on h0.id = s0.id
+           |when matched then update set *
+           |""".stripMargin)
+      checkAnswer(s"select _hoodie_record_key, _hoodie_partition_path, id, name, price, ts, cast(dt as string) from $tableName order by id")(
+        Seq("1", s"dt=$partitionValue", 1, "a1", 11, 1001, partitionValue),
+        Seq("2", s"dt=$partitionValue", 2, "a2", 10, 1000, partitionValue)
+      )
+      // Test update
+      spark.sql(s"update $tableName set price = price + 1 where id = 2")
+      checkAnswer(s"select _hoodie_record_key, _hoodie_partition_path, id, name, price, ts, cast(dt as string) from $tableName order by id")(
+        Seq("1", s"dt=$partitionValue", 1, "a1", 11, 1001, partitionValue),
+        Seq("2", s"dt=$partitionValue", 2, "a2", 11, 1000, partitionValue)
+      )
+      // Test delete
+      spark.sql(s"delete from $tableName where id = 1")
+      checkAnswer(s"select _hoodie_record_key, _hoodie_partition_path, id, name, price, ts, cast(dt as string) from $tableName order by id")(
+        Seq("2", s"dt=$partitionValue", 2, "a2", 11, 1000, partitionValue)
+      )
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
@@ -608,9 +608,9 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           assert(result3DF.count() == 3)
 
           val result4DF = spark.sql(
-            s"select type, key, ColumnStatsMetadata from hudi_metadata('$identifier') where type=3"
+            s"select type, key, ColumnStatsMetadata from hudi_metadata('$identifier') where type=3 or type=6"
           )
-          assert(result4DF.count() == 3)
+          assert(result4DF.count() == 6)
 
           val result5DF = spark.sql(
             s"select type, key, recordIndexMetadata from hudi_metadata('$identifier') where type=5"
@@ -621,6 +621,71 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
             s"select type, key, BloomFilterMetadata from hudi_metadata('$identifier') where BloomFilterMetadata is not null"
           )
           assert(result6DF.count() == 0)
+        }
+      }
+    }
+    spark.sessionState.conf.unsetConf(SPARK_SQL_INSERT_INTO_OPERATION.key)
+  }
+
+  test(s"Test hudi_metadata Table-Valued Function For PARTITION_STATS index") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        Seq("cow", "mor").foreach { tableType =>
+          val tableName = generateTableName
+          val identifier = tableName
+          spark.sql("set " + SPARK_SQL_INSERT_INTO_OPERATION.key + "=upsert")
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  ts long,
+               |  price int
+               |) using hudi
+               |partitioned by (ts)
+               |tblproperties (
+               |  type = '$tableType',
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts',
+               |  hoodie.datasource.write.recordkey.field = 'id',
+               |  hoodie.metadata.index.partition.stats.enable = 'true',
+               |  hoodie.metadata.index.column.stats.column.list = 'price'
+               |)
+               |location '${tmp.getCanonicalPath}/$tableName'
+               |""".stripMargin
+          )
+
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | values (1, 'a1', 1000, 10), (2, 'a2', 2000, 20), (3, 'a3', 3000, 30), (4, 'a4', 2000, 10), (5, 'a5', 3000, 20), (6, 'a6', 4000, 30)
+               | """.stripMargin
+          )
+
+          val result2DF = spark.sql(
+            s"select type, key, filesystemmetadata from hudi_metadata('$identifier') where type=1"
+          )
+          assert(result2DF.count() == 1)
+
+          val result3DF = spark.sql(
+            s"select type, key, filesystemmetadata from hudi_metadata('$identifier') where type=2"
+          )
+          assert(result3DF.count() == 3)
+
+          val result4DF = spark.sql(
+            s"select * from hudi_metadata('$identifier') where type=3"
+          )
+          assert(result4DF.count() == 3)
+          checkAnswer(spark.sql(s"select ColumnStatsMetadata.minValue.member1.value from hudi_metadata('$identifier') where type=3").collect())(
+            Seq(1000),
+            Seq(2000),
+            Seq(3000)
+          )
+          checkAnswer(spark.sql(s"select ColumnStatsMetadata.maxValue.member1.value from hudi_metadata('$identifier') where type=3").collect())(
+            Seq(2000),
+            Seq(3000),
+            Seq(4000)
+          )
         }
       }
     }


### PR DESCRIPTION
### Change Logs

Build storage partition stats index and use it for data skipping. Main changes are as follows:

- Index is saved as another partition in the metadata table.
- Each index entry is a key-value, where key is the hash(columnName).concat(hash(partitionName)), and value is the stats.
- New configs in `HoodieMetadataConfig` and the writer changes are in `HoodieBackedTableMetadataWriter` with some util methods in `HoodieTableMetadataUtil`
- On the read path, main changes are in `HoodieFileIndex`. First, the partition pruning happens as usual, then depending on data filters, data can be skipped further if partition stats index is available.

### Impact

Stats aggregated by storage partition. Efficient data skipping. Meta sync need not sync the partition metadata. Queries will use the index while planning in the driver.


### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
