### PR TITLE
[HUDI-7293]Incremental read of insert table using rebalance strategy

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieTableType;
-import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -109,8 +108,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.hudi.configuration.HadoopConfigurations.getParquetConf;
-import static org.apache.hudi.util.ExpressionUtils.splitExprByPartitionCall;
 import static org.apache.hudi.util.ExpressionUtils.filterSimpleCallExpression;
+import static org.apache.hudi.util.ExpressionUtils.splitExprByPartitionCall;
 
 /**
  * Hoodie batch table source that always read the latest snapshot of the underneath table.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -210,8 +210,7 @@ public class HoodieTableSource implements
               .setParallelism(1)
               .setMaxParallelism(1);
           SingleOutputStreamOperator<RowData> source;
-          if (HoodieTableSource.this.conf.containsKey(FlinkOptions.OPERATION.key())
-              && WriteOperationType.INSERT.value().equals(HoodieTableSource.this.conf.getString(FlinkOptions.OPERATION))) {
+          if (OptionsResolver.isAppendMode(HoodieTableSource.this.conf)) {
             source = monitorOperatorStream
                 .transform("split_reader", typeInfo, factory)
                 .uid(Pipelines.opUID("split_reader", conf))


### PR DESCRIPTION
### Change Logs

_For insert type tables, we do not need to use keyby to distribute inputsplit to avoid data skewing issues with the split reader operator._

### Impact

_none._

### Risk level (write none, low medium or high below)

_none._

### Documentation Update

_none_