### PR TITLE
[HUDI-7342] Use BaseFileUtils to hide format-specific logic in HoodiePartitionMetadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/BaseFileUtils.java
@@ -33,11 +33,14 @@ import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -218,4 +221,16 @@ public abstract class BaseFileUtils {
    * @return The subclass's {@link HoodieFileFormat}.
    */
   public abstract HoodieFileFormat getFormat();
+
+  /**
+   * Writes properties to the meta file.
+   *
+   * @param fs       {@link FileSystem} instance.
+   * @param filePath file path to write to.
+   * @param props    properties to write.
+   * @throws IOException upon write error.
+   */
+  public abstract void writeMetaFile(FileSystem fs,
+                                     Path filePath,
+                                     Properties props) throws IOException;
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -33,6 +33,7 @@ import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -42,6 +43,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.Reader.Options;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -51,10 +53,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.BinaryUtil.toBytes;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Utility functions for ORC files.
@@ -270,6 +274,20 @@ public class OrcUtils extends BaseFileUtils {
       return reader.getNumberOfRows();
     } catch (IOException io) {
       throw new HoodieIOException("Unable to get row count for ORC file:" + orcFilePath, io);
+    }
+  }
+
+  @Override
+  public void writeMetaFile(FileSystem fs, Path filePath, Properties props) throws IOException {
+    // Since we are only interested in saving metadata to the footer, the schema, blocksizes and other
+    // parameters are not important.
+    Schema schema = HoodieAvroUtils.getRecordKeySchema();
+    OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(fs.getConf()).fileSystem(fs)
+        .setSchema(AvroOrcUtils.createOrcSchema(schema));
+    try (Writer writer = OrcFile.createWriter(filePath, writerOptions)) {
+      for (String key : props.stringPropertyNames()) {
+        writer.addUserMetadata(key, ByteBuffer.wrap(getUTF8Bytes(props.getProperty(key))));
+      }
     }
   }
 }


### PR DESCRIPTION
### Change Logs

This PR refactors the logic of writing partition metadata by using BaseFileUtils to hide format-specific logic in HoodiePartitionMetadata.

This is part of the effort to provide Hudi storage abstraction and decouple `hudi-common` from hadoop dependencies. For reference, the single big-change PR can be found here: #10360.

### Impact

No behavior change.  The refactoring changes are covered by existing tests in `TestHoodiePartitionMetadata`.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
