### PR TITLE
[DOCS] Replace deprecated config refs

### DIFF
--- a/website/docs/azure_hoodie.md
+++ b/website/docs/azure_hoodie.md
@@ -37,14 +37,14 @@ This combination works out of the box. No extra config needed.
 - When writing Hudi dataset, use abfss URL
   ```scala
   inputDF.write
-    .format("org.apache.hudi")
+    .format("hudi")
     .options(opts)
-    .mode(SaveMode.Append)
+    .mode(Append)
     .save("abfss://<<storage-account>>.dfs.core.windows.net/hudi-tables/customer")
   ```
 - When reading Hudi dataset, use the mounting point
   ```scala
   spark.read
-    .format("org.apache.hudi")
+    .format("hudi")
     .load("/mountpoint/hudi-tables/customer")
   ```

--- a/website/docs/basic_configurations.md
+++ b/website/docs/basic_configurations.md
@@ -45,16 +45,20 @@ Options useful for reading tables via `read.format.option(...)`
 ### Write Options {#Write-Options}
 You can pass down any of the WriteClient level configs directly using `options()` or `option(k,v)` methods.
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-.format("org.apache.hudi")
-.options(clientOpts) // any of the Hudi client opts can be passed in as well
-.option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-.option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-.option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-.option(HoodieWriteConfig.TABLE_NAME, tableName)
-.mode(SaveMode.Append)
-.save(basePath);
+    .format("hudi")
+    .options(clientOpts) // any of the Hudi client opts can be passed in as well
+    .option(RECORDKEY_FIELD.key(), "_row_key")
+    .option(PARTITIONPATH_FIELD.key(), "partition")
+    .option(PRECOMBINE_FIELD.key(), "timestamp")
+    .option(TBL_NAME.key(), tableName)
+    .mode(Append)
+    .save(basePath);
 ```
 
 Options useful for writing tables via `write.format.option(...)`

--- a/website/docs/clustering.md
+++ b/website/docs/clustering.md
@@ -184,12 +184,12 @@ import org.apache.hudi.config.HoodieWriteConfig._
 
 
 val df =  //generate data frame
-df.write.format("org.apache.hudi").
+df.write.format("hudi").
         options(getQuickstartWriteConfigs).
-        option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-        option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-        option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-        option(TABLE_NAME, "tableName").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), "tableName").
         option("hoodie.parquet.small.file.limit", "0").
         option("hoodie.clustering.inline", "true").
         option("hoodie.clustering.inline.max.commits", "4").
@@ -283,18 +283,18 @@ We can also enable asynchronous clustering with Spark structured streaming sink 
 val commonOpts = Map(
    "hoodie.insert.shuffle.parallelism" -> "4",
    "hoodie.upsert.shuffle.parallelism" -> "4",
-   DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
-   DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
-   DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
-   HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   RECORDKEY_FIELD.key() -> "_row_key",
+   PARTITIONPATH_FIELD.key() -> "partition",
+   PRECOMBINE_FIELD.key() -> "timestamp",
+   TBL_NAME.key() -> "hoodie_test"
 )
 
 def getAsyncClusteringOpts(isAsyncClustering: String, 
                            clusteringNumCommit: String, 
                            executionStrategy: String):Map[String, String] = {
-   commonOpts + (DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE.key -> isAsyncClustering,
-           HoodieClusteringConfig.ASYNC_CLUSTERING_MAX_COMMITS.key -> clusteringNumCommit,
-           HoodieClusteringConfig.EXECUTION_STRATEGY_CLASS_NAME.key -> executionStrategy
+   commonOpts + (ASYNC_CLUSTERING_ENABLE.key() -> isAsyncClustering,
+           ASYNC_CLUSTERING_MAX_COMMITS.key() -> clusteringNumCommit,
+           EXECUTION_STRATEGY_CLASS_NAME.key() -> executionStrategy
    )
 }
 
@@ -304,7 +304,7 @@ def initStreamingWriteFuture(hudiOptions: Map[String, String]): Future[Unit] = {
       println("streaming starting")
       streamingInput
               .writeStream
-              .format("org.apache.hudi")
+              .format("hudi")
               .options(hudiOptions)
               .option("checkpointLocation", basePath + "/checkpoint")
               .mode(Append)

--- a/website/docs/compaction.md
+++ b/website/docs/compaction.md
@@ -126,27 +126,27 @@ regular ingestion.
 Compactions are scheduled and executed asynchronously inside the
 streaming job.Here is an example snippet in java
 
-```properties
-import org.apache.hudi.DataSourceWriteOptions;
+```java
 import org.apache.hudi.HoodieDataSourceHelpers;
-import org.apache.hudi.config.HoodieCompactionConfig;
-import org.apache.hudi.config.HoodieWriteConfig;
-
-import org.apache.spark.sql.streaming.OutputMode;
+import org.apache.hudi.DataSourceWriteOptions._;
+import org.apache.hudi.config.HoodieCompactionConfig._;
+import org.apache.hudi.config.HoodieWriteConfig._;
+import org.apache.spark.sql.streaming.OutputMode._;
 import org.apache.spark.sql.streaming.ProcessingTime;
 
 
- DataStreamWriter<Row> writer = streamingInput.writeStream().format("org.apache.hudi")
-        .option(DataSourceWriteOptions.OPERATION_OPT_KEY(), operationType)
-        .option(DataSourceWriteOptions.TABLE_TYPE_OPT_KEY(), tableType)
-        .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-        .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-        .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS_PROP, "10")
-        .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE_OPT_KEY(), "true")
-        .option(HoodieWriteConfig.TABLE_NAME, tableName).option("checkpointLocation", checkpointLocation)
-        .outputMode(OutputMode.Append());
- writer.trigger(new ProcessingTime(30000)).start(tablePath);
+DataStreamWriter<Row> writer = streamingInput.writeStream().format("hudi")
+      .option(OPERATION.key(), operationType)
+      .option(TABLE_TYPE.key(), tableType)
+      .option(RECORDKEY_FIELD.key(), "_row_key")
+      .option(PARTITIONPATH_FIELD.key(), "partition")
+      .option(PRECOMBINE_FIELD.key(), "timestamp")
+      .option(INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "10")
+      .option(ASYNC_COMPACT_ENABLE.key(), "true")
+      .option(TBL_NAME.key(), tableName)
+      .option("checkpointLocation", checkpointLocation)
+      .outputMode(Append);
+writer.trigger(new ProcessingTime(30000)).start(tablePath);
 ```
 
 ##### Hudi Streamer Continuous Mode

--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -212,18 +212,22 @@ The `hudi-spark` module offers the DataSource API to write (and read) a Spark Da
 
 Following is an example of how to use optimistic_concurrency_control via spark datasource
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write.format("hudi")
        .options(getQuickstartWriteConfigs)
-       .option(PRECOMBINE_FIELD_OPT_KEY, "ts")
+       .option(PRECOMBINE_FIELD.key(), "ts")
        .option("hoodie.cleaner.policy.failed.writes", "LAZY")
        .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
        .option("hoodie.write.lock.zookeeper.url", "zookeeper")
        .option("hoodie.write.lock.zookeeper.port", "2181")
        .option("hoodie.write.lock.zookeeper.base_path", "/test")
-       .option(RECORDKEY_FIELD_OPT_KEY, "uuid")
-       .option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath")
-       .option(TABLE_NAME, tableName)
+       .option(RECORDKEY_FIELD.key(), "uuid")
+       .option(PARTITIONPATH_FIELD.key(), "partitionpath")
+       .option(TBL_NAME.key(), tableName)
        .mode(Overwrite)
        .save(basePath)
 ```

--- a/website/docs/configurations.md
+++ b/website/docs/configurations.md
@@ -88,16 +88,20 @@ Options useful for reading tables via `read.format.option(...)`
 ### Write Options {#Write-Options}
 You can pass down any of the WriteClient level configs directly using `options()` or `option(k,v)` methods.
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-.format("org.apache.hudi")
-.options(clientOpts) // any of the Hudi client opts can be passed in as well
-.option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-.option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-.option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-.option(HoodieWriteConfig.TABLE_NAME, tableName)
-.mode(SaveMode.Append)
-.save(basePath);
+    .format("hudi")
+    .options(clientOpts) // any of the Hudi client opts can be passed in as well
+    .option(RECORDKEY_FIELD.key(), "_row_key")
+    .option(PARTITIONPATH_FIELD.key(), "partition")
+    .option(PRECOMBINE_FIELD.key(), "timestamp")
+    .option(TBL_NAME.key(), tableName)
+    .mode(Append)
+    .save(basePath);
 ```
 
 Options useful for writing tables via `write.format.option(...)`

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -140,15 +140,19 @@ As described in [Writing Data](/docs/writing_data#spark-datasource-writer), you 
 
 Here is an example invocation using spark datasource
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-       .format("org.apache.hudi")
+       .format("hudi")
        .options(clientOpts) // any of the Hudi client opts can be passed in as well
-       .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-       .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-       .option(HoodieWriteConfig.TABLE_NAME, tableName)
-       .mode(SaveMode.Append)
+       .option(RECORDKEY_FIELD.key(), "_row_key")
+       .option(PARTITIONPATH_FIELD.key(), "partition")
+       .option(PRECOMBINE_FIELD.key(), "timestamp")
+       .option(TBL_NAME.key(), tableName)
+       .mode(Append)
        .save(basePath);
 ```
  
@@ -205,10 +209,10 @@ val inserts = convertToStringList(dataGen.generateInserts(100)).toList
 val insertDf = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 insertDf.write.format("hudi").
         options(getQuickstartWriteConfigs).
-        option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-        option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-        option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-        option(TABLE_NAME, tableName).
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
         option(OPERATION.key(), INSERT_OPERATION_OPT_VAL).
         mode(Append).
         save(basePath)

--- a/website/docs/disaster_recovery.md
+++ b/website/docs/disaster_recovery.md
@@ -46,10 +46,10 @@ val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 ```
@@ -61,10 +61,10 @@ for (_ <- 1 to 4) {
   val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
   df.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-    option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-    option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-    option(TABLE_NAME, tableName).
+    option(PRECOMBINE_FIELD.key(), "ts").
+    option(RECORDKEY_FIELD.key(), "uuid").
+    option(PARTITIONPATH_FIELD.key(), "partitionpath").
+    option(TBL_NAME.key(), tableName).
     mode(Append).
     save(basePath)
 }
@@ -159,10 +159,10 @@ for (_ <- 1 to 3) {
   val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
   df.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-    option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-    option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-    option(TABLE_NAME, tableName).
+    option(PRECOMBINE_FIELD.key(), "ts").
+    option(RECORDKEY_FIELD.key(), "uuid").
+    option(PARTITIONPATH_FIELD.key(), "partitionpath").
+    option(TBL_NAME.key(), tableName).
     mode(Append).
     save(basePath)
 }

--- a/website/docs/docker_demo.md
+++ b/website/docs/docker_demo.md
@@ -1155,11 +1155,11 @@ Using Scala version 2.11.12 (OpenJDK 64-Bit Server VM, Java 1.8.0_212)
 Type in expressions to have them evaluated.
 Type :help for more information.
 
-scala> import org.apache.hudi.DataSourceReadOptions
-import org.apache.hudi.DataSourceReadOptions
+scala> import org.apache.hudi.DataSourceReadOptions._
+import org.apache.hudi.DataSourceReadOptions._
 
 # In the below query, 20180925045257 is the first commit's timestamp
-scala> val hoodieIncViewDF =  spark.read.format("org.apache.hudi").option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY, "20180924064621").load("/user/hive/warehouse/stock_ticks_cow")
+scala> val hoodieIncViewDF =  spark.read.format("hudi").option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL).option(BEGIN_INSTANTTIME.key(), "20180924064621").load("/user/hive/warehouse/stock_ticks_cow")
 SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
 SLF4J: Defaulting to no-operation (NOP) logger implementation
 SLF4J: See http://www.slf4j.org/codes#StaticLoggerBinder for further details.

