### PR TITLE
[HUDI-7367] Add makeQualified APIs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -42,6 +42,8 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem;
 import org.apache.hudi.hadoop.fs.NoOpConsistencyGuard;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.storage.HoodieLocation;
+import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageSchemes;
 
 import org.apache.hadoop.conf.Configuration;
@@ -120,6 +122,17 @@ public class FSUtils {
    */
   public static Path makeQualified(FileSystem fs, Path path) {
     return path.makeQualified(fs.getUri(), fs.getWorkingDirectory());
+  }
+
+  /**
+   * Makes location qualified with {@link HoodieStorage}'s URI.
+   *
+   * @param storage  instance of {@link HoodieStorage}.
+   * @param location to be qualified.
+   * @return qualified location, prefixed with the URI of the target HoodieStorage object provided.
+   */
+  public static HoodieLocation makeQualified(HoodieStorage storage, HoodieLocation location) {
+    return location.makeQualified(storage.getUri());
   }
 
   /**

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +52,11 @@ public class HoodieHadoopStorage extends HoodieStorage {
   @Override
   public String getScheme() {
     return fs.getScheme();
+  }
+
+  @Override
+  public URI getUri() {
+    return fs.getUri();
   }
 
   @Override

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieLocation.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieLocation.java
@@ -206,8 +206,7 @@ public class HoodieLocation implements Comparable<HoodieLocation>, Serializable 
     String authority = locationUri.getAuthority();
     String fragment = locationUri.getFragment();
 
-    if (scheme != null &&
-        (authority != null || defaultUri.getAuthority() == null)) {
+    if (scheme != null && (authority != null || defaultUri.getAuthority() == null)) {
       return location;
     }
 

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -33,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,14 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract String getScheme();
+
+  /**
+   * Returns a URI which identifies this HoodieStorage.
+   *
+   * @return the URI of this storage instance.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public abstract URI getUri();
 
   /**
    * Creates an OutputStream at the indicated location.

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieLocation.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieLocation.java
@@ -171,6 +171,21 @@ public class TestHoodieLocation {
   }
 
   @Test
+  public void testMakeQualified() throws URISyntaxException {
+    URI defaultUri = new URI("hdfs://host1/dir1");
+    assertEquals(new HoodieLocation("hdfs://host1/a/b/c"),
+        new HoodieLocation("/a/b/c").makeQualified(defaultUri));
+    assertEquals(new HoodieLocation("hdfs://host2/a/b/c"),
+        new HoodieLocation("hdfs://host2/a/b/c").makeQualified(defaultUri));
+    assertEquals(new HoodieLocation("hdfs://host1/a/b/c"),
+        new HoodieLocation("hdfs:/a/b/c").makeQualified(defaultUri));
+    assertEquals(new HoodieLocation("s3://a/b/c"),
+        new HoodieLocation("s3://a/b/c/").makeQualified(defaultUri));
+    assertThrows(IllegalStateException.class,
+        () -> new HoodieLocation("a").makeQualified(defaultUri));
+  }
+
+  @Test
   public void testEquals() {
     assertEquals(new HoodieLocation("/foo"), new HoodieLocation("/foo"));
     assertEquals(new HoodieLocation("/foo"), new HoodieLocation("/foo/"));

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -33,6 +33,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -97,6 +99,11 @@ public abstract class TestHoodieStorageBase {
   @Test
   public void testGetScheme() {
     assertEquals("file", getHoodieStorage().getScheme());
+  }
+
+  @Test
+  public void testGetUri() throws URISyntaxException {
+    assertEquals(new URI("file:///"), getHoodieStorage().getUri());
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR makes the following changes to properly support qualified location:
- Adds `getUri` to `HoodieStorage`.
- Adds `makeQualified` to `HoodieLocation`.
- Adds `makeQualified` to `FSUtils`.
- New tests for the functionality.

### Impact

Properly support qualified location with `HoodieStorage` and `HoodieLocation`.  This fixes the original test failures in #10591.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
