### PR TITLE
updated button size so join now is on one line

### DIFF
--- a/website/src/components/EventFeature/styles.module.css
+++ b/website/src/components/EventFeature/styles.module.css
@@ -28,5 +28,5 @@
   font-weight: bold; 
   display: inline-block; 
   text-align: center;
-  min-width: 230px
+  min-width: 280px
 }


### PR DESCRIPTION
For some reason, the button on the localhost and on prod are 2 different things- I updated the width to see if it changes join now on 1 line 

Below is the image of what is looks like in the hudi site and what I see on local host: 

<img width="1728" alt="Screenshot 2024-01-23 at 9 48 12 PM" src="https://github.com/apache/hudi/assets/5392555/ba9d21bd-aa9e-4a88-9ee9-9ff7d0549a38">

<img width="1728" alt="Screenshot 2024-01-23 at 9 48 00 PM" src="https://github.com/apache/hudi/assets/5392555/45f4a492-57f7-45c2-b627-117c5a2201fa">

@xushiyan @bhasudha 
