### PR TITLE
[MINOR]  Add serialVersionUID to HoodieRecord class

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -48,6 +48,7 @@ import java.util.stream.IntStream;
  */
 public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterface, KryoSerializable, Serializable {
 
+  private static final long serialVersionUID = 3015229555587559252L;
   public static final String COMMIT_TIME_METADATA_FIELD = HoodieMetadataField.COMMIT_TIME_METADATA_FIELD.getFieldName();
   public static final String COMMIT_SEQNO_METADATA_FIELD = HoodieMetadataField.COMMIT_SEQNO_METADATA_FIELD.getFieldName();
   public static final String RECORD_KEY_METADATA_FIELD = HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName();


### PR DESCRIPTION
### Change Logs
I try to upgrade my hudi version, but it does not work, then i find org.apache.hudi.common.model.HoodieRecord does not 
have a serialVersionUID

### Risk level (write none, low medium or high below)
high
when  user try to upgrade hudi, they will get the same error

Documentation Update
N/A

### Contributor's checklist
@yuzhaojing 
- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
