### PR TITLE
[HUDI-7315] Disable constructing NOT filter predicate when pushing do…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionPredicates.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionPredicates.java
@@ -510,7 +510,11 @@ public class ExpressionPredicates {
 
     @Override
     public FilterPredicate filter() {
-      return not(predicate.filter());
+      FilterPredicate filterPredicate = predicate.filter();
+      if (null == filterPredicate) {
+        return null;
+      }
+      return not(filterPredicate);
     }
 
     @Override
@@ -548,10 +552,12 @@ public class ExpressionPredicates {
 
     @Override
     public FilterPredicate filter() {
-      if (null == predicates[0].filter() || null == predicates[1].filter()) {
+      FilterPredicate filterPredicate0 = predicates[0].filter();
+      FilterPredicate filterPredicate1 = predicates[1].filter();
+      if (null == filterPredicate0 || null == filterPredicate1) {
         return null;
       }
-      return and(predicates[0].filter(), predicates[1].filter());
+      return and(filterPredicate0, filterPredicate1);
     }
 
     @Override
@@ -589,10 +595,12 @@ public class ExpressionPredicates {
 
     @Override
     public FilterPredicate filter() {
-      if (null == predicates[0].filter() || null == predicates[1].filter()) {
+      FilterPredicate filterPredicate0 = predicates[0].filter();
+      FilterPredicate filterPredicate1 = predicates[1].filter();
+      if (null == filterPredicate0 || null == filterPredicate1) {
         return null;
       }
-      return or(predicates[0].filter(), predicates[1].filter());
+      return or(filterPredicate0, filterPredicate1);
     }
 
     @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionPredicates.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionPredicates.java
@@ -180,5 +180,6 @@ public class TestExpressionPredicates {
 
     assertNull(And.getInstance().bindPredicates(greaterThanPredicate, lessThanPredicate).filter(), "Decimal type push down is unsupported, so we expect null");
     assertNull(Or.getInstance().bindPredicates(greaterThanPredicate, lessThanPredicate).filter(), "Decimal type push down is unsupported, so we expect null");
+    assertNull(Not.getInstance().bindPredicate(greaterThanPredicate).filter(), "Decimal type push down is unsupported, so we expect null");
   }
 }


### PR DESCRIPTION
…wn its wrapped filter unsupported, as its operand's primitive value is incomparable.

### Change Logs

This issue is extended from [HUDI-7309](https://issues.apache.org/jira/browse/HUDI-7309), as the risk still exists for the NOT filter predicate when the predicate it wraps does not support pushing down (e.g. expression with the operand typed Decimal).

This PR fixed the issue for the NOT filter predicate.

### Impact

Low impact

### Risk level (write none, low medium or high below)

Low risk.

### Documentation Update

No need to update.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