--- a/website/docs/encryption.md
+++ b/website/docs/encryption.md
@@ -26,7 +26,7 @@ jsc.hadoopConfiguration().set("parquet.encryption.key.list", "k1:AAECAwQFBgcICQo
 jsc.hadoopConfiguration().set("parquet.encryption.footer.key", "k1")
 jsc.hadoopConfiguration().set("parquet.encryption.column.keys", "k2:rider")
     
-spark.read().format("org.apache.hudi").load("path").show();
+spark.read().format("hudi").load("path").show();
 ```
 
 Here is an example.
@@ -42,7 +42,7 @@ jsc.hadoopConfiguration().set("parquet.encryption.key.list", "k1:AAECAwQFBgcICQo
 QuickstartUtils.DataGenerator dataGen = new QuickstartUtils.DataGenerator();
 List<String> inserts = convertToStringList(dataGen.generateInserts(3));
 Dataset<Row> inputDF1 = spark.read().json(jsc.parallelize(inserts, 1));
-inputDF1.write().format("org.apache.hudi")
+inputDF1.write().format("hudi")
 	.option("hoodie.table.name", "encryption_table")
     .option("hoodie.upsert.shuffle.parallelism","2")
     .option("hoodie.insert.shuffle.parallelism","2")
@@ -51,7 +51,7 @@ inputDF1.write().format("org.apache.hudi")
     .mode(SaveMode.Overwrite)
     .save("path");
 
-spark.read().format("org.apache.hudi").load("path").select("rider").show();
+spark.read().format("hudi").load("path").select("rider").show();
 ```
 
 Reading the table works if configured correctly

--- a/website/docs/faq_storage.md
+++ b/website/docs/faq_storage.md
@@ -68,13 +68,13 @@ You can bulk import portion of that data to a new hudi table. For example, if yo
 
 ```scala
 spark.read.parquet("your_data_set/path/to/month")
-     .write.format("org.apache.hudi")
+     .write.format("hudi")
      .option("hoodie.datasource.write.operation", "bulk_insert")
      .option("hoodie.datasource.write.storage.type", "storage_type") // COPY_ON_WRITE or MERGE_ON_READ
-     .option(RECORDKEY_FIELD_OPT_KEY, "<your key>").
-     .option(PARTITIONPATH_FIELD_OPT_KEY, "<your_partition>")
+     .option(RECORDKEY_FIELD.key(), "<your key>").
+     .option(PARTITIONPATH_FIELD.key(), "<your_partition>")
      ...
-     .mode(SaveMode.Append)
+     .mode(Append)
      .save(basePath);
 ```
 
@@ -82,12 +82,12 @@ Once you have the initial copy, you can simply run upsert operations on this by 
 
 ```scala
 spark.read.parquet("your_data_set/path/to/month").limit(n) // Limit n records
-     .write.format("org.apache.hudi")
+     .write.format("hudi")
      .option("hoodie.datasource.write.operation", "upsert")
-     .option(RECORDKEY_FIELD_OPT_KEY, "<your key>").
-     .option(PARTITIONPATH_FIELD_OPT_KEY, "<your_partition>")
+     .option(RECORDKEY_FIELD.key(), "<your key>").
+     .option(PARTITIONPATH_FIELD.key(), "<your_partition>")
      ...
-     .mode(SaveMode.Append)
+     .mode(Append)
      .save(basePath);
 ```
 
@@ -135,12 +135,12 @@ Example how schema reconciliation works with Spark:
 
 ```scala
 hudi_options = {
-    'hoodie.table.name': "test_recon1",
-    'hoodie.datasource.write.recordkey.field': 'uuid',
-    'hoodie.datasource.write.table.name': "test_recon1",
-    'hoodie.datasource.write.precombine.field': 'ts',
-    'hoodie.upsert.shuffle.parallelism': 2,
-    'hoodie.insert.shuffle.parallelism': 2,
+    "hoodie.table.name": "test_recon1",
+    "hoodie.datasource.write.recordkey.field": "uuid",
+    "hoodie.datasource.write.table.name": "test_recon1",
+    "hoodie.datasource.write.precombine.field": "ts",
+    "hoodie.upsert.shuffle.parallelism": 2,
+    "hoodie.insert.shuffle.parallelism": 2,
     "hoodie.datasource.write.hive_style_partitioning":"true",
     "hoodie.datasource.write.reconcile.schema": "true",
     "hoodie.datasource.hive_sync.jdbcurl":"thrift://localhost:9083",

--- a/website/docs/faq_writing_tables.md
+++ b/website/docs/faq_writing_tables.md
@@ -87,9 +87,9 @@ Hudi configuration options covering the datasource and low level Hudi write clie
 *   For Spark DataSource, you can use the "options" API of DataFrameWriter to pass in these configs.
 
 ```scala
-inputDF.write().format("org.apache.hudi")
+inputDF.write().format("hudi")
   .options(clientOpts) // any of the Hudi client opts can be passed in as well
-  .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
+  .option(RECORDKEY_FIELD.key(), "_row_key")
   ...
 ```
 

--- a/website/docs/hoodie_streaming_ingestion.md
+++ b/website/docs/hoodie_streaming_ingestion.md
@@ -594,6 +594,9 @@ values={[
 // spark-shell
 // prepare to stream write to new table
 import org.apache.spark.sql.streaming.Trigger
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
 
 val streamingTableName = "hudi_trips_cow_streaming"
 val baseStreamingPath = "file:///tmp/hudi_trips_cow_streaming"
@@ -607,10 +610,10 @@ val df = spark.readStream.
 // write stream to new hudi table
 df.writeStream.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, streamingTableName).
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), streamingTableName).
   outputMode("append").
   option("path", baseStreamingPath).
   option("checkpointLocation", checkpointLocation).
@@ -682,10 +685,10 @@ values={[
 // reload data
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 

--- a/website/docs/migration_guide.md
+++ b/website/docs/migration_guide.md
@@ -74,10 +74,10 @@ spark-submit --master local \
 #### Using Spark Datasource Writer
 
 For huge tables, this could be as simple as : 
-```java
+```scala
 for partition in [list of partitions in source table] {
         val inputDF = spark.read.format("any_input_format").load("partition_path")
-        inputDF.write.format("org.apache.hudi").option()....save("basePath")
+        inputDF.write.format("hudi").option()....save("basePath")
 }
 ```  
 

--- a/website/docs/precommit_validator.md
+++ b/website/docs/precommit_validator.md
@@ -30,10 +30,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects there is no row with `col` column as `null`
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQuerySingleResultPreCommitValidator").
   option("hoodie.precommit.validators.single.value.sql.queries", "select count(*) from <TABLE_NAME> where col is null#0").
   save(basePath)
@@ -53,10 +54,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQueryEqualityPreCommitValidator").
   option("hoodie.precommit.validators.equality.sql.queries", "select count(*) from <TABLE_NAME> where col is null").
   save(basePath)
@@ -71,10 +73,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects a change of null rows with the new commit
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator").
   option("hoodie.precommit.validators.inequality.sql.queries", "select count(*) from <TABLE_NAME> where col is null").
   save(basePath)

--- a/website/docs/querying_data.md
+++ b/website/docs/querying_data.md
@@ -31,10 +31,12 @@ classpath of drivers and executors using `--jars` option. Alternatively, hudi-sp
 Retrieve the data table at the present point in time.
 
 ```scala
+import org.apache.hudi.DataSourceReadOptions._
+
 val hudiSnapshotQueryDF = spark
      .read
      .format("hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
+     .option(QUERY_TYPE.key(), QUERY_TYPE_SNAPSHOT_OPT_VAL)
      .load(tablePath) 
 ```
 
@@ -46,10 +48,10 @@ The following snippet shows how to obtain all records changed after `beginInstan
 
 ```java
 Dataset<Row> hudiIncQueryDF = spark.read()
-     .format("org.apache.hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL())
-     .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(), <beginInstantTime>)
-     .option(DataSourceReadOptions.INCR_PATH_GLOB_OPT_KEY(), "/year=2020/month=*/day=*") // Optional, use glob pattern if querying certain partitions
+     .format("hudi")
+     .option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL)
+     .option(BEGIN_INSTANTTIME.key(), <beginInstantTime>)
+     .option(INCR_PATH_GLOB.key(), "/year=2020/month=*/day=*") // Optional, use glob pattern if querying certain partitions
      .load(tablePath); // For incremental query, pass in the root/base path of table
      
 hudiIncQueryDF.createOrReplaceTempView("hudi_trips_incremental")

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -250,6 +250,12 @@ Since, this is the first write, it will also auto-create the table.
 
 ```scala
 // spark-shell
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+import org.apache.hudi.common.table.HoodieTableConfig._
+import org.apache.hudi.DataSourceReadOptions._
+
 val columns = Seq("ts","uuid","rider","driver","fare","city")
 val data =
   Seq((1695159649087L,"334e26e9-8355-45cc-97c6-c31daf0df330","rider-A","driver-K",19.10,"san_francisco"),
@@ -260,8 +266,8 @@ val data =
 
 var inserts = spark.createDataFrame(data).toDF(columns:_*)
 inserts.write.format("hudi").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 ```
@@ -404,9 +410,9 @@ values={[
 val updatesDf = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-D").withColumn("fare", col("fare") * 10)
 
 updatesDf.write.format("hudi").
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(), "upsert").
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 ```
@@ -560,9 +566,9 @@ values={[
 val deletesDF = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-F")
 
 deletesDF.write.format("hudi").
-  option(OPERATION_OPT_KEY, "delete").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(), "delete").
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -812,9 +818,9 @@ var df = spark.createDataFrame(data).toDF(columns:_*)
 
 // Insert data
 df.write.format("hudi").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
+  option(PARTITIONPATH_FIELD.key(), "city").
   option(CDC_ENABLED.key(), "true").
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 
@@ -822,10 +828,10 @@ df.write.format("hudi").
 val updatesDf = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-A" || $"rider" === "rider-B").withColumn("fare", col("fare") * 10)
 
 updatesDf.write.format("hudi").
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
+  option(OPERATION.key(), "upsert").
+  option(PARTITIONPATH_FIELD.key(), "city").
   option(CDC_ENABLED.key(), "true").
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -1063,7 +1069,7 @@ values={[
 // spark-shell 
 updatesDf.write.format("hudi").
   ...
-  option(PRECOMBINE_FIELD_NAME.key(), "ts").
+  option(PRECOMBINE_FIELD.key(), "ts").
   ...
 ```
 

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -207,11 +207,11 @@ val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 var dfFromData1 = spark.createDataFrame(data1, schema)
 dfFromData1.write.format("hudi").
    options(getQuickstartWriteConfigs).
-   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+   option(PRECOMBINE_FIELD.key(), "preComb").
+   option(RECORDKEY_FIELD.key(), "rowId").
+   option(PARTITIONPATH_FIELD.key(), "partitionId").
    option("hoodie.index.type","SIMPLE").
-   option(TABLE_NAME.key, tableName).
+   option(TBL_NAME.key(), tableName).
    mode(Overwrite).
    save(basePath)
 
@@ -266,11 +266,11 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    option(PRECOMBINE_FIELD.key(), "preComb").
+    option(RECORDKEY_FIELD.key(), "rowId").
+    option(PARTITIONPATH_FIELD.key(), "partitionId").
     option("hoodie.index.type","SIMPLE").
-    option(TABLE_NAME.key, tableName).
+    option(TBL_NAME.key(), tableName).
     mode(Append).
     save(basePath)
 

--- a/website/docs/syncing_metastore.md
+++ b/website/docs/syncing_metastore.md
@@ -229,12 +229,12 @@ var dfFromData0 = spark.createDataFrame(data0,schema)
 
 dfFromData0.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "preComb").
