### PR TITLE
[HUDI-7347] Introduce SeekableDataInputStream for random access

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -143,7 +143,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
   // for max of Integer size
   private HoodieLogBlock readBlock() throws IOException {
     int blockSize;
-    long blockStartPos = inputStream.getPosition();
+    long blockStartPos = inputStream.getPos();
     try {
       // 1 Read the total size of the block
       blockSize = (int) inputStream.readLong();
@@ -179,7 +179,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
         nextBlockVersion.getVersion() != HoodieLogFormatVersion.DEFAULT_VERSION ? (int) inputStream.readLong() : blockSize;
 
     // 6. Read the content or skip content based on IO vs Memory trade-off by client
-    long contentPosition = inputStream.getPosition();
+    long contentPosition = inputStream.getPos();
     boolean shouldReadLazily = readBlockLazily && nextBlockVersion.getVersion() != HoodieLogFormatVersion.DEFAULT_VERSION;
     Option<byte[]> content = HoodieLogBlock.tryReadContent(inputStream, contentLength, shouldReadLazily);
 
@@ -194,7 +194,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     }
 
     // 9. Read the log block end position in the log file
-    long blockEndPos = inputStream.getPosition();
+    long blockEndPos = inputStream.getPos();
 
     HoodieLogBlock.HoodieLogBlockContentLocation logBlockContentLoc =
         new HoodieLogBlock.HoodieLogBlockContentLocation(hadoopConf, logFile, contentPosition, contentLength, blockEndPos);
@@ -268,7 +268,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     inputStream.seek(blockStartPos);
     LOG.info("Next available block in " + logFile + " starts at " + nextBlockOffset);
     int corruptedBlockSize = (int) (nextBlockOffset - blockStartPos);
-    long contentPosition = inputStream.getPosition();
+    long contentPosition = inputStream.getPos();
     Option<byte[]> corruptedBytes = HoodieLogBlock.tryReadContent(inputStream, corruptedBlockSize, readBlockLazily);
     HoodieLogBlock.HoodieLogBlockContentLocation logBlockContentLoc =
         new HoodieLogBlock.HoodieLogBlockContentLocation(hadoopConf, logFile, contentPosition, corruptedBlockSize, nextBlockOffset);
@@ -280,7 +280,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       // skip block corrupt check if writes are transactional. see https://issues.apache.org/jira/browse/HUDI-2118
       return false;
     }
-    long currentPos = inputStream.getPosition();
+    long currentPos = inputStream.getPos();
     long blockSizeFromFooter;
 
     try {
@@ -327,7 +327,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     byte[] dataBuf = new byte[BLOCK_SCAN_READ_BUFFER_SIZE];
     boolean eof = false;
     while (true) {
-      long currentPos = inputStream.getPosition();
+      long currentPos = inputStream.getPos();
       try {
         Arrays.fill(dataBuf, (byte) 0);
         inputStream.readFully(dataBuf, 0, dataBuf.length);
@@ -339,7 +339,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
         return currentPos + pos;
       }
       if (eof) {
-        return inputStream.getPosition();
+        return inputStream.getPos();
       }
       inputStream.seek(currentPos + dataBuf.length - HoodieLogFormat.MAGIC.length);
     }
@@ -436,7 +436,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       throw new HoodieNotSupportedException("Reverse log reader has not been enabled");
     }
     long blockSize = inputStream.readLong();
