### PR TITLE
[HUDI-7242] Avoid unnecessary bigquery table update when using sync tool

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -115,7 +115,7 @@ public class BigQuerySyncTool extends HoodieSyncTool {
 
   private boolean tableExists(HoodieBigQuerySyncClient bqSyncClient, String tableName) {
     if (bqSyncClient.tableExists(tableName)) {
-      LOG.info(tableName + " already exists");
+      LOG.info(tableName + " already exists. Skip table creation.");
       return true;
     }
     return false;

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -25,13 +25,16 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.sync.common.HoodieSyncConfig;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.ExternalTableDefinition;
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.HivePartitioningOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.Table;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,12 +42,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 public class TestHoodieBigQuerySyncClient {
   private static final String PROJECT_ID = "test_project";
@@ -124,5 +132,32 @@ public class TestHoodieBigQuerySyncClient {
     assertEquals(configuration.getQuery(),
         String.format("CREATE OR REPLACE EXTERNAL TABLE `%s.%s.%s` ( `field` STRING ) OPTIONS (enable_list_inference=true, uris=[\"%s\"], format=\"PARQUET\", "
             + "file_set_spec_type=\"NEW_LINE_DELIMITED_MANIFEST\")", PROJECT_ID, TEST_DATASET, TEST_TABLE, MANIFEST_FILE_URI));
+  }
+
+  @Test
+  void skipUpdatingSchema_partitioned() throws Exception {
+    BigQuerySyncConfig config = new BigQuerySyncConfig(properties);
+    client = new HoodieBigQuerySyncClient(config, mockBigQuery);
+    Table mockTable = mock(Table.class);
+    ExternalTableDefinition mockTableDefinition = mock(ExternalTableDefinition.class);
+    // The table schema has no change: it contains a "field" and a "partition_field".
+    Schema schema = Schema.of(Field.of("field", StandardSQLTypeName.STRING));
+    List<String> partitionFields = new ArrayList<String>();
+    partitionFields.add("partition_field");
+    List<Field> bqFields = new ArrayList<Field>();
+    // The "partition_field" always follows "field".
+    bqFields.add(Field.of("field", StandardSQLTypeName.STRING));
+    bqFields.add(Field.of("partition_field", StandardSQLTypeName.STRING));
+    Schema bqSchema = Schema.of(bqFields);
+    HivePartitioningOptions hivePartitioningOptions = HivePartitioningOptions.newBuilder().setRequirePartitionFilter(true).build();
+
+    when(mockBigQuery.getTable(any())).thenReturn(mockTable);
+    when(mockTable.getDefinition()).thenReturn(mockTableDefinition);
+    when(mockTableDefinition.getSchema()).thenReturn(bqSchema);
+    when(mockTableDefinition.getHivePartitioningOptions()).thenReturn(hivePartitioningOptions);
+
+    client.updateTableSchema(TEST_TABLE, schema, partitionFields);
+    // Expect no update.
+    verify(mockBigQuery, never()).update(mockTable);
   }
 }


### PR DESCRIPTION
### Change Logs

The [PR](https://github.com/apache/hudi/pull/9482) added a table schema update step for bigquery sync tool. It seems there're two issues (this PR focuses on the 1st one): 

1. When it reform the schema which is then compared to the bq table schema, the reformed schema puts partition fields in the beginning, while the bq table schema by default has partition fields at the end. So it unnecessarily triggers a schema update due to to order difference.

2. Though the sync tool for 0.14.0 does not support big lake connection id (there's a recent PR last month adding this support), a user can still recreate their table manually by adding connection id. The table update is adding the new schema into. external table definition. This does not work for biglake tables, and will cause error: "Schema can be specified only on the Table.Schema field for external tables with an associated connection_id but schema was provided on Table.Externaldataconfig.Schema". 


### Impact

Avoid the unnecessary table update.

### Risk level (write none, low medium or high below)

low. It only corrects the order of fields.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
