### PR TITLE
[HUDI-7297] Fix ambiguous error message when field type defined in sc…

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -459,60 +459,52 @@ public class ParquetSplitReaderUtil {
     switch (fieldType.getTypeRoot()) {
       case BOOLEAN:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBooleanVector(batchSize);
       case TINYINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapByteVector(batchSize);
       case DOUBLE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDoubleVector(batchSize);
       case FLOAT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.FLOAT, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapFloatVector(batchSize);
       case INTEGER:
       case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapIntVector(batchSize);
       case BIGINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT64,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT64, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapLongVector(batchSize);
       case SMALLINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapShortVector(batchSize);
       case CHAR:
       case VARCHAR:
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-            "TIME_MICROS original type is not ");
+                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-            "Unexpected type: %s", typeName);
+                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
@@ -575,5 +567,25 @@ public class ParquetSplitReaderUtil {
   private static int getFieldIndexInPhysicalType(String fieldName, GroupType groupType) {
     // get index from fileSchema type, else, return -1
     return groupType.containsField(fieldName) ? groupType.getFieldIndex(fieldName) : -1;
+  }
+
+  /**
+   * Construct the error message when primitive type mismatches.
+   * @param primitiveType Primitive type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Primitive type: %s. Field type: %s.", primitiveType, fieldType.getTypeRoot().name());
+  }
+
+  /**
+   * Construct the error message when original type mismatches.
+   * @param originalType Original type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Original type: %s. Field type: %s.", originalType, fieldType.getTypeRoot().name());
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -218,11 +218,17 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     List<Type> types = requestedSchema.getFields();
     List<ColumnDescriptor> descriptors = requestedSchema.getColumns();
     for (int i = 0; i < requestedTypes.length; i++) {
-      columns[i] = createWritableColumnVector(
-          batchSize,
-          requestedTypes[i],
-          types.get(i),
-          descriptors);
+      try {
+        columns[i] = createWritableColumnVector(
+                batchSize,
+                requestedTypes[i],
+                types.get(i),
+                descriptors);
+      } catch (IllegalArgumentException e) {
+        String fieldName = requestedSchema.getFieldName(i);
+        String message = e.getMessage() + " Field name: " + fieldName;
+        throw new IllegalArgumentException(message);
+      }
     }
     return columns;
   }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -459,60 +459,52 @@ public class ParquetSplitReaderUtil {
     switch (fieldType.getTypeRoot()) {
       case BOOLEAN:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBooleanVector(batchSize);
       case TINYINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapByteVector(batchSize);
       case DOUBLE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDoubleVector(batchSize);
       case FLOAT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.FLOAT, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapFloatVector(batchSize);
       case INTEGER:
       case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapIntVector(batchSize);
       case BIGINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT64,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT64, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapLongVector(batchSize);
       case SMALLINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapShortVector(batchSize);
       case CHAR:
       case VARCHAR:
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-            "TIME_MICROS original type is not ");
+                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-            "Unexpected type: %s", typeName);
+                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
@@ -575,5 +567,25 @@ public class ParquetSplitReaderUtil {
   private static int getFieldIndexInPhysicalType(String fieldName, GroupType groupType) {
     // get index from fileSchema type, else, return -1
     return groupType.containsField(fieldName) ? groupType.getFieldIndex(fieldName) : -1;
+  }
+
+  /**
+   * Construct the error message when primitive type mismatches.
+   * @param primitiveType Primitive type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Primitive type: %s. Field type: %s.", primitiveType, fieldType.getTypeRoot().name());
+  }
+
+  /**
+   * Construct the error message when original type mismatches.
+   * @param originalType Original type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Original type: %s. Field type: %s.", originalType, fieldType.getTypeRoot().name());
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -218,11 +218,17 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     List<Type> types = requestedSchema.getFields();
     List<ColumnDescriptor> descriptors = requestedSchema.getColumns();
     for (int i = 0; i < requestedTypes.length; i++) {
-      columns[i] = createWritableColumnVector(
-          batchSize,
-          requestedTypes[i],
-          types.get(i),
-          descriptors);
+      try {
+        columns[i] = createWritableColumnVector(
+                batchSize,
+                requestedTypes[i],
+                types.get(i),
+                descriptors);
+      } catch (IllegalArgumentException e) {
+        String fieldName = requestedSchema.getFieldName(i);
+        String message = e.getMessage() + " Field name: " + fieldName;
+        throw new IllegalArgumentException(message);
+      }
     }
     return columns;
   }

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -459,60 +459,52 @@ public class ParquetSplitReaderUtil {
     switch (fieldType.getTypeRoot()) {
       case BOOLEAN:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBooleanVector(batchSize);
       case TINYINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapByteVector(batchSize);
       case DOUBLE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDoubleVector(batchSize);
       case FLOAT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.FLOAT, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapFloatVector(batchSize);
       case INTEGER:
       case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapIntVector(batchSize);
       case BIGINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT64,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT64, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapLongVector(batchSize);
       case SMALLINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapShortVector(batchSize);
       case CHAR:
       case VARCHAR:
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-            "TIME_MICROS original type is not ");
+                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-            "Unexpected type: %s", typeName);
+                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
@@ -575,5 +567,25 @@ public class ParquetSplitReaderUtil {
   private static int getFieldIndexInPhysicalType(String fieldName, GroupType groupType) {
     // get index from fileSchema type, else, return -1
     return groupType.containsField(fieldName) ? groupType.getFieldIndex(fieldName) : -1;
+  }
+
+  /**
+   * Construct the error message when primitive type mismatches.
+   * @param primitiveType Primitive type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Primitive type: %s. Field type: %s.", primitiveType, fieldType.getTypeRoot().name());
+  }
+
+  /**
+   * Construct the error message when original type mismatches.
+   * @param originalType Original type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Original type: %s. Field type: %s.", originalType, fieldType.getTypeRoot().name());
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -218,11 +218,17 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     List<Type> types = requestedSchema.getFields();
     List<ColumnDescriptor> descriptors = requestedSchema.getColumns();
     for (int i = 0; i < requestedTypes.length; i++) {
-      columns[i] = createWritableColumnVector(
-          batchSize,
-          requestedTypes[i],
-          types.get(i),
-          descriptors);
+      try {
+        columns[i] = createWritableColumnVector(
+                batchSize,
+                requestedTypes[i],
+                types.get(i),
+                descriptors);
+      } catch (IllegalArgumentException e) {
+        String fieldName = requestedSchema.getFieldName(i);
+        String message = e.getMessage() + " Field name: " + fieldName;
+        throw new IllegalArgumentException(message);
+      }
     }
     return columns;
   }

--- a/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -459,60 +459,52 @@ public class ParquetSplitReaderUtil {
     switch (fieldType.getTypeRoot()) {
       case BOOLEAN:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBooleanVector(batchSize);
       case TINYINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapByteVector(batchSize);
       case DOUBLE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDoubleVector(batchSize);
       case FLOAT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.FLOAT, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapFloatVector(batchSize);
       case INTEGER:
       case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapIntVector(batchSize);
       case BIGINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT64,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT64, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapLongVector(batchSize);
       case SMALLINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapShortVector(batchSize);
       case CHAR:
       case VARCHAR:
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-            "TIME_MICROS original type is not ");
+                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-            "Unexpected type: %s", typeName);
+                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
@@ -575,5 +567,25 @@ public class ParquetSplitReaderUtil {
   private static int getFieldIndexInPhysicalType(String fieldName, GroupType groupType) {
     // get index from fileSchema type, else, return -1
     return groupType.containsField(fieldName) ? groupType.getFieldIndex(fieldName) : -1;
+  }
+
+  /**
+   * Construct the error message when primitive type mismatches.
+   * @param primitiveType Primitive type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Primitive type: %s. Field type: %s.", primitiveType, fieldType.getTypeRoot().name());
+  }
+
+  /**
+   * Construct the error message when original type mismatches.
+   * @param originalType Original type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Original type: %s. Field type: %s.", originalType, fieldType.getTypeRoot().name());
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -218,11 +218,17 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     List<Type> types = requestedSchema.getFields();
     List<ColumnDescriptor> descriptors = requestedSchema.getColumns();
     for (int i = 0; i < requestedTypes.length; i++) {
-      columns[i] = createWritableColumnVector(
-          batchSize,
-          requestedTypes[i],
-          types.get(i),
-          descriptors);
+      try {
+        columns[i] = createWritableColumnVector(
+                batchSize,
+                requestedTypes[i],
+                types.get(i),
+                descriptors);
+      } catch (IllegalArgumentException e) {
+        String fieldName = requestedSchema.getFieldName(i);
+        String message = e.getMessage() + " Field name: " + fieldName;
+        throw new IllegalArgumentException(message);
+      }
     }
     return columns;
   }

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -459,60 +459,52 @@ public class ParquetSplitReaderUtil {
     switch (fieldType.getTypeRoot()) {
       case BOOLEAN:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BOOLEAN, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBooleanVector(batchSize);
       case TINYINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapByteVector(batchSize);
       case DOUBLE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.DOUBLE, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDoubleVector(batchSize);
       case FLOAT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.FLOAT,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.FLOAT, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapFloatVector(batchSize);
       case INTEGER:
       case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapIntVector(batchSize);
       case BIGINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT64,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT64, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapLongVector(batchSize);
       case SMALLINT:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.INT32,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.INT32, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapShortVector(batchSize);
       case CHAR:
       case VARCHAR:
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
-            "Unexpected type: %s", typeName);
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-            "TIME_MICROS original type is not ");
+                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-            "Unexpected type: %s", typeName);
+                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
@@ -575,5 +567,25 @@ public class ParquetSplitReaderUtil {
   private static int getFieldIndexInPhysicalType(String fieldName, GroupType groupType) {
     // get index from fileSchema type, else, return -1
     return groupType.containsField(fieldName) ? groupType.getFieldIndex(fieldName) : -1;
+  }
+
+  /**
+   * Construct the error message when primitive type mismatches.
+   * @param primitiveType Primitive type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Primitive type: %s. Field type: %s.", primitiveType, fieldType.getTypeRoot().name());
+  }
+
+  /**
+   * Construct the error message when original type mismatches.
+   * @param originalType Original type
+   * @param fieldType Logical field type
+   * @return The error message
+   */
+  private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {
+    return String.format("Unexpected type exception. Original type: %s. Field type: %s.", originalType, fieldType.getTypeRoot().name());
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -218,11 +218,17 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     List<Type> types = requestedSchema.getFields();
     List<ColumnDescriptor> descriptors = requestedSchema.getColumns();
     for (int i = 0; i < requestedTypes.length; i++) {
-      columns[i] = createWritableColumnVector(
-          batchSize,
-          requestedTypes[i],
-          types.get(i),
-          descriptors);
+      try {
+        columns[i] = createWritableColumnVector(
+                batchSize,
+                requestedTypes[i],
+                types.get(i),
+                descriptors);
+      } catch (IllegalArgumentException e) {
+        String fieldName = requestedSchema.getFieldName(i);
+        String message = e.getMessage() + " Field name: " + fieldName;
+        throw new IllegalArgumentException(message);
+      }
     }
     return columns;
   }


### PR DESCRIPTION
…hema mismatches that in parquet file.

### Change Logs

Fix ambiguous error message when field type defined in schema mismatches that in parquet file.

### Impact

No impact for public API.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

There is no need to update the document.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