-    long blockEndPos = inputStream.getPosition();
+    long blockEndPos = inputStream.getPos();
     // blocksize should read everything about a block including the length as well
     try {
       inputStream.seek(reverseLogFilePosition - blockSize);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
@@ -40,7 +41,6 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.hadoop.fs.FSDataInputStream;
 
 import javax.annotation.Nonnull;
 
@@ -75,7 +75,7 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
 
   private final ThreadLocal<BinaryEncoder> encoderCache = new ThreadLocal<>();
 
-  public HoodieAvroDataBlock(Supplier<FSDataInputStream> inputStreamSupplier,
+  public HoodieAvroDataBlock(Supplier<SeekableDataInputStream> inputStreamSupplier,
                              Option<byte[]> content,
                              boolean readBlockLazily,
                              HoodieLogBlockContentLocation logBlockContentLocation,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCDCDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCDCDataBlock.java
@@ -20,9 +20,9 @@ package org.apache.hudi.common.table.log.block;
 
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import org.apache.avro.Schema;
-import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 public class HoodieCDCDataBlock extends HoodieAvroDataBlock {
 
   public HoodieCDCDataBlock(
-      Supplier<FSDataInputStream> inputStreamSupplier,
+      Supplier<SeekableDataInputStream> inputStreamSupplier,
       Option<byte[]> content,
       boolean readBlockLazily,
       HoodieLogBlockContentLocation logBlockContentLocation,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCommandBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCommandBlock.java
@@ -19,8 +19,7 @@
 package org.apache.hudi.common.table.log.block;
 
 import org.apache.hudi.common.util.Option;
-
-import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +43,7 @@ public class HoodieCommandBlock extends HoodieLogBlock {
     this(Option.empty(), null, false, Option.empty(), header, new HashMap<>());
   }
 
-  public HoodieCommandBlock(Option<byte[]> content, Supplier<FSDataInputStream> inputStreamSupplier, boolean readBlockLazily,
+  public HoodieCommandBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                             Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
                             Map<HeaderMetadataType, String> footer) {
     super(header, footer, blockContentLocation, content, inputStreamSupplier, readBlockLazily);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCorruptBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCorruptBlock.java
@@ -19,8 +19,7 @@
 package org.apache.hudi.common.table.log.block;
 
 import org.apache.hudi.common.util.Option;
-
-import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,7 +31,7 @@ import java.util.function.Supplier;
  */
 public class HoodieCorruptBlock extends HoodieLogBlock {
 
-  public HoodieCorruptBlock(Option<byte[]> corruptedBytes, Supplier<FSDataInputStream> inputStreamSupplier, boolean readBlockLazily,
+  public HoodieCorruptBlock(Option<byte[]> corruptedBytes, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                             Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
                             Map<HeaderMetadataType, String> footer) {
     super(header, footer, blockContentLocation, corruptedBytes, inputStreamSupplier, readBlockLazily);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDataBlock.java
@@ -24,9 +24,9 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import org.apache.avro.Schema;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +110,7 @@ public abstract class HoodieDataBlock extends HoodieLogBlock {
    * NOTE: This ctor is used on the write-path (ie when records ought to be written into the log)
    */
   protected HoodieDataBlock(Option<byte[]> content,
-                            Supplier<FSDataInputStream> inputStreamSupplier,
+                            Supplier<SeekableDataInputStream> inputStreamSupplier,
                             boolean readBlockLazily,
                             Option<HoodieLogBlockContentLocation> blockContentLocation,
                             Option<Schema> readerSchema,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.util.Lazy;
 
 import org.apache.avro.io.BinaryDecoder;
@@ -37,7 +38,6 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,14 +97,14 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
     this.recordsToDelete = recordsToDelete.stream().map(Pair::getLeft).toArray(DeleteRecord[]::new);
   }
 
-  public HoodieDeleteBlock(Option<byte[]> content, Supplier<FSDataInputStream> inputStreamSupplier, boolean readBlockLazily,
+  public HoodieDeleteBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                            Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
                            Map<HeaderMetadataType, String> footer) {
     // Setting `shouldWriteRecordPositions` to false as this constructor is only used by the reader
     this(content, inputStreamSupplier, readBlockLazily, blockContentLocation, header, footer, false);
   }
 
-  HoodieDeleteBlock(Option<byte[]> content, Supplier<FSDataInputStream> inputStreamSupplier, boolean readBlockLazily,
+  HoodieDeleteBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                     Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
                     Map<HeaderMetadataType, String> footer, boolean shouldWriteRecordPositions) {
     super(header, footer, blockContentLocation, content, inputStreamSupplier, readBlockLazily);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
@@ -42,7 +43,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -83,7 +83,7 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
   private final Path pathForReader;
   private final HoodieConfig hFileReaderConfig;
 
-  public HoodieHFileDataBlock(Supplier<FSDataInputStream> inputStreamSupplier,
+  public HoodieHFileDataBlock(Supplier<SeekableDataInputStream> inputStreamSupplier,
                               Option<byte[]> content,
                               boolean readBlockLazily,
                               HoodieLogBlockContentLocation logBlockContentLocation,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -25,9 +25,9 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.TypeUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +36,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -68,10 +67,7 @@ public abstract class HoodieLogBlock {
   private final Option<HoodieLogBlockContentLocation> blockContentLocation;
   // data for a specific block
   private Option<byte[]> content;
-  // TODO : change this to just InputStream so this works for any FileSystem
-  // create handlers to return specific type of inputstream based on FS
-  // input stream corresponding to the log file where this logBlock belongs
-  private final Supplier<FSDataInputStream> inputStreamSupplier;
+  private final Supplier<SeekableDataInputStream> inputStreamSupplier;
   // Toggle flag, whether to read blocks lazily (I/O intensive) or not (Memory intensive)
   protected boolean readBlockLazily;
 
@@ -80,7 +76,7 @@ public abstract class HoodieLogBlock {
       @Nonnull Map<HeaderMetadataType, String> logBlockFooter,
       @Nonnull Option<HoodieLogBlockContentLocation> blockContentLocation,
       @Nonnull Option<byte[]> content,
-      @Nullable Supplier<FSDataInputStream> inputStreamSupplier,
+      @Nullable Supplier<SeekableDataInputStream> inputStreamSupplier,
       boolean readBlockLazily) {
     this.logBlockHeader = logBlockHeader;
     this.logBlockFooter = logBlockFooter;
@@ -265,7 +261,7 @@ public abstract class HoodieLogBlock {
   /**
    * Convert bytes to LogMetadata, follow the same order as {@link HoodieLogBlock#getLogMetadataBytes}.
    */
-  public static Map<HeaderMetadataType, String> getLogMetadata(DataInputStream dis) throws IOException {
+  public static Map<HeaderMetadataType, String> getLogMetadata(SeekableDataInputStream dis) throws IOException {
 
     Map<HeaderMetadataType, String> metadata = new HashMap<>();
     // 1. Read the metadata written out
@@ -289,11 +285,11 @@ public abstract class HoodieLogBlock {
    * Read or Skip block content of a log block in the log file. Depends on lazy reading enabled in
    * {@link HoodieMergedLogRecordScanner}
    */
-  public static Option<byte[]> tryReadContent(FSDataInputStream inputStream, Integer contentLength, boolean readLazily)
+  public static Option<byte[]> tryReadContent(SeekableDataInputStream inputStream, Integer contentLength, boolean readLazily)
       throws IOException {
     if (readLazily) {
       // Seek to the end of the content block
-      inputStream.seek(inputStream.getPos() + contentLength);
+      inputStream.seek(inputStream.getPosition() + contentLength);
       return Option.empty();
     }
 
@@ -311,7 +307,7 @@ public abstract class HoodieLogBlock {
     checkState(!content.isPresent(), "Block has already been inflated");
     checkState(inputStreamSupplier != null, "Block should have input-stream provided");
 
-    try (FSDataInputStream inputStream = inputStreamSupplier.get()) {
+    try (SeekableDataInputStream inputStream = inputStreamSupplier.get()) {
       content = Option.of(new byte[(int) this.getBlockContentLocation().get().getBlockSize()]);
       inputStream.seek(this.getBlockContentLocation().get().getContentPositionInLogFile());
       inputStream.readFully(content.get(), 0, content.get().length);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -289,7 +289,7 @@ public abstract class HoodieLogBlock {
       throws IOException {
     if (readLazily) {
       // Seek to the end of the content block
-      inputStream.seek(inputStream.getPosition() + contentLength);
+      inputStream.seek(inputStream.getPos() + contentLength);
       return Option.empty();
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
@@ -27,13 +27,13 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -64,7 +64,7 @@ public class HoodieParquetDataBlock extends HoodieDataBlock {
   private final Option<Double> expectedCompressionRatio;
   private final Option<Boolean> useDictionaryEncoding;
 
-  public HoodieParquetDataBlock(Supplier<FSDataInputStream> inputStreamSupplier,
+  public HoodieParquetDataBlock(Supplier<SeekableDataInputStream> inputStreamSupplier,
                                 Option<byte[]> content,
                                 boolean readBlockLazily,
                                 HoodieLogBlockContentLocation logBlockContentLocation,

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopSeekableDataInputStream.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopSeekableDataInputStream.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop.fs;
+
+import org.apache.hudi.io.SeekableDataInputStream;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+/**
+ * An implementation of {@link SeekableDataInputStream} based on Hadoop's {@link FSDataInputStream}
+ */
+public class HadoopSeekableDataInputStream extends SeekableDataInputStream {
+  private final FSDataInputStream stream;
+
+  public HadoopSeekableDataInputStream(FSDataInputStream stream) {
+    super(stream);
+    this.stream = stream;
+  }
+
+  @Override
+  public long getPosition() throws IOException {
+    return stream.getPos();
+  }
+
+  @Override
+  public void seek(long pos) throws IOException {
+    stream.seek(pos);
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopSeekableDataInputStream.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopSeekableDataInputStream.java
@@ -37,7 +37,7 @@ public class HadoopSeekableDataInputStream extends SeekableDataInputStream {
   }
 
   @Override
-  public long getPosition() throws IOException {
+  public long getPos() throws IOException {
     return stream.getPos();
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/io/SeekableDataInputStream.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/SeekableDataInputStream.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A {@link InputStream} that supports random access by allowing to seek to
+ * an arbitrary position within the stream and read the content.
+ */
+public abstract class SeekableDataInputStream extends DataInputStream {
+  /**
+   * Creates a DataInputStream that uses the specified
+   * underlying InputStream.
+   *
+   * @param in the specified input stream
+   */
+  public SeekableDataInputStream(InputStream in) {
+    super(in);
+  }
+
+  /**
+   * @return current position of the stream. The next read() will be from that location.
+   */
+  public abstract long getPosition() throws IOException;
+
+  /**
+   * Seeks to a position within the stream.
+   *
+   * @param pos target position to seek to.
+   * @throws IOException upon error.
+   */
+  public abstract void seek(long pos) throws IOException;
+}

--- a/hudi-io/src/main/java/org/apache/hudi/io/SeekableDataInputStream.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/SeekableDataInputStream.java
@@ -41,7 +41,7 @@ public abstract class SeekableDataInputStream extends DataInputStream {
   /**
    * @return current position of the stream. The next read() will be from that location.
    */
-  public abstract long getPosition() throws IOException;
+  public abstract long getPos() throws IOException;
 
   /**
    * Seeks to a position within the stream.


### PR DESCRIPTION
### Change Logs

This PR introduces `SeekableDataInputStream` for random access on a file, i.e., seeking to a position in a file and reading the content.  The random access on a file is used by the log scanner and reader.  Before this PR, the log reader relies on `FSDataInputStream` which is coupled with Hadoop file system.  To allow Hadoop-independent file systems to be used to read log files, the interface `SeekableDataInputStream` is introduced to provide random access APIs without relying on `FSDataInputStream`.

`HadoopSeekableDataInputStream` implements `SeekableDataInputStream` with `FSDataInputStream` instance and is used to realize the same logic as before (no behavior change).

This is part of the effort to provide Hudi storage abstraction and decouple `hudi-common` from hadoop dependencies. For reference, the single big-change PR can be found here: #10360.

### Impact

Makes random access on files and log reading independent of Hadoop APIs.  No behavior change.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
