### PR TITLE
[HUDI-7284] stream sync doesn't differentiate replace commits

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -26,6 +26,9 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.MessageDigest;
@@ -49,6 +52,8 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
  * @see HoodieTimeline
  */
 public class HoodieDefaultTimeline implements HoodieTimeline {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieDefaultTimeline.class);
 
   private static final long serialVersionUID = 1L;
 
@@ -504,6 +509,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
             HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
             return metadata.getOperationType().equals(WriteOperationType.CLUSTER);
           } catch (IOException e) {
+            LOG.warn("Unable to read commit metadata for " + i + " due to " + e.getMessage());
             return false;
           }
         }).findFirst());
@@ -522,6 +528,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
               return false;
             }
           } catch (IOException e) {
+            LOG.warn("Unable to read commit metadata for " + i + " due to " + e.getMessage());
             return false;
           }
         }).findFirst());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -515,8 +515,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
         .getReverseOrderedInstants()
         .filter(i -> {
           try {
-            HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
-            return metadata.getOperationType().equals(WriteOperationType.CLUSTER) && !i.isCompleted();
+            if (!i.isCompleted()) {
+              HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
+              return metadata.getOperationType().equals(WriteOperationType.CLUSTER);
+            } else {
+              return false;
+            }
           } catch (IOException e) {
             return false;
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -495,6 +495,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     return this.firstNonSavepointCommit;
   }
 
+  @Override
   public Option<HoodieInstant> getLastClusterCommit() {
     return  Option.fromJavaOptional(getCommitsTimeline().filter(s -> s.getAction().equalsIgnoreCase(HoodieTimeline.REPLACE_COMMIT_ACTION))
         .getReverseOrderedInstants()
@@ -502,6 +503,20 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
           try {
             HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
             return metadata.getOperationType().equals(WriteOperationType.CLUSTER);
+          } catch (IOException e) {
+            return false;
+          }
+        }).findFirst());
+  }
+
+  @Override
+  public Option<HoodieInstant> getLastPendingClusterCommit() {
+    return  Option.fromJavaOptional(getCommitsTimeline().filter(s -> s.getAction().equalsIgnoreCase(HoodieTimeline.REPLACE_COMMIT_ACTION))
+        .getReverseOrderedInstants()
+        .filter(i -> {
+          try {
+            HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
+            return metadata.getOperationType().equals(WriteOperationType.CLUSTER) && !i.isCompleted();
           } catch (IOException e) {
             return false;
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -402,7 +402,7 @@ public interface HoodieTimeline extends Serializable {
   public Option<HoodieInstant> getLastClusterCommit();
 
   /**
-   * get the most recent cluster commit if present
+   * get the most recent pending cluster commit if present
    *
    */
   public Option<HoodieInstant> getLastPendingClusterCommit();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -396,6 +396,18 @@ public interface HoodieTimeline extends Serializable {
   Option<HoodieInstant> getFirstNonSavepointCommit();
 
   /**
+   * get the most recent cluster commit if present
+   *
+   */
+  public Option<HoodieInstant> getLastClusterCommit();
+
+  /**
+   * get the most recent cluster commit if present
+   *
+   */
+  public Option<HoodieInstant> getLastPendingClusterCommit();
+
+  /**
    * Read the completed instant details.
    */
   Option<byte[]> getInstantDetails(HoodieInstant instant);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -457,7 +457,7 @@ public class StreamSync implements Serializable, Closeable {
 
   private Option<String> getLastPendingClusteringInstant(Option<HoodieTimeline> commitTimelineOpt) {
     if (commitTimelineOpt.isPresent()) {
-      Option<HoodieInstant> pendingClusteringInstant = commitTimelineOpt.get().filterPendingReplaceTimeline().lastInstant();
+      Option<HoodieInstant> pendingClusteringInstant = commitTimelineOpt.get().getLastPendingClusterCommit();
       return pendingClusteringInstant.isPresent() ? Option.of(pendingClusteringInstant.get().getTimestamp()) : Option.empty();
     }
     return Option.empty();


### PR DESCRIPTION
### Change Logs

Differentiate between replace commits that are cluster and those that are not

### Impact

streamer won't get stuck

### Risk level (write none, low medium or high below)

low 

### Documentation Update

N/A


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
