### PR TITLE
[HUDI-7345] Remove usage of org.apache.hadoop.util.VersionUtil

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -65,7 +65,6 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.avro.util.Utf8;
-import org.apache.hadoop.util.VersionUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1310,11 +1309,11 @@ public class HoodieAvroUtils {
   }
 
   public static boolean gteqAvro1_9() {
-    return VersionUtil.compareVersions(AVRO_VERSION, "1.9") >= 0;
+    return StringUtils.compareVersions(AVRO_VERSION, "1.9") >= 0;
   }
 
   public static boolean gteqAvro1_10() {
-    return VersionUtil.compareVersions(AVRO_VERSION, "1.10") >= 0;
+    return StringUtils.compareVersions(AVRO_VERSION, "1.10") >= 0;
   }
 
   /**

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ComparableVersion.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ComparableVersion.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Stack;
+
+/**
+ * Generic implementation of version comparison.
+ *
+ * <p>Features:
+ * <ul>
+ * <li>mixing of '<code>-</code>' (dash) and '<code>.</code>' (dot) separators,</li>
+ * <li>transition between characters and digits also constitutes a separator:
+ *     <code>1.0alpha1 =&gt; [1, 0, alpha, 1]</code></li>
+ * <li>unlimited number of version components,</li>
+ * <li>version components in the text can be digits or strings,</li>
+ * <li>strings are checked for well-known qualifiers and the qualifier ordering is used for version ordering.
+ *     Well-known qualifiers (case insensitive) are:<ul>
+ *     <li><code>alpha</code> or <code>a</code></li>
+ *     <li><code>beta</code> or <code>b</code></li>
+ *     <li><code>milestone</code> or <code>m</code></li>
+ *     <li><code>rc</code> or <code>cr</code></li>
+ *     <li><code>snapshot</code></li>
+ *     <li><code>(the empty string)</code> or <code>ga</code> or <code>final</code></li>
+ *     <li><code>sp</code></li>
+ *     </ul>
+ *     Unknown qualifiers are considered after known qualifiers, with lexical order (always case insensitive),
+ *   </li>
+ * <li>a dash usually precedes a qualifier, and is always less important than something preceded with a dot.</li>
+ * </ul></p>
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
+ * This class is copied from {@code org.apache.hadoop.util.ComparableVersion} to avoid Hadoop dependency.
+ */
+public class ComparableVersion
+    implements Comparable<ComparableVersion> {
+  private String value;
+
+  private String canonical;
+
+  private ComparableVersion.ListItem items;
+
+  private interface Item {
+    int INTEGER_ITEM = 0;
+    int STRING_ITEM = 1;
+    int LIST_ITEM = 2;
+
+    int compareTo(ComparableVersion.Item item);
+
+    int getType();
+
+    boolean isNull();
+  }
+
+  /**
+   * Represents a numeric item in the version item list.
+   */
+  private static class IntegerItem
+      implements ComparableVersion.Item {
+    private static final BigInteger BIG_INTEGER_ZERO = new BigInteger("0");
+
+    private final BigInteger value;
+
+    public static final ComparableVersion.IntegerItem ZERO = new ComparableVersion.IntegerItem();
+
+    private IntegerItem() {
+      this.value = BIG_INTEGER_ZERO;
+    }
+
+    public IntegerItem(String str) {
+      this.value = new BigInteger(str);
+    }
+
+    public int getType() {
+      return INTEGER_ITEM;
+    }
+
+    public boolean isNull() {
+      return BIG_INTEGER_ZERO.equals(value);
+    }
+
+    public int compareTo(ComparableVersion.Item item) {
+      if (item == null) {
+        return BIG_INTEGER_ZERO.equals(value) ? 0 : 1; // 1.0 == 1, 1.1 > 1
+      }
+
+      switch (item.getType()) {
+        case INTEGER_ITEM:
+          return value.compareTo(((ComparableVersion.IntegerItem) item).value);
+
+        case STRING_ITEM:
+          return 1; // 1.1 > 1-sp
+
+        case LIST_ITEM:
+          return 1; // 1.1 > 1-1
+
+        default:
+          throw new RuntimeException("invalid item: " + item.getClass());
+      }
+    }
+
+    public String toString() {
+      return value.toString();
+    }
+  }
+
+  /**
+   * Represents a string in the version item list, usually a qualifier.
+   */
+  private static class StringItem
+      implements ComparableVersion.Item {
+    private static final String[] QUALIFIERS = {"alpha", "beta", "milestone", "rc", "snapshot", "", "sp"};
+
+    private static final List<String> QUALIFIER_LIST = Arrays.asList(QUALIFIERS);
+
+    private static final Properties ALIASES = new Properties();
+
+    static {
+      ALIASES.put("ga", "");
+      ALIASES.put("final", "");
+      ALIASES.put("cr", "rc");
+    }
+
+    /**
+     * A comparable value for the empty-string qualifier. This one is used to determine if a given qualifier makes
+     * the version older than one without a qualifier, or more recent.
+     */
+    private static final String RELEASE_VERSION_INDEX = String.valueOf(QUALIFIER_LIST.indexOf(""));
+
+    private String value;
+
+    public StringItem(String value, boolean followedByDigit) {
+      if (followedByDigit && value.length() == 1) {
+        // a1 = alpha-1, b1 = beta-1, m1 = milestone-1
+        switch (value.charAt(0)) {
+          case 'a':
+            value = "alpha";
+            break;
+          case 'b':
+            value = "beta";
+            break;
+          case 'm':
+            value = "milestone";
+            break;
+          default:
+            break;
+        }
+      }
+      this.value = ALIASES.getProperty(value, value);
+    }
+
+    public int getType() {
+      return STRING_ITEM;
+    }
+
+    public boolean isNull() {
+      return (comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0);
+    }
+
+    /**
+     * Returns a comparable value for a qualifier.
+     * <p>
+     * This method takes into account the ordering of known qualifiers then unknown qualifiers with lexical ordering.
+     * <p>
+     * just returning an Integer with the index here is faster, but requires a lot of if/then/else to check for -1
+     * or QUALIFIERS.size and then resort to lexical ordering. Most comparisons are decided by the first character,
+     * so this is still fast. If more characters are needed then it requires a lexical sort anyway.
+     *
+     * @param qualifier
+     * @return an equivalent value that can be used with lexical comparison
+     */
+    public static String comparableQualifier(String qualifier) {
+      int i = QUALIFIER_LIST.indexOf(qualifier);
+
+      return i == -1 ? (QUALIFIER_LIST.size() + "-" + qualifier) : String.valueOf(i);
+    }
+
+    public int compareTo(ComparableVersion.Item item) {
+      if (item == null) {
+        // 1-rc < 1, 1-ga > 1
+        return comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX);
+      }
+      switch (item.getType()) {
+        case INTEGER_ITEM:
+          return -1; // 1.any < 1.1 ?
+
+        case STRING_ITEM:
+          return comparableQualifier(value).compareTo(comparableQualifier(((ComparableVersion.StringItem) item).value));
+
+        case LIST_ITEM:
+          return -1; // 1.any < 1-1
+
+        default:
+          throw new RuntimeException("invalid item: " + item.getClass());
+      }
+    }
+
+    public String toString() {
+      return value;
+    }
+  }
+
+  /**
+   * Represents a version list item. This class is used both for the global item list and for sub-lists (which start
+   * with '-(number)' in the version specification).
+   */
+  private static class ListItem
+      extends ArrayList<ComparableVersion.Item>
+      implements ComparableVersion.Item {
+    public int getType() {
+      return LIST_ITEM;
+    }
+
+    public boolean isNull() {
+      return (size() == 0);
+    }
+
+    void normalize() {
+      for (ListIterator<ComparableVersion.Item> iterator = listIterator(size()); iterator.hasPrevious(); ) {
+        ComparableVersion.Item item = iterator.previous();
+        if (item.isNull()) {
+          iterator.remove(); // remove null trailing items: 0, "", empty list
+        } else {
+          break;
+        }
+      }
+    }
+
+    public int compareTo(ComparableVersion.Item item) {
+      if (item == null) {
+        if (size() == 0) {
+          return 0; // 1-0 = 1- (normalize) = 1
+        }
+        ComparableVersion.Item first = get(0);
+        return first.compareTo(null);
+      }
+      switch (item.getType()) {
+        case INTEGER_ITEM:
+          return -1; // 1-1 < 1.0.x
+
+        case STRING_ITEM:
+          return 1; // 1-1 > 1-sp
+
+        case LIST_ITEM:
+          Iterator<ComparableVersion.Item> left = iterator();
+          Iterator<ComparableVersion.Item> right = ((ComparableVersion.ListItem) item).iterator();
+
+          while (left.hasNext() || right.hasNext()) {
+            ComparableVersion.Item l = left.hasNext() ? left.next() : null;
+            ComparableVersion.Item r = right.hasNext() ? right.next() : null;
+
+            // if this is shorter, then invert the compare and mul with -1
+            int result = l == null ? -1 * r.compareTo(l) : l.compareTo(r);
+
+            if (result != 0) {
+              return result;
+            }
+          }
+
+          return 0;
+
+        default:
+          throw new RuntimeException("invalid item: " + item.getClass());
+      }
+    }
+
+    public String toString() {
+      StringBuilder buffer = new StringBuilder("(");
+      for (Iterator<ComparableVersion.Item> iter = iterator(); iter.hasNext(); ) {
+        buffer.append(iter.next());
+        if (iter.hasNext()) {
+          buffer.append(',');
+        }
+      }
+      buffer.append(')');
+      return buffer.toString();
+    }
+  }
+
+  public ComparableVersion(String version) {
+    parseVersion(version);
+  }
+
+  public final void parseVersion(String version) {
+    this.value = version;
+
+    items = new ComparableVersion.ListItem();
+
+    version = version.toLowerCase(Locale.ENGLISH);
+
+    ComparableVersion.ListItem list = items;
+
+    Stack<ComparableVersion.Item> stack = new Stack<ComparableVersion.Item>();
+    stack.push(list);
+
+    boolean isDigit = false;
+
+    int startIndex = 0;
+
+    for (int i = 0; i < version.length(); i++) {
+      char c = version.charAt(i);
+
+      if (c == '.') {
+        if (i == startIndex) {
+          list.add(ComparableVersion.IntegerItem.ZERO);
+        } else {
+          list.add(parseItem(isDigit, version.substring(startIndex, i)));
+        }
+        startIndex = i + 1;
+      } else if (c == '-') {
+        if (i == startIndex) {
+          list.add(ComparableVersion.IntegerItem.ZERO);
+        } else {
+          list.add(parseItem(isDigit, version.substring(startIndex, i)));
+        }
+        startIndex = i + 1;
+
+        if (isDigit) {
+          list.normalize(); // 1.0-* = 1-*
+
+          if ((i + 1 < version.length()) && Character.isDigit(version.charAt(i + 1))) {
+            // new ListItem only if previous were digits and new char is a digit,
+            // ie need to differentiate only 1.1 from 1-1
+            list.add(list = new ComparableVersion.ListItem());
+
+            stack.push(list);
+          }
+        }
+      } else if (Character.isDigit(c)) {
+        if (!isDigit && i > startIndex) {
+          list.add(new ComparableVersion.StringItem(version.substring(startIndex, i), true));
+          startIndex = i;
+        }
+
+        isDigit = true;
+      } else {
+        if (isDigit && i > startIndex) {
+          list.add(parseItem(true, version.substring(startIndex, i)));
+          startIndex = i;
+        }
+
+        isDigit = false;
+      }
+    }
+
+    if (version.length() > startIndex) {
+      list.add(parseItem(isDigit, version.substring(startIndex)));
+    }
+
+    while (!stack.isEmpty()) {
+      list = (ComparableVersion.ListItem) stack.pop();
+      list.normalize();
+    }
+
+    canonical = items.toString();
+  }
+
+  private static ComparableVersion.Item parseItem(boolean isDigit, String buf) {
+    return isDigit ? new ComparableVersion.IntegerItem(buf) : new ComparableVersion.StringItem(buf, false);
+  }
+
+  public int compareTo(ComparableVersion o) {
+    return items.compareTo(o.items);
+  }
+
+  public String toString() {
+    return value;
+  }
+
+  public boolean equals(Object o) {
+    return (o instanceof ComparableVersion) && canonical.equals(((ComparableVersion) o).canonical);
+  }
+
+  public int hashCode() {
+    return canonical.hashCode();
+  }
+}

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -33,8 +33,10 @@ import java.util.stream.Stream;
  */
 public class StringUtils {
 
-  public static final char[] HEX_CHAR = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  public static final char[] HEX_CHAR = new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
   public static final String EMPTY_STRING = "";
+  // Represents a failed index search
+  public static final int INDEX_NOT_FOUND = -1;
 
   /**
    * <p>
@@ -66,7 +68,7 @@ public class StringUtils {
     if (array == null) {
       return null;
     }
-    return org.apache.hadoop.util.StringUtils.join(separator, array);
+    return String.join(separator, array);
   }
 
   /**
@@ -85,7 +87,7 @@ public class StringUtils {
     if (list == null || list.size() == 0) {
       return null;
     }
-    return org.apache.hadoop.util.StringUtils.join(separator, list.toArray(new String[0]));
+    return String.join(separator, list.toArray(new String[0]));
   }
 
   public static String toHexString(byte[] bytes) {
@@ -193,5 +195,105 @@ public class StringUtils {
     String tail = str.substring(str.length() - tailLength);
 
     return head + "..." + tail;
+  }
+
+  /**
+   * Compares two version name strings using maven's ComparableVersion class.
+   *
+   * @param version1 the first version to compare
+   * @param version2 the second version to compare
+   * @return a negative integer if version1 precedes version2, a positive
+   * integer if version2 precedes version1, and 0 if and only if the two
+   * versions are equal.
+   */
+  public static int compareVersions(String version1, String version2) {
+    ComparableVersion v1 = new ComparableVersion(version1);
+    ComparableVersion v2 = new ComparableVersion(version2);
+    return v1.compareTo(v2);
+  }
+
+  /**
+   * Replaces all occurrences of a String within another String.
+   *
+   * <p>A <code>null</code> reference passed to this method is a no-op.</p>
+   *
+   * <pre>
+   * StringUtils.replace(null, *, *)        = null
+   * StringUtils.replace("", *, *)          = ""
+   * StringUtils.replace("any", null, *)    = "any"
+   * StringUtils.replace("any", *, null)    = "any"
+   * StringUtils.replace("any", "", *)      = "any"
+   * StringUtils.replace("aba", "a", null)  = "aba"
+   * StringUtils.replace("aba", "a", "")    = "b"
+   * StringUtils.replace("aba", "a", "z")   = "zbz"
+   * </pre>
+   * <p>
+   * This method is copied from hadoop StringUtils.
+   *
+   * @param text         text to search and replace in, may be null
+   * @param searchString the String to search for, may be null
+   * @param replacement  the String to replace it with, may be null
+   * @return the text with any replacements processed,
+   * <code>null</code> if null String input
+   * @see #replace(String text, String searchString, String replacement, int max)
+   */
+  public static String replace(String text, String searchString, String replacement) {
+    return replace(text, searchString, replacement, -1);
+  }
+
+  /**
+   * Replaces a String with another String inside a larger String,
+   * for the first <code>max</code> values of the search String.
+   *
+   * <p>A <code>null</code> reference passed to this method is a no-op.</p>
+   *
+   * <pre>
+   * StringUtils.replace(null, *, *, *)         = null
+   * StringUtils.replace("", *, *, *)           = ""
+   * StringUtils.replace("any", null, *, *)     = "any"
+   * StringUtils.replace("any", *, null, *)     = "any"
+   * StringUtils.replace("any", "", *, *)       = "any"
+   * StringUtils.replace("any", *, *, 0)        = "any"
+   * StringUtils.replace("abaa", "a", null, -1) = "abaa"
+   * StringUtils.replace("abaa", "a", "", -1)   = "b"
+   * StringUtils.replace("abaa", "a", "z", 0)   = "abaa"
+   * StringUtils.replace("abaa", "a", "z", 1)   = "zbaa"
+   * StringUtils.replace("abaa", "a", "z", 2)   = "zbza"
+   * StringUtils.replace("abaa", "a", "z", -1)  = "zbzz"
+   * </pre>
+   * <p>
+   * This method is copied from hadoop StringUtils.
+   *
+   * @param text         text to search and replace in, may be null
+   * @param searchString the String to search for, may be null
+   * @param replacement  the String to replace it with, may be null
+   * @param max          maximum number of values to replace, or <code>-1</code> if no maximum
+   * @return the text with any replacements processed,
+   * <code>null</code> if null String input
+   */
+  public static String replace(String text, String searchString, String replacement, int max) {
+    if (isNullOrEmpty(text) || isNullOrEmpty(searchString) || replacement == null || max == 0) {
+      return text;
+    }
+    int start = 0;
+    int end = text.indexOf(searchString, start);
+    if (end == INDEX_NOT_FOUND) {
+      return text;
+    }
+    int replLength = searchString.length();
+    int increase = replacement.length() - replLength;
+    increase = (increase < 0 ? 0 : increase);
+    increase *= (max < 0 ? 16 : (max > 64 ? 64 : max));
+    StringBuilder buf = new StringBuilder(text.length() + increase);
+    while (end != INDEX_NOT_FOUND) {
+      buf.append(text.substring(start, end)).append(replacement);
+      start = end + replLength;
+      if (--max == 0) {
+        break;
+      }
+      end = text.indexOf(searchString, start);
+    }
+    buf.append(text.substring(start));
+    return buf.toString();
   }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link StringUtils}.
