### PR TITLE
[MINOR] Clean default Hadoop configuration values in tests

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -61,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -123,6 +125,18 @@ public class HoodieClientTestUtils {
     }
 
     return SparkRDDReadClient.addHoodieSupport(sparkConf);
+  }
+
+  public static void overrideSparkHadoopConfiguration(SparkContext sparkContext) {
+    try {
+      // Clean the default Hadoop configurations since in our Hudi tests they are not used.
+      Field hadoopConfigurationField = sparkContext.getClass().getDeclaredField("_hadoopConfiguration");
+      hadoopConfigurationField.setAccessible(true);
+      Configuration testHadoopConfig = new Configuration(false);
+      hadoopConfigurationField.set(sparkContext, testHadoopConfig);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      LOG.warn(e.getMessage());
+    }
   }
 
   private static HashMap<String, String> getLatestFileIDsToFullPath(String basePath, HoodieTimeline commitTimeline,

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
@@ -83,7 +83,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -196,16 +195,7 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
     // Initialize a local spark env
     SparkConf sc = HoodieClientTestUtils.getSparkConfForTest(appName + "#" + testMethodName);
     SparkContext sparkContext = new SparkContext(sc);
-    try {
-      // Clean the default Hadoop configurations since in our Hudi tests they are not used.
-      Field hadoopConfigurationField = sparkContext.getClass().getDeclaredField("_hadoopConfiguration");
-      hadoopConfigurationField.setAccessible(true);
-      Configuration testHadoopConfig = new Configuration(false);
-      hadoopConfigurationField.set(sparkContext, testHadoopConfig);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      LOG.warn(e.getMessage());
-    }
-
+    HoodieClientTestUtils.overrideSparkHadoopConfiguration(sparkContext);
     jsc = new JavaSparkContext(sparkContext);
     jsc.setLogLevel("ERROR");
     hadoopConf = jsc.hadoopConfiguration();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.HoodieSparkKryoRegistrar$;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
@@ -75,7 +74,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -203,18 +201,7 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
       SparkRDDReadClient.addHoodieSupport(sparkConf);
       spark = SparkSession.builder().config(sparkConf).getOrCreate();
       sqlContext = spark.sqlContext();
-
-      try {
-        // Clean the default Hadoop configurations since in our Hudi tests they are not used.
-        SparkContext sparkContext = spark.sparkContext();
-        Field hadoopConfigurationField = sparkContext.getClass().getDeclaredField("_hadoopConfiguration");
-        hadoopConfigurationField.setAccessible(true);
-        Configuration testHadoopConfig = new Configuration(false);
-        hadoopConfigurationField.set(sparkContext, testHadoopConfig);
-      } catch (NoSuchFieldException | IllegalAccessException e) {
-        // Ignore the exceptions.
-      }
-
+      HoodieClientTestUtils.overrideSparkHadoopConfiguration(spark.sparkContext());
       jsc = new JavaSparkContext(spark.sparkContext());
       context = new HoodieSparkEngineContext(jsc);
       timelineService = HoodieClientTestUtils.initTimelineService(


### PR DESCRIPTION
### Change Logs

These default Hadoop configurations are not used in Hudi tests.

### Impact

The runtime of tests based on these Hadoop configurations should be reduced.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
