### PR TITLE
[MINOR] Fix UT error in HUDI-6941 with stage task numbers

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2082,9 +2082,9 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     })
   }
 
-  class StageParallelismListener(var checkMessage: String) extends SparkListener {
+  class StageParallelismListener(var stageName: String) extends SparkListener {
     override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
-      if (stageSubmitted.stageInfo.name.contains(checkMessage)) {
+      if (stageSubmitted.stageInfo.name.contains(stageName)) {
         assertResult(1)(stageSubmitted.stageInfo.numTasks)
       }
     }
@@ -2124,7 +2124,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            |union
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
-      spark.sparkContext.addSparkListener(new StageParallelismListener(checkMessage = "collect at HoodieSparkEngineContext.java"))
+      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = "collect at HoodieSparkEngineContext.java"))
       val df = spark.sql(
         s"""
            |select * from ${targetTable} where day='2023-10-12' and hour=11
@@ -2171,7 +2171,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            |union
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
-      spark.sparkContext.addSparkListener(new StageParallelismListener(checkMessage = "collect at HoodieSparkEngineContext.java"))
+      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = "collect at HoodieSparkEngineContext.java"))
       val df = spark.sql(
         s"""
            |select * from ${targetTable} where day='2023-10-12' and hour=11

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2083,7 +2083,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   }
 
   class StageParallelismListener(var stageName: String) extends SparkListener {
-    
     override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
       if (stageSubmitted.stageInfo.name.contains(stageName)) {
         assertResult(1)(stageSubmitted.stageInfo.numTasks)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2083,6 +2083,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   }
 
   class StageParallelismListener(var stageName: String) extends SparkListener {
+    
     override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
       if (stageSubmitted.stageInfo.name.contains(stageName)) {
         assertResult(1)(stageSubmitted.stageInfo.numTasks)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.table.timeline.HoodieInstant
@@ -2125,7 +2126,8 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            |union
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
-      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = "collect at HoodieSparkEngineContext.java"))
+      val stageClassName = classOf[HoodieSparkEngineContext].getSimpleName
+      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = stageClassName))
       val df = spark.sql(
         s"""
            |select * from ${targetTable} where day='2023-10-12' and hour=11
@@ -2172,7 +2174,8 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            |union
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
-      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = "collect at HoodieSparkEngineContext.java"))
+      val stageClassName = classOf[HoodieSparkEngineContext].getSimpleName
+      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = stageClassName))
       val df = spark.sql(
         s"""
            |select * from ${targetTable} where day='2023-10-12' and hour=11

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2082,6 +2082,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     })
   }
 
+  // add a listener for stages for parallelism checking with stage name
   class StageParallelismListener(var stageName: String) extends SparkListener {
     override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
       if (stageSubmitted.stageInfo.name.contains(stageName)) {


### PR DESCRIPTION
### Change Logs

https://issues.apache.org/jira/browse/HUDI-6941 Aim to judge number of task in query job，but is not accurate to get number of tasks，need add a SparkListener to check task numbers exactly
error is:
![2ee1959c600bd400e3f3074362516281f9ec1bab9ee7897e29f152cc6cc0d7dd.0.JPG](https://github.com/apache/hudi/assets/10645422/c79fd1ec-33e6-4636-9756-a0218a7735f8)

expect is:
![76df1ca7299ea735a0d7baade91eea2935c931130cfd1b376c6ee8ed6fce17e6.0.JPG](https://github.com/apache/hudi/assets/10645422/7c5395fb-625b-4cb9-b494-db10556dfe1b)

test is:
![1706001331642.png](https://github.com/apache/hudi/assets/10645422/4266185a-69d1-421f-bf5c-7cfd68f67c76)



### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
