### PR TITLE
[HUDI-7351] Hive-sync partition pushdown does not work with glue

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -579,6 +579,14 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   }
 
   @Override
+  public List<FieldSchema> getMetastoreFieldSchemas(String tableName) {
+    Map<String, String> schema = getMetastoreSchema(tableName);
+    return schema.entrySet().stream()
+          .map(f -> new FieldSchema(f.getKey(), f.getValue()))
+          .collect(Collectors.toList());
+  }
+
+  @Override
   public boolean tableExists(String tableName) {
     GetTableRequest request = GetTableRequest.builder()
         .databaseName(databaseName)


### PR DESCRIPTION
### Change Logs

Turns out the pushdown feature `hoodie.datasource.hive_sync.filter_pushdown_enabled` can't work on glue due to missing implementation to retrieve schema.

This provide an implementation and makes glue sync benefit from this feature.

This fixes #10569

### Impact

No impact

### Risk level (write none, low medium or high below)

No risk

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
