### PR TITLE
[HUDI-7271] copy a conf let following modification not to impact the global conf

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -128,7 +128,8 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
   private transient NonThrownExecutor executor;
 
   public ClusteringOperator(Configuration conf, RowType rowType) {
-    this.conf = conf;
+    // copy a conf let following modification not to impact the global conf
+    this.conf = new Configuration(conf);
     this.rowType = BulkInsertWriterHelper.addMetadataFields(rowType, false);
     this.asyncClustering = OptionsResolver.needsAsyncClustering(conf);
     this.sortClusteringEnabled = OptionsResolver.sortClusteringEnabled(conf);


### PR DESCRIPTION
…global conf

### Change Logs

```
CREATE TABLE IF NOT EXISTS hudi_catalog.tmp.table
    (
        bb STRING,
        dt STRING
    )
    PARTITIONED BY
    (
        dt
    )
WITH
    (
        'connector' = 'hudi',
        'path' = '',
        'table.type' = 'COPY_ON_WRITE',
        'write.operation' = 'insert',
        'hoodie.datasource.write.recordkey.field' = 'dt',
        'hoodie.parquet.max.file.size' = '536870912', -- 512M
        'clustering.async.enabled' = 'true',
        'clustering.schedule.enabled' = 'true',
        'hoodie.clustering.async.max.commits' = '1000000',
        'clustering.plan.strategy.small.file.limit' = '268435456', -- 256M
        'clustering.plan.strategy.target.file.max.bytes' = '1610612736', -- 1.5G
        'clustering.plan.partition.filter.mode' = 'RECENT_DAYS',
        'clustering.plan.strategy.daybased.lookback.partitions' = '2',
        'clustering.plan.strategy.daybased.skipfromlatest.partitions' = '0',
        'clustering.plan.strategy.max.num.groups'='750',
        'hoodie.cleaner.policy' = 'KEEP_LATEST_COMMITS',
        'clean.retain_commits' = '300',
        'archive.max_commits' = '500',
        'archive.min_commits' = '400',
        'write.precombine' = 'false'
    ) ; 
```

```
INSERT
INTO
	hudi_catalog.tmp.table/*+ OPTIONS('clustering.async.enabled'='true','clustering.schedule.enabled'='false')*/

(
	bb,
	dt
)
SELECT 
    log,
    DATE_FORMAT(`timestamp`, 'yyyy-MM-dd') AS dt
FROM
    kafkatable
```

if user set 'clustering.async.enabled'='true' and 'clustering.schedule.enabled'='false' then the hoodie.parquet.max.file.size
will be replaced by clustering.plan.strategy.target.file.max.bytes.  so it will impact the global conf in org.apache.hudi.sink.bulk.BulkInsertWriterHelper#write, however the checkpoint interval can not reach the clustering.plan.strategy.target.file.max.bytes , so it makes the result not well. 

so this modification just make BulkInsertWriteFunction and clusteringOperation has self configuration

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
