### PR TITLE
[HUDI-7239] add maxPendingClusteringPlanNums for clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -151,6 +151,12 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .sinceVersion("0.9.0")
       .withDocumentation("Config to control frequency of async clustering");
 
+  public static final ConfigProperty<String> ASYNC_CLUSTERING_PLAN_MAX_PENDING_NUMS = ConfigProperty
+          .key("hoodie.clustering.plan.max.pending.nums")
+          .defaultValue("1")
+          .sinceVersion("0.14.1")
+          .withDocumentation("Config to control max count of async clustering plan");
+
   public static final ConfigProperty<Integer> CLUSTERING_MAX_PARALLELISM = ConfigProperty
       .key("hoodie.clustering.max.parallelism")
       .defaultValue(15)
@@ -601,6 +607,11 @@ public class HoodieClusteringConfig extends HoodieConfig {
 
     public Builder withAsyncClustering(Boolean asyncClustering) {
       clusteringConfig.setValue(ASYNC_CLUSTERING_ENABLE, String.valueOf(asyncClustering));
+      return this;
+    }
+
+    public Builder withAsyncClusteringPlanMaxPendingNums(int pendingNums) {
+      clusteringConfig.setValue(ASYNC_CLUSTERING_PLAN_MAX_PENDING_NUMS, String.valueOf(pendingNums));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1685,6 +1685,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.ASYNC_CLUSTERING_MAX_COMMITS);
   }
 
+  public int getAsyncClusterPlanMaxPendingNums() {
+    return getInt(HoodieClusteringConfig.ASYNC_CLUSTERING_PLAN_MAX_PENDING_NUMS);
+  }
+
   public String getPayloadClass() {
     return getString(HoodiePayloadConfig.PAYLOAD_CLASS_NAME);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -788,6 +788,13 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(4)
       .withDescription("Max delta commits needed to trigger clustering, default 4 commits");
 
+  public static final ConfigOption<Integer> CLUSTERING_MAX_PENDING_NUMS = ConfigOptions
+          .key("clustering.max.pending_nums")
+          .intType()
+          .defaultValue(1)
+          .withDescription("Maximum number of outstanding inflight/requested clustering.  "
+                  + "Clustering Plan will not be scheduled unless outstanding clustering is less than this number");
+
   @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_TASKS = ConfigOptions
       .key("clustering.tasks")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -178,6 +178,7 @@ public class FlinkWriteClients {
                     .withAsyncClusteringMaxCommits(conf.getInteger(FlinkOptions.CLUSTERING_DELTA_COMMITS))
                     .withScheduleInlineClustering(conf.getBoolean(FlinkOptions.CLUSTERING_SCHEDULE_ENABLED))
                     .withAsyncClustering(conf.getBoolean(FlinkOptions.CLUSTERING_ASYNC_ENABLED))
+                    .withAsyncClusteringPlanMaxPendingNums(conf.getInteger(FlinkOptions.CLUSTERING_MAX_PENDING_NUMS))
                     .build())
             .withCleanConfig(HoodieCleanConfig.newBuilder()
                 .withAsyncClean(conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED))

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
@@ -24,7 +24,6 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ClusteringUtils;


### PR DESCRIPTION
### Change Logs

when async clustering start, currently if satisfy the delta-commit, it will generate clustering plan. however, when last clustering plan isn't completed, the next clustering plan will also schedule, maybe we can support a param to controll the max pending cluster plan num.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
