### PR TITLE
[HUDI-7249][Close compaction when using append mode

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
@@ -96,6 +96,8 @@ public class HoodieTableSink implements
 
       // Append mode
       if (OptionsResolver.isAppendMode(conf)) {
+        // close compaction for append mode
+        conf.set(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
         DataStream<Object> pipeline = Pipelines.append(conf, rowType, dataStream);
         if (OptionsResolver.needsAsyncClustering(conf)) {
           return Pipelines.cluster(conf, rowType, pipeline);


### PR DESCRIPTION
### Change Logs

Close compaction when using append mode

### Impact

Unnecessary operations for StreamWriteOperatorCoordinator when using append mode. 
And it brought in the memory consumption of jobmanager container when scheduling compcation.

### Risk level (write none, low medium or high below)


### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
