### PR TITLE
[HUDI-7316] Update AbstractHoodieLogRecordReader (and implementation) to accept already-constructed HoodieTableMetaClient and update Spark engine callers to pass meta client directly

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
@@ -132,6 +132,7 @@ public class HoodieMergedReadHandle<T, I, K, O> extends HoodieReadHandle<T, I, K
         .withDiskMapType(config.getCommonConfig().getSpillableDiskMapType())
         .withBitCaskDiskMapCompressionEnabled(config.getCommonConfig().isBitCaskDiskMapCompressionEnabled())
         .withRecordMerger(config.getRecordMerger())
+        .withTableMetaClient(hoodieTable.getMetaClient())
         .build();
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -207,6 +207,7 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
         .withOptimizedLogBlocksScan(executionHelper.enableOptimizedLogBlockScan(config))
         .withRecordMerger(config.getRecordMerger())
         .withInstantRange(instantRange)
+        .withTableMetaClient(metaClient)
         .build();
 
     Option<HoodieBaseFile> oldDataFileOpt =

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieLogCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieLogCompactionPlanGenerator.java
@@ -98,6 +98,7 @@ public class HoodieLogCompactionPlanGenerator<T extends HoodieRecordPayload, I, 
         .withBufferSize(writeConfig.getMaxDFSStreamBufferSize())
         .withOptimizedLogBlocksScan(true)
         .withRecordMerger(writeConfig.getRecordMerger())
+        .withTableMetaClient(metaClient)
         .build();
     scanner.scan(true);
     int totalBlocks = scanner.getCurrentInstantLogBlocks().size();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -321,6 +321,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
               .withDiskMapType(config.getCommonConfig().getSpillableDiskMapType())
               .withBitCaskDiskMapCompressionEnabled(config.getCommonConfig().isBitCaskDiskMapCompressionEnabled())
               .withRecordMerger(config.getRecordMerger())
+              .withTableMetaClient(table.getMetaClient())
               .build();
 
           Option<HoodieFileReader> baseFileReader = StringUtils.isNullOrEmpty(clusteringOp.getDataFilePath())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
@@ -444,6 +444,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
             .withLatestInstantTime(instant)
             .withBufferSize(config.getMaxDFSStreamBufferSize())
             .withOptimizedLogBlocksScan(true)
+            .withTableMetaClient(metaClient)
             .build();
         scanner.scan(true);
         List<String> prevInstants = scanner.getValidBlockInstants();
@@ -457,6 +458,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
             .withLatestInstantTime(currentInstant)
             .withBufferSize(config.getMaxDFSStreamBufferSize())
             .withOptimizedLogBlocksScan(true)
+            .withTableMetaClient(table.getMetaClient())
             .build();
         scanner2.scan(true);
         List<String> currentInstants = scanner2.getValidBlockInstants();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -157,10 +157,11 @@ public abstract class AbstractHoodieLogRecordReader {
                                           InternalSchema internalSchema,
                                           Option<String> keyFieldOverride,
                                           boolean enableOptimizedLogBlocksScan,
-                                          HoodieRecordMerger recordMerger) {
+                                          HoodieRecordMerger recordMerger,
+                                          Option<HoodieTableMetaClient> hoodieTableMetaClientOption) {
     this.readerSchema = readerSchema;
     this.latestInstantTime = latestInstantTime;
-    this.hoodieTableMetaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).build();
+    this.hoodieTableMetaClient = hoodieTableMetaClientOption.orElseGet(() -> HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).build());
     // load class from the payload fully qualified class name
     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
     this.payloadClassFQN = tableConfig.getPayloadClass();
@@ -1032,6 +1033,10 @@ public abstract class AbstractHoodieLogRecordReader {
     }
 
     public Builder withOptimizedLogBlocksScan(boolean enableOptimizedLogBlocksScan) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withTableMetaClient(HoodieTableMetaClient hoodieTableMetaClient) {
       throw new UnsupportedOperationException();
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -498,6 +498,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         .enableFullScan(allowFullScan)
         .withPartition(partitionName)
         .withEnableOptimizedLogBlocksScan(metadataConfig.doEnableOptimizedLogBlocksScan())
+        .withTableMetaClient(metadataMetaClient)
         .build();
 
     Long logScannerOpenMs = timer.endTimer();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLogRecordReader.java
@@ -22,6 +22,7 @@ import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.Option;
@@ -212,6 +213,11 @@ public class HoodieMetadataLogRecordReader implements Closeable {
 
     public Builder withEnableOptimizedLogBlocksScan(boolean enableOptimizedLogBlocksScan) {
       scannerBuilder.withOptimizedLogBlocksScan(enableOptimizedLogBlocksScan);
+      return this;
+    }
+
+    public Builder withTableMetaClient(HoodieTableMetaClient hoodieTableMetaClient) {
+      scannerBuilder.withTableMetaClient(hoodieTableMetaClient);
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1837,6 +1837,7 @@ public class HoodieTableMetadataUtil {
                 engineType,
                 Collections.emptyList(), // TODO: support different merger classes, which is currently only known to write config
                 metaClient.getTableConfig().getRecordMergerStrategy()))
+            .withTableMetaClient(metaClient)
             .build();
         ClosableIterator<String> recordKeyIterator = ClosableIterator.wrap(mergedLogRecordScanner.getRecords().keySet().iterator());
         return new ClosableIterator<HoodieRecord>() {


### PR DESCRIPTION

### Change Logs

- Update AbstractHoodieLogRecordReader and implementations to accept a HoodieTableMetaClient directly, and skip constructing one if provided
-- org.apache.hudi.common.table.log.AbstractHoodieLogRecordReader#AbstractHoodieLogRecordReader
-- org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner
-- org.apache.hudi.common.table.log.HoodieUnMergedLogRecordScanner

- Update Spark engine-related callers of AbstractHoodieLogRecordReader to pass in an already constructed HoodieTableMetaClient, if feasible and applicable. Specifically, for cases where the Spark driver would already have a HoodieTableMetaClient created, and would a launch a Spark stage where each task would be creating/using a AbstractHoodieLogRecordReader instance. 

See HUDI-7316 for context

### Impact
Currently, when using Spark engine, there are cases where each Spark task needs to construct/use a AbstractHoodieLogRecordReader instance, and while doing so will create a HoodieMetaClient and will read the active timeline for it. This causes a file listing call to the Distributed file system service (such as HDFS namenode). If the caller (that initiated this Spark stage from the driver) can feasibly pass in a HoodieMetaClient (with active timeline already loaded) then allowing the caller to pass in this existing HoodieMetaClient to AbstractHoodieLogRecordReader implementations will avoid this unnecessary file listing call. For users that launch Spark jobs with hundreds or thousands of executors, this could potentially avoid hundreds or thousands of file listing calls (which would likely happen around the same time, since all these tasks would be initiated in the same spark stage).

### Risk level (write none, low medium or high below)

low

### Documentation Update



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