-  option(RECORDKEY_FIELD_OPT_KEY, "rowId").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionId").
-  option(TABLE_NAME, tableName).
-  option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL).
-  option(OPERATION_OPT_KEY, "upsert").
+  option(PRECOMBINE_FIELD.key(), "preComb").
+  option(RECORDKEY_FIELD.key(), "rowId").
+  option(PARTITIONPATH_FIELD.key(), "partitionId").
+  option(TBL_NAME.key(), tableName).
+  option(TABLE_TYPE.key(), "COPY_ON_WRITE").
+  option(OPERATION.key(), "upsert").
   option("hoodie.index.type","SIMPLE").
   option("hoodie.datasource.write.hive_style_partitioning","true").
   option("hoodie.datasource.hive_sync.jdbcurl","jdbc:hive2://hiveserver:10000/").

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -98,14 +98,16 @@ backwards compatibility and not breaking existing pipelines, this config is set 
 Unless Hive sync is enabled, the dataset written by Hudi using one of the methods above can simply be queries via the Spark datasource like any other source.
 
 ```scala
+import org.apache.hudi.DataSourceReadOptions._
+
 val hudiSnapshotQueryDF = spark
      .read()
      .format("hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
+     .option(QUERY_TYPE.key(), QUERY_TYPE_SNAPSHOT_OPT_VAL)
      .load(basePath) 
 val hudiIncQueryDF = spark.read().format("hudi")
-     .option(DataSourceReadOptions.VIEW_TYPE_OPT_KEY(), DataSourceReadOptions.VIEW_TYPE_INCREMENTAL_OPT_VAL())
-     .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(), <beginInstantTime>)
+     .option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL)
+     .option(BEGIN_INSTANTTIME.key(), <beginInstantTime>)
      .load(basePath);
 ```
 

--- a/website/docs/write_operations.md
+++ b/website/docs/write_operations.md
@@ -29,9 +29,15 @@ of initial load. However, this just does a best-effort job at sizing files vs gu
 Hudi supports implementing two types of deletes on data stored in Hudi tables, by enabling the user to specify a different record payload implementation.
 - **Soft Deletes** : Retain the record key and just null out the values for all the other fields.
   This can be achieved by ensuring the appropriate fields are nullable in the table schema and simply upserting the table after setting these fields to null.
+<<<<<<< HEAD
 - **Hard Deletes** : This method entails completely eradicating all evidence of a record from the table, including any duplicates. There are three distinct approaches to accomplish this: 
   - Using DataSource, set `OPERATION_OPT_KEY` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted. 
   - Using DataSource, set `PAYLOAD_CLASS_OPT_KEY` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
+=======
+- **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways. 
+  - Using DataSource, set `OPERATION.key()` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted. 
+  - Using DataSource, set `PAYLOAD_CLASS_NAME.key()` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
+>>>>>>> a0c24b081db (remove deprecated config refs)
   - Using DataSource or Hudi Streamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
 
 ### BOOTSTRAP

--- a/website/docs/write_operations.md
+++ b/website/docs/write_operations.md
@@ -29,15 +29,9 @@ of initial load. However, this just does a best-effort job at sizing files vs gu
 Hudi supports implementing two types of deletes on data stored in Hudi tables, by enabling the user to specify a different record payload implementation.
 - **Soft Deletes** : Retain the record key and just null out the values for all the other fields.
   This can be achieved by ensuring the appropriate fields are nullable in the table schema and simply upserting the table after setting these fields to null.
-<<<<<<< HEAD
 - **Hard Deletes** : This method entails completely eradicating all evidence of a record from the table, including any duplicates. There are three distinct approaches to accomplish this: 
-  - Using DataSource, set `OPERATION_OPT_KEY` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted. 
-  - Using DataSource, set `PAYLOAD_CLASS_OPT_KEY` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
-=======
-- **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways. 
   - Using DataSource, set `OPERATION.key()` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted. 
   - Using DataSource, set `PAYLOAD_CLASS_NAME.key()` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
->>>>>>> a0c24b081db (remove deprecated config refs)
   - Using DataSource or Hudi Streamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
 
 ### BOOTSTRAP

--- a/website/docs/writing_data.md
+++ b/website/docs/writing_data.md
@@ -25,47 +25,38 @@ The `hudi-spark` module offers the DataSource API to write (and read) a Spark Da
 
 **`HoodieWriteConfig`**:
 
-**TABLE_NAME** (Required)<br/>
+**TBL_NAME.key()** (Required)<br/>
 
 
 **`DataSourceWriteOptions`**:
 
