### PR TITLE
[HUDI-7282] avoid verification failure due to append writing of the c…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClusteringUtil.java
@@ -49,7 +49,7 @@ public class ClusteringUtil {
   private static final Logger LOG = LoggerFactory.getLogger(ClusteringUtil.class);
 
   public static void validateClusteringScheduling(Configuration conf) {
-    if (OptionsResolver.isBucketIndexType(conf)) {
+    if (!OptionsResolver.isAppendMode(conf) && OptionsResolver.isBucketIndexType(conf)) {
       HoodieIndex.BucketIndexEngineType bucketIndexEngineType = OptionsResolver.getBucketEngineType(conf);
       switch (bucketIndexEngineType) {
         case SIMPLE:

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.util.ClusteringUtil;
 import org.apache.hudi.util.FlinkTables;
@@ -112,6 +113,16 @@ public class TestClusteringUtil {
     List<String> actualInstants = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient())
         .stream().map(HoodieInstant::getTimestamp).collect(Collectors.toList());
     assertThat(actualInstants, is(oriInstants));
+  }
+  
+  @Test
+  void validateClusteringScheduling() throws Exception {
+    beforeEach();
+    ClusteringUtil.validateClusteringScheduling(this.conf);
+    
+    // validate bucket index
+    this.conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    ClusteringUtil.validateClusteringScheduling(this.conf);
   }
 
   /**


### PR DESCRIPTION
### Change Logs

The ClusteringUtil#validateClusteringScheduling function skip the append mode check.

### Impact

The change is In order to enable Flink to write the Hudi Cow table in append mode and enable cluster merging to pass the verification normally, even if the index.type is bucket. Because append mode does not involve index types.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
