### PR TITLE
[HUDI-7296] Reduce CI Time by Minimizing Duplicate Code Coverage in Tests

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
@@ -40,23 +40,29 @@ import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 @Tag("functional")
 public class TestBootstrapRead extends TestBootstrapReadBase {
   private static Stream<Arguments> testArgs() {
+    boolean fullTest = false;
     Stream.Builder<Arguments> b = Stream.builder();
-    String[] bootstrapType = {"full", "metadata", "mixed"};
-    Boolean[] dashPartitions = {true,false};
-    HoodieTableType[] tableType = {COPY_ON_WRITE, MERGE_ON_READ};
-    Integer[] nPartitions = {0, 1, 2};
-    for (HoodieTableType tt : tableType) {
-      for (Boolean dash : dashPartitions) {
-        for (String bt : bootstrapType) {
-          for (Integer n : nPartitions) {
-            // can't be mixed bootstrap if it's nonpartitioned
-            // don't need to test slash partitions if it's nonpartitioned
-            if ((!bt.equals("mixed") && dash) || n > 0) {
-              b.add(Arguments.of(bt, dash, tt, n));
+    if (fullTest) {
+      String[] bootstrapType = {"full", "metadata", "mixed"};
+      Boolean[] dashPartitions = {true,false};
+      HoodieTableType[] tableType = {COPY_ON_WRITE, MERGE_ON_READ};
+      Integer[] nPartitions = {0, 1, 2};
+      for (HoodieTableType tt : tableType) {
+        for (Boolean dash : dashPartitions) {
+          for (String bt : bootstrapType) {
+            for (Integer n : nPartitions) {
+              // can't be mixed bootstrap if it's nonpartitioned
+              // don't need to test slash partitions if it's nonpartitioned
+              if ((!bt.equals("mixed") && dash) || n > 0) {
+                b.add(Arguments.of(bt, dash, tt, n));
+              }
             }
           }
         }
       }
+    } else {
+      b.add(Arguments.of("metadata", true, COPY_ON_WRITE, 0));
+      b.add(Arguments.of("mixed", false, MERGE_ON_READ, 2));
     }
     return b.build();
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -52,8 +52,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDeltaStreamerSchemaEvolutionBase {
 
-
-
   @AfterEach
   public void teardown() throws Exception {
     super.teardown();
@@ -90,7 +88,6 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
       b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true));
       b.add(Arguments.of("MERGE_ON_READ", false, false, true, true, true, false, true));
     }
-
     return b.build();
   }
 
@@ -131,7 +128,6 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
       b.add(Arguments.of("MERGE_ON_READ", true, true, true, false, false));
       b.add(Arguments.of("MERGE_ON_READ", true, false, true, true, false));
     }
-
     return b.build();
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -52,6 +52,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDeltaStreamerSchemaEvolutionBase {
 
+
+
   @AfterEach
   public void teardown() throws Exception {
     super.teardown();
@@ -59,26 +61,36 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
   }
 
   protected static Stream<Arguments> testArgs() {
+    boolean fullTest = false;
     Stream.Builder<Arguments> b = Stream.builder();
-    //only testing row-writer enabled for now
-    for (Boolean rowWriterEnable : new Boolean[] {true}) {
-      for (Boolean nullForDeletedCols : new Boolean[] {false, true}) {
-        for (Boolean useKafkaSource : new Boolean[] {false, true}) {
-          for (Boolean addFilegroups : new Boolean[] {false, true}) {
-            for (Boolean multiLogFiles : new Boolean[] {false, true}) {
-              for (Boolean shouldCluster : new Boolean[] {false, true}) {
-                for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
-                  if (!multiLogFiles || tableType.equals("MERGE_ON_READ")) {
-                    b.add(Arguments.of(tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
+    if (fullTest) {
+      //only testing row-writer enabled for now
+      for (Boolean rowWriterEnable : new Boolean[] {true}) {
+        for (Boolean nullForDeletedCols : new Boolean[] {false, true}) {
+          for (Boolean useKafkaSource : new Boolean[] {false, true}) {
+            for (Boolean addFilegroups : new Boolean[] {false, true}) {
+              for (Boolean multiLogFiles : new Boolean[] {false, true}) {
+                for (Boolean shouldCluster : new Boolean[] {false, true}) {
+                  for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
+                    if (!multiLogFiles || tableType.equals("MERGE_ON_READ")) {
+                      b.add(Arguments.of(tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
+                    }
                   }
                 }
+                b.add(Arguments.of("MERGE_ON_READ", false, true, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
               }
-              b.add(Arguments.of("MERGE_ON_READ", false, true, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
             }
           }
         }
       }
+    } else {
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, false));
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, true));
+      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true));
+      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true));
+      b.add(Arguments.of("MERGE_ON_READ", false, false, true, true, true, false, true));
     }
+
     return b.build();
   }
 
@@ -97,20 +109,29 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
   }
 
   protected static Stream<Arguments> testParamsWithSchemaTransformer() {
+    boolean fullTest = false;
     Stream.Builder<Arguments> b = Stream.builder();
-    for (Boolean useTransformer : new Boolean[] {false, true}) {
-      for (Boolean setSchema : new Boolean[] {false, true}) {
-        for (Boolean rowWriterEnable : new Boolean[] {true}) {
-          for (Boolean nullForDeletedCols : new Boolean[] {false, true}) {
-            for (Boolean useKafkaSource : new Boolean[] {false, true}) {
-              for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
-                b.add(Arguments.of(tableType, rowWriterEnable, useKafkaSource, nullForDeletedCols, useTransformer, setSchema));
+    if (fullTest) {
+      for (Boolean useTransformer : new Boolean[] {false, true}) {
+        for (Boolean setSchema : new Boolean[] {false, true}) {
+          for (Boolean rowWriterEnable : new Boolean[] {true}) {
+            for (Boolean nullForDeletedCols : new Boolean[] {false, true}) {
+              for (Boolean useKafkaSource : new Boolean[] {false, true}) {
+                for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
+                  b.add(Arguments.of(tableType, rowWriterEnable, useKafkaSource, nullForDeletedCols, useTransformer, setSchema));
+                }
               }
             }
           }
         }
       }
+    } else {
+      b.add(Arguments.of("COPY_ON_WRITE", true, true, true, true, true));
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, false, false, true));
+      b.add(Arguments.of("MERGE_ON_READ", true, true, true, false, false));
+      b.add(Arguments.of("MERGE_ON_READ", true, false, true, true, false));
     }
+
     return b.build();
   }
 


### PR DESCRIPTION
### Change Logs

testBootstrapRead and TestHoodieDeltaStreamerSchemaEvolutionQuick have many combinations of params. While it is good to test everything, there are lots of code paths that have extensive duplicate testing. Reduce the number of tests while still maintaining code coverage

### Impact

faster CI

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
