### PR TITLE
[MINOR] Fix violations of Sonarqube rule java:S2184

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
@@ -551,7 +551,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
       int maxReqPerSec = getMaxReqPerSec(numRSAlive, maxQpsPerRegionServer, qpsFraction);
       int numTasks = numTasksDuringPut;
       int maxParallelPutsTask = Math.max(1, Math.min(numTasks, maxExecutors));
-      int multiPutBatchSizePerSecPerTask = Math.max(1, (int) Math.ceil(maxReqPerSec / maxParallelPutsTask));
+      int multiPutBatchSizePerSecPerTask = Math.max(1, (int) Math.ceil((double) maxReqPerSec / maxParallelPutsTask));
       LOG.info("HbaseIndexThrottling: qpsFraction :" + qpsFraction);
       LOG.info("HbaseIndexThrottling: numRSAlive :" + numRSAlive);
       LOG.info("HbaseIndexThrottling: maxReqPerSec :" + maxReqPerSec);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBasePutBatchSizeCalculator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBasePutBatchSizeCalculator.java
@@ -34,28 +34,28 @@ public class TestHBasePutBatchSizeCalculator {
     int putBatchSize = batchSizeCalculator.getBatchSize(10, 16667, 1200, 200, 0.1f);
     // Total puts that can be sent  in 1 second = (10 * 16667 * 0.1) = 16,667
     // Total puts per batch will be (16,667 / parallelism) = 83.335, where 200 is the maxExecutors
-    assertEquals(putBatchSize, 83);
+    assertEquals(putBatchSize, 84);
 
     // Number of Region Servers are halved, total requests sent in a second are also halved, so batchSize is also halved
     int putBatchSize2 = batchSizeCalculator.getBatchSize(5, 16667, 1200, 200, 0.1f);
-    assertEquals(putBatchSize2, 41);
+    assertEquals(putBatchSize2, 42);
 
     // If the parallelism is halved, batchSize has to double
     int putBatchSize3 = batchSizeCalculator.getBatchSize(10, 16667, 1200, 100, 0.1f);
-    assertEquals(putBatchSize3, 166);
+    assertEquals(putBatchSize3, 167);
 
     // If the parallelism is halved, batchSize has to double.
     // This time parallelism is driven by numTasks rather than numExecutors
     int putBatchSize4 = batchSizeCalculator.getBatchSize(10, 16667, 100, 200, 0.1f);
-    assertEquals(putBatchSize4, 166);
+    assertEquals(putBatchSize4, 167);
 
     // If sleepTimeMs is halved, batchSize has to halve
     int putBatchSize5 = batchSizeCalculator.getBatchSize(10, 16667, 1200, 200, 0.05f);
-    assertEquals(putBatchSize5, 41);
+    assertEquals(putBatchSize5, 42);
 
     // If maxQPSPerRegionServer is doubled, batchSize also doubles
     int putBatchSize6 = batchSizeCalculator.getBatchSize(10, 33334, 1200, 200, 0.1f);
-    assertEquals(putBatchSize6, 166);
+    assertEquals(putBatchSize6, 167);
   }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/SizeAwareDataOutputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/SizeAwareDataOutputStream.java
@@ -55,7 +55,7 @@ public class SizeAwareDataOutputStream {
   }
 
   public void write(byte[] v, int offset, int len) throws IOException {
-    size.addAndGet(len + offset);
+    size.addAndGet((long) len + offset);
     outputStream.write(v, offset, len);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
@@ -102,7 +102,7 @@ public class HoodieWithTimelineServer implements Serializable {
     try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
 
       System.out.println("Sleeping for " + cfg.delaySecs + " secs ");
-      Thread.sleep(cfg.delaySecs * 1000);
+      Thread.sleep(cfg.delaySecs * 1000L);
       System.out.println("Woke up after sleeping for " + cfg.delaySecs + " secs ");
 
       HttpGet request = new HttpGet(url);


### PR DESCRIPTION
### Change Logs

This PR fixes 4 violations of Sonarqube Rule java:S2184 : ['Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).
For more details, please see
[MITRE, CWE-190](http://cwe.mitre.org/data/definitions/190) - Integer Overflow or Wraparound
[CERT, NUM50-J.](https://wiki.sei.cmu.edu/confluence/x/AjdGBQ)- Convert integers to floating point for floating-point operations
[CERT, INT18-C.](https://wiki.sei.cmu.edu/confluence/x/I9cxBQ) - Evaluate integer expressions in a larger size before comparing or assigning to that size

The patch was automatically generated using the ViolationFixer tool.

### Impact

Code quality improvements.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed