### PR TITLE
[HUDI-7346] Remove usage of org.apache.hadoop.hbase.util.Bytes

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -46,7 +46,6 @@ import org.springframework.shell.Shell;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -285,6 +285,6 @@ public class TestTableCommand extends CLIFunctionalTestHarness {
     byte[] data = new byte[(int) fileToRead.length()];
     fis.read(data);
     fis.close();
-    return new String(data, StandardCharsets.UTF_8);
+    return fromUTF8Bytes(data);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.Partitioner;
 import org.apache.spark.SparkConf;
@@ -96,6 +95,8 @@ import static org.apache.hadoop.hbase.security.SecurityConstants.MASTER_KRB_PRIN
 import static org.apache.hadoop.hbase.security.SecurityConstants.REGIONSERVER_KRB_PRINCIPAL;
 import static org.apache.hadoop.hbase.security.User.HBASE_SECURITY_AUTHORIZATION_CONF_KEY;
 import static org.apache.hadoop.hbase.security.User.HBASE_SECURITY_CONF_KEY;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Hoodie Index implementation backed by HBase.
@@ -107,10 +108,10 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
   public static final String DEFAULT_SPARK_DYNAMIC_ALLOCATION_MAX_EXECUTORS_CONFIG_NAME =
       "spark.dynamicAllocation.maxExecutors";
 
-  private static final byte[] SYSTEM_COLUMN_FAMILY = Bytes.toBytes("_s");
-  private static final byte[] COMMIT_TS_COLUMN = Bytes.toBytes("commit_ts");
-  private static final byte[] FILE_NAME_COLUMN = Bytes.toBytes("file_name");
-  private static final byte[] PARTITION_PATH_COLUMN = Bytes.toBytes("partition_path");
+  private static final byte[] SYSTEM_COLUMN_FAMILY = getUTF8Bytes("_s");
+  private static final byte[] COMMIT_TS_COLUMN = getUTF8Bytes("commit_ts");
+  private static final byte[] FILE_NAME_COLUMN = getUTF8Bytes("file_name");
+  private static final byte[] PARTITION_PATH_COLUMN = getUTF8Bytes("partition_path");
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkHoodieHBaseIndex.class);
   private static Connection hbaseConnection = null;
@@ -217,7 +218,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
   }
 
   private Get generateStatement(String key) throws IOException {
-    return new Get(Bytes.toBytes(getHBaseKey(key))).readVersions(1).addColumn(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN)
+    return new Get(getUTF8Bytes(getHBaseKey(key))).readVersions(1).addColumn(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN)
         .addColumn(SYSTEM_COLUMN_FAMILY, FILE_NAME_COLUMN).addColumn(SYSTEM_COLUMN_FAMILY, PARTITION_PATH_COLUMN);
   }
 
@@ -272,10 +273,10 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
               taggedRecords.add(currentRecord);
               continue;
             }
-            String keyFromResult = Bytes.toString(result.getRow());
-            String commitTs = Bytes.toString(result.getValue(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN));
-            String fileId = Bytes.toString(result.getValue(SYSTEM_COLUMN_FAMILY, FILE_NAME_COLUMN));
-            String partitionPath = Bytes.toString(result.getValue(SYSTEM_COLUMN_FAMILY, PARTITION_PATH_COLUMN));
+            String keyFromResult = fromUTF8Bytes(result.getRow());
+            String commitTs = fromUTF8Bytes(result.getValue(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN));
+            String fileId = fromUTF8Bytes(result.getValue(SYSTEM_COLUMN_FAMILY, FILE_NAME_COLUMN));
+            String partitionPath = fromUTF8Bytes(result.getValue(SYSTEM_COLUMN_FAMILY, PARTITION_PATH_COLUMN));
             if (!HoodieIndexUtils.checkIfValidCommit(completedCommitsTimeline, commitTs)) {
               // if commit is invalid, treat this as a new taggedRecord
               taggedRecords.add(currentRecord);
@@ -369,14 +370,14 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
                     // This is an update, no need to update index
                     continue;
                   }
-                  Put put = new Put(Bytes.toBytes(getHBaseKey(recordDelegate.getRecordKey())));
-                  put.addColumn(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN, Bytes.toBytes(loc.get().getInstantTime()));
-                  put.addColumn(SYSTEM_COLUMN_FAMILY, FILE_NAME_COLUMN, Bytes.toBytes(loc.get().getFileId()));
-                  put.addColumn(SYSTEM_COLUMN_FAMILY, PARTITION_PATH_COLUMN, Bytes.toBytes(recordDelegate.getPartitionPath()));
+                  Put put = new Put(getUTF8Bytes(getHBaseKey(recordDelegate.getRecordKey())));
+                  put.addColumn(SYSTEM_COLUMN_FAMILY, COMMIT_TS_COLUMN, getUTF8Bytes(loc.get().getInstantTime()));
+                  put.addColumn(SYSTEM_COLUMN_FAMILY, FILE_NAME_COLUMN, getUTF8Bytes(loc.get().getFileId()));
+                  put.addColumn(SYSTEM_COLUMN_FAMILY, PARTITION_PATH_COLUMN, getUTF8Bytes(recordDelegate.getPartitionPath()));
                   mutations.add(put);
                 } else {
                   // Delete existing index for a deleted record
-                  Delete delete = new Delete(Bytes.toBytes(getHBaseKey(recordDelegate.getRecordKey())));
+                  Delete delete = new Delete(getUTF8Bytes(getHBaseKey(recordDelegate.getRecordKey())));
                   mutations.add(delete);
                 }
               }
@@ -616,7 +617,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
       while (scannerIterator.hasNext()) {
         Result result = scannerIterator.next();
         currentVersionResults.add(result);
-        statements.add(generateStatement(Bytes.toString(result.getRow()), 0L, rollbackTime - 1));
+        statements.add(generateStatement(fromUTF8Bytes(result.getRow()), 0L, rollbackTime - 1));
 
         if (scannerIterator.hasNext() &&  statements.size() < multiGetBatchSize) {
           continue;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestSparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestSparkHoodieHBaseIndex.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -84,6 +83,7 @@ import scala.Tuple2;
 import static org.apache.hadoop.hbase.HConstants.ZOOKEEPER_CLIENT_PORT;
 import static org.apache.hadoop.hbase.HConstants.ZOOKEEPER_QUORUM;
 import static org.apache.hadoop.hbase.HConstants.ZOOKEEPER_ZNODE_PARENT;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -124,7 +124,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
     utility = new HBaseTestingUtility(hbaseConfig);
     utility.startMiniCluster();
     hbaseConfig = utility.getConnection().getConfiguration();
-    utility.createTable(TableName.valueOf(TABLE_NAME), Bytes.toBytes("_s"),2);
+    utility.createTable(TableName.valueOf(TABLE_NAME), getUTF8Bytes("_s"), 2);
   }
 
   @AfterAll

--- a/hudi-common/src/main/java/org/apache/hudi/avro/GenericAvroSerializer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/GenericAvroSerializer.java
@@ -35,9 +35,9 @@ import org.apache.avro.io.EncoderFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 
@@ -81,7 +81,7 @@ public class GenericAvroSerializer<D extends GenericContainer> extends Serialize
     if (schemaCache.containsKey(schemaByteBuffer)) {
       return schemaCache.get(schemaByteBuffer);
     } else {
-      String schema = new String(schemaBytes, StandardCharsets.UTF_8);
+      String schema = fromUTF8Bytes(schemaBytes);
       Schema parsedSchema = new Schema.Parser().parse(schema);
       schemaCache.put(schemaByteBuffer, parsedSchema);
       return parsedSchema;

--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +99,7 @@ public class HFileBootstrapIndex extends BootstrapIndex {
 
   // Additional Metadata written to HFiles.
   public static final String INDEX_INFO_KEY_STRING = "INDEX_INFO";
-  public static final byte[] INDEX_INFO_KEY = Bytes.toBytes(INDEX_INFO_KEY_STRING);
+  public static final byte[] INDEX_INFO_KEY = getUTF8Bytes(INDEX_INFO_KEY_STRING);
 
   private final boolean isPresent;
 
@@ -513,11 +512,11 @@ public class HFileBootstrapIndex extends BootstrapIndex {
     @Override
     public List<BootstrapFileMapping> getSourceFileMappingForPartition(String partition) {
       try (HFileScanner scanner = partitionIndexReader().getScanner(true, false)) {
-        KeyValue keyValue = new KeyValue(Bytes.toBytes(getPartitionKey(partition)), new byte[0], new byte[0],
+        KeyValue keyValue = new KeyValue(getUTF8Bytes(getPartitionKey(partition)), new byte[0], new byte[0],
             HConstants.LATEST_TIMESTAMP, KeyValue.Type.Put, new byte[0]);
         if (scanner.seekTo(keyValue) == 0) {
           ByteBuffer readValue = scanner.getValue();
-          byte[] valBytes = Bytes.toBytes(readValue);
+          byte[] valBytes = IOUtils.toBytes(readValue);
           HoodieBootstrapPartitionMetadata metadata =
               TimelineMetadataUtils.deserializeAvroMetadata(valBytes, HoodieBootstrapPartitionMetadata.class);
           return metadata.getFileIdToBootstrapFile().entrySet().stream()
@@ -546,11 +545,11 @@ public class HFileBootstrapIndex extends BootstrapIndex {
       Collections.sort(fileGroupIds);
       try (HFileScanner scanner = fileIdIndexReader().getScanner(true, false)) {
         for (HoodieFileGroupId fileGroupId : fileGroupIds) {
-          KeyValue keyValue = new KeyValue(Bytes.toBytes(getFileGroupKey(fileGroupId)), new byte[0], new byte[0],
+          KeyValue keyValue = new KeyValue(getUTF8Bytes(getFileGroupKey(fileGroupId)), new byte[0], new byte[0],
               HConstants.LATEST_TIMESTAMP, KeyValue.Type.Put, new byte[0]);
           if (scanner.seekTo(keyValue) == 0) {
             ByteBuffer readValue = scanner.getValue();
-            byte[] valBytes = Bytes.toBytes(readValue);
+            byte[] valBytes = IOUtils.toBytes(readValue);
             HoodieBootstrapFilePartitionInfo fileInfo = TimelineMetadataUtils.deserializeAvroMetadata(valBytes,
                 HoodieBootstrapFilePartitionInfo.class);
             BootstrapFileMapping mapping = new BootstrapFileMapping(bootstrapBasePath,
@@ -639,7 +638,7 @@ public class HFileBootstrapIndex extends BootstrapIndex {
         Option<byte[]> bytes = TimelineMetadataUtils.serializeAvroMetadata(bootstrapPartitionMetadata, HoodieBootstrapPartitionMetadata.class);
         if (bytes.isPresent()) {
           indexByPartitionWriter
-              .append(new KeyValue(Bytes.toBytes(getPartitionKey(partitionPath)), new byte[0], new byte[0],
+              .append(new KeyValue(getUTF8Bytes(getPartitionKey(partitionPath)), new byte[0], new byte[0],
                   HConstants.LATEST_TIMESTAMP, KeyValue.Type.Put, bytes.get()));
           numPartitionKeysAdded++;
         }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,6 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToJsonBytes;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeCommitMetadata;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * All the metadata that gets stored along with a commit.
@@ -249,9 +249,8 @@ public class HoodieCommitMetadata implements Serializable {
   // TODO: refactor this method to avoid doing the json tree walking (HUDI-4822).
   public static Option<Pair<String, List<String>>> getFileSliceForFileGroupFromDeltaCommit(byte[] bytes, HoodieFileGroupId fileGroupId) {
     try {
-      String jsonStr = new String(
-          convertCommitMetadataToJsonBytes(deserializeCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieCommitMetadata.class),
-          StandardCharsets.UTF_8);
+      String jsonStr = fromUTF8Bytes(
+          convertCommitMetadataToJsonBytes(deserializeCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieCommitMetadata.class));
       if (jsonStr.isEmpty()) {
         return Option.empty();
       }
@@ -517,9 +516,8 @@ public class HoodieCommitMetadata implements Serializable {
         return clazz.newInstance();
       }
       return fromJsonString(
-          new String(
-              convertCommitMetadataToJsonBytes(deserializeCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieCommitMetadata.class),
-              StandardCharsets.UTF_8),
+          fromUTF8Bytes(
+              convertCommitMetadataToJsonBytes(deserializeCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieCommitMetadata.class)),
           clazz);
     } catch (Exception e) {
       throw new IOException("unable to read commit metadata for bytes length: " + bytes.length, e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieConsistentHashingMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieConsistentHashingMetadata.java
@@ -31,11 +31,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -159,7 +159,7 @@ public class HoodieConsistentHashingMetadata implements Serializable {
 
   public static HoodieConsistentHashingMetadata fromBytes(byte[] bytes) throws IOException {
     try {
-      return fromJsonString(new String(bytes, StandardCharsets.UTF_8), HoodieConsistentHashingMetadata.class);
+      return fromJsonString(fromUTF8Bytes(bytes), HoodieConsistentHashingMetadata.class);
     } catch (Exception e) {
       throw new IOException("unable to read hashing metadata", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +32,7 @@ import java.util.Map;
 
 import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToJsonBytes;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeReplaceCommitMetadata;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * All the metadata that gets stored along with a commit.
@@ -117,9 +117,8 @@ public class HoodieReplaceCommitMetadata extends HoodieCommitMetadata {
         return clazz.newInstance();
       }
       return fromJsonString(
-          new String(
-              convertCommitMetadataToJsonBytes(deserializeReplaceCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieReplaceCommitMetadata.class),
-              StandardCharsets.UTF_8),
+          fromUTF8Bytes(
+              convertCommitMetadataToJsonBytes(deserializeReplaceCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieReplaceCommitMetadata.class)),
           clazz);
     } catch (Exception e) {
       throw new IOException("unable to read commit metadata for bytes length: " + bytes.length, e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -30,9 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
+
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * Provides support for seamlessly applying changes captured via Debezium for PostgresDB.
@@ -141,7 +142,7 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
         || (field.schema().getType() == Schema.Type.UNION && field.schema().getTypes().stream().anyMatch(s -> s.getType() == Schema.Type.BYTES)))
         // Check length first as an optimization
         && ((ByteBuffer) ((GenericData.Record) incomingRecord).get(field.name())).array().length == DEBEZIUM_TOASTED_VALUE.length()
-        && DEBEZIUM_TOASTED_VALUE.equals(new String(((ByteBuffer) ((GenericData.Record) incomingRecord).get(field.name())).array(), StandardCharsets.UTF_8)));
+        && DEBEZIUM_TOASTED_VALUE.equals(fromUTF8Bytes(((ByteBuffer) ((GenericData.Record) incomingRecord).get(field.name())).array())));
   }
 }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,6 +83,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * <code>HoodieTableMetaClient</code> allows to access meta-data about a hoodie table It returns meta-data about
@@ -212,8 +212,7 @@ public class HoodieTableMetaClient implements Serializable {
       functionalIndexMetadata = Option.of(new HoodieFunctionalIndexMetadata(Collections.singletonMap(indexName, functionalIndexDefinition)));
     }
     try {
-      //fs.mkdirs(new Path(indexMetaPath).getParent());
-      FileIOUtils.createFileInPath(fs, new Path(indexMetaPath), Option.of(functionalIndexMetadata.get().toJson().getBytes(StandardCharsets.UTF_8)));
+      FileIOUtils.createFileInPath(fs, new Path(indexMetaPath), Option.of(getUTF8Bytes(functionalIndexMetadata.get().toJson())));
     } catch (IOException e) {
       throw new HoodieIOException("Could not write functional index metadata at path: " + indexMetaPath, e);
     }
@@ -241,7 +240,7 @@ public class HoodieTableMetaClient implements Serializable {
     this.functionalIndexMetadata = Option.of(newFunctionalIndexMetadata);
     try {
       // update the index metadata file as well
-      FileIOUtils.createFileInPath(fs, new Path(indexMetaPath), Option.of(functionalIndexMetadata.get().toJson().getBytes(StandardCharsets.UTF_8)));
+      FileIOUtils.createFileInPath(fs, new Path(indexMetaPath), Option.of(getUTF8Bytes(functionalIndexMetadata.get().toJson())));
     } catch (IOException e) {
       throw new HoodieIOException("Could not write functional index metadata at path: " + indexMetaPath, e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -40,6 +40,7 @@ import org.apache.hudi.hadoop.fs.BoundedFsDataInputStream;
 import org.apache.hudi.hadoop.fs.SchemeAwareFSDataInputStream;
 import org.apache.hudi.hadoop.fs.TimedFSDataInputStream;
 import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.io.util.IOUtils;
 import org.apache.hudi.storage.StorageSchemes;
 
 import org.apache.avro.Schema;
@@ -49,7 +50,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -332,7 +332,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       } catch (EOFException e) {
         eof = true;
       }
-      long pos = Bytes.indexOf(dataBuf, HoodieLogFormat.MAGIC);
+      long pos = IOUtils.indexOf(dataBuf, HoodieLogFormat.MAGIC);
       if (pos >= 0) {
         return currentPos + pos;
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -51,7 +51,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,6 +63,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.recordNeedsRewriteForExtendedAvroTypePromotion;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
@@ -305,7 +305,7 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
       while ((len = in.read(buffer)) > 0) {
         baos.write(buffer, 0, len);
       }
-      return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+      return fromUTF8Bytes(baos.toByteArray());
     } catch (IOException e) {
       throw new HoodieIOException("IOException while decompressing text", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -34,12 +34,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * Represents the LSM Timeline for the Hoodie table.
@@ -150,7 +151,7 @@ public class LSMTimeline {
       try {
         Option<byte[]> content = FileIOUtils.readDataFromPath(metaClient.getFs(), versionFilePath);
         if (content.isPresent()) {
-          return Integer.parseInt(new String(content.get(), StandardCharsets.UTF_8));
+          return Integer.parseInt(fromUTF8Bytes(content.get()));
         }
       } catch (Exception e) {
         // fallback to manifest file listing.
@@ -189,7 +190,7 @@ public class LSMTimeline {
     // read and deserialize the valid files.
     byte[] content = FileIOUtils.readDataFromPath(metaClient.getFs(), getManifestFilePath(metaClient, latestVersion)).get();
     try {
-      return HoodieLSMTimelineManifest.fromJsonString(new String(content, StandardCharsets.UTF_8), HoodieLSMTimelineManifest.class);
+      return HoodieLSMTimelineManifest.fromJsonString(fromUTF8Bytes(content), HoodieLSMTimelineManifest.class);
     } catch (Exception e) {
       throw new HoodieException("Error deserializing manifest entries", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
@@ -19,9 +19,9 @@
 package org.apache.hudi.common.util;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -56,7 +56,7 @@ public final class Base64CodecUtil {
    * @return base64 encoded data
    */
   public static String encode(byte[] data) {
-    return new String(Base64.getEncoder().encode(data), StandardCharsets.UTF_8);
+    return fromUTF8Bytes(Base64.getEncoder().encode(data));
   }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/HashID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/HashID.java
@@ -20,11 +20,11 @@
 package org.apache.hudi.common.util.hash;
 
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.util.IOUtils;
 
 import net.jpountz.xxhash.XXHash32;
 import net.jpountz.xxhash.XXHash64;
 import net.jpountz.xxhash.XXHashFactory;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.Serializable;
 import java.security.MessageDigest;
@@ -122,10 +122,10 @@ public class HashID implements Serializable {
     switch (bits) {
       case BITS_32:
         XXHash32 hash32 = factory.hash32();
-        return Bytes.toBytes(hash32.hash(message, 0, message.length, HASH_SEED));
+        return IOUtils.toBytes(hash32.hash(message, 0, message.length, HASH_SEED));
       case BITS_64:
         XXHash64 hash64 = factory.hash64();
-        return Bytes.toBytes(hash64.hash(message, 0, message.length, HASH_SEED));
+        return IOUtils.toBytes(hash64.hash(message, 0, message.length, HASH_SEED));
       default:
         throw new HoodieIOException("XX" + bits + " hash is unsupported!");
     }

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
@@ -18,10 +18,10 @@
 
 package org.apache.hudi.internal.schema.io;
 
+import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +47,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.SCHEMA_COMMIT_ACTION;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -163,7 +163,7 @@ public class FileBasedInternalSchemaStorageManager extends AbstractInternalSchem
           try (FSDataInputStream is = fs.open(latestFilePath)) {
             content = FileIOUtils.readAsByteArray(is);
             LOG.info(String.format("read history schema success from file : %s", latestFilePath));
-            return new String(content, StandardCharsets.UTF_8);
+            return fromUTF8Bytes(content);
           } catch (IOException e) {
             throw new HoodieIOException("Could not read history schema from " + latestFilePath, e);
           }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReaderImplBase.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReaderImplBase.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.CollectionUtils.toStream;
-import static org.apache.hudi.common.util.StringUtils.getStringFromUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 public abstract class HoodieAvroHFileReaderImplBase extends HoodieAvroFileReaderBase
     implements HoodieSeekingFileReader<IndexedRecord> {
@@ -109,7 +109,7 @@ public abstract class HoodieAvroHFileReaderImplBase extends HoodieAvroFileReader
     getKeySchema(readerSchema).ifPresent(keyFieldSchema -> {
       final Object keyObject = record.get(keyFieldSchema.pos());
       if (keyObject != null && keyObject.toString().isEmpty()) {
-        record.put(keyFieldSchema.pos(), getStringFromUTF8Bytes(keyBytes, keyOffset, keyLength));
+        record.put(keyFieldSchema.pos(), fromUTF8Bytes(keyBytes, keyOffset, keyLength));
       }
     });
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -58,6 +57,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.TypeUtils.unsafeCast;
 import static org.apache.hudi.io.hfile.HFileUtils.isPrefixOfKey;
 
@@ -109,8 +109,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
     HFileReader reader = getSharedHFileReader();
     try {
       return new String[] {
-          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MIN_RECORD)).get()),
-          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MAX_RECORD)).get())};
+          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MIN_RECORD)).get()),
+          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MAX_RECORD)).get())};
     } catch (IOException e) {
       throw new HoodieIOException("Cannot read min and max record keys from HFile.", e);
     }
@@ -122,7 +122,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
       HFileReader reader = getSharedHFileReader();
       ByteBuffer byteBuffer = reader.getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK).get();
       return BloomFilterFactory.fromByteBuffer(byteBuffer,
-          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_BLOOM_FILTER_TYPE_CODE)).get()));
+          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_BLOOM_FILTER_TYPE_CODE)).get()));
     } catch (IOException e) {
       throw new HoodieException("Could not read bloom filter from " + path, e);
     }
@@ -227,7 +227,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
   private static Schema fetchSchema(HFileReader reader) {
     try {
       return new Schema.Parser().parse(
-          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(SCHEMA_KEY)).get()));
+          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(SCHEMA_KEY)).get()));
     } catch (IOException e) {
       throw new HoodieIOException("Unable to read schema from HFile", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -57,7 +58,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.util.StringUtils.getStringFromUTF8Bytes;
 import static org.apache.hudi.common.util.TypeUtils.unsafeCast;
 import static org.apache.hudi.io.hfile.HFileUtils.isPrefixOfKey;
 
@@ -109,8 +109,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
     HFileReader reader = getSharedHFileReader();
     try {
       return new String[] {
-          getStringFromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MIN_RECORD)).get()),
-          getStringFromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MAX_RECORD)).get())};
+          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MIN_RECORD)).get()),
+          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MAX_RECORD)).get())};
     } catch (IOException e) {
       throw new HoodieIOException("Cannot read min and max record keys from HFile.", e);
     }
