### PR TITLE
[HUDI-7303] Fix date field type unexpectedly convert to Long when usi…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionPredicates.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionPredicates.java
@@ -602,10 +602,10 @@ public class ExpressionPredicates {
       case TINYINT:
       case SMALLINT:
       case INTEGER:
+      case DATE:
       case TIME_WITHOUT_TIME_ZONE:
         return predicateSupportsLtGt(functionDefinition, intColumn(columnName), (Integer) literal);
       case BIGINT:
-      case DATE:
       case TIMESTAMP_WITHOUT_TIME_ZONE:
         return predicateSupportsLtGt(functionDefinition, longColumn(columnName), (Long) literal);
       case FLOAT:

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ExpressionUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ExpressionUtils.java
@@ -160,7 +160,7 @@ public class ExpressionUtils {
             .orElse(null);
       case DATE:
         return expr.getValueAs(LocalDate.class)
-            .map(LocalDate::toEpochDay)
+            .map(date -> (int) date.toEpochDay())
             .orElse(null);
       // NOTE: All integral types of size less than Int are encoded as Ints in MT
       case BOOLEAN:
@@ -212,7 +212,7 @@ public class ExpressionUtils {
       case TIMESTAMP_WITHOUT_TIME_ZONE:
         return logicalTimestamp ? new Timestamp((long) val) : val;
       case DATE:
-        return LocalDate.ofEpochDay((long) val);
+        return LocalDate.ofEpochDay((int) val);
       default:
         return val;
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestExpressionUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestExpressionUtils.java
@@ -140,7 +140,7 @@ class TestExpressionUtils {
       if (dataList.get(i) instanceof LocalTime) {
         assertEquals(((LocalTime) dataList.get(i)).get(ChronoField.MILLI_OF_DAY), ExpressionUtils.getValueFromLiteral((ValueLiteralExpression) childExprs.get(1)));
       } else if (dataList.get(i) instanceof LocalDate) {
-        assertEquals(((LocalDate) dataList.get(i)).toEpochDay(), ExpressionUtils.getValueFromLiteral((ValueLiteralExpression) childExprs.get(1)));
+        assertEquals((int) ((LocalDate) dataList.get(i)).toEpochDay(), ExpressionUtils.getValueFromLiteral((ValueLiteralExpression) childExprs.get(1)));
       } else if (dataList.get(i) instanceof LocalDateTime) {
         assertEquals(((LocalDateTime) dataList.get(i)).toInstant(ZoneOffset.UTC).toEpochMilli(), ExpressionUtils.getValueFromLiteral((ValueLiteralExpression) childExprs.get(1)));
       } else {


### PR DESCRIPTION
…ng date comparison operator.

### Change Logs

When using between, less than (less than or equal) or greater than (greater than or equal) operators with field typed of date, the date type will unexpected convert to Long, which is incompatible with its primitive type INT32.

### Impact

No impact.

### Risk level (write none, low medium or high below)

Low risk level.

### Documentation Update

No need to update the documentation.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
