### PR TITLE
[MINOR] Add UT org.apache.hudi.io.TestHoodieTimelineArchiver#testRetryArchivalAfterPreviousFailedDeletion

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -537,6 +537,14 @@ public class HoodieTestDataGenerator implements AutoCloseable {
         .forEach(f -> createMetadataFile(f, basePath, configuration, commitMetadata));
   }
 
+  public static void createOnlyCompletedCommitFile(String basePath, String instantTime, Configuration configuration) {
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    createOnlyCompletedCommitFile(basePath, instantTime, configuration, commitMetadata);
+  }
+
+  public static void createOnlyCompletedCommitFile(String basePath, String instantTime, Configuration configuration, HoodieCommitMetadata commitMetadata) {
+    createMetadataFile(HoodieTimeline.makeCommitFileName(instantTime), basePath, configuration, commitMetadata);
+  }
   public static void createDeltaCommitFile(String basePath, String instantTime, Configuration configuration) {
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     createDeltaCommitFile(basePath, instantTime, configuration, commitMetadata);

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -545,6 +545,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   public static void createOnlyCompletedCommitFile(String basePath, String instantTime, Configuration configuration, HoodieCommitMetadata commitMetadata) {
     createMetadataFile(HoodieTimeline.makeCommitFileName(instantTime), basePath, configuration, commitMetadata);
   }
+
   public static void createDeltaCommitFile(String basePath, String instantTime, Configuration configuration) {
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     createDeltaCommitFile(basePath, instantTime, configuration, commitMetadata);


### PR DESCRIPTION

### Change Logs

- Add unit test  org.apache.hudi.io.TestHoodieTimelineArchiver#testRetryArchivalAfterPreviousFailedDeletion to simulate scenario where an archival call does not delete all the completed `.commit` files on the timeline and archival is retried again. The expected behavior is that the subsequent archival retry should "clean up" the leftover `.commit` files. This scenario can happen if `org.apache.hudi.client.timeline.HoodieTimelineArchiver#deleteArchivedInstants` encounters transient failures when deleting completed instant files, such as due to the edge case that was resolved by HUDI-7207

### Impact

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
