### PR TITLE
[HUDI-7308] LockManager::unlock should not call updateLockHeldTimerMetrics if lockDurationTimer has not been started

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -54,7 +54,7 @@ public class LockManager implements Serializable, AutoCloseable {
   private final RetryHelper<Boolean, HoodieLockException> lockRetryHelper;
   private transient HoodieLockMetrics metrics;
   private volatile LockProvider lockProvider;
-  private boolean lockAcquired = false;
+  private volatile boolean lockAcquired = false;
 
   public LockManager(HoodieWriteConfig writeConfig, FileSystem fs) {
     this(writeConfig, fs, writeConfig.getProps());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/InProcessLockProviderWithRuntimeError.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/InProcessLockProviderWithRuntimeError.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.client.transaction;
 
 import java.util.concurrent.TimeUnit;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/InProcessLockProviderWithRuntimeError.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/InProcessLockProviderWithRuntimeError.java
@@ -1,0 +1,25 @@
+package org.apache.hudi.client.transaction;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.common.config.LockConfiguration;
+
+public class InProcessLockProviderWithRuntimeError extends InProcessLockProvider {
+
+  public InProcessLockProviderWithRuntimeError(
+      LockConfiguration lockConfiguration,
+      Configuration conf) {
+    super(lockConfiguration, conf);
+  }
+
+  @Override
+  public boolean tryLock(long time, TimeUnit unit) {
+    throw new RuntimeException();
+  }
+
+  @Override
+  public void unlock() {
+    return;
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
@@ -71,7 +71,8 @@ public class TestTransactionManager extends HoodieCommonTestHarness {
             .withNumRetries(2)
             .withRetryWaitTimeInMillis(10L)
             .withClientNumRetries(2)
-            .withClientRetryWaitTimeInMillis(10L).build())
+            .withClientRetryWaitTimeInMillis(10L)
+            .build())
         .forTable("testtable")
         .withMetricsConfig(HoodieMetricsConfig.newBuilder().withReporterType(MetricsReporterType.INMEMORY.toString()).withLockingMetrics(true).on(true).build())
         .build();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
@@ -29,15 +29,19 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.exception.HoodieLockException;
+import org.apache.hudi.metrics.MetricsReporterType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.TestInfo;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,14 +51,14 @@ public class TestTransactionManager extends HoodieCommonTestHarness {
   TransactionManager transactionManager;
 
   @BeforeEach
-  private void init() throws IOException {
+  private void init(TestInfo testInfo) throws IOException {
     initPath();
     initMetaClient();
-    this.writeConfig = getWriteConfig();
+    this.writeConfig = getWriteConfig(testInfo.getTags().contains("useLockProviderWithRuntimeError"));
     this.transactionManager = new TransactionManager(this.writeConfig, this.metaClient.getFs());
   }
 
-  private HoodieWriteConfig getWriteConfig() {
+  private HoodieWriteConfig getWriteConfig(boolean useLockProviderWithRuntimeError) {
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
@@ -62,13 +66,14 @@ public class TestTransactionManager extends HoodieCommonTestHarness {
         .build())
         .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
         .withLockConfig(HoodieLockConfig.newBuilder()
-            .withLockProvider(InProcessLockProvider.class)
+            .withLockProvider(useLockProviderWithRuntimeError ? InProcessLockProviderWithRuntimeError.class : InProcessLockProvider.class)
             .withLockWaitTimeInMillis(50L)
             .withNumRetries(2)
             .withRetryWaitTimeInMillis(10L)
             .withClientNumRetries(2)
-            .withClientRetryWaitTimeInMillis(10L)
-            .build())
+            .withClientRetryWaitTimeInMillis(10L).build())
+        .forTable("testtable")
+        .withMetricsConfig(HoodieMetricsConfig.newBuilder().withReporterType(MetricsReporterType.INMEMORY.toString()).withLockingMetrics(true).on(true).build())
         .build();
   }
 
@@ -243,6 +248,19 @@ public class TestTransactionManager extends HoodieCommonTestHarness {
     transactionManager.endTransaction(Option.empty());
     Assertions.assertFalse(transactionManager.getCurrentTransactionOwner().isPresent());
     Assertions.assertFalse(transactionManager.getLastCompletedTransactionOwner().isPresent());
+  }
+
+  @Test
+  @Tag("useLockProviderWithRuntimeError")
+  public void testTransactionsWithUncheckedLockProviderRuntimeException() {
+    assertThrows(RuntimeException.class, () -> {
+      try {
+        transactionManager.beginTransaction(Option.empty(), Option.empty());
+      } finally {
+        transactionManager.endTransaction(Option.empty());
+      }
+    });
+
   }
 
   private Option<HoodieInstant> getInstant(String timestamp) {


### PR DESCRIPTION
### Change Logs
- Add a new flag to `org.apache.hudi.client.transaction.lock.LockManager` , that is set once the HoodieLockMetrics lock duration timer had started, and is unset after said timer has been ended. This flag is used to prevent closing the lock duration timer if it has not already been started
- This is needed to avoid the scenario in https://issues.apache.org/jira/browse/HUDI-7308 , where if an exception is raised while LockManager tries to acquire lock of LockProvider, and the caller then directly calls LockManager::close (in order to ensure lock is released for other users) , another exception ``HoodieException("Timer was not started")`  will be thrown, which may "suppress" the original exception encountered when LockManager tried to acquire lock.  

### Impact

- This should allow users to easily identify/debug issues when an implementation of LockProvider throws an exception during `java.util.concurrent.locks.Lock#tryLock(long, java.util.concurrent.TimeUnit)`

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
