### PR TITLE
[HUDI-7246] Fix Data Skipping Issue: No Results When Query Conditions Involve Both Columns with and without Column Stats

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -48,17 +48,17 @@ case class IndexRow(fileName: String,
                     // Corresponding A column is LongType
                     A_minValue: Long = -1,
                     A_maxValue: Long = -1,
-                    A_nullCount: Long = -1,
+                    A_nullCount: java.lang.Long = null,
 
                     // Corresponding B column is StringType
                     B_minValue: String = null,
                     B_maxValue: String = null,
-                    B_nullCount: Long = -1,
+                    B_nullCount: java.lang.Long = null,
 
                     // Corresponding B column is TimestampType
                     C_minValue: Timestamp = null,
                     C_maxValue: Timestamp = null,
-                    C_nullCount: Long = -1) {
+                    C_nullCount: java.lang.Long = null) {
   def toRow: Row = Row(productIterator.toSeq: _*)
 }
 
@@ -89,7 +89,8 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
   @MethodSource(Array(
     "testBasicLookupFilterExpressionsSource",
     "testAdvancedLookupFilterExpressionsSource",
-    "testCompositeFilterExpressionsSource"
+    "testCompositeFilterExpressionsSource",
+    "testSupportedAndUnsupportedDataSkippingColumnsSource"
   ))
   def testLookupFilterExpressions(sourceFilterExprStr: String, input: Seq[IndexRow], expectedOutput: Seq[String]): Unit = {
     // We have to fix the timezone to make sure all date-bound utilities output
@@ -194,6 +195,38 @@ object TestDataSkippingUtils {
           IndexRow("file_4", valueCount = 1, B_minValue = "ABC123", B_maxValue = "ABC345", B_nullCount = 0) // all strings start w/ "ABC" (after upper)
         ),
         Seq("file_1", "file_2", "file_3"))
+    )
+  }
+
+  def testSupportedAndUnsupportedDataSkippingColumnsSource(): java.util.stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(
+      arguments(
+        "A = 1 and B is not null",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null)
+        ),
+        Seq("file_1", "file_2")
+      ),
+      arguments(
+        "B = 1 and B is not null",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null)
+        ),
+        Seq("file_1", "file_2", "file_3")
+      ),
+      arguments(
+        "A = 1 and A is not null and B is not null and B > 2",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null)
+        ),
+        Seq("file_1", "file_2")
+      )
     )
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkippingQuery.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkippingQuery.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestDataSkippingQuery extends HoodieSparkSqlTestBase {
+
+  test("Test the data skipping query involves conditions " +
+    "that cover both columns supported by column stats and those that are not supported.") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql("set hoodie.metadata.enable = true")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = true")
+      spark.sql("set hoodie.enable.data.skipping = true")
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  attributes map<string, string>,
+           |  price double,
+           |  ts long,
+           |  dt string
+           |) using hudi
+           | tblproperties (primaryKey = 'id')
+           | partitioned by (dt)
+           | location '${tmp.getCanonicalPath}'
+                  """.stripMargin)
+      spark.sql(
+        s"""
+           | insert into $tableName values
+           | (1, 'a1', map('color', 'red', 'size', 'M'), 10, 1000, '2021-01-05'),
+           | (2, 'a2', map('color', 'blue', 'size', 'L'), 20, 2000, '2021-01-06'),
+           | (3, 'a3', map('color', 'green', 'size', 'S'), 30, 3000, '2021-01-07')
+                  """.stripMargin)
+      // Check the case where the WHERE condition only includes columns not supported by column stats
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+      // Check the case where the WHERE condition only includes columns supported by column stats
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where name='a1'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+      // Check the case where the WHERE condition includes both columns supported by column stats and those that are not
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red' and name='a1'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+    }
+  }
+
+  test("Test data skipping when specifying columns with column stats support.") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql("set hoodie.metadata.enable = true")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = true")
+      spark.sql("set hoodie.enable.data.skipping = true")
+      spark.sql("set hoodie.metadata.index.column.stats.column.list = name")
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  attributes map<string, string>,
+           |  price double,
+           |  ts long,
+           |  dt string
+           |) using hudi
+           | tblproperties (primaryKey = 'id')
+           | partitioned by (dt)
+           | location '${tmp.getCanonicalPath}'
+                  """.stripMargin)
+      spark.sql(
+        s"""
+           | insert into $tableName values
+           | (1, 'a1', map('color', 'red', 'size', 'M'), 10, 1000, '2021-01-05'),
+           | (2, 'a2', map('color', 'blue', 'size', 'L'), 20, 2000, '2021-01-06'),
+           | (3, 'a3', map('color', 'green', 'size', 'S'), 30, 3000, '2021-01-07')
+                  """.stripMargin)
+      // Check the case where the WHERE condition only includes columns not supported by column stats
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+      // Check the case where the WHERE condition only includes columns supported by column stats
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where name='a1'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+      // Check the case where the WHERE condition includes both columns supported by column stats and those that are not
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red' and name='a1'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+      // Check WHERE condition that includes both columns with existing column stats and columns of types
+      // that support column stats but for which column stats do not exist
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where ts=1000 and name='a1'")(
+        Seq(1, "a1", 10.0, 1000, "2021-01-05")
+      )
+    }
+  }
+}


