### PR TITLE
[MINOR] Disable org.apache.hudi.TestHoodieSparkSqlWriter#testInsertDatasetWithTimelineTimezoneUTC

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.functions.{expr, lit}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertNull, assertTrue, fail}
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Disabled, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider._
@@ -1341,8 +1341,9 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
   /*
    * Test case for instant is generated with commit timezone when TIMELINE_TIMEZONE set to UTC
    * related to HUDI-5978
+   * Issue [HUDI-7275] is tracking this test being disabled
    */
-  @Test
+  @Disabled
   def testInsertDatasetWithTimelineTimezoneUTC(): Unit = {
     val defaultTimezone = TimeZone.getDefault
     try {


### PR DESCRIPTION
### Change Logs

This test was causing following tests to get stuck. Something to do with the lock provider maybe. After investigating for a couple hours I wasn't able to discover anything.  Created [HUDI-7275](https://issues.apache.org/jira/browse/HUDI-7275) to track.

### Impact

Possibly the cause of some CI OOMs

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
