### PR TITLE
[HUDI-7291] Pushing Down Partition Pruning Conditions to Column Stats Earlier During Data Skipping

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.avro.model._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieData
-import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.BinaryUtil.toBytes
 import org.apache.hudi.common.util.ValidationUtils.checkState
@@ -106,14 +106,14 @@ class ColumnStatsIndexSupport(spark: SparkSession,
    *
    * Please check out scala-doc of the [[transpose]] method explaining this view in more details
    */
-  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean)(block: DataFrame => T): T = {
+  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, prunedFileSlices: Set[String])(block: DataFrame => T): T = {
     cachedColumnStatsIndexViews.get(targetColumns) match {
       case Some(cachedDF) =>
         block(cachedDF)
 
       case None =>
         val colStatsRecords: HoodieData[HoodieMetadataColumnStats] =
-          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
+          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter(r => prunedFileSlices.contains(r.getFileName))
 
         withPersistedData(colStatsRecords, StorageLevel.MEMORY_ONLY) {
           val (transposedRows, indexSchema) = transpose(colStatsRecords, targetColumns)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -116,7 +116,8 @@ class ColumnStatsIndexSupport(spark: SparkSession,
           // NOTE: In order to ensure that testing and unexpected logic are normal, judgment logic is added.
           loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
         } else {
-          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter((r: HoodieMetadataColumnStats) => prunedFileSlices.contains(r.getFileName))
+          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter(
+            (r: HoodieMetadataColumnStats) => prunedFileSlices.contains(r.getFileName): java.lang.Boolean)
         }
 
         withPersistedData(colStatsRecords, StorageLevel.MEMORY_ONLY) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.avro.model._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieData
-import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
+import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.BinaryUtil.toBytes
 import org.apache.hudi.common.util.ValidationUtils.checkState

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -116,7 +116,7 @@ class ColumnStatsIndexSupport(spark: SparkSession,
           // NOTE: In order to ensure that testing and unexpected logic are normal, judgment logic is added.
           loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
         } else {
-          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter(r => prunedFileSlices.contains(r.getFileName))
+          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter((r: HoodieMetadataColumnStats) => prunedFileSlices.contains(r.getFileName))
         }
 
         withPersistedData(colStatsRecords, StorageLevel.MEMORY_ONLY) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -225,7 +225,6 @@ case class HoodieFileIndex(spark: SparkSession,
       .map(fileSlice => fileSlice.getBaseFile.get().getFileName)
       .toSet
 
-
     // If there are no data filters, return all the file slices.
     // If there are no file slices, return empty list.
     if (prunedPartitionsAndFileSlices.isEmpty || dataFilters.isEmpty) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -218,6 +218,14 @@ case class HoodieFileIndex(spark: SparkSession,
 
     val prunedPartitionsAndFileSlices = getFileSlicesForPrunedPartitions(partitionFilters)
 
+    val prunedFileSlices: Set[String] = prunedPartitionsAndFileSlices
+      .flatMap {
+        case (_, fileSlices) => fileSlices
+      }
+      .map(fileSlice => fileSlice.getBaseFile.get().getFileName)
+      .toSet
+
+
     // If there are no data filters, return all the file slices.
     // If there are no file slices, return empty list.
     if (prunedPartitionsAndFileSlices.isEmpty || dataFilters.isEmpty) {
@@ -229,7 +237,7 @@ case class HoodieFileIndex(spark: SparkSession,
       //    - Record-level Index is present
       //    - List of predicates (filters) is present
       val candidateFilesNamesOpt: Option[Set[String]] =
-      lookupCandidateFilesInMetadataTable(dataFilters) match {
+      lookupCandidateFilesInMetadataTable(dataFilters, prunedFileSlices) match {
         case Success(opt) => opt
         case Failure(e) =>
           logError("Failed to lookup candidate files in File Index", e)
@@ -328,7 +336,7 @@ case class HoodieFileIndex(spark: SparkSession,
    * @param queryFilters list of original data filters passed down from querying engine
    * @return list of pruned (data-skipped) candidate base-files and log files' names
    */
-  private def lookupCandidateFilesInMetadataTable(queryFilters: Seq[Expression]): Try[Option[Set[String]]] = Try {
+  private def lookupCandidateFilesInMetadataTable(queryFilters: Seq[Expression], prunedFileSlices: Set[String]): Try[Option[Set[String]]] = Try {
     // NOTE: For column stats, Data Skipping is only effective when it references columns that are indexed w/in
     //       the Column Stats Index (CSI). Following cases could not be effectively handled by Data Skipping:
     //          - Expressions on top-level column's fields (ie, for ex filters like "struct.field > 0", since
@@ -350,7 +358,7 @@ case class HoodieFileIndex(spark: SparkSession,
     } else if (functionalIndex.isIndexAvailable && !queryFilters.isEmpty) {
       val shouldReadInMemory = functionalIndex.shouldReadInMemory(this, queryReferencedColumns)
       val indexDf = functionalIndex.loadFunctionalIndexDataFrame("", shouldReadInMemory)
-      Some(getCandidateFiles(indexDf, queryFilters))
+      Some(getCandidateFiles(indexDf, queryFilters, prunedFileSlices))
     } else if (!columnStatsIndex.isIndexAvailable || queryFilters.isEmpty || queryReferencedColumns.isEmpty) {
       validateConfig()
       Option.empty
@@ -362,13 +370,13 @@ case class HoodieFileIndex(spark: SparkSession,
       //       on-cluster: total number of rows of the expected projected portion of the index has to be below the
       //       threshold (of 100k records)
       val shouldReadInMemory = columnStatsIndex.shouldReadInMemory(this, queryReferencedColumns)
-      columnStatsIndex.loadTransposed(queryReferencedColumns, shouldReadInMemory) { transposedColStatsDF =>
-        Some(getCandidateFiles(transposedColStatsDF, queryFilters))
+      columnStatsIndex.loadTransposed(queryReferencedColumns, shouldReadInMemory, prunedFileSlices) { transposedColStatsDF =>
+        Some(getCandidateFiles(transposedColStatsDF, queryFilters, prunedFileSlices))
       }
     }
   }
 
-  private def getCandidateFiles(indexDf: DataFrame, queryFilters: Seq[Expression]): Set[String] = {
+  private def getCandidateFiles(indexDf: DataFrame, queryFilters: Seq[Expression], prunedFileSlices: Set[String]): Set[String] = {
     val indexSchema = indexDf.schema
     val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema)).reduce(And)
     val prunedCandidateFileNames =
@@ -390,7 +398,7 @@ case class HoodieFileIndex(spark: SparkSession,
       .collect()
       .map(_.getString(0))
       .toSet
-    val notIndexedFileNames = lookupFileNamesMissingFromIndex(allIndexedFileNames)
+    val notIndexedFileNames = prunedFileSlices -- allIndexedFileNames
 
     prunedCandidateFileNames ++ notIndexedFileNames
   }


### PR DESCRIPTION
In the current implementation of data skipping, column statistics for the entire table are read and then subjected to data skipping filtering operations based on these stats. When the table has a large volume of data and a high number of partitions, this approach can reduce the efficiency of data skipping, as partition pruning conditions are not utilized.

By pushing down the conditions for partition filtering to after the column statistics are read and applying pruning at that point, the size of the column stats that are subsequently involved in data skipping will be significantly reduced. This not only saves time on later computations but also conserves memory.

During a test conducted on a table with a total of 25TB distributed across 60 subpartitions, a query was performed on one of the subpartitions, which was 1.4TB in size. Overall, this simple test demonstrated that data skipping can lead to a savings of several seconds. In scenarios involving partition pruning, time savings are indeed achievable. Additionally, there will be a substantial reduction in the memory footprint for the list of candidate files needed for further computation.

In scenarios where partition pruning is not applied, this query would only result in a minimal increase in cost. This minor cost increase is inconsequential either when the data volume is large—making these seconds-level overheads negligible—or when the data volume is small, eliminating the need for partitioning altogether, in which case the filter operation would not be time-consuming.

### Change Logs

Pushing Down Partition Pruning Conditions to Column Stats During Data Skipping

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
