### PR TITLE
[HUDI-7261] TVF to query hudi table's filesystem state through spark-sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -226,6 +226,21 @@ object DataSourceReadOptions {
       .withDocumentation("When this is set, the result set of the table valued function hudi_query_timeline(...)" +
         " will include archived timeline")
 
+  val CREATE_FILESYSTEM_RELATION: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.read.create.filesystem.relation")
+    .defaultValue("false")
+    .markAdvanced()
+    .sinceVersion("1.0.0")
+    .withDocumentation("When this is set, the relation created by DefaultSource is for a view representing" +
+      " the result set of the table valued function hudi_filesystem_view(...)")
+
+  val FILESYSTEM_RELATION_ARG_SUBPATH:  ConfigProperty[String] =
+    ConfigProperty.key("hoodie.datasource.read.table.valued.function.filesystem.relation.subpath")
+      .defaultValue("")
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("A regex under the table's base path to get file system view information")
+
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */
   @Deprecated
   val QUERY_TYPE_OPT_KEY = QUERY_TYPE.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -224,9 +224,14 @@ object DefaultSource {
       parameters.get(INCREMENTAL_FORMAT.key).contains(INCREMENTAL_FORMAT_CDC_VAL)
     val isMultipleBaseFileFormatsEnabled = metaClient.getTableConfig.isMultipleBaseFileFormatsEnabled
 
+
     val createTimeLineRln = parameters.get(DataSourceReadOptions.CREATE_TIMELINE_RELATION.key())
+    val createFSRln = parameters.get(DataSourceReadOptions.CREATE_FILESYSTEM_RELATION.key())
+
     if (createTimeLineRln.isDefined) {
       new TimelineRelation(sqlContext, parameters, metaClient)
+    } else if (createFSRln.isDefined) {
+      new FileSystemRelation(sqlContext, parameters, metaClient)
     } else {
       log.info(s"Is bootstrapped table => $isBootstrappedTable, tableType is: $tableType, queryType is: $queryType")
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FileSystemRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FileSystemRelation.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.{FileSlice, HoodieFileGroup, HoodieLogFile}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.{Row, SQLContext}
+import org.slf4j.LoggerFactory
+
+import java.util.function.{Consumer, Predicate, ToLongFunction}
+import scala.collection.JavaConversions
+
+/**
+ * Relation to implement the Hoodie's file-system view for the table
+ * valued function hudi_filesystem_view(...).
+ *
+ * The relation implements a simple buildScan() routine and does not support
+ * any filtering primitives. Any column or predicate filtering needs to be done
+ * explicitly by the execution layer.
+ *
+ */
+class FileSystemRelation(val sqlContext: SQLContext,
+                         val optParams: Map[String, String],
+                         val metaClient: HoodieTableMetaClient) extends BaseRelation with TableScan {
+
+  private val log = LoggerFactory.getLogger(classOf[FileSystemRelation])
+
+  // The schema for the FileSystemRelation view
+  override def schema: StructType = StructType(Array(
+    StructField("File_ID", StringType, nullable = true),
+    StructField("Partition_Path", StringType, nullable = true),
+    StructField("Base_Instant_Time", StringType, nullable = true),
+    StructField("Base_File_Path", StringType, nullable = true),
+    StructField("Base_File_Size", LongType, nullable = true),
+    StructField("Log_File_Count", LongType, nullable = true),
+    StructField("Log_File_Size", LongType, nullable = true),
+    StructField("Log_File_Scheduled", LongType, nullable = true),
+    StructField("Log_File_Unscheduled", LongType, nullable = true)
+  ))
+
+  // The buildScan(...) method implementation from TableScan
+  // This builds the dataframe containing all the columns for the FileSystemView
+  override def buildScan(): RDD[Row] = {
+    val data = collection.mutable.ArrayBuffer[Row]()
+    val subPath = optParams.getOrElse(DataSourceReadOptions.FILESYSTEM_RELATION_ARG_SUBPATH.key(), "")
+    val path = String.format("%s/%s/*", metaClient.getBasePathV2, subPath)
+    val fileStatusList = FSUtils.getGlobStatusExcludingMetaFolder(metaClient.getFs, new Path(path))
+
+
+    val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getWriteTimeline, fileStatusList.toArray(new Array[FileStatus](0)))
+    val fileGroups = fsView.getAllFileGroups
+
+    fileGroups.forEach(toJavaConsumer((fg: HoodieFileGroup) => {
+        fg.getAllFileSlices.forEach(toJavaConsumer((fs: FileSlice) => {
+        val logFileSize = fs.getLogFiles.mapToLong(toJavaLongFunction((lf: HoodieLogFile) => {
+          lf.getFileSize
+        })).sum()
+
+        val logFileCompactionSize = fs.getLogFiles.filter(toJavaPredicate((lf: HoodieLogFile) => {
+          lf.getDeltaCommitTime == fs.getBaseInstantTime
+        })).mapToLong(toJavaLongFunction((lf: HoodieLogFile) => {
+          lf.getFileSize
+        })).sum()
+
+        val logFileNonCompactionSize = fs.getLogFiles.filter(toJavaPredicate((lf: HoodieLogFile) => {
+          lf.getDeltaCommitTime != fs.getBaseInstantTime
+        })).mapToLong(toJavaLongFunction((lf: HoodieLogFile) => {
+          lf.getFileSize
+        })).sum()
+
+
+        val r = Row(
+          fg.getFileGroupId.getFileId,
+          fg.getPartitionPath,
+          fs.getBaseInstantTime,
+          if (fs.getBaseFile.isPresent) fs.getBaseFile.get.getPath else "",
+          if (fs.getBaseFile.isPresent) fs.getBaseFile.get.getFileSize else -1,
+          fs.getLogFiles.count,
+          logFileSize,
+          logFileCompactionSize,
+          logFileNonCompactionSize
+        )
+        data += r
+      }))
+    }))
+
+    // Using deprecated `JavaConversions` to be compatible with scala versions < 2.12.
+    // Can replace with JavaConverters.seqAsJavaList(...) once the support for scala versions < 2.12 is stopped
+    sqlContext.createDataFrame(JavaConversions.seqAsJavaList(data), schema).rdd
+  }
+
+  private def toJavaConsumer[T](consumer: (T) => Unit): Consumer[T] = {
+    new Consumer[T] {
+      override def accept(t: T): Unit = {
+        consumer(t)
+      }
+    }
+  }
+
+  private def toJavaLongFunction[T](apply: (T) => Long): ToLongFunction[T] = {
+    new ToLongFunction[T] {
+      override def applyAsLong(t: T): Long = {
+        apply(t)
+      }
+    }
+  }
+
+  private def toJavaPredicate[T](tst: (T) => Boolean): Predicate[T] = {
+    new Predicate[T] {
+      override def test(t: T): Boolean = {
+        tst(t)
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logcal/HoodieFileSystemViewTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logcal/HoodieFileSystemViewTableValuedFunction.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logcal
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+
+object HoodieFileSystemViewTableValuedFunctionOptionsParser {
+  def parseOptions(exprs: Seq[Expression], funcName: String): (String, Map[String, String]) = {
+    val args = exprs.map(_.eval().toString)
+
+    if (args.size < 1 || args.size > 2) {
+      throw new AnalysisException(s"Expect arguments (table_name or table_path) for function `$funcName`")
+    }
+
+    val identifier = args.head
+    val subPathOpts = if (args.size == 2) {
+      Map(DataSourceReadOptions.FILESYSTEM_RELATION_ARG_SUBPATH.key() -> args(1))
+    } else {
+      Map.empty[String, String]
+    }
+    (identifier, Map(DataSourceReadOptions.CREATE_FILESYSTEM_RELATION.key() -> "true") ++ subPathOpts)
+  }
+}
+
+
+case class HoodieFileSystemViewTableValuedFunction(args: Seq[Expression]) extends LeafNode {
+
+  override def output: Seq[Attribute] = Nil
+
+  override lazy val resolved: Boolean = false
+
+}
+
+object HoodieFileSystemViewTableValuedFunction {
+
+  val FUNC_NAME = "hudi_filesystem_view";
+
+}
+
+case class HoodieFileSystemViewTableValuedFunctionByPath(args: Seq[Expression]) extends LeafNode {
+
+  override def output: Seq[Attribute] = Nil
+
+  override lazy val resolved: Boolean = false
+
+}

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/analysis/TableValuedFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/analysis/TableValuedFunctions.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hudi.analysis
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
-import org.apache.spark.sql.catalyst.plans.logcal.{HoodieQuery, HoodieTableChanges, HoodieTimelineTableValuedFunction}
+import org.apache.spark.sql.catalyst.plans.logcal.{HoodieFileSystemViewTableValuedFunction, HoodieQuery, HoodieTableChanges, HoodieTimelineTableValuedFunction}
 
 object TableValuedFunctions {
 
@@ -38,6 +38,11 @@ object TableValuedFunctions {
       FunctionIdentifier(HoodieTimelineTableValuedFunction.FUNC_NAME),
       new ExpressionInfo(HoodieTimelineTableValuedFunction.getClass.getCanonicalName, HoodieTimelineTableValuedFunction.FUNC_NAME),
       (args: Seq[Expression]) => new HoodieTimelineTableValuedFunction(args)
+    ),
+    (
+      FunctionIdentifier(HoodieFileSystemViewTableValuedFunction.FUNC_NAME),
+      new ExpressionInfo(HoodieFileSystemViewTableValuedFunction.getClass.getCanonicalName, HoodieFileSystemViewTableValuedFunction.FUNC_NAME),
+      (args: Seq[Expression]) => new HoodieFileSystemViewTableValuedFunction(args)
     )
   )
 }


### PR DESCRIPTION
Depends on [HUDI-7243]

A new TVF, `hudi_filesystem_view(...)` is added to support querying timeline through spark-sql. The information displayed is influenced by the 'fsview' command of hudi-cli

A new relation, `FileSystemRelation`, is added to transparently support this functionality. The relation implements buildScan(...) method of TableScan trait. It does not support filter or predicate push-down. Column filtering and predicate evaluation needs to be done by the execution layer. This seems reasonable for the initial implementation for this tool which is mainly going to be used as a debugging/introspection tool. The relation defines a fixed schema required to display basic file information of a given hudi table

### Change Logs

A new TVF, `hudi_filesystem_view(...)` is added to support querying timeline through spark-sql. The information displayed is influenced by the 'fsview' command of hudi-cli

A new relation, `FileSystemRelation`, is added to transparently support this functionality. The relation implements buildScan(...) method of TableScan trait. It does not support filter or predicate push-down. Column filtering and predicate evaluation needs to be done by the execution layer. This seems reasonable for the initial implementation for this tool which is mainly going to be used as a debugging/introspection tool. The relation defines a fixed schema required to display basic file information of a given hudi table

### Impact

New TVF function is added to introspect fileystem state for a given hudi table through spark-sql

### Risk level (write none, low medium or high below)

Low

### Documentation Update

TBD

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
