### PR TITLE
[HUDI-7312] Spark3ParsePartitionUtil support inferPartitionColumnValue with all unnest type

### DIFF
--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
@@ -235,7 +235,7 @@ object Spark3ParsePartitionUtil extends SparkParsePartitionUtil {
 
     if (typeInference) {
       // First tries integral types
-      Try({JByte.parseByte(raw); ByteType })
+      Try({ JByte.parseByte(raw); ByteType })
         .orElse(Try { JShort.parseShort(raw); ShortType })
         .orElse(Try { JBoolean.parseBoolean(raw); BooleanType })
         .orElse(Try({ Integer.parseInt(raw); IntegerType }))


### PR DESCRIPTION


### Change Logs

Spark3ParsePartitionUtil support inferPartitionColumnValue with all unnest type

### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