@@ -122,7 +122,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
       HFileReader reader = getSharedHFileReader();
       ByteBuffer byteBuffer = reader.getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK).get();
       return BloomFilterFactory.fromByteBuffer(byteBuffer,
-          getStringFromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_BLOOM_FILTER_TYPE_CODE)).get()));
+          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_BLOOM_FILTER_TYPE_CODE)).get()));
     } catch (IOException e) {
       throw new HoodieException("Could not read bloom filter from " + path, e);
     }
@@ -227,7 +227,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
   private static Schema fetchSchema(HFileReader reader) {
     try {
       return new Schema.Parser().parse(
-          getStringFromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(SCHEMA_KEY)).get()));
+          StringUtils.fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(SCHEMA_KEY)).get()));
     } catch (IOException e) {
       throw new HoodieIOException("Unable to read schema from HFile", e);
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystemHFileInLiningBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystemHFileInLiningBase.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +43,7 @@ import static org.apache.hudi.common.testutils.FileSystemTestUtils.FILE_SCHEME;
 import static org.apache.hudi.common.testutils.FileSystemTestUtils.RANDOM;
 import static org.apache.hudi.common.testutils.FileSystemTestUtils.getPhantomFile;
 import static org.apache.hudi.common.testutils.FileSystemTestUtils.getRandomOuterInMemPath;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Tests {@link InLineFileSystem} to inline HFile.
@@ -141,8 +141,8 @@ public abstract class TestInLineFileSystemHFileInLiningBase {
     KeyValue kv;
     for (int i = 0; i < (maxRows); i++) {
       String key = String.format(LOCAL_FORMATTER, i);
-      kv = new KeyValue(Bytes.toBytes(key), Bytes.toBytes("family"), Bytes.toBytes("qual"),
-          Bytes.toBytes(VALUE_PREFIX + key));
+      kv = new KeyValue(getUTF8Bytes(key), getUTF8Bytes("family"), getUTF8Bytes("qual"),
+          getUTF8Bytes(VALUE_PREFIX + key));
       writer.append(kv);
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -38,11 +38,11 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Properties;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -199,11 +199,11 @@ public class TestPostgresDebeziumAvroPayload {
         .combineAndGetUpdateValue(oldVal, avroSchema).get();
 
     assertEquals("valid string value", outputRecord.get("string_col"));
-    assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_col")).array(), StandardCharsets.UTF_8));
+    assertEquals("valid byte value", fromUTF8Bytes(((ByteBuffer) outputRecord.get("byte_col")).array()));
     assertNull(outputRecord.get("string_null_col_1"));
     assertNull(outputRecord.get("byte_null_col_1"));
     assertEquals("valid string value", ((Utf8) outputRecord.get("string_null_col_2")).toString());
-    assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_null_col_2")).array(), StandardCharsets.UTF_8));
+    assertEquals("valid byte value", fromUTF8Bytes(((ByteBuffer) outputRecord.get("byte_null_col_2")).array()));
   }
 
   private GenericRecord createRecord(int primaryKeyValue, @Nullable Operation op, @Nullable Long lsnValue) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputSplitUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputSplitUtils.java
@@ -21,8 +21,8 @@ package org.apache.hudi.hadoop;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 public class InputSplitUtils {
@@ -36,7 +36,7 @@ public class InputSplitUtils {
   public static String readString(DataInput in) throws IOException {
     byte[] bytes = new byte[in.readInt()];
     in.readFully(bytes);
-    return new String(bytes, StandardCharsets.UTF_8);
+    return fromUTF8Bytes(bytes);
   }
 
   public static void writeBoolean(Boolean valueToWrite, DataOutput out) throws IOException {

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -109,13 +109,19 @@ public class StringUtils {
     return str.getBytes(StandardCharsets.UTF_8);
   }
 
-  public static String getStringFromUTF8Bytes(byte[] bytes) {
-    return getStringFromUTF8Bytes(bytes, 0, bytes.length);
+  public static String fromUTF8Bytes(byte[] bytes) {
+    return fromUTF8Bytes(bytes, 0, bytes.length);
   }
 
-  public static String getStringFromUTF8Bytes(byte[] bytes,
-                                              int offset,
-                                              int length) {
+  public static String fromUTF8Bytes(byte[] bytes,
+                                     int offset,
+                                     int length) {
+    if (bytes == null) {
+      return null;
+    }
+    if (length == 0) {
+      return "";
+    }
     return new String(bytes, offset, length, StandardCharsets.UTF_8);
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileFileInfoBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileFileInfoBlock.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hudi.common.util.StringUtils.getStringFromUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * Represents a {@link HFileBlockType#FILE_INFO} block.
@@ -48,7 +48,7 @@ public class HFileFileInfoBlock extends HFileBlock {
         byteBuff, startOffsetInBuff + HFILEBLOCK_HEADER_SIZE, pbMagicLength) != 0) {
       throw new IOException(
           "Unexpected Protobuf magic at the beginning of the HFileFileInfoBlock: "
-              + getStringFromUTF8Bytes(byteBuff, startOffsetInBuff + HFILEBLOCK_HEADER_SIZE, pbMagicLength));
+              + fromUTF8Bytes(byteBuff, startOffsetInBuff + HFILEBLOCK_HEADER_SIZE, pbMagicLength));
     }
     ByteArrayInputStream inputStream = new ByteArrayInputStream(
         byteBuff,

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileUtils.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hudi.common.util.StringUtils.getStringFromUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * Util methods for reading and writing HFile.
@@ -104,7 +104,7 @@ public class HFileUtils {
    * @return the String with UTF-8 decoding.
    */
   public static String getValue(KeyValue kv) {
-    return getStringFromUTF8Bytes(kv.getBytes(), kv.getValueOffset(), kv.getValueLength());
+    return fromUTF8Bytes(kv.getBytes(), kv.getValueOffset(), kv.getValueLength());
   }
 
   /**

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/Key.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/Key.java
@@ -21,7 +21,7 @@ package org.apache.hudi.io.hfile;
 
 import org.apache.hudi.io.util.IOUtils;
 
-import static org.apache.hudi.common.util.StringUtils.getStringFromUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.io.hfile.DataSize.SIZEOF_INT16;
 import static org.apache.hudi.io.hfile.HFileUtils.compareKeys;
 import static org.apache.hudi.io.util.IOUtils.readShort;
@@ -66,7 +66,7 @@ public class Key implements Comparable<Key> {
   }
 
   public String getContentInString() {
-    return getStringFromUTF8Bytes(getBytes(), getContentOffset(), getContentLength());
+    return fromUTF8Bytes(getBytes(), getContentOffset(), getContentLength());
   }
 
   @Override

--- a/hudi-io/src/main/java/org/apache/hudi/io/util/IOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/IOUtils.java
@@ -202,6 +202,35 @@ public class IOUtils {
   }
 
   /**
+   * Returns the start position of the first occurrence of the specified {@code
+   * target} within {@code array}, or {@code -1} if there is no such occurrence.
+   *
+   * <p>More formally, returns the lowest index {@code i} such that the range
+   * [i, i + target.length) in {@code array} contains exactly the same elements
+   * as {@code target}.
+   *
+   * @param array  the array to search for the sequence {@code target}.
+   * @param target the array to search for as a sub-sequence of {@code array}.
+   * @return the start position if found; {@code -1} if there is no such occurrence.
+   */
+  public static int indexOf(byte[] array, byte[] target) {
+    if (target.length == 0) {
+      return 0;
+    }
+
+    outer:
+    for (int i = 0; i < array.length - target.length + 1; i++) {
+      for (int j = 0; j < target.length; j++) {
+        if (array[i + j] != target[j]) {
+          continue outer;
+        }
+      }
+      return i;
+    }
+    return -1;
+  }
+
+  /**
    * @param bytes  input byte array.
    * @param offset offset to start reading.
    * @param length length of bytes to read.
@@ -213,6 +242,38 @@ public class IOUtils {
       sb.append((char) bytes[i]);
     }
     return sb.toString();
+  }
+
+  /**
+   * Converts an int value to a byte array using big-endian.
+   *
+   * @param val value to convert.
+   * @return the byte array.
+   */
+  public static byte[] toBytes(int val) {
+    byte[] b = new byte[4];
+    for (int i = 3; i > 0; i--) {
+      b[i] = (byte) val;
+      val >>>= 8;
+    }
+    b[0] = (byte) val;
+    return b;
+  }
+
+  /**
+   * Converts a long value to a byte array using big-endian.
+   *
+   * @param val value to convert.
+   * @return the byte array.
+   */
+  public static byte[] toBytes(long val) {
+    byte[] b = new byte[8];
+    for (int i = 7; i > 0; i--) {
+      b[i] = (byte) val;
+      val >>>= 8;
+    }
+    b[0] = (byte) val;
+    return b;
   }
 
   /**
@@ -276,5 +337,25 @@ public class IOUtils {
   public static DataInputStream getDataInputStream(ByteBuffer byteBuffer) {
     return new DataInputStream(new ByteArrayInputStream(
         byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.limit() - byteBuffer.arrayOffset()));
+  }
+
+  /**
+   * Returns a new byte array, copied from the given {@code buf}, from the index 0 (inclusive)
+   * to the limit (exclusive), regardless of the current position.
+   * The position and the other index parameters are not changed.
+   *
+   * @param buf a byte buffer.
+   * @return the byte array.
+   */
+  public static byte[] toBytes(ByteBuffer buf) {
+    ByteBuffer dup = buf.duplicate();
+    dup.position(0);
+    return readBytes(dup);
+  }
+
+  private static byte[] readBytes(ByteBuffer buf) {
+    byte[] result = new byte[buf.remaining()];
+    buf.get(result);
+    return result;
   }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/io/util/TestIOUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/util/TestIOUtils.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -106,5 +107,32 @@ public class TestIOUtils {
     assertEquals(18, IOUtils.compareTo(bytes1, 0, 6, bytes2, 0, 6));
     assertEquals(-155, IOUtils.compareTo(bytes1, 1, 4, bytes2, 0, 5));
     assertEquals(22, IOUtils.compareTo(bytes1, 4, 2, bytes2, 2, 4));
+  }
+
+  @Test
+  public void testIndexOf() {
+    byte[] array = new byte[] {(byte) 0x9b, 0, 0x18, 0x65, 0x2e, (byte) 0xf3};
+    assertEquals(0, IOUtils.indexOf(array, new byte[] {}));
+    assertEquals(0, IOUtils.indexOf(array, new byte[] {(byte) 0x9b, 0}));
+    assertEquals(2, IOUtils.indexOf(array, new byte[] {0x18, 0x65, 0x2e}));
+    assertEquals(4, IOUtils.indexOf(array, new byte[] {0x2e, (byte) 0xf3}));
+    assertEquals(-1, IOUtils.indexOf(array, new byte[] {0x2e, (byte) 0xf3, 0x31}));
+    assertEquals(-1, IOUtils.indexOf(array, new byte[] {0x31}));
+  }
+
+  @Test
+  public void testToBytes() {
+    assertArrayEquals(new byte[] {0, 0, 0, 20}, IOUtils.toBytes(20));
+    assertArrayEquals(new byte[] {0x02, (byte) 0x93, (byte) 0xed, (byte) 0x88}, IOUtils.toBytes(43249032));
+    assertArrayEquals(new byte[] {0x19, (byte) 0x99, (byte) 0x9a, 0x61}, IOUtils.toBytes(Integer.MAX_VALUE / 5 + 200));
+    assertArrayEquals(new byte[] {(byte) 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff}, IOUtils.toBytes(Integer.MAX_VALUE));
+    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 0, 20}, IOUtils.toBytes(20L));
+    assertArrayEquals(new byte[] {0, 0, 0, 0, 0x49, 0x52, 0x45, 0x32}, IOUtils.toBytes(1230128434L));
+    assertArrayEquals(
+        new byte[] {0x19, (byte) 0x99, (byte) 0x99, (byte) 0x99, (byte) 0x99, (byte) 0x99, (byte) 0x9a, 0x61},
+        IOUtils.toBytes(Long.MAX_VALUE / 5 + 200));
+    assertArrayEquals(
+        new byte[] {(byte) 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff},
+        IOUtils.toBytes(Long.MAX_VALUE));
   }
 }

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/test/java/org/apache/hudi/metaserver/store/TestRelationalDBBasedStore.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/test/java/org/apache/hudi/metaserver/store/TestRelationalDBBasedStore.java
@@ -24,20 +24,21 @@ import org.apache.hudi.metaserver.thrift.TAction;
 import org.apache.hudi.metaserver.thrift.THoodieInstant;
 import org.apache.hudi.metaserver.thrift.TState;
 import org.apache.hudi.metaserver.thrift.Table;
+
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests on metadata store base on relation database of hoodie meta server.
@@ -100,8 +101,8 @@ public class TestRelationalDBBasedStore {
     assertTrue(store.scanInstants(tableId, Arrays.asList(TState.REQUESTED, TState.INFLIGHT), -1).isEmpty());
 
     // instant meta CRUD
-    byte[] requestedMeta = "requested".getBytes(StandardCharsets.UTF_8);
-    byte[] inflightMeta = "inflight".getBytes(StandardCharsets.UTF_8);
+    byte[] requestedMeta = getUTF8Bytes("requested");
+    byte[] inflightMeta = getUTF8Bytes("inflight");
     store.saveInstantMetadata(tableId, requested, requestedMeta);
     store.saveInstantMetadata(tableId, inflight, inflightMeta);
     assertTrue(store.deleteInstantMetadata(tableId, requested));

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
@@ -61,7 +61,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -70,6 +69,8 @@ import java.util.List;
 import java.util.Properties;
 
 import scala.Tuple2;
+
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * Loads data from Parquet Sources.
@@ -306,7 +307,7 @@ public class HDFSParquetImporterUtils implements Serializable {
     try (FSDataInputStream inputStream = fs.open(p)) {
       inputStream.readFully(0, buf.array(), 0, buf.array().length);
     }
-    return new String(buf.array(), StandardCharsets.UTF_8);
+    return fromUTF8Bytes(buf.array());
   }
 
   public static int handleErrors(JavaSparkContext jsc, String instantTime, JavaRDD<WriteStatus> writeResponse) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -67,6 +66,7 @@ import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil.toUnsignedBigInteger;
 
@@ -578,6 +578,6 @@ public class TestProtoConversionUtil {
   private static String randomString(int size) {
     byte[] bytes = new byte[size];
     RANDOM.nextBytes(bytes);
-    return new String(bytes, StandardCharsets.UTF_8);
+    return fromUTF8Bytes(bytes);
   }
 }


### PR DESCRIPTION
### Change Logs

As above, to avoid dependency on `org.apache.hadoop.hbase.util.Bytes`.

This is part of the effort to provide Hudi storage abstraction and decouple `hudi-common` from hadoop dependencies. For reference, the single big-change PR can be found here: #10360.

### Impact

No behavior change.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
