### PR TITLE
[HUDI-7379] Exclude jackson-module-afterburner from hudi-aws module

### DIFF
--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -158,6 +158,10 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-afterburner</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Change Logs

Exclude jackson-module-afterburner from hudi-aws module which has not relocated the jackson-databind and conflicts with hudi-flink-bundle.

### Impact

Fixes Flink Hudi Table write issue.

### Risk level (write none, low medium or high below)

none

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