+ */
+public class TestStringUtils {
+
+  private static final String[] STRINGS = {"This", "is", "a", "test"};
+
+  @Test
+  public void testStringJoinWithDelim() {
+    String joinedString = StringUtils.joinUsingDelim("-", STRINGS);
+    assertEquals(STRINGS.length, joinedString.split("-").length);
+  }
+
+  @Test
+  public void testStringJoin() {
+    assertNotEquals(null, StringUtils.join(""));
+    assertNotEquals(null, StringUtils.join(STRINGS));
+  }
+
+  @Test
+  public void testStringJoinWithJavaImpl() {
+    assertNull(StringUtils.join(",", null));
+    assertEquals("", String.join(",", Collections.singletonList("")));
+    assertEquals(",", String.join(",", Arrays.asList("", "")));
+    assertEquals("a,", String.join(",", Arrays.asList("a", "")));
+  }
+
+  @Test
+  public void testStringNullToEmpty() {
+    String str = "This is a test";
+    assertEquals(str, StringUtils.nullToEmpty(str));
+    assertEquals("", StringUtils.nullToEmpty(null));
+  }
+
+  @Test
+  public void testStringObjToString() {
+    assertNull(StringUtils.objToString(null));
+    assertEquals("Test String", StringUtils.objToString("Test String"));
+
+    // assert byte buffer
+    ByteBuffer byteBuffer1 = ByteBuffer.wrap(getUTF8Bytes("1234"));
+    ByteBuffer byteBuffer2 = ByteBuffer.wrap(getUTF8Bytes("5678"));
+    // assert equal because ByteBuffer has overwritten the toString to return a summary string
+    assertEquals(byteBuffer1.toString(), byteBuffer2.toString());
+    // assert not equal
+    assertNotEquals(StringUtils.objToString(byteBuffer1), StringUtils.objToString(byteBuffer2));
+  }
+
+  @Test
+  public void testStringEmptyToNull() {
+    assertNull(StringUtils.emptyToNull(""));
+    assertEquals("Test String", StringUtils.emptyToNull("Test String"));
+  }
+
+  @Test
+  public void testStringNullOrEmpty() {
+    assertTrue(StringUtils.isNullOrEmpty(null));
+    assertTrue(StringUtils.isNullOrEmpty(""));
+    assertNotEquals(null, StringUtils.isNullOrEmpty("this is not empty"));
+    assertTrue(StringUtils.isNullOrEmpty(""));
+  }
+
+  @Test
+  public void testSplit() {
+    assertEquals(new ArrayList<>(), StringUtils.split(null, ","));
+    assertEquals(new ArrayList<>(), StringUtils.split("", ","));
+    assertEquals(Arrays.asList("a", "b", "c"), StringUtils.split("a,b, c", ","));
+    assertEquals(Arrays.asList("a", "b", "c"), StringUtils.split("a,b,, c ", ","));
+  }
+
+  @Test
+  public void testHexString() {
+    String str = "abcd";
+    assertEquals(StringUtils.toHexString(getUTF8Bytes(str)), toHexString(getUTF8Bytes(str)));
+  }
+
+  private static String toHexString(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  @Test
+  public void testTruncate() {
+    assertNull(StringUtils.truncate(null, 10, 10));
+    assertEquals("http://use...ons/latest", StringUtils.truncate("http://username:password@myregistry.com:5000/versions/latest", 10, 10));
+    assertEquals("http://abc.com", StringUtils.truncate("http://abc.com", 10, 10));
+  }
+
+  @Test
+  public void testCompareVersions() {
+    assertTrue(StringUtils.compareVersions("1.10", "1.9") > 0);
+    assertTrue(StringUtils.compareVersions("1.9", "1.10") < 0);
+    assertTrue(StringUtils.compareVersions("1.100.1", "1.10") > 0);
+    assertTrue(StringUtils.compareVersions("1.10.1", "1.10") > 0);
+    assertTrue(StringUtils.compareVersions("1.10", "1.10") == 0);
+  }
+}


### PR DESCRIPTION
### Change Logs

As above.  `ComparableVersion` class is copied from`org.apache.hadoop.util.ComparableVersion` to avoid Hadoop dependency.

This is part of the effort to provide Hudi storage abstraction and decouple `hudi-common` from hadoop dependencies. For reference, the single big-change PR can be found here: #10360.

### Impact

No behavior change.  This PR reduces the dependency on `org.apache.hadoop` classes.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
