### PR TITLE
[HUDI-7373] Make schema evolution doc and config correct

### DIFF
--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -24,8 +24,7 @@ type reconciliations. The following table summarizes the schema changes compatib
 
 The incoming schema will automatically have missing columns added with null values from the table schema.
 For this we need to enable the following config
-`hoodie.write.handle.missing.cols.with.lossless.type.promotion`, otherwise the pipeline will fail. Note: This particular config will also do best effort to solve some of the backward incompatible
-type promotions eg., 'long' to 'int'.
+`hoodie.write.set.null.for.missing.columns`, otherwise the pipeline will fail.
 
 | Schema Change                                                   | COW | MOR | Remarks                                                                                                                                                                                                                                                                                       |
 |:----------------------------------------------------------------|:----|:----|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-0.14.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.1/schema_evolution.md
@@ -24,8 +24,7 @@ type reconciliations. The following table summarizes the schema changes compatib
 
 The incoming schema will automatically have missing columns added with null values from the table schema.
 For this we need to enable the following config
-`hoodie.write.handle.missing.cols.with.lossless.type.promotion`, otherwise the pipeline will fail. Note: This particular config will also do best effort to solve some of the backward incompatible
-type promotions eg., 'long' to 'int'.
+`hoodie.write.set.null.for.missing.columns`, otherwise the pipeline will fail.
 
 | Schema Change                                                   | COW | MOR | Remarks                                                                                                                                                                                                                                                                                       |
 |:----------------------------------------------------------------|:----|:----|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
### Change Logs

hoodie.write.set.null.for.missing.columns was renamed to

hoodie.write.handle.missing.cols.with.lossless.type.promotion. The config only adds the missing columns. The "reverse type promotion" is not controlled by a config. Additionally, this commit never made it to the release, so hoodie.write.handle.missing.cols.with.lossless.type.promotion will not work, only hoodie.write.set.null.for.missing.columns .

### Impact

Users can get the correct config

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
