### PR TITLE
[HUDI-7381] Fix compaction write stats and metrics for create and upsert time

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.CompactionOperation;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.HoodieWriteStat.RuntimeStats;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -239,18 +240,25 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
     scanner.close();
     Iterable<List<WriteStatus>> resultIterable = () -> result;
     return StreamSupport.stream(resultIterable.spliterator(), false).flatMap(Collection::stream).peek(s -> {
-      s.getStat().setTotalUpdatedRecordsCompacted(scanner.getNumMergedRecordsInLog());
-      s.getStat().setTotalLogFilesCompacted(scanner.getTotalLogFiles());
-      s.getStat().setTotalLogRecords(scanner.getTotalLogRecords());
-      s.getStat().setPartitionPath(operation.getPartitionPath());
-      s.getStat()
+      final HoodieWriteStat stat = s.getStat();
+      stat.setTotalUpdatedRecordsCompacted(scanner.getNumMergedRecordsInLog());
+      stat.setTotalLogFilesCompacted(scanner.getTotalLogFiles());
+      stat.setTotalLogRecords(scanner.getTotalLogRecords());
+      stat.setPartitionPath(operation.getPartitionPath());
+      stat
           .setTotalLogSizeCompacted(operation.getMetrics().get(CompactionStrategy.TOTAL_LOG_FILE_SIZE).longValue());
-      s.getStat().setTotalLogBlocks(scanner.getTotalLogBlocks());
-      s.getStat().setTotalCorruptLogBlock(scanner.getTotalCorruptBlocks());
-      s.getStat().setTotalRollbackBlocks(scanner.getTotalRollbacks());
+      stat.setTotalLogBlocks(scanner.getTotalLogBlocks());
+      stat.setTotalCorruptLogBlock(scanner.getTotalCorruptBlocks());
+      stat.setTotalRollbackBlocks(scanner.getTotalRollbacks());
       RuntimeStats runtimeStats = new RuntimeStats();
+      // scan time has to be obtained from scanner.
       runtimeStats.setTotalScanTime(scanner.getTotalTimeTakenToReadAndMergeBlocks());
-      s.getStat().setRuntimeStats(runtimeStats);
+      // create and upsert time are obtained from the create or merge handle.
+      if (stat.getRuntimeStats() != null) {
+        runtimeStats.setTotalCreateTime(stat.getRuntimeStats().getTotalCreateTime());
+        runtimeStats.setTotalUpsertTime(stat.getRuntimeStats().getTotalUpsertTime());
+      }
+      stat.setRuntimeStats(runtimeStats);
     }).collect(toList());
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
@@ -308,6 +308,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
     writeStatuses.forEach(writeStatus -> {
       final HoodieWriteStat.RuntimeStats stats = writeStatus.getStat().getRuntimeStats();
       assertNotNull(stats);
+      assertEquals(stats.getTotalCreateTime(), 0);
       assertTrue(stats.getTotalUpsertTime() > 0);
       assertTrue(stats.getTotalScanTime() > 0);
     });

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
@@ -412,45 +412,39 @@ public class HoodieWriteStat implements Serializable {
     /**
      * Total time taken to read and merge logblocks in a log file.
      */
-    @Nullable
     private long totalScanTime;
 
     /**
      * Total time taken by a Hoodie Merge for an existing file.
      */
-    @Nullable
     private long totalUpsertTime;
 
     /**
      * Total time taken by a Hoodie Insert to a file.
      */
-    @Nullable
     private long totalCreateTime;
 
-    @Nullable
     public long getTotalScanTime() {
       return totalScanTime;
     }
 
-    public void setTotalScanTime(@Nullable long totalScanTime) {
+    public void setTotalScanTime(long totalScanTime) {
       this.totalScanTime = totalScanTime;
     }
 
-    @Nullable
     public long getTotalUpsertTime() {
       return totalUpsertTime;
     }
 
-    public void setTotalUpsertTime(@Nullable long totalUpsertTime) {
+    public void setTotalUpsertTime(long totalUpsertTime) {
       this.totalUpsertTime = totalUpsertTime;
     }
 
-    @Nullable
     public long getTotalCreateTime() {
       return totalCreateTime;
     }
 
-    public void setTotalCreateTime(@Nullable long totalCreateTime) {
+    public void setTotalCreateTime(long totalCreateTime) {
       this.totalCreateTime = totalCreateTime;
     }
   }


### PR DESCRIPTION
### Change Logs

This regression was introduced during refactoring, where we were not fetching the create and upsert times from the merge handle and only scan time was being set by the HoodieCompactor.

### Impact

No change in public APIs

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
