### PR TITLE
[HUDI-7262] Validate checksum only if it exists

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -45,6 +45,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_CHECKSUM;
+
 public class ConfigUtils {
   public static final String STREAMER_CONFIG_PREFIX = "hoodie.streamer.";
   @Deprecated
@@ -565,7 +567,9 @@ public class ConfigUtils {
           props.clear();
           props.load(is);
           found = true;
-          ValidationUtils.checkArgument(HoodieTableConfig.validateChecksum(props));
+          if (props.containsKey(TABLE_CHECKSUM.key())) {
+            ValidationUtils.checkArgument(HoodieTableConfig.validateChecksum(props));
+          }
           return props;
         } catch (IOException e) {
           LOG.warn(String.format("Could not read properties from %s: %s", path, e));

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_CHECKSUM;
 import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -161,14 +162,15 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
     // Should return backup config if hoodie.properties is corrupted
     Properties props = new Properties();
+    props.put(TABLE_CHECKSUM.key(), "0");
     try (FSDataOutputStream out = fs.create(cfgPath)) {
-      props.store(out, "No checksum in file so is invalid");
+      props.store(out, "Wrong checksum in file so is invalid");
     }
     new HoodieTableConfig(fs, metaPath.toString(), null, null);
 
     // Should throw exception if both hoodie.properties and backup are corrupted
     try (FSDataOutputStream out = fs.create(backupCfgPath)) {
-      props.store(out, "No checksum in file so is invalid");
+      props.store(out, "Wrong checksum in file so is invalid");
     }
     assertThrows(IllegalArgumentException.class, () -> new HoodieTableConfig(fs, metaPath.toString(), null, null));
   }


### PR DESCRIPTION
### Change Logs

Only validate the checksum if it exists.
Otherwise, some operations would throw exceptions. For example:
1. If a HUDI table was created with 0.10 Hudi version and read by 0.14.0, an `IllegalArgumentExeption` would be thrown out because checksum property doesn't exist in hoodie.properties.
2. Fail to upgrade a table created with 0.10 HUDI version using 0.14 version, an `IllegalArgumentExeption` would be thrown out because checksum property doesn't exist in hoodie.properties.

See more information in [issue#10404](https://github.com/apache/hudi/issues/10404).

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
