### PR TITLE
[HUDI-7323] Use a schema supplier instead of a static value

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -109,6 +109,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
@@ -206,13 +207,13 @@ public class UtilHelpers {
     return null;
   }
 
-  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, Option<Schema> sourceSchema,
+  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, Supplier<Option<Schema>> sourceSchemaSupplier,
                                                       boolean isErrorTableWriterEnabled) throws IOException {
 
     try {
       Function<List<String>, Transformer> chainedTransformerFunction = classNames ->
-          isErrorTableWriterEnabled ? new ErrorTableAwareChainedTransformer(classNames, sourceSchema)
-              : new ChainedTransformer(classNames, sourceSchema);
+          isErrorTableWriterEnabled ? new ErrorTableAwareChainedTransformer(classNames, sourceSchemaSupplier)
+              : new ChainedTransformer(classNames, sourceSchemaSupplier);
       return classNamesOpt.map(classNames -> classNames.isEmpty() ? null : chainedTransformerFunction.apply(classNames));
     } catch (Throwable e) {
       throw new IOException("Could not load transformer class(es) " + classNamesOpt.get(), e);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -123,6 +123,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import scala.Tuple2;
@@ -289,15 +290,11 @@ public class StreamSync implements Serializable, Closeable {
     Source source = UtilHelpers.createSource(cfg.sourceClassName, props, hoodieSparkContext.jsc(), sparkSession, schemaProvider, metrics);
     this.formatAdapter = new SourceFormatAdapter(source, this.errorTableWriter, Option.of(props));
 
-    this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
-        Option.ofNullable(schemaProvider).map(SchemaProvider::getSourceSchema), this.errorTableWriter.isPresent());
-    if (this.cfg.operation == WriteOperationType.BULK_INSERT && source.getSourceType() == Source.SourceType.ROW
-        && this.props.getBoolean(DataSourceWriteOptions.ENABLE_ROW_WRITER().key(), false)) {
-      // enable row writer only when operation is BULK_INSERT, and source is ROW type and if row writer is not explicitly disabled.
-      this.useRowWriter = true;
-    } else {
-      this.useRowWriter = false;
-    }
+    Supplier<Option<Schema>> schemaSupplier = schemaProvider == null ? Option::empty : () -> Option.ofNullable(schemaProvider.getSourceSchema());
+    this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames), schemaSupplier, this.errorTableWriter.isPresent());
+    // enable row writer only when operation is BULK_INSERT, and source is ROW type and if row writer is not explicitly disabled.
+    this.useRowWriter = this.cfg.operation == WriteOperationType.BULK_INSERT && source.getSourceType() == Source.SourceType.ROW
+        && this.props.getBoolean(DataSourceWriteOptions.ENABLE_ROW_WRITER().key(), false);
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ChainedTransformer.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -51,26 +52,26 @@ public class ChainedTransformer implements Transformer {
   private static final String ID_TRANSFORMER_CLASS_NAME_DELIMITER = ":";
 
   protected final List<TransformerInfo> transformers;
-  private final Option<Schema> sourceSchemaOpt;
+  private final Supplier<Option<Schema>> sourceSchemaSupplier;
 
   public ChainedTransformer(List<Transformer> transformersList) {
     this.transformers = new ArrayList<>(transformersList.size());
     for (Transformer transformer : transformersList) {
       this.transformers.add(new TransformerInfo(transformer));
     }
-    this.sourceSchemaOpt = Option.empty();
+    this.sourceSchemaSupplier = Option::empty;
   }
 
   /**
    * Creates a chained transformer using the input transformer class names. Refer {@link HoodieStreamer.Config#transformerClassNames}
    * for more information on how the transformers can be configured.
    *
-   * @param sourceSchemaOpt                   Schema from the dataset the transform is applied to
+   * @param sourceSchemaSupplier              Supplies the schema (if schema provider is present) for the dataset the transform is applied to
    * @param configuredTransformers            List of configured transformer class names.
    */
-  public ChainedTransformer(List<String> configuredTransformers, Option<Schema> sourceSchemaOpt) {
+  public ChainedTransformer(List<String> configuredTransformers, Supplier<Option<Schema>> sourceSchemaSupplier) {
     this.transformers = new ArrayList<>(configuredTransformers.size());
-    this.sourceSchemaOpt = sourceSchemaOpt;
+    this.sourceSchemaSupplier = sourceSchemaSupplier;
 
     Set<String> identifiers = new HashSet<>();
     for (String configuredTransformer : configuredTransformers) {
@@ -120,6 +121,7 @@ public class ChainedTransformer implements Transformer {
 
   private StructType getExpectedTransformedSchema(TransformerInfo transformerInfo, JavaSparkContext jsc, SparkSession sparkSession,
                                                   Option<StructType> incomingStructOpt, Option<Dataset<Row>> rowDatasetOpt, TypedProperties properties) {
+    Option<Schema> sourceSchemaOpt = sourceSchemaSupplier.get();
     if (!sourceSchemaOpt.isPresent() && !rowDatasetOpt.isPresent()) {
       throw new HoodieTransformPlanException("Either source schema or source dataset should be available to fetch the schema");
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * A {@link Transformer} to chain other {@link Transformer}s and apply sequentially.
@@ -38,8 +39,8 @@ import java.util.List;
  * if that column is not dropped in any of the transformations.
  */
 public class ErrorTableAwareChainedTransformer extends ChainedTransformer {
-  public ErrorTableAwareChainedTransformer(List<String> configuredTransformers, Option<Schema> sourceSchemaOpt) {
-    super(configuredTransformers, sourceSchemaOpt);
+  public ErrorTableAwareChainedTransformer(List<String> configuredTransformers, Supplier<Option<Schema>> sourceSchemaSupplier) {
+    super(configuredTransformers, sourceSchemaSupplier);
   }
 
   public ErrorTableAwareChainedTransformer(List<Transformer> transformers) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
@@ -88,7 +88,7 @@ public class TestChainedTransformer extends SparkClientFunctionalTestHarness {
   })
   public void testChainedTransformerValidationFails(String transformerName) {
     try {
-      ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty());
+      ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option::empty);
       fail();
     } catch (Exception e) {
       assertTrue(e instanceof HoodieTransformPlanException, e.getMessage());
@@ -103,14 +103,14 @@ public class TestChainedTransformer extends SparkClientFunctionalTestHarness {
       "org.apache.hudi.utilities.transform.FlatteningTransformer,org.apache.hudi.utilities.transform.FlatteningTransformer"
   })
   public void testChainedTransformerValidationPasses(String transformerName) {
-    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty());
+    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option::empty);
     assertNotNull(transformer);
   }
 
   @Test
   public void testChainedTransformerTransformedSchema() {
     String transformerName = "org.apache.hudi.utilities.transform.FlatteningTransformer";
-    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.of(NESTED_AVRO_SCHEMA));
+    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), () -> Option.of(NESTED_AVRO_SCHEMA));
     StructType transformedSchema = transformer.transformedSchema(jsc(), spark(), null, new TypedProperties());
     // Verify transformed nested fields are present in the transformed schema
     assertTrue(Arrays.asList(transformedSchema.fieldNames()).contains("fare_amount"));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
@@ -26,6 +26,7 @@ import org.apache.hudi.utilities.exception.HoodieTransformPlanException;
 import org.apache.hudi.utilities.transform.ChainedTransformer;
 import org.apache.hudi.utilities.transform.Transformer;
 
+import org.apache.avro.Schema;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -39,13 +40,17 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.NESTED_AVRO_SCHEMA;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 import static org.apache.spark.sql.types.DataTypes.createStructField;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -116,5 +121,23 @@ public class TestChainedTransformer extends SparkClientFunctionalTestHarness {
     assertTrue(Arrays.asList(transformedSchema.fieldNames()).contains("fare_amount"));
     assertTrue(Arrays.asList(transformedSchema.fieldNames()).contains("fare_currency"));
     assertNotNull(transformer);
+  }
+
+  @Test
+  public void assertSchemaSupplierIsCalledPerInvocationOfTransformedSchema() {
+    String transformerName = "org.apache.hudi.utilities.transform.FlatteningTransformer";
+    AtomicInteger count = new AtomicInteger(0);
+    Supplier<Option<Schema>> schemaSupplier = () -> {
+      if (count.getAndIncrement() == 0) {
+        return Option.of(AVRO_SCHEMA);
+      } else {
+        return Option.of(NESTED_AVRO_SCHEMA);
+      }
+    };
+    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), schemaSupplier);
+    StructType transformedSchema1 = transformer.transformedSchema(jsc(), spark(), null, new TypedProperties());
+    StructType transformedSchema2 = transformer.transformedSchema(jsc(), spark(), null, new TypedProperties());
+    assertNotEquals(transformedSchema1, transformedSchema2);
+    assertEquals(2, count.get());
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
@@ -129,7 +129,7 @@ public class TestErrorTableAwareChainedTransformer extends SparkClientFunctional
   })
   public void testErrorTableAwareChainedTransformerValidationFails(String transformerName) {
     assertThrows(HoodieTransformException.class,
-        () -> new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty()));
+        () -> new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")), Option::empty));
   }
 
   @ParameterizedTest
@@ -141,7 +141,7 @@ public class TestErrorTableAwareChainedTransformer extends SparkClientFunctional
   })
   public void testErrorTableAwareChainedTransformerValidationPasses(String transformerName) {
     ErrorTableAwareChainedTransformer transformer = new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")),
-        Option.empty());
+        Option::empty);
     assertNotNull(transformer);
   }
 }


### PR DESCRIPTION
### Change Logs

Updates the `Transformer` classes to take in a `Supplier<Option<Schema>>` instead of `Option<Schema>` so that the latest value can be used when the `transformedSchema` method is called.

### Impact

- Provides more accurate schema
- Lazy evaluation of the schema also avoids an extra call to schema registries and potential exceptions that come with that

### Risk level (write none, low medium or high below)

None, this code is not actively used

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
