### PR TITLE
[HUDI-7365] Fix a flaky test for timestamp output format

### DIFF
--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -67,12 +67,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
@@ -815,7 +817,11 @@ public class TestHoodieParquetInputFormat {
               Instant.ofEpochMilli(testTimestampLong), ZoneOffset.UTC);
           assertEquals(Timestamp.valueOf(localDateTime).toString(), String.valueOf(writable.get()[0]));
         } else {
-          assertEquals(new Timestamp(testTimestampLong).toString(), String.valueOf(writable.get()[0]));
+          Date date = new Date();
+          date.setTime(testTimestampLong);
+          assertEquals(
+              new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(date),
+              String.valueOf(writable.get()[0]));
         }
         // test long
         assertEquals(testTimestampLong * 1000, ((LongWritable) writable.get()[1]).get());


### PR DESCRIPTION
### Change Logs

We fix the time format for the timestamp. Previously, the Timestamp.toString() function prints nano seconds, which is not included in the actual output.

### Impact

Less flaky test.

### Risk level (write none, low medium or high below)

No.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
