### PR TITLE
[HUDI-7366] Fix HoodieLocation with encoded paths

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieLocation.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieLocation.java
@@ -108,7 +108,8 @@ public class HoodieLocation implements Comparable<HoodieLocation>, Serializable 
           parentUri.getAuthority(),
           parentPathWithSeparator,
           null,
-          parentUri.getFragment()).resolve(normalizedChild);
+          parentUri.getFragment())
+          .resolve(new URI(null, null, normalizedChild, null, null));
       this.uri = new URI(
           parentUri.getScheme(),
           parentUri.getAuthority(),

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieLocation.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieLocation.java
@@ -116,6 +116,18 @@ public class TestHoodieLocation {
   }
 
   @Test
+  public void testEncoded() {
+    // encoded character like `%2F` should be kept as is
+    assertEquals(new HoodieLocation("s3://foo/bar/1%2F2%2F3"), new HoodieLocation("s3://foo/bar", "1%2F2%2F3"));
+    assertEquals("s3://foo/bar/1%2F2%2F3", new HoodieLocation("s3://foo/bar", "1%2F2%2F3").toString());
+    assertEquals(new HoodieLocation("s3://foo/bar/1%2F2%2F3"),
+        new HoodieLocation(new HoodieLocation("s3://foo/bar"), "1%2F2%2F3"));
+    assertEquals("s3://foo/bar/1%2F2%2F3",
+        new HoodieLocation(new HoodieLocation("s3://foo/bar"), "1%2F2%2F3").toString());
+    assertEquals("s3://foo/bar/1%2F2%2F3", new HoodieLocation("s3://foo/bar/1%2F2%2F3").toString());
+  }
+
+  @Test
   public void testPathToUriConversion() throws URISyntaxException {
     assertEquals(new URI(null, null, "/foo?bar", null, null),
         new HoodieLocation("/foo?bar").toUri());


### PR DESCRIPTION
### Change Logs

This PR fixes HoodieLocation with encoded paths, e.g., `s3://foo/bar/1%2F2%2F3`, which should be kept as is.

New tests are added.  The tests pass now whereas they failed without the fix before.

### Impact

Bug fix.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
