### PR TITLE
[HUDI-7270] Support schema evolution by Flink SQL using HoodieCatalog

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -25,14 +25,12 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
-import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.avro.Schema;
@@ -392,9 +390,15 @@ public class HoodieCatalog extends AbstractCatalog {
   }
 
   @Override
-  public void alterTable(ObjectPath tablePath, CatalogBaseTable catalogBaseTable, boolean ignoreIfNotExists)
+  public void alterTable(
+      ObjectPath tablePath, CatalogBaseTable newCatalogTable, boolean ignoreIfNotExists)
       throws TableNotExistException, CatalogException {
-    throw new UnsupportedOperationException("alterTable is not implemented.");
+    HoodieCatalogUtil.alterTable(this, tablePath, newCatalogTable, Collections.emptyList(), ignoreIfNotExists, hadoopConf, this::inferTablePath, this::refreshTableProperties);
+  }
+
+  public void alterTable(ObjectPath tablePath, CatalogBaseTable newCatalogTable, List tableChanges,
+      boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+    HoodieCatalogUtil.alterTable(this, tablePath, newCatalogTable, tableChanges, ignoreIfNotExists, hadoopConf, this::inferTablePath, this::refreshTableProperties);
   }
 
   @Override
@@ -470,9 +474,7 @@ public class HoodieCatalog extends AbstractCatalog {
       }
     }
 
