### PR TITLE
[HUDI-7314] Hudi Create table support index type check

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.HoodieAvroUtils.getRootLevelFieldName
 import org.apache.hudi.common.model.{HoodieRecordMerger, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.util.ValidationUtils
+import org.apache.hudi.config.HoodieIndexConfig
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
 
@@ -232,6 +233,12 @@ object HoodieOptionConfig {
       tableType.get.equalsIgnoreCase(SQL_VALUE_TABLE_TYPE_COW) ||
       tableType.get.equalsIgnoreCase(SQL_VALUE_TABLE_TYPE_MOR),
       s"'type' must be '$SQL_VALUE_TABLE_TYPE_COW' or '$SQL_VALUE_TABLE_TYPE_MOR'")
+
+    // validate table index type
+    val indexType = sqlOptions.get(HoodieIndexConfig.INDEX_TYPE.key())
+    if (!indexType.isEmpty) {
+      HoodieIndexConfig.INDEX_TYPE.checkValues(indexType.get)
+    }
   }
 
   def buildConf[T](): HoodieSQLOptionBuilder[T] = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2202,7 +2202,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                |""".stripMargin)
         }
       }
-
     })
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2203,28 +2203,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
         }
       }
 
-      val targetTable1 = generateTableName
-      spark.sql(
-        s"""
-           |create table ${targetTable1} (
-           |  `id` string,
-           |  `name` string,
-           |  `dt` bigint,
-           |  `day` STRING,
-           |  `hour` INT
-           |) using hudi
-           |OPTIONS ('hoodie.datasource.write.hive_style_partitioning' 'false', 'hoodie.datasource.meta.sync.enable' 'false', 'hoodie.datasource.hive_sync.enable' 'false')
-           |tblproperties (
-           |  'primaryKey' = 'id',
-           |  'type' = 'mor',
-           |  'preCombineField'='dt',
-           |  'hoodie.index.type' = 'BUCKET',
-           |  'hoodie.bucket.index.hash.field' = 'id',
-           |  'hoodie.bucket.index.num.buckets'=512
-           | )
-           |partitioned by (`day`,`hour`)
-           |location '${tmp.getCanonicalPath}'
-           |""".stripMargin)
     })
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2173,6 +2173,61 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     })
   }
 
+  test("Test inaccurate index type") {
+    withRecordType()(withTempDir { tmp =>
+      val targetTable = generateTableName
+
+      assertThrows[IllegalArgumentException] {
+        try {
+          spark.sql(
+            s"""
+               |create table ${targetTable} (
+               |  `id` string,
+               |  `name` string,
+               |  `dt` bigint,
+               |  `day` STRING,
+               |  `hour` INT
+               |) using hudi
+               |OPTIONS ('hoodie.datasource.write.hive_style_partitioning' 'false', 'hoodie.datasource.meta.sync.enable' 'false', 'hoodie.datasource.hive_sync.enable' 'false')
+               |tblproperties (
+               |  'primaryKey' = 'id',
+               |  'type' = 'mor',
+               |  'preCombineField'='dt',
+               |  'hoodie.index.type' = 'BUCKET_aa',
+               |  'hoodie.bucket.index.hash.field' = 'id',
+               |  'hoodie.bucket.index.num.buckets'=512
+               | )
+               |partitioned by (`day`,`hour`)
+               |location '${tmp.getCanonicalPath}'
+               |""".stripMargin)
+        }
+      }
+
+      val targetTable1 = generateTableName
+      spark.sql(
+        s"""
+           |create table ${targetTable1} (
+           |  `id` string,
+           |  `name` string,
+           |  `dt` bigint,
+           |  `day` STRING,
+           |  `hour` INT
+           |) using hudi
+           |OPTIONS ('hoodie.datasource.write.hive_style_partitioning' 'false', 'hoodie.datasource.meta.sync.enable' 'false', 'hoodie.datasource.hive_sync.enable' 'false')
+           |tblproperties (
+           |  'primaryKey' = 'id',
+           |  'type' = 'mor',
+           |  'preCombineField'='dt',
+           |  'hoodie.index.type' = 'BUCKET',
+           |  'hoodie.bucket.index.hash.field' = 'id',
+           |  'hoodie.bucket.index.num.buckets'=512
+           | )
+           |partitioned by (`day`,`hour`)
+           |location '${tmp.getCanonicalPath}'
+           |""".stripMargin)
+    })
+  }
+
   test("Test vectorized read nested columns for LegacyHoodieParquetFileFormat") {
     withSQLConf(
       "hoodie.datasource.read.use.new.parquet.file.format" -> "false",


### PR DESCRIPTION
### Change Logs

Currently Hudi is not check index type when create table，even when user set inaccurate index name is passed when set absent value. such as:
create table ${targetTable} (
  `id` string,
  `name` string,
  `dt` bigint,
  `day` STRING,
  `hour` INT
) using hudi
OPTIONS ('hoodie.datasource.write.hive_style_partitioning' 'false', 'hoodie.datasource.meta.sync.enable' 'false', 'hoodie.datasource.hive_sync.enable' 'false')
tblproperties (
  'primaryKey' = 'id',
  'type' = 'mor',
  'preCombineField'='dt',
  'hoodie.index.type' = 'BUCKET_XXX',
  'hoodie.bucket.index.hash.field' = 'id',
  'hoodie.bucket.index.num.buckets'=512
 )
partitioned by (`day`,`hour`)

Need fix it with check

### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
