### PR TITLE
[WIP][HUDI-6472] fix spark sql does not ignore case

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -95,7 +95,9 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
     }
     val config = buildHoodieInsertConfig(catalogTable, sparkSession, isOverWritePartition, isOverWriteTable, partitionSpec, extraOptions, staticOverwritePartitionPathOpt)
 
-    val alignedQuery = alignQueryOutput(query, catalogTable, partitionSpec, sparkSession.sessionState.conf)
+    val optimizer = sparkSession.sessionState.optimizer
+    val optimizerPlan = optimizer.execute(query)
+    val alignedQuery = alignQueryOutput(optimizerPlan, catalogTable, partitionSpec, sparkSession.sessionState.conf)
 
     val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, mode, config, Dataset.ofRows(sparkSession, alignedQuery))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
@@ -376,7 +376,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
     })
   }
 
-  /* TODO [HUDI-6472]
   test("Test MergeInto When PrimaryKey And PreCombineField Of Source Table And Target Table Differ In Case Only") {
     withRecordType()(withTempDir { tmp =>
       spark.sql("set hoodie.payload.combined.schema.validate = true")
@@ -556,7 +555,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
       )
     })
   }
-*/
 
   test("Test only insert when source table contains history") {
     withRecordType()(withTempDir { tmp =>


### PR DESCRIPTION
### Change Logs
github issue: #10558 

first:
SimpleAnalyzer will case sensitive, use sessionState analyzer replace it.

second:
after support `first` feature, will get exception.
```shell
Unexpected exception thrown: java.lang.RuntimeException: After applying rule org.apache.spark.sql.catalyst.optimizer.FoldablePropagation in batch Operator Optimization before Inferring Filters, the structural integrity of the plan is broken.
org.opentest4j.AssertionFailedError: Unexpected exception thrown: java.lang.RuntimeException: After applying rule org.apache.spark.sql.catalyst.optimizer.FoldablePropagation in batch Operator Optimization before Inferring Filters, the structural integrity of the plan is broken.
	at org.junit.jupiter.api.AssertDoesNotThrow.createAssertionFailedError(AssertDoesNotThrow.java:83)
	at org.junit.jupiter.api.AssertDoesNotThrow.assertDoesNotThrow(AssertDoesNotThrow.java:54)
	at org.junit.jupiter.api.AssertDoesNotThrow.assertDoesNotThrow(AssertDoesNotThrow.java:37)
	at org.junit.jupiter.api.Assertions.assertDoesNotThrow(Assertions.java:3060)
	at org.apache.spark.sql.hudi.TestInsertTable.$anonfun$new$226(TestInsertTable.scala:2469)
	at org.apache.spark.sql.hudi.TestInsertTable.$anonfun$new$226$adapted(TestInsertTable.scala:2438)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.apache.spark.sql.hudi.TestInsertTable.$anonfun$new$225(TestInsertTable.scala:2438)

```
 we will use primariKey to replace datafram schema, because avro is case-sensitive.
And optimizer rule `FoldablePropagation` will replace attributes with aliases of the original foldable expressions if possible.
we need optimizer it before we use primaryKey name replace it, because avro is case-sensitive.
for example, a sql `insert into table $tableName select 1 as ID, name, price, ts from $tableNameA order by ID`
```shell
if primaryKey is id, and logical plan has resolved, when we use id replace ID#22 name, the analyze plan will like:
   Project [id#22, name#24, price#25, ts#26L]
     +- Sort [ID#22 ASC NULLS FIRST], true
        +- Project [1 AS ID#22, name#24, price#25, ts#26L]
           +- SubqueryAlias spark_catalog.default.h1
              +- Relation default.h1[ID#23,name#24,price#25,ts#26L] parquet
this logical plan will be optimizer in FoldablePropagation rule:
   Project [1 AS ID#22, name#24, price#25, ts#26L]
     +- Sort [1 ASC NULLS FIRST], true
        +- Project [1 AS ID#22, name#24, price#25, ts#26L]
           +- Relation default.h1[ID#23,name#24,price#25,ts#26L] parquet
in optimizer, `RuleExecutor` will use `isPlanIntegral` to check prePlan and curPlan schema are the same, ut will failed
```

### Impact

`insert into` and `merge sql` will increase the optimizer analysis.

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
