### PR TITLE
[HUDI-7355] Empty commit should be enbale default to avoid Timeout Exception

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -370,7 +370,7 @@ public class OptionsResolver {
    * Returns whether to commit even when current batch has no data, for flink defaults false
    */
   public static boolean allowCommitOnEmptyBatch(Configuration conf) {
-    return conf.getBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
+    return conf.getBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), true);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
@@ -46,6 +46,14 @@ public class TestOptionsResolver {
     conf.setString(FlinkOptions.INDEX_TYPE, "bloom");
     assertEquals(HoodieIndex.IndexType.BLOOM, OptionsResolver.getIndexType(conf));
   }
+
+  @Test
+  void testAllowCommitOnEmptyBatch() {
+    Configuration conf = getConf();
+    // set uppercase index
+    boolean b = OptionsResolver.allowCommitOnEmptyBatch(conf);
+    assertEquals(true, b);
+  }
   
   private Configuration getConf() {
     Configuration conf = new Configuration();


### PR DESCRIPTION
### Change Logs

Empty commit should be enbale default to avoid Timeout Exception，hoodie.allow.empty.commit default is true，but Flink Option set it to false，cause Flink Join occur many Timeout Exceptions，such as：

**org.apache.hudi.exception.HoodieException: Timeout(601000ms) while waiting for instant initialize**

![1706500764470.png](https://github.com/apache/hudi/assets/10645422/74dd5b66-cab9-43ac-ab9c-bfc38640b190)

![1706500760376.png](https://github.com/apache/hudi/assets/10645422/33505926-454f-4034-9917-8b7ad87bc475)


### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
