### PR TITLE
[HUDI-7258] Fix dynamodb http endpoint

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
@@ -159,7 +159,7 @@ public class DynamoDBBasedLockProvider implements LockProvider<LockItem> {
             ? this.dynamoDBLockConfiguration.getString(DynamoDbBasedLockConfig.DYNAMODB_ENDPOINT_URL)
             : DynamoDbClient.serviceMetadata().endpointFor(Region.of(region)).toString();
 
-    if (!endpointURL.startsWith("https://") || !endpointURL.startsWith("http://")) {
+    if (!endpointURL.startsWith("https://") && !endpointURL.startsWith("http://")) {
       endpointURL = "https://" + endpointURL;
     }
 


### PR DESCRIPTION
fixes #10394

### Change Logs

New dynamodb lock provider introduced in 0.14 fails to connect to http /https based dynamodb endpoint. It only works when no protocol is prepended , and only support https.

This fixes the issue

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