### PR DESCRIPTION
In the current code version, support for column stats has not yet been extended to handle complex nested data types, such as map-type data structures. Take the table tbl as an example, which is defined with three fields: an integer field id, a string field name, and a map-type field attributes. Within this table structure, the id and name fields support column stats, and as such, HUDI will generate the corresponding column stats indices for these two fields at the time of table creation. However, no corresponding index will be generated for the attributes field. The specific table creation statement is as follows:
```
create table tbl (
  id int,
  name string,
  attributes map<string, string>
) ...
```
To elaborate further, consider the following insert operation:
```
insert into tbl values
(1, 'a1', map('color', 'red', 'size', 'M')),
(2, 'a2', map('color', 'blue', 'size', 'L'));
```
After the execution of the insert, the content of the column stats should be as follows:
```
a.parquet   id     min: 1   max: 1   null: 0
b.parquet   id     min: 2   max: 2   null: 0
a.parquet   name   min: 'a1' max: 'a1' null: 0
b.parquet   name   min: 'a2' max: 'a2' null: 0
```
This means that there is no column stats index for the attributes column.
Based on the table tbl, when we execute a query:

#### Queries containing both columns supported and not supported by column stats
Let's consider a query adjusted to:
`select * from tbl where attributes.color = 'red' and name = 'a1'`
At this point, queryReferencedColumns includes attributes and name, and the queryFilters are as follows. 
```
isnotnull(attributes#95)
isnotnull(name#94)
(attributes#95[color] = red)
(name#94 = a1)
```

The content of transposedColStatsDF is shown below:
```
+--------------------+----------+-------------------+-------------------+--------------------+-------------+-------------+--------------+
|            fileName|valueCount|attributes_minValue|attributes_maxValue|attributes_nullCount|name_minValue|name_maxValue|name_nullCount|
+--------------------+----------+-------------------+-------------------+--------------------+-------------+-------------+--------------+
|3363b50e-ca25-4fb...|         1|               null|               null|                   1|           a2|           a2|             0|
|876af2ed-d529-4df...|         1|               null|               null|                   1|           a1|           a1|             0|
+--------------------+----------+-------------------+-------------------+--------------------+-------------+-------------+--------------+
```

This implies that targetIndexedColumns is the intersection of targetColumnNames and indexedColumns, and indexedColumns, by default, includes all the schema fields of the table (tableSchema.fieldNames.toSet) when we haven't explicitly configured a column stats list. This includes the Map type attributes, and targetColumnNames includes columns relevant to the query, so the intersection still results in targetColumnNames and name.
Returning to the code for transposedRows, because there are no corresponding column stats for attributes, rows where min=null, max=null, and null_count=valueCount are added to avoid errors during subsequent where filtering. This is the origin of attributes_minValue, attributes_maxValue, and attributes_nullCount in the resulting DataFrame.
Let's revisit getCandidateFiles and take a closer look at the assembly of indexFilter. The queryFilters mentioned earlier are processed in translateIntoColumnStatsIndexFilterExpr, where expressions are transformed, defaulting to True if they cannot be converted. We can skip over name since it's a string type and can be converted directly.
For map types, there are two expressions: isnotnull(attributes#95) This hits the case:
```
case IsNotNull(attribute: AttributeReference) =>
  getTargetIndexedColumnName(attribute, indexSchema)
    .map(colName => LessThan(genColNumNullsExpr(colName), genColValueCountExpr))
```
The corresponding value is 'attributes_nullCount < 'valueCount.
However, EqualTo expressions like (attributes#95[color] = red) should, theoretically, match equalTo cases but actually do not since AllowedTransformationExpression does not support the getMapValue type, resulting in a None and no match.
Ultimately, nothing matches, resulting in None, which means the expression for attributes ends up being 'attributes_nullCount < 'valueCount And True.
Herein lies a problem:
`acc ++= Seq(null, null, valueCount)`
The null_count for attributes always equals valueCount, so the expression 'attributes_nullCount < 'valueCount will always be False. As a result, prunedCandidateFileNames will always be empty. However, since indexDf does have value, allIndexedFileNames will not be empty, leading notIndexedFileNames to be empty.
Consequently, the end result is that getCandidateFiles will always return an empty set! This presents a significant issue because the indexFilter effectively fails to filter any files based on the attributes column, due to the fact that its null_count is always set to match valueCount, rendering the condition perpetually false. 

#### Problem Summary
Under the existing code implementation, when data skipping is enabled and the index columns have not been explicitly specified in the parameters, if the query conditions include both columns that are supported by column stats and those that are not, no data will ever be retrieved!
#### Problem Fix
We can see that the variables directly causing the issue are indexDf and indexFilter:

-  indexDf includes unsupported columns, filled with inappropriate values.
-  indexFilter also contains query conditions not supported by the index. And indexDf is filled with inappropriate values to adapt to these conditions.
-  Moreover, the unsupported query conditions in indexFilter are obtained from filtering the schema derived from indexDf.

A more straightforward fix would be to set the null_count for non-existent columns directly to null (refer to [HUDI-4250][HUDI-4202]), and incorporate this check into the isNotNull evaluation. This way, there would be no erroneous filtering leading to exceptions. However, I'm not sure what issues were encountered with null before? [HUDI-5557] removed this scenario, but setting it to value_count could also lead to errors. I would like to inquire if the issues with null and value_count are similar?  @rfyu @alexeykudinkin 

### Change Logs

When data skipping, filter the columns.

### Impact

None

### Risk level (write none, low medium or high below)

medium

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
