### PR TITLE
[HUDI-7288] Fix ArrayIndexOutOfBoundsException when upgrade unPartitionedTable created by 0.10/0.11 HUDI version

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
@@ -77,7 +77,7 @@ public class FourToFiveUpgradeHandler implements UpgradeHandler {
 
   private boolean hasDefaultPartitionPath(HoodieWriteConfig config, HoodieTable  table) throws IOException {
     HoodieTableConfig tableConfig = table.getMetaClient().getTableConfig();
-    if (!tableConfig.getPartitionFields().isPresent()) {
+    if (!tableConfig.isTablePartitioned()) {
       return false;
     }
     String checkPartitionPath = DEPRECATED_DEFAULT_PARTITION_PATH;


### PR DESCRIPTION
### Change Logs

When upgrade a nonPartitionedTable which created by 0.10/0.11 HUDI version, an `ArrayIndexOutOfBoundsException` would throw out.
Because the hoodie.table.partition.fields is empty in hoodie.properties. BTW, the empty config would be filtered out from hoodie.properties file since 0.12 version by [PR#6821](https://github.com/apache/hudi/pull/6821)

![image](https://github.com/apache/hudi/assets/1525333/bcb77911-cba9-4d13-b204-d28dd6bcca8c)
![image](https://github.com/apache/hudi/assets/1525333/e6f0a072-14a8-4b78-ae66-86d0d8091b43)
The pr aims to fix the minor bug.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
