### PR TITLE
[HUDI-7279] make sampling rate configurable for BOUNDED_IN_MEMORY executor type

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -357,12 +357,14 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.write.buffer.record.sampling.rate")
       .defaultValue(String.valueOf(64))
       .markAdvanced()
+      .sinceVersion("1.0.0")
       .withDocumentation("Sampling rate of in-memory buffer used to estimate object size. Higher value lead to lower CPU usage.");
 
   public static final ConfigProperty<String> WRITE_BUFFER_RECORD_CACHE_LIMIT = ConfigProperty
       .key("hoodie.write.buffer.record.cache.limit")
       .defaultValue(String.valueOf(128 * 1024))
       .markAdvanced()
+      .sinceVersion("1.0.0")
       .withDocumentation("Maximum queue size of in-memory buffer for parallelizing network reads and lake storage writes.");
 
   public static final ConfigProperty<String> WRITE_EXECUTOR_DISRUPTOR_BUFFER_LIMIT_BYTES = ConfigProperty

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -353,6 +353,18 @@ public class HoodieWriteConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Size of in-memory buffer used for parallelizing network reads and lake storage writes.");
 
+  public static final ConfigProperty<String> WRITE_BUFFER_RECORD_SAMPLING_RATE = ConfigProperty
+      .key("hoodie.write.buffer.record.sampling.rate")
+      .defaultValue(String.valueOf(64))
+      .markAdvanced()
+      .withDocumentation("Sampling rate of in-memory buffer used to estimate object size. Higher value lead to lower CPU usage.");
+
+  public static final ConfigProperty<String> WRITE_BUFFER_RECORD_CACHE_LIMIT = ConfigProperty
+      .key("hoodie.write.buffer.record.cache.limit")
+      .defaultValue(String.valueOf(128 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum queue size of in-memory buffer for parallelizing network reads and lake storage writes.");
+
   public static final ConfigProperty<String> WRITE_EXECUTOR_DISRUPTOR_BUFFER_LIMIT_BYTES = ConfigProperty
       .key("hoodie.write.executor.disruptor.buffer.limit.bytes")
       .defaultValue(String.valueOf(1024))
@@ -1364,6 +1376,14 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public int getWriteBufferLimitBytes() {
     return Integer.parseInt(getStringOrDefault(WRITE_BUFFER_LIMIT_BYTES_VALUE));
+  }
+
+  public int getWriteBufferRecordSamplingRate() {
+    return Integer.parseInt(getStringOrDefault(WRITE_BUFFER_RECORD_SAMPLING_RATE));
+  }
+
+  public int getWriteBufferRecordCacheLimit() {
+    return Integer.parseInt(getStringOrDefault(WRITE_BUFFER_RECORD_CACHE_LIMIT));
   }
 
   public String getWriteExecutorDisruptorWaitStrategy() {
@@ -2840,6 +2860,16 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withWriteBufferLimitBytes(int writeBufferLimit) {
       writeConfig.setValue(WRITE_BUFFER_LIMIT_BYTES_VALUE, String.valueOf(writeBufferLimit));
+      return this;
+    }
+
+    public Builder withWriteBufferRecordSamplingRate(int recordSamplingRate) {
+      writeConfig.setValue(WRITE_BUFFER_RECORD_SAMPLING_RATE, String.valueOf(recordSamplingRate));
+      return this;
+    }
+
+    public Builder withWriteBufferRecordCacheLimit(int recordCacheLimit) {
+      writeConfig.setValue(WRITE_BUFFER_RECORD_CACHE_LIMIT, String.valueOf(recordCacheLimit));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/ExecutorFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/ExecutorFactory.java
@@ -48,8 +48,8 @@ public class ExecutorFactory {
     ExecutorType executorType = config.getExecutorType();
     switch (executorType) {
       case BOUNDED_IN_MEMORY:
-        return new BoundedInMemoryExecutor<>(config.getWriteBufferLimitBytes(), inputItr, consumer,
-            transformFunction, preExecuteRunnable);
+        return new BoundedInMemoryExecutor<>(config.getWriteBufferLimitBytes(), config.getWriteBufferRecordSamplingRate(), config.getWriteBufferRecordCacheLimit(),
+            inputItr, consumer, transformFunction, preExecuteRunnable);
       case DISRUPTOR:
         return new DisruptorExecutor<>(config.getWriteExecutorDisruptorWriteBufferLimitBytes(), inputItr, consumer,
             transformFunction, config.getWriteExecutorDisruptorWaitStrategy(), preExecuteRunnable);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
@@ -46,10 +46,24 @@ public class BoundedInMemoryExecutor<I, O, E> extends BaseHoodieQueueBasedExecut
         Option.of(consumer), transformFunction, new DefaultSizeEstimator<>(), preExecuteRunnable);
   }
 
+  public BoundedInMemoryExecutor(final long bufferLimitInBytes, int recordSamplingRate, int recordCacheLimit, final Iterator<I> inputItr,
+                                 HoodieConsumer<O, E> consumer, Function<I, O> transformFunction, Runnable preExecuteRunnable) {
+    this(bufferLimitInBytes, recordSamplingRate, recordCacheLimit, Collections.singletonList(new IteratorBasedQueueProducer<>(inputItr)),
+        Option.of(consumer), transformFunction, new DefaultSizeEstimator<>(), preExecuteRunnable);
+  }
+
   public BoundedInMemoryExecutor(final long bufferLimitInBytes, List<HoodieProducer<I>> producers,
                                  Option<HoodieConsumer<O, E>> consumer, final Function<I, O> transformFunction,
                                  final SizeEstimator<O> sizeEstimator, Runnable preExecuteRunnable) {
     super(producers, consumer, new BoundedInMemoryQueue<>(bufferLimitInBytes, transformFunction, sizeEstimator), preExecuteRunnable);
+  }
+
+  public BoundedInMemoryExecutor(final long bufferLimitInBytes, int recordSamplingRate, int recordCacheLimit, List<HoodieProducer<I>> producers,
+                                 Option<HoodieConsumer<O, E>> consumer, final Function<I, O> transformFunction,
+                                 final SizeEstimator<O> sizeEstimator, Runnable preExecuteRunnable) {
+    super(producers, consumer,
+        new BoundedInMemoryQueue<>(bufferLimitInBytes, transformFunction, sizeEstimator, recordSamplingRate, recordCacheLimit),
+        preExecuteRunnable);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

When writing data with BoundedInMemoryQueue, the size of record is sampled periodically and BoundedInMemoryQueue is adjusted dynamically during runtime. Prior to this PR, the sampling rate is fixed and not configurable.

As I tested, about 9% CPU is used to estimate the object size to calculate the queue size. 

Currently the sampling rate is set to 64. If we can set the rate to 128, then we can save 4.5% CPU theoretically.
Note: Increasing sampling rate has diminishing returns beyond a certain threshold depending on record layout/schema.

![image](https://github.com/apache/hudi/assets/19326824/ff75623e-0d68-4cbf-adbc-66923683e552)


### Impact

improve performance by setting higher sampling rate

### Risk level (write none, low medium or high below)

low 

### Documentation Update

- Add a new configuration named `hoodie.write.buffer.record.sampling.rate`, default 64. Higher value leads to lower CPU usage for object size estimation.
- Add a new config named `hoodie.write.buffer.record.cache.limit` for better memory footprint control, default 128*1024.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