-**RECORDKEY_FIELD_OPT_KEY** (Required): Primary key field(s). Record keys uniquely identify a record/row within each partition. If one wants to have a global uniqueness, there are two options. You could either make the dataset non-partitioned, or, you can leverage Global indexes to ensure record keys are unique irrespective of the partition path. Record keys can either be a single column or refer to multiple columns. `KEYGENERATOR_CLASS_OPT_KEY` property should be set accordingly based on whether it is a simple or complex key. For eg: `"col1"` for simple field, `"col1,col2,col3,etc"` for complex field. Nested fields can be specified using the dot notation eg: `a.b.c`. <br/>
-Default value: `"uuid"`<br/>
-
-**PARTITIONPATH_FIELD_OPT_KEY** (Required): Columns to be used for partitioning the table. To prevent partitioning, provide empty string as value eg: `""`. Specify partitioning/no partitioning using `KEYGENERATOR_CLASS_OPT_KEY`. If partition path needs to be url encoded, you can set `URL_ENCODE_PARTITIONING_OPT_KEY`. If synchronizing to hive, also specify using `HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY.`<br/>
-Default value: `"partitionpath"`<br/>
-
-**PRECOMBINE_FIELD_OPT_KEY** (Required): When two records within the same batch have the same key value, the record with the largest value from the field specified will be choosen. If you are using default payload of OverwriteWithLatestAvroPayload for HoodieRecordPayload (`WRITE_PAYLOAD_CLASS`), an incoming record will always takes precendence compared to the one in storage ignoring this `PRECOMBINE_FIELD_OPT_KEY`. <br/>
-Default value: `"ts"`<br/>
-
-**OPERATION_OPT_KEY**: The [write operations](/docs/write_operations) to use.<br/>
-Available values:<br/>
-`UPSERT_OPERATION_OPT_VAL` (default), `BULK_INSERT_OPERATION_OPT_VAL`, `INSERT_OPERATION_OPT_VAL`, `DELETE_OPERATION_OPT_VAL`
-
-**TABLE_TYPE_OPT_KEY**: The [type of table](/docs/concepts#table-types) to write to. Note: After the initial creation of a table, this value must stay consistent when writing to (updating) the table using the Spark `SaveMode.Append` mode.<br/>
-Available values:<br/>
-[`COW_TABLE_TYPE_OPT_VAL`](/docs/concepts#copy-on-write-table) (default), [`MOR_TABLE_TYPE_OPT_VAL`](/docs/concepts#merge-on-read-table)
-
-**KEYGENERATOR_CLASS_OPT_KEY**: Refer to [Key Generation](/docs/key_generation) section below.
-
-**HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY**: If using hive, specify if the table should or should not be partitioned.<br/>
-Available values:<br/>
-`classOf[MultiPartKeysValueExtractor].getCanonicalName` (default), `classOf[SlashEncodedDayPartitionValueExtractor].getCanonicalName`, `classOf[TimestampBasedKeyGenerator].getCanonicalName`, `classOf[NonPartitionedExtractor].getCanonicalName`, `classOf[GlobalDeleteKeyGenerator].getCanonicalName` (to be used when `OPERATION_OPT_KEY` is set to `DELETE_OPERATION_OPT_VAL`)
+| Config                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Required | Available Values                                                                                                                                                                                                                                                                                                                                                                  |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| RECORDKEY_FIELD                | Primary key field(s). Record keys uniquely identify a record/row within each partition. If one wants to have a global uniqueness, there are two options. You could either make the dataset non-partitioned, or, you can leverage Global indexes to ensure record keys are unique irrespective of the partition path. Record keys can either be a single column or refer to multiple columns. `KEYGENERATOR_CLASS_NAME.key()` property should be set accordingly based on whether it is a simple or complex key. For eg: `"col1"` for simple field, `"col1,col2,col3,etc"` for complex field. Nested fields can be specified using the dot notation eg: `a.b.c`. | optional | "uuid" (default)                                                                                                                                                                                                                                                                                                                                                                  |
+| PARTITIONPATH_FIELD            | Columns to be used for partitioning the table. To prevent partitioning, provide empty string as value eg: `""`. Specify partitioning/no partitioning using `KEYGENERATOR_CLASS_NAME.key()`. If partition path needs to be url encoded, you can set `URL_ENCODE_PARTITIONING.key()`. If synchronizing to hive, also specify using `META_SYNC_PARTITION_EXTRACTOR_CLASS.key()`.                                                                                                                                                                                                                                                                                   | optional | "partitionpath" (default)                                                                                                                                                                                                                                                                                                                                                         |
+| PRECOMBINE_FIELD               | When two records within the same batch have the same key value, the record with the largest value from the field specified will be choosen. If you are using default payload of OverwriteWithLatestAvroPayload for HoodieRecordPayload (`WRITE_PAYLOAD_CLASS`), an incoming record will always takes precendence compared to the one in storage ignoring this `PRECOMBINE_FIELD.key()`.                                                                                                                                                                                                                                                                         | optional | "ts" (default)                                                                                                                                                                                                                                                                                                                                                                    |
+| OPERATION                      | The [write operations](/docs/write_operations) to use.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | optional | `UPSERT_OPERATION_OPT_VAL` (default), `BULK_INSERT_OPERATION_OPT_VAL`, `INSERT_OPERATION_OPT_VAL`, `DELETE_OPERATION_OPT_VAL`                                                                                                                                                                                                                                                     |
+| TABLE_TYPE                     | The [type of table](/docs/concepts#table-types) to write to. Note: After the initial creation of a table, this value must stay consistent when writing to (updating) the table using the Spark `SaveMode.Append` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                          | optional | [`COW_TABLE_TYPE_OPT_VAL`](/docs/concepts#copy-on-write-table) (default), [`MOR_TABLE_TYPE_OPT_VAL`](/docs/concepts#merge-on-read-table)                                                                                                                                                                                                                                          |
+| KEYGENERATOR_CLASS             | Refer to [Key Generation](/docs/key_generation) section below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | optional |                                                                                                                                                                                                                                                                                                                                                                                   |
+| HIVE_PARTITION_EXTRACTOR_CLASS | If using hive, specify if the table should or should not be partitioned.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | optional | `classOf[MultiPartKeysValueExtractor].getCanonicalName` (default), `classOf[SlashEncodedDayPartitionValueExtractor].getCanonicalName`, `classOf[TimestampBasedKeyGenerator].getCanonicalName`, `classOf[NonPartitionedExtractor].getCanonicalName`, `classOf[GlobalDeleteKeyGenerator].getCanonicalName` (to be used when `OPERATION.key()` is set to `DELETE_OPERATION_OPT_VAL`) |
 
 
 Example:
 Upsert a DataFrame, specifying the necessary field names for `recordKey => _row_key`, `partitionPath => partition`, and `precombineKey => timestamp`
 
 ```java
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-       .format("org.apache.hudi")
+       .format("hudi")
        .options(clientOpts) //Where clientOpts is of type Map[String, String]. clientOpts can include any other options necessary.
-       .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-       .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-       .option(HoodieWriteConfig.TABLE_NAME, tableName)
-       .mode(SaveMode.Append)
+       .option(RECORDKEY_FIELD.key(), "_row_key")
+       .option(PARTITIONPATH_FIELD.key(), "partition")
+       .option(PRECOMBINE_FIELD.key(), "timestamp")
+       .option(TBL_NAME.key(), tableName)
+       .mode(Append)
        .save(basePath);
 ```
 
@@ -86,10 +77,10 @@ val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 ```
@@ -211,11 +202,11 @@ val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"insert_overwrite_table").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(),"insert_overwrite_table").
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -269,11 +260,11 @@ val df = spark.
   filter("partitionpath = 'americas/united_states/san_francisco'")
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"insert_overwrite").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(),"insert_overwrite").
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -326,24 +317,24 @@ val softDeleteDf = nullifyColumns.
 // simply upsert the table after setting these fields to null
 softDeleteDf.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(), "upsert").
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 ```
 
 - **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways. 
 
-1. Using Datasource, set `OPERATION_OPT_KEY` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted.
+1. Using Datasource, set `OPERATION.key()` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted.
 
 Example, first read in a dataset:
 ```scala
 val roViewDF = spark.
         read.
-        format("org.apache.hudi").
+        format("hudi").
         load(basePath + "/*/*/*/*")
 roViewDF.createOrReplaceTempView("hudi_ro_table")
 spark.sql("select count(*) from hudi_ro_table").show() // should return 10 (number of records inserted above)
@@ -358,26 +349,26 @@ Lastly, execute the deletion of these records:
 ```scala
 val deletes = dataGen.generateDeletes(df.collectAsList())
 val df = spark.read.json(spark.sparkContext.parallelize(deletes, 2));
-df.write.format("org.apache.hudi").
+df.write.format("hudi").
 options(getQuickstartWriteConfigs).
-option(OPERATION_OPT_KEY,"delete").
-option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-option(TABLE_NAME, tableName).
+option(OPERATION.key(),"delete").
+option(PRECOMBINE_FIELD.key(), "ts").
+option(RECORDKEY_FIELD.key(), "uuid").
+option(PARTITIONPATH_FIELD.key(), "partitionpath").
+option(TBL_NAME.key(), tableName).
 mode(Append).
 save(basePath);
 ```
 
-2. Using DataSource, set `PAYLOAD_CLASS_OPT_KEY` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
+2. Using DataSource, set `PAYLOAD_CLASS_NAME.key()` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
 
 This example will remove all the records from the table that exist in the DataSet `deleteDF`:
 ```scala
  deleteDF // dataframe containing just records to be deleted
-   .write().format("org.apache.hudi")
+   .write().format("hudi")
    .option(...) // Add HUDI options like record-key, partition-path and others as needed for your setup
    // specify record_key, partition_key, precombine_fieldkey & usual params
-   .option(DataSourceWriteOptions.PAYLOAD_CLASS_OPT_KEY, "org.apache.hudi.EmptyHoodieRecordPayload")
+   .option(DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key(), "org.apache.hudi.EmptyHoodieRecordPayload")
 ```
 
 3. Using DataSource or DeltaStreamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
@@ -441,16 +432,16 @@ Following is an example of how to use optimistic_concurrency_control via spark d
 ```java
 inputDF.write.format("hudi")
        .options(getQuickstartWriteConfigs)
-       .option(PRECOMBINE_FIELD_OPT_KEY, "ts")
+       .option(PRECOMBINE_FIELD.key(), "ts")
        .option("hoodie.cleaner.policy.failed.writes", "LAZY")
        .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
        .option("hoodie.write.lock.zookeeper.url", "zookeeper")
        .option("hoodie.write.lock.zookeeper.port", "2181")
        .option("hoodie.write.lock.zookeeper.lock_key", "test_table")
        .option("hoodie.write.lock.zookeeper.base_path", "/test")
-       .option(RECORDKEY_FIELD_OPT_KEY, "uuid")
-       .option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath")
-       .option(TABLE_NAME, tableName)
+       .option(RECORDKEY_FIELD.key(), "uuid")
+       .option(PARTITIONPATH_FIELD.key(), "partitionpath")
+       .option(TBL_NBAME.key(), tableName)
        .mode(Overwrite)
        .save(basePath)
 ```
@@ -470,7 +461,6 @@ You can push a commit notification to an HTTP URL and can specify custom values 
 | CALLBACK_HTTP_TIMEOUT_IN_SECONDS | Callback timeout in seconds | optional | 3 |
 | CALLBACK_CLASS_NAME | Full path of callback class and must be a subclass of HoodieWriteCommitCallback class, org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback by default | optional | org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback |
 | CALLBACK_HTTP_API_KEY_VALUE | Http callback API key | optional | hudi_write_commit_http_callback |
-| | | | |
 
 #### Kafka Endpoints
 You can push a commit notification to a Kafka topic so it can be used by other real time systems.
@@ -482,7 +472,6 @@ You can push a commit notification to a Kafka topic so it can be used by other r
 | RETRIES | Times to retry the produce | optional | 3 |
 | ACKS | kafka acks level, all by default to ensure strong durability | optional | all |
 | BOOTSTRAP_SERVERS | Bootstrap servers of kafka cluster, to be used for publishing commit metadata | required | N/A |
-| | | | |
 
 #### Pulsar Endpoints
 You can push a commit notification to a Pulsar topic so it can be used by other real time systems. 

--- a/website/versioned_docs/version-0.14.0/azure_hoodie.md
+++ b/website/versioned_docs/version-0.14.0/azure_hoodie.md
@@ -37,14 +37,14 @@ This combination works out of the box. No extra config needed.
 - When writing Hudi dataset, use abfss URL
   ```scala
   inputDF.write
-    .format("org.apache.hudi")
+    .format("hudi")
     .options(opts)
-    .mode(SaveMode.Append)
+    .mode(Append)
     .save("abfss://<<storage-account>>.dfs.core.windows.net/hudi-tables/customer")
   ```
 - When reading Hudi dataset, use the mounting point
   ```scala
   spark.read
-    .format("org.apache.hudi")
+    .format("hudi")
     .load("/mountpoint/hudi-tables/customer")
   ```

--- a/website/versioned_docs/version-0.14.0/basic_configurations.md
+++ b/website/versioned_docs/version-0.14.0/basic_configurations.md
@@ -45,16 +45,20 @@ Options useful for reading tables via `read.format.option(...)`
 ### Write Options {#Write-Options}
 You can pass down any of the WriteClient level configs directly using `options()` or `option(k,v)` methods.
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-.format("org.apache.hudi")
-.options(clientOpts) // any of the Hudi client opts can be passed in as well
-.option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-.option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-.option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-.option(HoodieWriteConfig.TABLE_NAME, tableName)
-.mode(SaveMode.Append)
-.save(basePath);
+  .format("hudi")
+  .options(clientOpts) // any of the Hudi client opts can be passed in as well
+  .option(RECORDKEY_FIELD.key(), "_row_key")
+  .option(PARTITIONPATH_FIELD.key(), "partition")
+  .option(PRECOMBINE_FIELD.key(), "timestamp")
+  .option(TBL_NAME.key(), tableName)
+  .mode(Append)
+  .save(basePath);
 ```
 
 Options useful for writing tables via `write.format.option(...)`

--- a/website/versioned_docs/version-0.14.0/clustering.md
+++ b/website/versioned_docs/version-0.14.0/clustering.md
@@ -184,12 +184,12 @@ import org.apache.hudi.config.HoodieWriteConfig._
 
 
 val df =  //generate data frame
-df.write.format("org.apache.hudi").
+df.write.format("hudi").
         options(getQuickstartWriteConfigs).
-        option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-        option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-        option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-        option(TABLE_NAME, "tableName").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), "tableName").
         option("hoodie.parquet.small.file.limit", "0").
         option("hoodie.clustering.inline", "true").
         option("hoodie.clustering.inline.max.commits", "4").
@@ -283,18 +283,18 @@ We can also enable asynchronous clustering with Spark structured streaming sink 
 val commonOpts = Map(
    "hoodie.insert.shuffle.parallelism" -> "4",
    "hoodie.upsert.shuffle.parallelism" -> "4",
-   DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
-   DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
-   DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
-   HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   RECORDKEY_FIELD.key() -> "_row_key",
+   PARTITIONPATH_FIELD.key() -> "partition",
+   PRECOMBINE_FIELD.key() -> "timestamp",
+   TBL_NAME.key() -> "hoodie_test"
 )
 
-def getAsyncClusteringOpts(isAsyncClustering: String, 
-                           clusteringNumCommit: String, 
+def getAsyncClusteringOpts(isAsyncClustering: String,
+                           clusteringNumCommit: String,
                            executionStrategy: String):Map[String, String] = {
-   commonOpts + (DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE.key -> isAsyncClustering,
-           HoodieClusteringConfig.ASYNC_CLUSTERING_MAX_COMMITS.key -> clusteringNumCommit,
-           HoodieClusteringConfig.EXECUTION_STRATEGY_CLASS_NAME.key -> executionStrategy
+   commonOpts + (ASYNC_CLUSTERING_ENABLE.key() -> isAsyncClustering,
+           ASYNC_CLUSTERING_MAX_COMMITS.key() -> clusteringNumCommit,
+           EXECUTION_STRATEGY_CLASS_NAME.key() -> executionStrategy
    )
 }
 
@@ -304,7 +304,7 @@ def initStreamingWriteFuture(hudiOptions: Map[String, String]): Future[Unit] = {
       println("streaming starting")
       streamingInput
               .writeStream
-              .format("org.apache.hudi")
+              .format("hudi")
               .options(hudiOptions)
               .option("checkpointLocation", basePath + "/checkpoint")
               .mode(Append)

--- a/website/versioned_docs/version-0.14.0/compaction.md
+++ b/website/versioned_docs/version-0.14.0/compaction.md
@@ -126,27 +126,27 @@ regular ingestion.
 Compactions are scheduled and executed asynchronously inside the
 streaming job.Here is an example snippet in java
 
-```properties
-import org.apache.hudi.DataSourceWriteOptions;
+```java
 import org.apache.hudi.HoodieDataSourceHelpers;
-import org.apache.hudi.config.HoodieCompactionConfig;
-import org.apache.hudi.config.HoodieWriteConfig;
-
-import org.apache.spark.sql.streaming.OutputMode;
+import org.apache.hudi.DataSourceWriteOptions._;
+import org.apache.hudi.config.HoodieCompactionConfig._;
+import org.apache.hudi.config.HoodieWriteConfig._;
+import org.apache.spark.sql.streaming.OutputMode._;
 import org.apache.spark.sql.streaming.ProcessingTime;
 
 
- DataStreamWriter<Row> writer = streamingInput.writeStream().format("org.apache.hudi")
-        .option(DataSourceWriteOptions.OPERATION_OPT_KEY(), operationType)
-        .option(DataSourceWriteOptions.TABLE_TYPE_OPT_KEY(), tableType)
-        .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-        .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-        .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS_PROP, "10")
-        .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE_OPT_KEY(), "true")
-        .option(HoodieWriteConfig.TABLE_NAME, tableName).option("checkpointLocation", checkpointLocation)
-        .outputMode(OutputMode.Append());
- writer.trigger(new ProcessingTime(30000)).start(tablePath);
+DataStreamWriter<Row> writer = streamingInput.writeStream().format("hudi")
+        .option(OPERATION.key(), operationType)
+        .option(TABLE_TYPE.key(), tableType)
+        .option(RECORDKEY_FIELD.key(), "_row_key")
+        .option(PARTITIONPATH_FIELD.key(), "partition")
+        .option(PRECOMBINE_FIELD.key(), "timestamp")
+        .option(INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "10")
+        .option(ASYNC_COMPACT_ENABLE.key(), "true")
+        .option(TBL_NAME.key(), tableName)
+        .option("checkpointLocation", checkpointLocation)
+        .outputMode(Append);
+writer.trigger(new ProcessingTime(30000)).start(tablePath);
 ```
 
 ##### Hudi Streamer Continuous Mode

--- a/website/versioned_docs/version-0.14.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.14.0/concurrency_control.md
@@ -195,20 +195,24 @@ The `hudi-spark` module offers the DataSource API to write (and read) a Spark Da
 
 Following is an example of how to use optimistic_concurrency_control via spark datasource
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write.format("hudi")
-       .options(getQuickstartWriteConfigs)
-       .option(PRECOMBINE_FIELD_OPT_KEY, "ts")
-       .option("hoodie.cleaner.policy.failed.writes", "LAZY")
-       .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
-       .option("hoodie.write.lock.zookeeper.url", "zookeeper")
-       .option("hoodie.write.lock.zookeeper.port", "2181")
-       .option("hoodie.write.lock.zookeeper.base_path", "/test")
-       .option(RECORDKEY_FIELD_OPT_KEY, "uuid")
-       .option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath")
-       .option(TABLE_NAME, tableName)
-       .mode(Overwrite)
-       .save(basePath)
+        .options(getQuickstartWriteConfigs)
+        .option(PRECOMBINE_FIELD.key(), "ts")
+        .option("hoodie.cleaner.policy.failed.writes", "LAZY")
+        .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
+        .option("hoodie.write.lock.zookeeper.url", "zookeeper")
+        .option("hoodie.write.lock.zookeeper.port", "2181")
+        .option("hoodie.write.lock.zookeeper.base_path", "/test")
+        .option(RECORDKEY_FIELD.key(), "uuid")
+        .option(PARTITIONPATH_FIELD.key(), "partitionpath")
+        .option(TBL_NAME.key(), tableName)
+        .mode(Overwrite)
+        .save(basePath)
 ```
 
 ## Multi Writing via Hudi Streamer

--- a/website/versioned_docs/version-0.14.0/configurations.md
+++ b/website/versioned_docs/version-0.14.0/configurations.md
@@ -95,16 +95,20 @@ Options useful for reading tables via `read.format.option(...)`
 ### Write Options {#Write-Options}
 You can pass down any of the WriteClient level configs directly using `options()` or `option(k,v)` methods.
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-.format("org.apache.hudi")
-.options(clientOpts) // any of the Hudi client opts can be passed in as well
-.option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-.option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-.option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-.option(HoodieWriteConfig.TABLE_NAME, tableName)
-.mode(SaveMode.Append)
-.save(basePath);
+  .format("hudi")
+  .options(clientOpts) // any of the Hudi client opts can be passed in as well
+  .option(RECORDKEY_FIELD.key(), "_row_key")
+  .option(PARTITIONPATH_FIELD.key(), "partition")
+  .option(PRECOMBINE_FIELD.key(), "timestamp")
+  .option(TBL_NAME.key(), tableName)
+  .mode(Append)
+  .save(basePath);
 ```
 
 Options useful for writing tables via `write.format.option(...)`

--- a/website/versioned_docs/version-0.14.0/deployment.md
+++ b/website/versioned_docs/version-0.14.0/deployment.md
@@ -140,16 +140,20 @@ As described in [Writing Data](/docs/writing_data#spark-datasource-writer), you 
 
 Here is an example invocation using spark datasource
 
-```java
+```scala
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-       .format("org.apache.hudi")
-       .options(clientOpts) // any of the Hudi client opts can be passed in as well
-       .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-       .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-       .option(HoodieWriteConfig.TABLE_NAME, tableName)
-       .mode(SaveMode.Append)
-       .save(basePath);
+        .format("hudi")
+        .options(clientOpts) // any of the Hudi client opts can be passed in as well
+        .option(RECORDKEY_FIELD.key(), "_row_key")
+        .option(PARTITIONPATH_FIELD.key(), "partition")
+        .option(PRECOMBINE_FIELD.key(), "timestamp")
+        .option(TBL_NAME.key(), tableName)
+        .mode(Append)
+        .save(basePath);
 ```
  
 ## Upgrading 
@@ -205,10 +209,10 @@ val inserts = convertToStringList(dataGen.generateInserts(100)).toList
 val insertDf = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 insertDf.write.format("hudi").
         options(getQuickstartWriteConfigs).
-        option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-        option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-        option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-        option(TABLE_NAME, tableName).
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
         option(OPERATION.key(), INSERT_OPERATION_OPT_VAL).
         mode(Append).
         save(basePath)

--- a/website/versioned_docs/version-0.14.0/disaster_recovery.md
+++ b/website/versioned_docs/version-0.14.0/disaster_recovery.md
@@ -46,10 +46,10 @@ val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
+  option(PRECOMBINE_FIELD.key(), "ts").
+  option(RECORDKEY_FIELD.key(), "uuid").
+  option(PARTITIONPATH_FIELD.key(), "partitionpath").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 ```
@@ -61,10 +61,10 @@ for (_ <- 1 to 4) {
   val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
   df.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-    option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-    option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-    option(TABLE_NAME, tableName).
+    option(PRECOMBINE_FIELD.key(), "ts").
+    option(RECORDKEY_FIELD.key(), "uuid").
+    option(PARTITIONPATH_FIELD.key(), "partitionpath").
+    option(TBL_NAME.key(), tableName).
     mode(Append).
     save(basePath)
 }
@@ -159,10 +159,10 @@ for (_ <- 1 to 3) {
   val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
   df.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-    option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-    option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-    option(TABLE_NAME, tableName).
+    option(PRECOMBINE_FIELD.key(), "ts").
+    option(RECORDKEY_FIELD.key(), "uuid").
+    option(PARTITIONPATH_FIELD.key(), "partitionpath").
+    option(TBL_NAME.key(), tableName).
     mode(Append).
     save(basePath)
 }

--- a/website/versioned_docs/version-0.14.0/docker_demo.md
+++ b/website/versioned_docs/version-0.14.0/docker_demo.md
@@ -1155,11 +1155,11 @@ Using Scala version 2.11.12 (OpenJDK 64-Bit Server VM, Java 1.8.0_212)
 Type in expressions to have them evaluated.
 Type :help for more information.
 
-scala> import org.apache.hudi.DataSourceReadOptions
-import org.apache.hudi.DataSourceReadOptions
+scala> import org.apache.hudi.DataSourceReadOptions._
+import org.apache.hudi.DataSourceReadOptions._
 
 # In the below query, 20180925045257 is the first commit's timestamp
-scala> val hoodieIncViewDF =  spark.read.format("org.apache.hudi").option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY, "20180924064621").load("/user/hive/warehouse/stock_ticks_cow")
+scala> val hoodieIncViewDF =  spark.read.format("hudi").option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL).option(BEGIN_INSTANTTIME.key(), "20180924064621").load("/user/hive/warehouse/stock_ticks_cow")
 SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
 SLF4J: Defaulting to no-operation (NOP) logger implementation
 SLF4J: See http://www.slf4j.org/codes#StaticLoggerBinder for further details.

--- a/website/versioned_docs/version-0.14.0/encryption.md
+++ b/website/versioned_docs/version-0.14.0/encryption.md
@@ -26,7 +26,7 @@ jsc.hadoopConfiguration().set("parquet.encryption.key.list", "k1:AAECAwQFBgcICQo
 jsc.hadoopConfiguration().set("parquet.encryption.footer.key", "k1")
 jsc.hadoopConfiguration().set("parquet.encryption.column.keys", "k2:rider")
     
-spark.read().format("org.apache.hudi").load("path").show();
+spark.read().format("hudi").load("path").show();
 ```
 
 Here is an example.
@@ -42,7 +42,7 @@ jsc.hadoopConfiguration().set("parquet.encryption.key.list", "k1:AAECAwQFBgcICQo
 QuickstartUtils.DataGenerator dataGen = new QuickstartUtils.DataGenerator();
 List<String> inserts = convertToStringList(dataGen.generateInserts(3));
 Dataset<Row> inputDF1 = spark.read().json(jsc.parallelize(inserts, 1));
-inputDF1.write().format("org.apache.hudi")
+inputDF1.write().format("hudi")
 	.option("hoodie.table.name", "encryption_table")
     .option("hoodie.upsert.shuffle.parallelism","2")
     .option("hoodie.insert.shuffle.parallelism","2")
@@ -51,7 +51,7 @@ inputDF1.write().format("org.apache.hudi")
     .mode(SaveMode.Overwrite)
     .save("path");
 
-spark.read().format("org.apache.hudi").load("path").select("rider").show();
+spark.read().format("hudi").load("path").select("rider").show();
 ```
 
 Reading the table works if configured correctly

--- a/website/versioned_docs/version-0.14.0/faq.md
+++ b/website/versioned_docs/version-0.14.0/faq.md
@@ -243,9 +243,9 @@ Hudi configuration options covering the datasource and low level Hudi write clie
 *   For Spark DataSource, you can use the "options" API of DataFrameWriter to pass in these configs.
 
 ```scala
-inputDF.write().format("org.apache.hudi")
+inputDF.write().format("hudi")
   .options(clientOpts) // any of the Hudi client opts can be passed in as well
-  .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
+  .option(RECORDKEY_FIELD.key(), "_row_key")
   ...
 ```
 
@@ -495,13 +495,13 @@ You can bulk import portion of that data to a new hudi table. For example, if yo
 
 ```scala
 spark.read.parquet("your_data_set/path/to/month")
-     .write.format("org.apache.hudi")
+     .write.format("hudi")
      .option("hoodie.datasource.write.operation", "bulk_insert")
      .option("hoodie.datasource.write.storage.type", "storage_type") // COPY_ON_WRITE or MERGE_ON_READ
-     .option(RECORDKEY_FIELD_OPT_KEY, "<your key>").
-     .option(PARTITIONPATH_FIELD_OPT_KEY, "<your_partition>")
+     .option(RECORDKEY_FIELD.key(), "<your key>")
+     .option(PARTITIONPATH_FIELD.key(), "<your_partition>")
      ...
-     .mode(SaveMode.Append)
+     .mode(Append)
      .save(basePath);
 ```
 
@@ -509,12 +509,12 @@ Once you have the initial copy, you can simply run upsert operations on this by 
 
 ```scala
 spark.read.parquet("your_data_set/path/to/month").limit(n) // Limit n records
-     .write.format("org.apache.hudi")
+     .write.format("hudi")
      .option("hoodie.datasource.write.operation", "upsert")
-     .option(RECORDKEY_FIELD_OPT_KEY, "<your key>").
-     .option(PARTITIONPATH_FIELD_OPT_KEY, "<your_partition>")
+     .option(RECORDKEY_FIELD.key(), "<your key>")
+     .option(PARTITIONPATH_FIELD.key(), "<your_partition>")
      ...
-     .mode(SaveMode.Append)
+     .mode(Append)
      .save(basePath);
 ```
 
@@ -562,12 +562,12 @@ Example how schema reconciliation works with Spark:
 
 ```scala
 hudi_options = {
-    'hoodie.table.name': "test_recon1",
-    'hoodie.datasource.write.recordkey.field': 'uuid',
-    'hoodie.datasource.write.table.name': "test_recon1",
-    'hoodie.datasource.write.precombine.field': 'ts',
-    'hoodie.upsert.shuffle.parallelism': 2,
-    'hoodie.insert.shuffle.parallelism': 2,
+    "hoodie.table.name": "test_recon1",
+    "hoodie.datasource.write.recordkey.field": "uuid",
+    "hoodie.datasource.write.table.name": "test_recon1",
+    "hoodie.datasource.write.precombine.field": "ts",
+    "hoodie.upsert.shuffle.parallelism": 2,
+    "hoodie.insert.shuffle.parallelism": 2,
     "hoodie.datasource.write.hive_style_partitioning":"true",
     "hoodie.datasource.write.reconcile.schema": "true",
     "hoodie.datasource.hive_sync.jdbcurl":"thrift://localhost:9083",

--- a/website/versioned_docs/version-0.14.0/hoodie_streaming_ingestion.md
+++ b/website/versioned_docs/version-0.14.0/hoodie_streaming_ingestion.md
@@ -405,6 +405,9 @@ values={[
 // spark-shell
 // prepare to stream write to new table
 import org.apache.spark.sql.streaming.Trigger
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
 
 val streamingTableName = "hudi_trips_cow_streaming"
 val baseStreamingPath = "file:///tmp/hudi_trips_cow_streaming"
@@ -417,16 +420,16 @@ val df = spark.readStream.
 
 // write stream to new hudi table
 df.writeStream.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, streamingTableName).
-  outputMode("append").
-  option("path", baseStreamingPath).
-  option("checkpointLocation", checkpointLocation).
-  trigger(Trigger.Once()).
-  start()
+        options(getQuickstartWriteConfigs).
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), streamingTableName).
+        outputMode("append").
+        option("path", baseStreamingPath).
+        option("checkpointLocation", checkpointLocation).
+        trigger(Trigger.Once()).
+        start()
 
 ```
 
@@ -492,21 +495,21 @@ values={[
 // spark-shell
 // reload data
 df.write.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
-  mode(Overwrite).
-  save(basePath)
+        options(getQuickstartWriteConfigs).
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Overwrite).
+        save(basePath)
 
 // read stream and output results to console
 spark.readStream.
-  format("hudi").
-  load(basePath).
-  writeStream.
-  format("console").
-  start()
+        format("hudi").
+        load(basePath).
+        writeStream.
+        format("console").
+        start()
 
 // read stream to streaming df
 val df = spark.readStream.

--- a/website/versioned_docs/version-0.14.0/migration_guide.md
+++ b/website/versioned_docs/version-0.14.0/migration_guide.md
@@ -77,7 +77,7 @@ For huge tables, this could be as simple as :
 ```java
 for partition in [list of partitions in source table] {
         val inputDF = spark.read.format("any_input_format").load("partition_path")
-        inputDF.write.format("org.apache.hudi").option()....save("basePath")
+        inputDF.write.format("hudi").option()....save("basePath")
 }
 ```  
 

--- a/website/versioned_docs/version-0.14.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.0/precommit_validator.md
@@ -30,10 +30,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects there is no row with `col` column as `null`
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQuerySingleResultPreCommitValidator").
   option("hoodie.precommit.validators.single.value.sql.queries", "select count(*) from <TABLE_NAME> where col is null#0").
   save(basePath)
@@ -53,10 +54,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQueryEqualityPreCommitValidator").
   option("hoodie.precommit.validators.equality.sql.queries", "select count(*) from <TABLE_NAME> where col is null").
   save(basePath)
@@ -71,10 +73,11 @@ Example:
 ```scala
 // In this example, we set up a validator that expects a change of null rows with the new commit
 
+import org.apache.hudi.config.HoodieWriteConfig._
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig._
 
 df.write.format("hudi").mode(Overwrite).
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   option("hoodie.precommit.validators", "org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator").
   option("hoodie.precommit.validators.inequality.sql.queries", "select count(*) from <TABLE_NAME> where col is null").
   save(basePath)

--- a/website/versioned_docs/version-0.14.0/querying_data.md
+++ b/website/versioned_docs/version-0.14.0/querying_data.md
@@ -31,11 +31,13 @@ classpath of drivers and executors using `--jars` option. Alternatively, hudi-sp
 Retrieve the data table at the present point in time.
 
 ```scala
+import org.apache.hudi.DataSourceReadOptions._
+
 val hudiSnapshotQueryDF = spark
-     .read
-     .format("hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
-     .load(tablePath) 
+  .read
+  .format("hudi")
+  .option(QUERY_TYPE.key(), QUERY_TYPE_SNAPSHOT_OPT_VAL)
+  .load(tablePath) 
 ```
 
 ### Incremental query {#spark-incr-query}
@@ -46,11 +48,11 @@ The following snippet shows how to obtain all records changed after `beginInstan
 
 ```java
 Dataset<Row> hudiIncQueryDF = spark.read()
-     .format("org.apache.hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL())
-     .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(), <beginInstantTime>)
-     .option(DataSourceReadOptions.INCR_PATH_GLOB_OPT_KEY(), "/year=2020/month=*/day=*") // Optional, use glob pattern if querying certain partitions
-     .load(tablePath); // For incremental query, pass in the root/base path of table
+    .format("hudi")
+    .option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL)
+    .option(BEGIN_INSTANTTIME.key(), <beginInstantTime>)
+    .option(INCR_PATH_GLOB.key(), "/year=2020/month=*/day=*") // Optional, use glob pattern if querying certain partitions
+    .load(tablePath); // For incremental query, pass in the root/base path of table
      
 hudiIncQueryDF.createOrReplaceTempView("hudi_trips_incremental")
 spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hudi_trips_incremental where fare > 20.0").show()

--- a/website/versioned_docs/version-0.14.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.14.0/quick-start-guide.md
@@ -250,6 +250,12 @@ Since, this is the first write, it will also auto-create the table.
 
 ```scala
 // spark-shell
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+import org.apache.hudi.common.table.HoodieTableConfig._
+import org.apache.hudi.DataSourceReadOptions._
+
 val columns = Seq("ts","uuid","rider","driver","fare","city")
 val data =
   Seq((1695159649087L,"334e26e9-8355-45cc-97c6-c31daf0df330","rider-A","driver-K",19.10,"san_francisco"),
@@ -260,8 +266,8 @@ val data =
 
 var inserts = spark.createDataFrame(data).toDF(columns:_*)
 inserts.write.format("hudi").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 ```
@@ -404,9 +410,9 @@ values={[
 val updatesDf = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-D").withColumn("fare", col("fare") * 10)
 
 updatesDf.write.format("hudi").
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(), "upsert").
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 ```
@@ -560,9 +566,9 @@ values={[
 val deletesDF = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-F")
 
 deletesDF.write.format("hudi").
-  option(OPERATION_OPT_KEY, "delete").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
-  option(TABLE_NAME, tableName).
+  option(OPERATION.key(), "delete").
+  option(PARTITIONPATH_FIELD.key(), "city").
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -812,9 +818,9 @@ var df = spark.createDataFrame(data).toDF(columns:_*)
 
 // Insert data
 df.write.format("hudi").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
+  option(PARTITIONPATH_FIELD.key(), "city").
   option(CDC_ENABLED.key(), "true").
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   mode(Overwrite).
   save(basePath)
 
@@ -822,10 +828,10 @@ df.write.format("hudi").
 val updatesDf = spark.read.format("hudi").load(basePath).filter($"rider" === "rider-A" || $"rider" === "rider-B").withColumn("fare", col("fare") * 10)
 
 updatesDf.write.format("hudi").
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PARTITIONPATH_FIELD_NAME.key(), "city").
+  option(OPERATION.key(), "upsert").
+  option(PARTITIONPATH_FIELD.key(), "city").
   option(CDC_ENABLED.key(), "true").
-  option(TABLE_NAME, tableName).
+  option(TBL_NAME.key(), tableName).
   mode(Append).
   save(basePath)
 
@@ -1063,7 +1069,7 @@ values={[
 // spark-shell 
 updatesDf.write.format("hudi").
   ...
-  option(PRECOMBINE_FIELD_NAME.key(), "ts").
+  option(PRECOMBINE_FIELD.key(), "ts").
   ...
 ```
 

--- a/website/versioned_docs/version-0.14.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.0/schema_evolution.md
@@ -186,17 +186,17 @@ val schema = StructType( Array(
 val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
                 Row("row_2", "part_0", 0L, "john", "v_0", 0),
                 Row("row_3", "part_0", 0L, "tom", "v_0", 0))
-        
+
 var dfFromData1 = spark.createDataFrame(data1, schema)
 dfFromData1.write.format("hudi").
-   options(getQuickstartWriteConfigs).
-   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
-   option("hoodie.index.type","SIMPLE").
-   option(TABLE_NAME.key, tableName).
-   mode(Overwrite).
-   save(basePath)
+  options(getQuickstartWriteConfigs).
+  option(PRECOMBINE_FIELD.key(), "preComb").
+  option(RECORDKEY_FIELD.key(), "rowId").
+  option(PARTITIONPATH_FIELD.key(), "partitionId").
+  option("hoodie.index.type","SIMPLE").
+  option(TBL_NAME.key(), tableName).
+  mode(Overwrite).
+  save(basePath)
 
 var tripsSnapshotDF1 = spark.read.format("hudi").load(basePath + "/*/*")
 tripsSnapshotDF1.createOrReplaceTempView("hudi_trips_snapshot")
@@ -248,14 +248,14 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
 
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
-    options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
-    option("hoodie.index.type","SIMPLE").
-    option(TABLE_NAME.key, tableName).
-    mode(Append).
-    save(basePath)
+  options(getQuickstartWriteConfigs).
+  option(PRECOMBINE_FIELD.key(), "preComb").
+  option(RECORDKEY_FIELD.key(), "rowId").
+  option(PARTITIONPATH_FIELD.key(), "partitionId").
+  option("hoodie.index.type","SIMPLE").
+  option(TBL_NAME.key(), tableName).
+  mode(Append).
+  save(basePath)
 
 var tripsSnapshotDF2 = spark.read.format("hudi").load(basePath + "/*/*")
 tripsSnapshotDF2.createOrReplaceTempView("hudi_trips_snapshot")

--- a/website/versioned_docs/version-0.14.0/syncing_metastore.md
+++ b/website/versioned_docs/version-0.14.0/syncing_metastore.md
@@ -211,30 +211,30 @@ val tableName = "hudi_cow"
 val basePath = "/user/hive/warehouse/hudi_cow"
 
 val schema = StructType(Array(
-StructField("rowId", StringType,true),
-StructField("partitionId", StringType,true),
-StructField("preComb", LongType,true),
-StructField("name", StringType,true),
-StructField("versionId", StringType,true),
-StructField("toBeDeletedStr", StringType,true),
-StructField("intToLong", IntegerType,true),
-StructField("longToInt", LongType,true)
+  StructField("rowId", StringType,true),
+  StructField("partitionId", StringType,true),
+  StructField("preComb", LongType,true),
+  StructField("name", StringType,true),
+  StructField("versionId", StringType,true),
+  StructField("toBeDeletedStr", StringType,true),
+  StructField("intToLong", IntegerType,true),
+  StructField("longToInt", LongType,true)
 ))
 
-val data0 = Seq(Row("row_1", "2021/01/01",0L,"bob","v_0","toBeDel0",0,1000000L), 
-               Row("row_2", "2021/01/01",0L,"john","v_0","toBeDel0",0,1000000L), 
-               Row("row_3", "2021/01/02",0L,"tom","v_0","toBeDel0",0,1000000L))
+val data0 = Seq(Row("row_1", "2021/01/01",0L,"bob","v_0","toBeDel0",0,1000000L),
+  Row("row_2", "2021/01/01",0L,"john","v_0","toBeDel0",0,1000000L),
+  Row("row_3", "2021/01/02",0L,"tom","v_0","toBeDel0",0,1000000L))
 
 var dfFromData0 = spark.createDataFrame(data0,schema)
 
 dfFromData0.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "preComb").
-  option(RECORDKEY_FIELD_OPT_KEY, "rowId").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionId").
-  option(TABLE_NAME, tableName).
-  option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL).
-  option(OPERATION_OPT_KEY, "upsert").
+  option(PRECOMBINE_FIELD.key(), "preComb").
+  option(RECORDKEY_FIELD.key(), "rowId").
+  option(PARTITIONPATH_FIELD.key(), "partitionId").
+  option(TBL_NAME.key(), tableName).
+  option(TABLE_TYPE.key(), "COPY_ON_WRITE").
+  option(OPERATION.key(), "upsert").
   option("hoodie.index.type","SIMPLE").
   option("hoodie.datasource.write.hive_style_partitioning","true").
   option("hoodie.datasource.hive_sync.jdbcurl","jdbc:hive2://hiveserver:10000/").

--- a/website/versioned_docs/version-0.14.0/troubleshooting.md
+++ b/website/versioned_docs/version-0.14.0/troubleshooting.md
@@ -98,15 +98,17 @@ backwards compatibility and not breaking existing pipelines, this config is set 
 Unless Hive sync is enabled, the dataset written by Hudi using one of the methods above can simply be queries via the Spark datasource like any other source.
 
 ```scala
+import org.apache.hudi.DataSourceReadOptions._
+
 val hudiSnapshotQueryDF = spark
-     .read()
-     .format("hudi")
-     .option(DataSourceReadOptions.QUERY_TYPE_OPT_KEY(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
-     .load(basePath) 
+  .read()
+  .format("hudi")
+  .option(QUERY_TYPE.key(), QUERY_TYPE_SNAPSHOT_OPT_VAL)
+  .load(basePath)
 val hudiIncQueryDF = spark.read().format("hudi")
-     .option(DataSourceReadOptions.VIEW_TYPE_OPT_KEY(), DataSourceReadOptions.VIEW_TYPE_INCREMENTAL_OPT_VAL())
-     .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(), <beginInstantTime>)
-     .load(basePath);
+  .option(QUERY_TYPE.key(), QUERY_TYPE_INCREMENTAL_OPT_VAL)
+  .option(BEGIN_INSTANTTIME.key(), <beginInstantTime>)
+    .load(basePath);
 ```
 
 if Hive Sync is enabled in the [deltastreamer](https://github.com/apache/hudi/blob/d3edac4612bde2fa9deca9536801dbc48961fb95/docker/demo/sparksql-incremental.commands#L50) tool or [datasource](https://hudi.apache.org/docs/configurations#hoodiedatasourcehive_syncenable), the dataset is available in Hive as a couple of tables, that can now be read using HiveQL, Presto or SparkSQL. See [here](https://hudi.apache.org/docs/querying_data/) for more.

--- a/website/versioned_docs/version-0.14.0/write_operations.md
+++ b/website/versioned_docs/version-0.14.0/write_operations.md
@@ -29,10 +29,10 @@ of initial load. However, this just does a best-effort job at sizing files vs gu
 Hudi supports implementing two types of deletes on data stored in Hudi tables, by enabling the user to specify a different record payload implementation.
 - **Soft Deletes** : Retain the record key and just null out the values for all the other fields.
   This can be achieved by ensuring the appropriate fields are nullable in the table schema and simply upserting the table after setting these fields to null.
-- **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways. 
-  - Using DataSource, set `OPERATION_OPT_KEY` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted. 
-  - Using DataSource, set `PAYLOAD_CLASS_OPT_KEY` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
-  - Using DataSource or Hudi Streamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
+- **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways.
+    - Using DataSource, set `OPERATION.key()` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted.
+    - Using DataSource, set `PAYLOAD_CLASS_NAME.key()` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted.
+    - Using DataSource or Hudi Streamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
 
 ### BOOTSTRAP
 Hudi supports migrating your existing large tables into a Hudi table using the `bootstrap` operation. There are a couple of ways to approach this. Please refer to 

--- a/website/versioned_docs/version-0.14.0/writing_data.md
+++ b/website/versioned_docs/version-0.14.0/writing_data.md
@@ -17,47 +17,38 @@ The `hudi-spark` module offers the DataSource API to write (and read) a Spark Da
 
 **`HoodieWriteConfig`**:
 
-**TABLE_NAME** (Required)<br/>
+**TBL_NAME.key()** (Required)<br/>
 
 
 **`DataSourceWriteOptions`**:
 
-**RECORDKEY_FIELD_OPT_KEY** (Required): Primary key field(s). Record keys uniquely identify a record/row within each partition. If one wants to have a global uniqueness, there are two options. You could either make the dataset non-partitioned, or, you can leverage Global indexes to ensure record keys are unique irrespective of the partition path. Record keys can either be a single column or refer to multiple columns. `KEYGENERATOR_CLASS_OPT_KEY` property should be set accordingly based on whether it is a simple or complex key. For eg: `"col1"` for simple field, `"col1,col2,col3,etc"` for complex field. Nested fields can be specified using the dot notation eg: `a.b.c`. <br/>
-Default value: `"uuid"`<br/>
-
-**PARTITIONPATH_FIELD_OPT_KEY** (Required): Columns to be used for partitioning the table. To prevent partitioning, provide empty string as value eg: `""`. Specify partitioning/no partitioning using `KEYGENERATOR_CLASS_OPT_KEY`. If partition path needs to be url encoded, you can set `URL_ENCODE_PARTITIONING_OPT_KEY`. If synchronizing to hive, also specify using `HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY.`<br/>
-Default value: `"partitionpath"`<br/>
-
-**PRECOMBINE_FIELD_OPT_KEY** (Required): When two records within the same batch have the same key value, the record with the largest value from the field specified will be choosen. If you are using default payload of OverwriteWithLatestAvroPayload for HoodieRecordPayload (`WRITE_PAYLOAD_CLASS`), an incoming record will always takes precendence compared to the one in storage ignoring this `PRECOMBINE_FIELD_OPT_KEY`. <br/>
-Default value: `"ts"`<br/>
-
-**OPERATION_OPT_KEY**: The [write operations](/docs/write_operations) to use.<br/>
-Available values:<br/>
-`UPSERT_OPERATION_OPT_VAL` (default), `BULK_INSERT_OPERATION_OPT_VAL`, `INSERT_OPERATION_OPT_VAL`, `DELETE_OPERATION_OPT_VAL`
-
-**TABLE_TYPE_OPT_KEY**: The [type of table](/docs/concepts#table-types) to write to. Note: After the initial creation of a table, this value must stay consistent when writing to (updating) the table using the Spark `SaveMode.Append` mode.<br/>
-Available values:<br/>
-[`COW_TABLE_TYPE_OPT_VAL`](/docs/concepts#copy-on-write-table) (default), [`MOR_TABLE_TYPE_OPT_VAL`](/docs/concepts#merge-on-read-table)
-
-**KEYGENERATOR_CLASS_OPT_KEY**: Refer to [Key Generation](/docs/key_generation) section below.
-
-**HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY**: If using hive, specify if the table should or should not be partitioned.<br/>
-Available values:<br/>
-`classOf[MultiPartKeysValueExtractor].getCanonicalName` (default), `classOf[SlashEncodedDayPartitionValueExtractor].getCanonicalName`, `classOf[TimestampBasedKeyGenerator].getCanonicalName`, `classOf[NonPartitionedExtractor].getCanonicalName`, `classOf[GlobalDeleteKeyGenerator].getCanonicalName` (to be used when `OPERATION_OPT_KEY` is set to `DELETE_OPERATION_OPT_VAL`)
+| Config                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Required | Available Values                                                                                                                                                                                                                                                                                                                                                                  |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| RECORDKEY_FIELD                | Primary key field(s). Record keys uniquely identify a record/row within each partition. If one wants to have a global uniqueness, there are two options. You could either make the dataset non-partitioned, or, you can leverage Global indexes to ensure record keys are unique irrespective of the partition path. Record keys can either be a single column or refer to multiple columns. `KEYGENERATOR_CLASS_NAME.key()` property should be set accordingly based on whether it is a simple or complex key. For eg: `"col1"` for simple field, `"col1,col2,col3,etc"` for complex field. Nested fields can be specified using the dot notation eg: `a.b.c`. | optional | "uuid" (default)                                                                                                                                                                                                                                                                                                                                                                  |
+| PARTITIONPATH_FIELD            | Columns to be used for partitioning the table. To prevent partitioning, provide empty string as value eg: `""`. Specify partitioning/no partitioning using `KEYGENERATOR_CLASS_NAME.key()`. If partition path needs to be url encoded, you can set `URL_ENCODE_PARTITIONING.key()`. If synchronizing to hive, also specify using `META_SYNC_PARTITION_EXTRACTOR_CLASS.key()`.                                                                                                                                                                                                                                                                                   | optional | "partitionpath" (default)                                                                                                                                                                                                                                                                                                                                                         |
+| PRECOMBINE_FIELD               | When two records within the same batch have the same key value, the record with the largest value from the field specified will be choosen. If you are using default payload of OverwriteWithLatestAvroPayload for HoodieRecordPayload (`WRITE_PAYLOAD_CLASS`), an incoming record will always takes precendence compared to the one in storage ignoring this `PRECOMBINE_FIELD.key()`.                                                                                                                                                                                                                                                                         | optional | "ts" (default)                                                                                                                                                                                                                                                                                                                                                                    |
+| OPERATION                      | The [write operations](/docs/write_operations) to use.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | optional | `UPSERT_OPERATION_OPT_VAL` (default), `BULK_INSERT_OPERATION_OPT_VAL`, `INSERT_OPERATION_OPT_VAL`, `DELETE_OPERATION_OPT_VAL`                                                                                                                                                                                                                                                     |
+| TABLE_TYPE                     | The [type of table](/docs/concepts#table-types) to write to. Note: After the initial creation of a table, this value must stay consistent when writing to (updating) the table using the Spark `SaveMode.Append` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                          | optional | [`COW_TABLE_TYPE_OPT_VAL`](/docs/concepts#copy-on-write-table) (default), [`MOR_TABLE_TYPE_OPT_VAL`](/docs/concepts#merge-on-read-table)                                                                                                                                                                                                                                          |
+| KEYGENERATOR_CLASS             | Refer to [Key Generation](/docs/key_generation) section below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | optional |                                                                                                                                                                                                                                                                                                                                                                                   |
+| HIVE_PARTITION_EXTRACTOR_CLASS | If using hive, specify if the table should or should not be partitioned.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | optional | `classOf[MultiPartKeysValueExtractor].getCanonicalName` (default), `classOf[SlashEncodedDayPartitionValueExtractor].getCanonicalName`, `classOf[TimestampBasedKeyGenerator].getCanonicalName`, `classOf[NonPartitionedExtractor].getCanonicalName`, `classOf[GlobalDeleteKeyGenerator].getCanonicalName` (to be used when `OPERATION.key()` is set to `DELETE_OPERATION_OPT_VAL`) |
 
 
 Example:
 Upsert a DataFrame, specifying the necessary field names for `recordKey => _row_key`, `partitionPath => partition`, and `precombineKey => timestamp`
 
 ```java
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import org.apache.spark.sql.SaveMode._
+
 inputDF.write()
-       .format("org.apache.hudi")
+       .format("hudi")
        .options(clientOpts) //Where clientOpts is of type Map[String, String]. clientOpts can include any other options necessary.
-       .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
-       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
-       .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-       .option(HoodieWriteConfig.TABLE_NAME, tableName)
-       .mode(SaveMode.Append)
+       .option(RECORDKEY_FIELD.key(), "_row_key")
+        .option(PARTITIONPATH_FIELD.key(), "partition")
+        .option(PRECOMBINE_FIELD.key(), "timestamp")
+        .option(TBL_NAME.key(), tableName)
+        .mode(Append)
        .save(basePath);
 ```
 
@@ -77,13 +68,13 @@ Generate some new trips, load them into a DataFrame and write the DataFrame into
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
-  mode(Overwrite).
-  save(basePath)
+        options(getQuickstartWriteConfigs).
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Overwrite).
+        save(basePath)
 ```
 :::info
 `mode(Overwrite)` overwrites and recreates the table if it already exists.
@@ -202,14 +193,14 @@ spark.
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"insert_overwrite_table").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
-  mode(Append).
-  save(basePath)
+        options(getQuickstartWriteConfigs).
+        option(OPERATION.key(),"insert_overwrite_table").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Append).
+        save(basePath)
 
 // Should have different keys now, from query before.
 spark.
@@ -260,14 +251,14 @@ val df = spark.
   read.json(spark.sparkContext.parallelize(inserts, 2)).
   filter("partitionpath = 'americas/united_states/san_francisco'")
 df.write.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"insert_overwrite").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
-  mode(Append).
-  save(basePath)
+        options(getQuickstartWriteConfigs).
+        option(OPERATION.key(),"insert_overwrite").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Append).
+        save(basePath)
 
 // Should have different keys now for San Francisco alone, from query before.
 spark.
@@ -317,25 +308,25 @@ val softDeleteDf = nullifyColumns.
 
 // simply upsert the table after setting these fields to null
 softDeleteDf.write.format("hudi").
-  options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY, "upsert").
-  option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-  option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-  option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-  option(TABLE_NAME, tableName).
-  mode(Append).
-  save(basePath)
+        options(getQuickstartWriteConfigs).
+        option(OPERATION.key(), "upsert").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Append).
+        save(basePath)
 ```
 
 - **Hard Deletes** : A stronger form of deletion is to physically remove any trace of the record from the table. This can be achieved in 3 different ways. 
 
-1. Using Datasource, set `OPERATION_OPT_KEY` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted.
+1. Using Datasource, set `OPERATION.key()` to `DELETE_OPERATION_OPT_VAL`. This will remove all the records in the DataSet being submitted.
 
 Example, first read in a dataset:
 ```scala
 val roViewDF = spark.
         read.
-        format("org.apache.hudi").
+        format("hudi").
         load(basePath + "/*/*/*/*")
 roViewDF.createOrReplaceTempView("hudi_ro_table")
 spark.sql("select count(*) from hudi_ro_table").show() // should return 10 (number of records inserted above)
@@ -350,26 +341,26 @@ Lastly, execute the deletion of these records:
 ```scala
 val deletes = dataGen.generateDeletes(df.collectAsList())
 val df = spark.read.json(spark.sparkContext.parallelize(deletes, 2));
-df.write.format("org.apache.hudi").
-options(getQuickstartWriteConfigs).
-option(OPERATION_OPT_KEY,"delete").
-option(PRECOMBINE_FIELD_OPT_KEY, "ts").
-option(RECORDKEY_FIELD_OPT_KEY, "uuid").
-option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
-option(TABLE_NAME, tableName).
-mode(Append).
-save(basePath);
+df.write.format("hudi").
+        options(getQuickstartWriteConfigs).
+        option(OPERATION.key(),"delete").
+        option(PRECOMBINE_FIELD.key(), "ts").
+        option(RECORDKEY_FIELD.key(), "uuid").
+        option(PARTITIONPATH_FIELD.key(), "partitionpath").
+        option(TBL_NAME.key(), tableName).
+        mode(Append).
+        save(basePath);
 ```
 
-2. Using DataSource, set `PAYLOAD_CLASS_OPT_KEY` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted. 
+2. Using DataSource, set `PAYLOAD_CLASS_NAME.key()` to `"org.apache.hudi.EmptyHoodieRecordPayload"`. This will remove all the records in the DataSet being submitted.
 
 This example will remove all the records from the table that exist in the DataSet `deleteDF`:
 ```scala
  deleteDF // dataframe containing just records to be deleted
-   .write().format("org.apache.hudi")
-   .option(...) // Add HUDI options like record-key, partition-path and others as needed for your setup
-   // specify record_key, partition_key, precombine_fieldkey & usual params
-   .option(DataSourceWriteOptions.PAYLOAD_CLASS_OPT_KEY, "org.apache.hudi.EmptyHoodieRecordPayload")
+        .write().format("hudi")
+        .option(...) // Add HUDI options like record-key, partition-path and others as needed for your setup
+// specify record_key, partition_key, precombine_fieldkey & usual params
+.option(PAYLOAD_CLASS_NAME.key(), "org.apache.hudi.EmptyHoodieRecordPayload")
 ```
 
 3. Using DataSource or DeltaStreamer, add a column named `_hoodie_is_deleted` to DataSet. The value of this column must be set to `true` for all the records to be deleted and either `false` or left null for any records which are to be upserted.
@@ -430,21 +421,21 @@ The `hudi-spark` module offers the DataSource API to write (and read) a Spark Da
 
 Following is an example of how to use optimistic_concurrency_control via spark datasource. Read more in depth about concurrency control in the [concurrency control concepts](https://hudi.apache.org/docs/concurrency_control) section  
 
-```java
+```scala
 inputDF.write.format("hudi")
-       .options(getQuickstartWriteConfigs)
-       .option(PRECOMBINE_FIELD_OPT_KEY, "ts")
-       .option("hoodie.cleaner.policy.failed.writes", "LAZY")
-       .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
-       .option("hoodie.write.lock.zookeeper.url", "zookeeper")
-       .option("hoodie.write.lock.zookeeper.port", "2181")
-       .option("hoodie.write.lock.zookeeper.lock_key", "test_table")
-       .option("hoodie.write.lock.zookeeper.base_path", "/test")
-       .option(RECORDKEY_FIELD_OPT_KEY, "uuid")
-       .option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath")
-       .option(TABLE_NAME, tableName)
-       .mode(Overwrite)
-       .save(basePath)
+        .options(getQuickstartWriteConfigs)
+        .option(PRECOMBINE_FIELD.key(), "ts")
+        .option("hoodie.cleaner.policy.failed.writes", "LAZY")
+        .option("hoodie.write.concurrency.mode", "optimistic_concurrency_control")
+        .option("hoodie.write.lock.zookeeper.url", "zookeeper")
+        .option("hoodie.write.lock.zookeeper.port", "2181")
+        .option("hoodie.write.lock.zookeeper.lock_key", "test_table")
+        .option("hoodie.write.lock.zookeeper.base_path", "/test")
+        .option(RECORDKEY_FIELD.key(), "uuid")
+        .option(PARTITIONPATH_FIELD.key(), "partitionpath")
+        .option(TBL_NBAME.key(), tableName)
+        .mode(Overwrite)
+        .save(basePath)
 ```
 
 ### Commit Notifications
@@ -462,7 +453,6 @@ You can push a commit notification to an HTTP URL and can specify custom values 
 | CALLBACK_HTTP_TIMEOUT_IN_SECONDS | Callback timeout in seconds | optional | 3 |
 | CALLBACK_CLASS_NAME | Full path of callback class and must be a subclass of HoodieWriteCommitCallback class, org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback by default | optional | org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback |
 | CALLBACK_HTTP_API_KEY_VALUE | Http callback API key | optional | hudi_write_commit_http_callback |
-| | | | |
 
 #### Kafka Endpoints
 You can push a commit notification to a Kafka topic so it can be used by other real time systems.
@@ -474,7 +464,6 @@ You can push a commit notification to a Kafka topic so it can be used by other r
 | RETRIES | Times to retry the produce | optional | 3 |
 | ACKS | kafka acks level, all by default to ensure strong durability | optional | all |
 | BOOTSTRAP_SERVERS | Bootstrap servers of kafka cluster, to be used for publishing commit metadata | required | N/A |
-| | | | |
 
 #### Pulsar Endpoints
 You can push a commit notification to a Pulsar topic so it can be used by other real time systems. 
@@ -492,7 +481,6 @@ You can push a commit notification to a Pulsar topic so it can be used by other 
 | hoodie.write.commit.callback.pulsar.connection-timeout | Duration of waiting for a connection to a broker to be established.     | optional | 10s    |
 | hoodie.write.commit.callback.pulsar.request-timeout | Duration of waiting for completing a request.  | optional | 60s    |
 | hoodie.write.commit.callback.pulsar.keepalive-interval | Duration of keeping alive interval for each client broker connection. | optional | 30s    |
-| |                                                                             | |        |
 
 #### Bring your own implementation
 You can extend the HoodieWriteCommitCallback class to implement your own way to asynchronously handle the callback


### PR DESCRIPTION
### Change Logs

Fixed all code examples and refs for deprecated configs in the docs in current and 0.14.0

### Impact

Doc change

### Risk level (write none, low medium or high below)

MEDIUM

### Documentation Update

Changes to docs and configs.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [NA] Adequate tests were added if applicable
- [NA] CI passed
