### PR TITLE
[HUDI-7138] Fix the conversion of typed properties to map in scala

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieConversionUtils.scala
@@ -21,7 +21,8 @@ package org.apache.hudi
 import org.apache.hudi.common.config.TypedProperties
 
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters.dictionaryAsScalaMapConverter
 
 object HoodieConversionUtils {
 

--- a/hudi-client/hudi-spark-client/src/test/scala/org/apache/hudi/TestHoodieConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/test/scala/org/apache/hudi/TestHoodieConversionUtils.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.common.config.TypedProperties
+import org.junit.jupiter.api.Test
+
+class TestHoodieConversionUtils {
+
+  @Test
+  def testTypePropsConversion(): Unit = {
+    val props:TypedProperties = new TypedProperties()
+    props.setProperty("hoodie.record.key", "record.key")
+    props.setProperty("hoodie.partition.key", "partition.key")
+    props.put("hoodie.inline.properties", new TypedProperties())
+
+    val scalaMap: Map[String, String] = HoodieConversionUtils.fromProperties(props)
+    assert(scalaMap.size == 3)
+  }
+}


### PR DESCRIPTION
### Change Logs

Fix the conversion of typed properties to map in scala

### Impact

Affects API to deduce schema in schema evolution

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