-    // enable auto-commit though ~
-    options.put(HoodieWriteConfig.AUTO_COMMIT_ENABLE.key(), "true");
-    try (HoodieFlinkWriteClient<?> writeClient = createWriteClient(options, tablePathStr, tablePath)) {
+    try (HoodieFlinkWriteClient<?> writeClient = HoodieCatalogUtil.createWriteClient(options, tablePathStr, tablePath, hadoopConf)) {
       writeClient.deletePartitions(Collections.singletonList(partitionPathStr),
               writeClient.createNewInstantTime())
           .forEach(writeStatus -> {
@@ -594,20 +596,26 @@ public class HoodieCatalog extends AbstractCatalog {
     return newOptions;
   }
 
-  private HoodieFlinkWriteClient<?> createWriteClient(
-      Map<String, String> options,
-      String tablePathStr,
-      ObjectPath tablePath) {
-    return FlinkWriteClients.createWriteClientV2(
-        Configuration.fromMap(options)
-            .set(FlinkOptions.TABLE_NAME, tablePath.getObjectName())
-            .set(FlinkOptions.SOURCE_AVRO_SCHEMA,
-                StreamerUtil.createMetaClient(tablePathStr, hadoopConf)
-                    .getTableConfig().getTableCreateSchema().get().toString()));
+  private void refreshTableProperties(ObjectPath tablePath, CatalogBaseTable newCatalogTable) {
+    Map<String, String> options = newCatalogTable.getOptions();
+    final String avroSchema = AvroSchemaConverter.convertToSchema(
+        ((ResolvedCatalogTable) newCatalogTable).getResolvedSchema().toPhysicalRowDataType().getLogicalType(),
+        AvroSchemaUtils.getAvroRecordQualifiedName(tablePath.getObjectName())).toString();
+    options.put(FlinkOptions.SOURCE_AVRO_SCHEMA.key(), avroSchema);
+    String tablePathStr = inferTablePath(catalogPathStr, tablePath);
+    try {
+      TableOptionProperties.overwriteProperties(tablePathStr, hadoopConf, options);
+    } catch (IOException e) {
+      throw new CatalogException(String.format("Update table path %s exception.", tablePathStr), e);
+    }
   }
 
   @VisibleForTesting
   protected String inferTablePath(String catalogPath, ObjectPath tablePath) {
     return String.format("%s/%s/%s", catalogPath, tablePath.getDatabaseName(), tablePath.getObjectName());
+  }
+
+  private String inferTablePath(ObjectPath tablePath, CatalogBaseTable table) {
+    return inferTablePath(catalogPathStr, tablePath);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalogUtil.java
@@ -18,15 +18,34 @@
 
 package org.apache.hudi.table.catalog;
 
+import org.apache.hudi.adapter.Utils;
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
+import org.apache.hudi.exception.HoodieCatalogException;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.Type;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.hudi.util.AvroSchemaConverter;
+import org.apache.hudi.util.FlinkWriteClients;
+import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -44,8 +63,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
 import static org.apache.hudi.table.catalog.CatalogOptions.HIVE_SITE_FILE;
 
@@ -171,5 +195,95 @@ public class HoodieCatalogUtil {
     }
 
     return values;
+  }
+
+  protected static void alterTable(
+      AbstractCatalog catalog,
+      ObjectPath tablePath,
+      CatalogBaseTable newCatalogTable,
+      List tableChanges,
+      boolean ignoreIfNotExists,
+      org.apache.hadoop.conf.Configuration hadoopConf,
+      BiFunction<ObjectPath, CatalogBaseTable, String> inferTablePathFunc,
+      BiConsumer<ObjectPath, CatalogBaseTable> postAlterTableFunc) throws TableNotExistException, CatalogException {
+    checkNotNull(tablePath, "Table path cannot be null");
+    checkNotNull(newCatalogTable, "New catalog table cannot be null");
+
+    if (!isUpdatePermissible(catalog, tablePath, newCatalogTable, ignoreIfNotExists)) {
+      return;
+    }
+    if (!tableChanges.isEmpty()) {
+      CatalogBaseTable oldTable = catalog.getTable(tablePath);
+      HoodieFlinkWriteClient<?> writeClient = createWriteClient(tablePath, oldTable, hadoopConf, inferTablePathFunc);
+      Pair<InternalSchema, HoodieTableMetaClient> pair = writeClient.getInternalSchemaAndMetaClient();
+      InternalSchema oldSchema = pair.getLeft();
+      Function<LogicalType, Type> convertFunc = (LogicalType logicalType) -> AvroInternalSchemaConverter.convertToField(AvroSchemaConverter.convertToSchema(logicalType));
+      InternalSchema newSchema = Utils.applyTableChange(oldSchema, tableChanges, convertFunc);
+      if (!oldSchema.equals(newSchema)) {
+        writeClient.setOperationType(WriteOperationType.ALTER_SCHEMA);
+        writeClient.commitTableChange(newSchema, pair.getRight());
+      }
+    }
+    postAlterTableFunc.accept(tablePath, newCatalogTable);
+  }
+
+  protected static HoodieFlinkWriteClient<?> createWriteClient(
+      ObjectPath tablePath,
+      CatalogBaseTable table,
+      org.apache.hadoop.conf.Configuration hadoopConf,
+      BiFunction<ObjectPath, CatalogBaseTable, String> inferTablePathFunc) {
+    Map<String, String> options = table.getOptions();
+    String tablePathStr = inferTablePathFunc.apply(tablePath, table);
+    return createWriteClient(options, tablePathStr, tablePath, hadoopConf);
+  }
+
+  protected static HoodieFlinkWriteClient<?> createWriteClient(
+      Map<String, String> options,
+      String tablePathStr,
+      ObjectPath tablePath,
+      org.apache.hadoop.conf.Configuration hadoopConf) {
+    // enable auto-commit though ~
+    options.put(HoodieWriteConfig.AUTO_COMMIT_ENABLE.key(), "true");
+    return FlinkWriteClients.createWriteClientV2(
+        org.apache.flink.configuration.Configuration.fromMap(options)
+            .set(FlinkOptions.TABLE_NAME, tablePath.getObjectName())
+            .set(
+                FlinkOptions.SOURCE_AVRO_SCHEMA,
+                StreamerUtil.createMetaClient(tablePathStr, hadoopConf)
+                    .getTableConfig().getTableCreateSchema().get().toString()));
+  }
+
+  private static boolean sameOptions(Map<String, String> parameters1, Map<String, String> parameters2, ConfigOption<String> option) {
+    return parameters1.getOrDefault(option.key(), String.valueOf(option.defaultValue()))
+        .equalsIgnoreCase(parameters2.getOrDefault(option.key(), String.valueOf(option.defaultValue())));
+  }
+
+  private static boolean isUpdatePermissible(AbstractCatalog catalog, ObjectPath tablePath, CatalogBaseTable newCatalogTable, boolean ignoreIfNotExists) throws TableNotExistException {
+    if (!newCatalogTable.getOptions().getOrDefault(CONNECTOR.key(), "").equalsIgnoreCase("hudi")) {
+      throw new HoodieCatalogException(String.format("The %s is not hoodie table", tablePath.getObjectName()));
+    }
+    if (newCatalogTable instanceof CatalogView) {
+      throw new HoodieCatalogException("Hoodie catalog does not support to ALTER VIEW");
+    }
+
+    if (!catalog.tableExists(tablePath)) {
+      if (!ignoreIfNotExists) {
+        throw new TableNotExistException(catalog.getName(), tablePath);
+      } else {
+        return false;
+      }
+    }
+    CatalogBaseTable oldCatalogTable = catalog.getTable(tablePath);
+    List<String> oldPartitionKeys = HoodieCatalogUtil.getPartitionKeys((CatalogTable) oldCatalogTable);
+    List<String> newPartitionKeys = HoodieCatalogUtil.getPartitionKeys((CatalogTable) newCatalogTable);
+    if (!oldPartitionKeys.equals(newPartitionKeys)) {
+      throw new HoodieCatalogException("Hoodie catalog does not support to alter table partition keys");
+    }
+    Map<String, String> oldOptions = oldCatalogTable.getOptions();
+    if (!sameOptions(oldOptions, newCatalogTable.getOptions(), FlinkOptions.TABLE_TYPE)
+        || !sameOptions(oldOptions, newCatalogTable.getOptions(), FlinkOptions.INDEX_TYPE)) {
+      throw new HoodieCatalogException("Hoodie catalog does not support to alter table type and index type");
+    }
+    return true;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
@@ -104,15 +104,33 @@ public class TableOptionProperties {
   public static void createProperties(String basePath,
                                       Configuration hadoopConf,
                                       Map<String, String> options) throws IOException {
+    Path propertiesFilePath = writePropertiesFile(basePath, hadoopConf, options, false);
+    LOG.info(String.format("Create file %s success.", propertiesFilePath));
+  }
+
+  /**
+   * Overwrite the {@link #FILE_NAME} meta file.
+   */
+  public static void overwriteProperties(String basePath,
+      Configuration hadoopConf,
+      Map<String, String> options) throws IOException {
+    Path propertiesFilePath = writePropertiesFile(basePath, hadoopConf, options, true);
+    LOG.info(String.format("Update file %s success.", propertiesFilePath));
+  }
+
+  private static Path writePropertiesFile(String basePath,
+      Configuration hadoopConf,
+      Map<String, String> options,
+      boolean isOverwrite) throws IOException {
     Path propertiesFilePath = getPropertiesFilePath(basePath);
     FileSystem fs = FSUtils.getFs(basePath, hadoopConf);
-    try (FSDataOutputStream outputStream = fs.create(propertiesFilePath)) {
+    try (FSDataOutputStream outputStream = fs.create(propertiesFilePath, isOverwrite)) {
       Properties properties = new Properties();
       properties.putAll(options);
       properties.store(outputStream,
           "Table option properties saved on " + new Date(System.currentTimeMillis()));
     }
-    LOG.info(String.format("Create file %s success.", propertiesFilePath));
+    return propertiesFilePath;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolutionBySQLWithDFSCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolutionBySQLWithDFSCatalog.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.table.catalog.HoodieCatalog;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Catalog;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hudi.table.catalog.CatalogOptions.CATALOG_PATH;
+import static org.apache.hudi.table.catalog.CatalogOptions.DEFAULT_DATABASE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * IT cases for schema evolution by alter table SQL using {@link HoodieCatalog}.
+ */
+public class ITTestSchemaEvolutionBySQLWithDFSCatalog extends ITTestSchemaEvolutionBySQL {
+
+  @TempDir
+  File tempFile;
+
+  @Override
+  protected Catalog createCatalog() {
+    Map<String, String> catalogOptions = new HashMap<>();
+    assertThrows(
+        ValidationException.class,
+        () -> catalog = new HoodieCatalog(CATALOG_NAME, Configuration.fromMap(catalogOptions)));
+    String catalogPathStr = tempFile.getAbsolutePath();
+    catalogOptions.put(CATALOG_PATH.key(), catalogPathStr);
+    catalogOptions.put(DEFAULT_DATABASE.key(), DB_NAME);
+    return new HoodieCatalog(DB_NAME, Configuration.fromMap(catalogOptions));
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolutionBySQLWithHMSCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolutionBySQLWithHMSCatalog.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.table.catalog.HoodieCatalogTestUtils;
+import org.apache.hudi.table.catalog.HoodieHiveCatalog;
+
+import org.apache.flink.table.catalog.Catalog;
+
+/**
+ * IT cases for schema evolution by alter table SQL using {@link HoodieHiveCatalog}.
+ */
+public class ITTestSchemaEvolutionBySQLWithHMSCatalog extends ITTestSchemaEvolutionBySQL {
+
+  @Override
+  protected Catalog createCatalog() {
+    return HoodieCatalogTestUtils.createHiveCatalog(CATALOG_NAME);
+  }
+}


### PR DESCRIPTION
### Change Logs

Since Flink 1.17, Flink SQL support more advanced alter table syntax.

```
-- add a new column 
ALTER TABLE MyTable ADD category_id STRING COMMENT 'identifier of the category';
-- modify a column type, comment and position
ALTER TABLE MyTable MODIFY measurement double COMMENT 'unit is bytes per second' AFTER `id`;
-- drop columns
ALTER TABLE MyTable DROP (col1, col2, col3);
-- rename column
ALTER TABLE MyTable RENAME request_body TO payload;
```
Find more detail information in [Flink Alter Table SQL ](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/table/sql/alter/).

We could support schema evolution by Flink SQL.
The [last pr](https://github.com/apache/hudi/pull/10426) supported it based on `HoodieHiveCatalog`.
This pr aims to support schema evolution based on `HoodieCatalog`.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
