### PR TITLE
[HUDI-7310] Optimize Column Stats Partition Pruning for Non-Partition Pruning Queries

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -115,13 +115,11 @@ class ColumnStatsIndexSupport(spark: SparkSession,
 
       case None =>
         val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = if (!shouldPrunePartition) {
-          // NOTE: This judgment has three purposes:
+          // NOTE: This judgment has two purposes:
           //  1. Since this filter can cause extra unnecessary costs in non-partitioned tables or
           //     when partition pruning is not applied, adding a switch prevents this situation.
           //  2. Some tests directly inspect this method without obtaining prunedPartitionsAndFileSlices,
           //     so we need to ensure these tests are accurate.
-          //  3. Prevented the situation stats when querying empty partitions results in
-          //     prunedFileNames being empty and listing all files
           loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
         } else {
           val filterFunction = new SerializableFunction[HoodieMetadataColumnStats, java.lang.Boolean] {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -107,58 +107,68 @@ class ColumnStatsIndexSupport(spark: SparkSession,
    *
    * Please check out scala-doc of the [[transpose]] method explaining this view in more details
    */
-  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, prunedFileNames: Set[String],
-                        usePrunedPartitionsForColumnFiltering: Boolean = false)(block: DataFrame => T): T = {
+  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean)(block: DataFrame => T): T = {
     cachedColumnStatsIndexViews.get(targetColumns) match {
       case Some(cachedDF) =>
         block(cachedDF)
-
       case None =>
-        val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = if (!usePrunedPartitionsForColumnFiltering) {
-          // NOTE: This judgment has two purposes:
-          //  1. Since this filter can cause extra unnecessary costs in non-partitioned tables or
-          //     when partition pruning is not applied, adding a switch prevents this situation.
-          //  2. Some tests directly inspect this method without obtaining prunedPartitionsAndFileSlices,
-          //     so we need to ensure these tests are accurate.
-          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
-        } else {
-          val filterFunction = new SerializableFunction[HoodieMetadataColumnStats, java.lang.Boolean] {
-            override def apply(r: HoodieMetadataColumnStats): java.lang.Boolean = {
-              prunedFileNames.contains(r.getFileName)
-            }
-          }
-          loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter(filterFunction)
-        }
-
-        withPersistedData(colStatsRecords, StorageLevel.MEMORY_ONLY) {
-          val (transposedRows, indexSchema) = transpose(colStatsRecords, targetColumns)
-          val df = if (shouldReadInMemory) {
-            // NOTE: This will instantiate a [[Dataset]] backed by [[LocalRelation]] holding all of the rows
-            //       of the transposed table in memory, facilitating execution of the subsequently chained operations
-            //       on it locally (on the driver; all such operations are actually going to be performed by Spark's
-            //       Optimizer)
-            createDataFrameFromRows(spark, transposedRows.collectAsList().asScala, indexSchema)
-          } else {
-            val rdd = HoodieJavaRDD.getJavaRDD(transposedRows)
-            spark.createDataFrame(rdd, indexSchema)
-          }
-
-          if (allowCaching) {
-            cachedColumnStatsIndexViews.put(targetColumns, df)
-            // NOTE: Instead of collecting the rows from the index and hold them in memory, we instead rely
-            //       on Spark as (potentially distributed) cache managing data lifecycle, while we simply keep
-            //       the referenced to persisted [[DataFrame]] instance
-            df.persist(StorageLevel.MEMORY_ONLY)
-
-            block(df)
-          } else {
-            withPersistedDataset(df) {
-              block(df)
-            }
-          }
-        }
+        loadTransposedImpl(targetColumns, shouldReadInMemory, None)(block)
     }
   }
+
+  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, prunedFileNames: Set[String])(block: DataFrame => T): T = {
+    cachedColumnStatsIndexViews.get(targetColumns) match {
+      case Some(cachedDF) =>
+        block(cachedDF)
+      case None =>
+        loadTransposedImpl(targetColumns, shouldReadInMemory, Some(prunedFileNames))(block)
+    }
+  }
+
+
+  private def loadTransposedImpl[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, prunedFileNamesOpt: Option[Set[String]])(block: DataFrame => T): T = {
+    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = prunedFileNamesOpt match {
+      case Some(prunedFileNames) =>
+        val filterFunction = new SerializableFunction[HoodieMetadataColumnStats, java.lang.Boolean] {
+          override def apply(r: HoodieMetadataColumnStats): java.lang.Boolean = {
+            prunedFileNames.contains(r.getFileName)
+          }
+        }
+        loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory).filter(filterFunction)
+      case None =>
+        loadColumnStatsIndexRecords(targetColumns, shouldReadInMemory)
+    }
+
+    withPersistedData(colStatsRecords, StorageLevel.MEMORY_ONLY) {
+      val (transposedRows, indexSchema) = transpose(colStatsRecords, targetColumns)
+      val df = if (shouldReadInMemory) {
+        // NOTE: This will instantiate a [[Dataset]] backed by [[LocalRelation]] holding all of the rows
+        //       of the transposed table in memory, facilitating execution of the subsequently chained operations
+        //       on it locally (on the driver; all such operations are actually going to be performed by Spark's
+        //       Optimizer)
+        createDataFrameFromRows(spark, transposedRows.collectAsList().asScala, indexSchema)
+      } else {
+        val rdd = HoodieJavaRDD.getJavaRDD(transposedRows)
+        spark.createDataFrame(rdd, indexSchema)
+      }
+
+      if (allowCaching) {
+        cachedColumnStatsIndexViews.put(targetColumns, df)
+        // NOTE: Instead of collecting the rows from the index and hold them in memory, we instead rely
+        //       on Spark as (potentially distributed) cache managing data lifecycle, while we simply keep
+        //       the referenced to persisted [[DataFrame]] instance
+        df.persist(StorageLevel.MEMORY_ONLY)
+
+        block(df)
+      } else {
+        withPersistedDataset(df) {
+          block(df)
+        }
+      }
+    }
+
+  }
+
 
   /**
    * Loads a view of the Column Stats Index in a raw format, returning it as [[DataFrame]]

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -107,14 +107,14 @@ class ColumnStatsIndexSupport(spark: SparkSession,
    *
    * Please check out scala-doc of the [[transpose]] method explaining this view in more details
    */
-  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, shouldPrunePartition: Boolean = false,
-                        prunedFileNames: Set[String] = Set.empty)(block: DataFrame => T): T = {
+  def loadTransposed[T](targetColumns: Seq[String], shouldReadInMemory: Boolean, prunedFileNames: Set[String],
+                        usePrunedPartitionsForColumnFiltering: Boolean = false)(block: DataFrame => T): T = {
     cachedColumnStatsIndexViews.get(targetColumns) match {
       case Some(cachedDF) =>
         block(cachedDF)
 
       case None =>
-        val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = if (!shouldPrunePartition) {
+        val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = if (!usePrunedPartitionsForColumnFiltering) {
           // NOTE: This judgment has two purposes:
           //  1. Since this filter can cause extra unnecessary costs in non-partitioned tables or
           //     when partition pruning is not applied, adding a switch prevents this situation.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -329,7 +329,8 @@ case class HoodieFileIndex(spark: SparkSession,
    * @param queryFilters list of original data filters passed down from querying engine
    * @return list of pruned (data-skipped) candidate base-files and log files' names
    */
-  private def lookupCandidateFilesInMetadataTable(queryFilters: Seq[Expression], shouldPushDownFilesFilter: Boolean,
+  private def lookupCandidateFilesInMetadataTable(queryFilters: Seq[Expression],
+                                                  shouldPushDownFilesFilter: Boolean,
                                                   prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])]): Try[Option[Set[String]]] = Try {
     // NOTE: For column stats, Data Skipping is only effective when it references columns that are indexed w/in
     //       the Column Stats Index (CSI). Following cases could not be effectively handled by Data Skipping:

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
@@ -180,7 +180,7 @@ class ColumnStatIndexTestBase extends HoodieSparkClientTestBase {
     val (expectedColStatsSchema, _) = composeIndexSchema(sourceTableSchema.fieldNames, indexedColumns, sourceTableSchema)
     val validationSortColumns = Seq("c1_maxValue", "c1_minValue", "c2_maxValue", "c2_minValue")
 
-    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory) { transposedColStatsDF =>
+    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory, Set.empty) { transposedColStatsDF =>
       // Match against expected column stats table
       val expectedColStatsIndexTableDf =
         spark.read

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
@@ -180,7 +180,7 @@ class ColumnStatIndexTestBase extends HoodieSparkClientTestBase {
     val (expectedColStatsSchema, _) = composeIndexSchema(sourceTableSchema.fieldNames, indexedColumns, sourceTableSchema)
     val validationSortColumns = Seq("c1_maxValue", "c1_minValue", "c2_maxValue", "c2_minValue")
 
-    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory, Set.empty) { transposedColStatsDF =>
+    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory) { transposedColStatsDF =>
       // Match against expected column stats table
       val expectedColStatsIndexTableDf =
         spark.read

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -130,7 +130,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       .build()
 
     val columnStatsIndex = new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
-    columnStatsIndex.loadTransposed(Seq("c2"), false) { transposedDF =>
+    columnStatsIndex.loadTransposed(Seq("c2"), false, Set.empty) { transposedDF =>
       val result = transposedDF.select("valueCount", "c2_nullCount")
         .collect().head
 
@@ -194,7 +194,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { emptyTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { emptyTransposedColStatsDF =>
         assertEquals(0, emptyTransposedColStatsDF.collect().length)
       }
     }
@@ -222,7 +222,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
         assertEquals(expectedColStatsIndexTableDf.schema, partialTransposedColStatsDF.schema)
         // NOTE: We have to drop the `fileName` column as it contains semi-random components
         //       that we can't control in this test. Nevertheless, since we manually verify composition of the
@@ -276,7 +276,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       // Nevertheless, the last update was written with a new schema (that is a subset of the original table schema),
       // we should be able to read CSI, which will be properly padded (with nulls) after transposition
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { transposedUpdatedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { transposedUpdatedColStatsDF =>
         assertEquals(expectedColStatsIndexUpdatedDF.schema, transposedUpdatedColStatsDF.schema)
 
         assertEquals(asJson(sort(expectedColStatsIndexUpdatedDF)), asJson(sort(transposedUpdatedColStatsDF.drop("fileName"))))
@@ -352,7 +352,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
         Literal(true)
       )
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
         val andConditionActualFilter = andConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
           .reduce(And)
         assertEquals(expectedAndConditionIndexedFilter, andConditionActualFilter)
@@ -374,7 +374,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
         Literal(true)
       )
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
         val orConditionActualFilter = orConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
           .reduce(And)
         assertEquals(expectedOrConditionIndexedFilter, orConditionActualFilter)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -130,7 +130,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       .build()
 
     val columnStatsIndex = new ColumnStatsIndexSupport(spark, schema, metadataConfig, metaClient)
-    columnStatsIndex.loadTransposed(Seq("c2"), false, Set.empty) { transposedDF =>
+    columnStatsIndex.loadTransposed(Seq("c2"), false) { transposedDF =>
       val result = transposedDF.select("valueCount", "c2_nullCount")
         .collect().head
 
@@ -194,7 +194,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { emptyTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { emptyTransposedColStatsDF =>
         assertEquals(0, emptyTransposedColStatsDF.collect().length)
       }
     }
@@ -222,7 +222,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
         assertEquals(expectedColStatsIndexTableDf.schema, partialTransposedColStatsDF.schema)
         // NOTE: We have to drop the `fileName` column as it contains semi-random components
         //       that we can't control in this test. Nevertheless, since we manually verify composition of the
@@ -276,7 +276,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
       // Nevertheless, the last update was written with a new schema (that is a subset of the original table schema),
       // we should be able to read CSI, which will be properly padded (with nulls) after transposition
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { transposedUpdatedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { transposedUpdatedColStatsDF =>
         assertEquals(expectedColStatsIndexUpdatedDF.schema, transposedUpdatedColStatsDF.schema)
 
         assertEquals(asJson(sort(expectedColStatsIndexUpdatedDF)), asJson(sort(transposedUpdatedColStatsDF.drop("fileName"))))
@@ -352,7 +352,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
         Literal(true)
       )
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
         val andConditionActualFilter = andConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
           .reduce(And)
         assertEquals(expectedAndConditionIndexedFilter, andConditionActualFilter)
@@ -374,7 +374,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
         Literal(true)
       )
 
-      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory, Set.empty) { partialTransposedColStatsDF =>
+      columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
         val orConditionActualFilter = orConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
           .reduce(And)
         assertEquals(expectedOrConditionIndexedFilter, orConditionActualFilter)


### PR DESCRIPTION
In HUDI-7291, I applied the partition pruning conditions to the column stats earlier, reducing the amount of data during the data skipping process. However, for non-partitioned tables, or partitioned tables where the query does not involve partition conditions, this optimization introduces additional unnecessary serialization overhead. Therefore, a check has been added here to avoid filtering in such cases.

### Change Logs

None

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
