### PR TITLE
[HUDI-7529] fix multiple tasks get the lock at the same time when use…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockInfo.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockInfo.java
@@ -21,7 +21,9 @@ package org.apache.hudi.client.transaction.lock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.hudi.common.util.JsonUtils;
+import org.apache.hudi.exception.HoodieIOException;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class LockInfo {
@@ -53,6 +55,14 @@ public class LockInfo {
     lockStacksInfo = new ArrayList<>();
     for (StackTraceElement ste : stacks) {
       lockStacksInfo.add(String.format("%s.%s (%s:%s)", ste.getClassName(), ste.getMethodName(), ste.getFileName(), ste.getLineNumber()));
+    }
+  }
+
+  public static LockInfo getLockInfoByJson(String json) throws IOException {
+    try {
+      return JsonUtils.getObjectMapper().readValue(json, LockInfo.class);
+    } catch (JsonProcessingException e) {
+      throw new HoodieIOException("get lock info error", e);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestFileBasedLockProvider.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestFileBasedLockProvider.java
@@ -20,10 +20,17 @@
 package org.apache.hudi.client;
 
 import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider;
+import org.apache.hudi.client.transaction.lock.LockInfo;
 import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,7 +46,9 @@ import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_NUM_R
 import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFileBasedLockProvider {
@@ -108,5 +117,97 @@ public class TestFileBasedLockProvider {
       FileSystemBasedLockProvider fileBasedLockProvider = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
       fileBasedLockProvider.unlock();
     });
+  }
+
+  @Test
+  public void testUnlockInMultiThread() throws IOException {
+
+    String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY, null);
+    if (StringUtils.isNullOrEmpty(lockDirectory)) {
+      lockDirectory = lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key())
+          + org.apache.hadoop.fs.Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
+    }
+    org.apache.hadoop.fs.Path lockFile = new org.apache.hadoop.fs.Path(lockDirectory + org.apache.hadoop.fs.Path.SEPARATOR + "lock");
+    FileSystem fs = FSUtils.getFs(lockFile.toString(), hadoopConf);
+    // lockOne create lock first
+    FileSystemBasedLockProvider fileBasedLockProviderOne = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
+    assertTrue(fileBasedLockProviderOne.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    assertTrue(fs.exists(lockFile));
+
+    FileSystemBasedLockProvider fileBasedLockProviderTwo = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
+    // lockTwo lock fail
+    assertFalse(fileBasedLockProviderTwo.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    // lockTwo can not release lock
+    fileBasedLockProviderTwo.unlock();
+    assertTrue(fs.exists(lockFile));
+    fileBasedLockProviderTwo.close();
+    assertTrue(fs.exists(lockFile));
+
+    // the same lockTwo
+    FileSystemBasedLockProvider fileBasedLockProviderThree = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
+    assertFalse(fileBasedLockProviderThree.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fileBasedLockProviderThree.unlock();
+    assertTrue(fs.exists(lockFile));
+    fileBasedLockProviderThree.close();
+    assertTrue(fs.exists(lockFile));
+
+    // lockOne release lock
+    fileBasedLockProviderOne.unlock();
+    assertFalse(fs.exists(lockFile));
+
+    // test close release lock
+    assertTrue(fileBasedLockProviderOne.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    assertTrue(fs.exists(lockFile));
+    fileBasedLockProviderOne.close();
+    assertFalse(fs.exists(lockFile));
+
+    // lockTwo can get lock
+    assertTrue(fileBasedLockProviderTwo.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    assertTrue(fs.exists(lockFile));
+  }
+
+  @Test
+  public void testLockExpire() throws IOException, InterruptedException {
+    String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY, null);
+    if (StringUtils.isNullOrEmpty(lockDirectory)) {
+      lockDirectory = lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key())
+          + org.apache.hadoop.fs.Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
+    }
+    org.apache.hadoop.fs.Path lockFile = new org.apache.hadoop.fs.Path(lockDirectory + org.apache.hadoop.fs.Path.SEPARATOR + "lock");
+    FileSystem fs = FSUtils.getFs(lockFile.toString(), hadoopConf);
+    FileSystemBasedLockProvider fileBasedLockProviderOne = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
+    FileSystemBasedLockProvider fileBasedLockProviderTwo = new FileSystemBasedLockProvider(lockConfiguration, hadoopConf);
+
+    // if lock expire, current lock will be released, and current lock can not release others
+    assertTrue(fileBasedLockProviderOne.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    Thread.sleep(60000);
+    assertTrue(fs.exists(lockFile));
+    FSDataInputStream fis = fs.open(lockFile);
+    String lockJson = FileIOUtils.readAsUTFString(fis);
+    fis.close();
+    LockInfo lockInfoBaseOne = LockInfo.getLockInfoByJson(lockJson);
+    LockInfo lockInfoOne = fileBasedLockProviderOne.getLockInfo();
+    assertEquals(lockInfoBaseOne.getLockCreateTime(), lockInfoOne.getLockCreateTime());
+
+    assertTrue(fileBasedLockProviderTwo.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fis = fs.open(lockFile);
+    lockJson = FileIOUtils.readAsUTFString(fis);
+    LockInfo lockInfoBaseTwo = LockInfo.getLockInfoByJson(lockJson);
+    LockInfo lockInfoTwo = fileBasedLockProviderTwo.getLockInfo();
+    assertEquals(lockInfoBaseTwo.getLockCreateTime(), lockInfoTwo.getLockCreateTime());
+    assertNotEquals(lockInfoBaseOne.getLockCreateTime(), lockInfoBaseTwo.getLockCreateTime());
+
+    // lockOne has expired, can not release other lock
+    fileBasedLockProviderOne.unlock();
+    assertTrue(fs.exists(lockFile));
+    fileBasedLockProviderOne.close();
+    assertTrue(fs.exists(lockFile));
   }
 }


### PR DESCRIPTION
config:
- occ open
- use FileSystemBasedLock
- mdt is open in write defualt

there has three job, jobA, jobB, jobC, these three jobs are running at the same time.

jobA get lock success, jobB has been trying to get lock, jobC also try to get lock.

jobB failed because can not get lock, but it delete lock file when close write client, now, jobC will get lock, it cause concurrent problem.

In our case, jobC will rollback jobA mdt commit which has been succeed commited. So, the data table timeline has the repleaseCommit instance, but mdt without this update, it cause partition path be deleted and can not reserve the latest file split in our case

### Change Logs

- will check lock create_time in memory before delete lock file
- only lock owner or lock is expired can delete lock

### Impact

- the lock file may always exist. If the process exits normally and the expiration time is not set up

### Risk level (write none, low medium or high below)

medium

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
