### PR TITLE
[HUDI-6092] Set the timeout for the forked JVM for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,6 +592,7 @@
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
             </systemPropertyVariables>
             <useSystemClassLoader>false</useSystemClassLoader>
+            <forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Change Logs

After we set this parameter, the surefire will try to ping the forked JVM after the timeout.
If not set this parameter, surefire will rely on os to handle the orphan processes.

### Impact

Low.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
