### PR TITLE
[HUDI-7318] HoodieTableMetaClient need support a config to user for whether to checkTableValidity

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -194,6 +194,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .defaultValue(true)
       .withDocumentation("Whether or not, this is a bootstrapped table, with bootstrap base data and an mapping index defined, default true.");
 
+  public static final ConfigProperty<Boolean> TABLE_VALIDITY_ENABLE = ConfigProperty
+          .key("hoodie.table.validity.check.enable")
+          .defaultValue(true)
+          .withDocumentation("Whether to check table validity, default true.");
+
   public static final ConfigProperty<String> BOOTSTRAP_INDEX_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.index.class")
       .defaultValue(HFileBootstrapIndex.class.getName())
@@ -621,6 +626,10 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public String getTableName() {
     return getString(NAME);
+  }
+
+  public boolean getTableValidityCheck() {
+    return getBoolean(TABLE_VALIDITY_ENABLE);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -159,7 +159,9 @@ public class HoodieTableMetaClient implements Serializable {
     this.basePath = new SerializablePath(new CachingPath(basePath));
     this.metaPath = new SerializablePath(new CachingPath(basePath, METAFOLDER_NAME));
     this.fs = getFs();
-    TableNotFoundException.checkTableValidity(fs, this.basePath.get(), metaPath.get());
+    if (tableConfig.getTableValidityCheck()) {
+      TableNotFoundException.checkTableValidity(fs, this.basePath.get(), metaPath.get());
+    }
     this.tableConfig = new HoodieTableConfig(fs, metaPath.toString(), payloadClassName, recordMergerStrategy);
     this.functionalIndexMetadata = getFunctionalIndexMetadata();
     this.tableType = tableConfig.getTableType();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -159,10 +159,10 @@ public class HoodieTableMetaClient implements Serializable {
     this.basePath = new SerializablePath(new CachingPath(basePath));
     this.metaPath = new SerializablePath(new CachingPath(basePath, METAFOLDER_NAME));
     this.fs = getFs();
+    this.tableConfig = new HoodieTableConfig(fs, metaPath.toString(), payloadClassName, recordMergerStrategy);
     if (tableConfig.getTableValidityCheck()) {
       TableNotFoundException.checkTableValidity(fs, this.basePath.get(), metaPath.get());
     }
-    this.tableConfig = new HoodieTableConfig(fs, metaPath.toString(), payloadClassName, recordMergerStrategy);
     this.functionalIndexMetadata = getFunctionalIndexMetadata();
     this.tableType = tableConfig.getTableType();
     Option<TimelineLayoutVersion> tableConfigVersion = tableConfig.getTimelineLayoutVersion();


### PR DESCRIPTION

### Change Logs

HoodieTableMetaClient need support a config to user for whether to checkTableValidity avoid large numebr of file listing in flink or spark job: currently user would had a large number of list rpc requet to hdfs due to HoodieTableMetaClient be called create，TableNotFoundException#checkTableValidity would cause so much list rpc request to namenode, add a config for user to decide whether enable it，default is true.

### Impact

none

### Risk level (write none, low medium or high below)

lower

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
