### PR TITLE
[HUDI-7267]fix dataSkipping with null column stats

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -276,7 +276,7 @@ class ColumnStatsIndexSupport(spark: SparkSession,
                   //       behavior is consistent with reading non-existent columns from Parquet)
                   //
                   // This is a way to determine current column's index without explicit iteration (we're adding 3 stats / column)
-                  acc ++= Seq(null, null, valueCount)
+                  acc ++= Seq(null, null, null)
               }
           }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -32,7 +32,7 @@ import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
 import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, IsNull, Literal, Or}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
@@ -348,7 +348,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       )
 
       val expectedAndConditionIndexedFilter = And(
-        GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1)),
+        Or(IsNull(UnresolvedAttribute("c1_maxValue")),GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1))),
         Literal(true)
       )
 
@@ -370,7 +370,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       )
 
       val expectedOrConditionIndexedFilter = Or(
-        GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1)),
+        Or(IsNull(UnresolvedAttribute("c1_maxValue")), GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1))),
         Literal(true)
       )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkipQuery.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkipQuery.scala
@@ -39,7 +39,7 @@ class TestDataSkipQuery extends HoodieSparkSqlTestBase {
              |      type = 'cow',
              |      preCombineField = 'ts'
              |)
-             |partitioned by (dt);
+             |partitioned by (dt)
        """.stripMargin)
 
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkipQuery.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDataSkipQuery.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestDataSkipQuery extends HoodieSparkSqlTestBase {
+
+  test("Test data skipping query Table with array struct") {
+    withSQLConf("hoodie.metadata.enable" -> "true",
+                       "hoodie.metadata.index.column.stats.enable" -> "true",
+                       "hoodie.enable.data.skipping" -> "true") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        // create table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |      id int,
+             |      info array<struct<name: string, age: int>>,
+             |      ts bigint,
+             |      dt string
+             |) using hudi
+             |options (
+             |      primaryKey = 'id',
+             |      type = 'cow',
+             |      preCombineField = 'ts'
+             |)
+             |partitioned by (dt);
+       """.stripMargin)
+
+
+        spark.sql(s"insert into $tableName " +
+          s" select 1 as id, array(named_struct('name', 'Eva', 'age', 28)) as info, 1000 as ts, '20210101' as dt")
+        spark.sql(s"select id, explode(info) from $tableName where id = 1 and dt = '20210101';").show(false)
+
+        checkAnswer(s"select id, ts, dt from $tableName where id = 1 and dt = '20210101';")(
+          Seq(1, 1000, "20210101")
+        )
+
+        checkAnswer(s"select id, ts, dt from $tableName where id = 1 and size(info) > 0 and dt = '20210101'")(
+          Seq(1, 1000, "20210101")
+        )
+
+        checkAnswer(s"select id, ts, dt from $tableName where id is not null and size(info) > 0 and dt = '20210101'")(
+          Seq(1, 1000, "20210101")
+        )
+
+        checkAnswer(s"select id, ts, dt from $tableName where id = 1 and info is not null and dt = '20210101'")(
+          Seq(1, 1000, "20210101")
+        )
+
+        checkAnswer(s"select id, ts, dt from $tableName where ts = 1000 and id is not null and dt = '20210101'")(
+          Seq(1, 1000, "20210101")
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
from the picture, csi will use parquet chunk block meta calculate min/max value, and save it to mdt col stat. For complex cols, such as *info array<struct<name: string, age: int>>* , parquet meta will contain only `info.array.name`, `infor.array.age`, but hudi will only calculate `info` column, so this meta in mdt will be null.

And if sql expression contain `IsNotNull(info)`, the file will all be skip.

And consider common cols, which will be add in the future and old file will not contain this col, may cause some other question. So, make code logical clean, Check for null before evaluating the value：min/mav/nullValue.
![image](https://github.com/apache/hudi/assets/20125927/9fda89c1-2b8b-48b4-a2b7-f1bced3db596)

### Change Logs

-  Check for null before evaluating the value：min/mav/nullValue

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
