### PR TITLE
[MINOR] Handle parsing of all zero timestamps with MDT suffixes.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -90,6 +90,10 @@ public class HoodieInstantTimeGenerator {
       LocalDateTime dt = LocalDateTime.parse(timestampInMillis, MILLIS_INSTANT_TIME_FORMATTER);
       return Date.from(dt.atZone(ZoneId.systemDefault()).toInstant());
     } catch (DateTimeParseException e) {
+      // MDT uses timestamps which add suffixes to the instant time. Hence, we are checking for all timestamps that start with all zeros.
+      if (timestamp.startsWith(HoodieTimeline.INIT_INSTANT_TS)) {
+        return new Date(0);
+      }
       throw new ParseException(e.getMessage(), e.getErrorIndex());
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -610,6 +610,19 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
   }
 
   @Test
+  public void testAllZeroTimestampParsing() throws ParseException {
+    String allZeroTs = "00000000000000";
+    Date allZeroDate = HoodieActiveTimeline.parseDateFromInstantTime(allZeroTs);
+    assertEquals(allZeroDate, new Date(0), "Parsing of all zero timestamp should succeed");
+
+    // MDT uses timestamps which add suffixes to the instant time. These should also be parsable for all zero case.
+    for (int index = 0; index < 10; ++index) {
+      allZeroDate = HoodieActiveTimeline.parseDateFromInstantTime(allZeroTs + "00" + index);
+      assertEquals(allZeroDate, new Date(0), "Parsing of all zero timestamp should succeed");
+    }
+  }
+
+  @Test
   public void testMetadataCompactionInstantDateParsing() throws ParseException {
     // default second granularity instant ID
     String secondGranularityInstant = "20210101120101123";


### PR DESCRIPTION
[MINOR] Handle parsing of all zero timestamps with MDT suffixes.

### Change Logs

MDT uses an all zero timestamp if there are no exiting commits on the dataset. If additional indexes are initialized, they will use a suffix (001, 002 ..) on the all zero timestamp. This timestamp is a special case and should be not raise parse exception.

### Impact

Prevents date parse exception when MDT and/or indexes are enabled on an empty dataset.


### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
