### PR TITLE
[HUDI-6902] Fix string format of the timestamp in a test

### DIFF
--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -47,6 +47,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.IOConstants;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -819,9 +820,9 @@ public class TestHoodieParquetInputFormat {
         } else {
           Date date = new Date();
           date.setTime(testTimestampLong);
-          assertEquals(
-              new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(date),
-              String.valueOf(writable.get()[0]));
+          Timestamp actualTime = ((TimestampWritable) writable.get()[0]).getTimestamp();
+          SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+          assertEquals(dateFormat.format(date), dateFormat.format(actualTime));
         }
         // test long
         assertEquals(testTimestampLong * 1000, ((LongWritable) writable.get()[1]).get());


### PR DESCRIPTION
### Change Logs

The underlying reason is that in Hive 2.x version, the string format of the TimestampWritable depends on the length of the underlying timestamp. I.e., the string format can be any one of the following, depending on how many nano seconds the time has. 

yyyy-MM-dd HH:mm:ss
yyyy-MM-dd HH:mm:ss.S
yyyy-MM-dd HH:mm:ss.SS
yyyy-MM-dd HH:mm:ss.SSS

In order to make the comparison stable, we harden the string format.

### Impact

Less flaky.

### Risk level (write none, low medium or high below)

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
