### PR TITLE
[HUDI-7351] Handle case when glue expression larger than 2048 limit

### DIFF
--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <dynamodb-local.version>1.15.0</dynamodb-local.version>
-        <moto.version>latest</moto.version>
+        <moto.version>5.0.1</moto.version>
     </properties>
 
     <dependencies>

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -158,7 +158,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   public List<Partition> getPartitionsByFilter(String tableName, String filter) {
     try {
       if (filter.length() <= GLUE_EXPRESSION_MAX_CHARS) {
-        LOG.error("Pushdown filters: {}", filter);
+        LOG.info("Pushdown filters: {}", filter);
         return getPartitions(GetPartitionsRequest.builder()
               .databaseName(databaseName)
               .tableName(tableName)

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -114,6 +114,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   protected final GlueAsyncClient awsGlue;
   private static final String GLUE_PARTITION_INDEX_ENABLE = "partition_filtering.enabled";
   private static final int PARTITION_INDEX_MAX_NUMBER = 3;
+  private static final int GLUE_EXPRESSION_MAX_CHARS = 2048;
   /**
    * athena v2/v3 table property
    * see https://docs.aws.amazon.com/athena/latest/ug/querying-hudi.html
@@ -156,10 +157,15 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public List<Partition> getPartitionsByFilter(String tableName, String filter) {
     try {
-      return getPartitions(GetPartitionsRequest.builder()
+      if (filter.length() <= GLUE_EXPRESSION_MAX_CHARS) {
+        return getPartitions(GetPartitionsRequest.builder()
               .databaseName(databaseName)
               .tableName(tableName)
               .expression(filter));
+      } else {
+        LOG.warn("Falling back to listing all partition since expression filter length > {}", GLUE_EXPRESSION_MAX_CHARS);
+        return getAllPartitions(tableName);
+      }
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Failed to get partitions for table " + tableId(databaseName, tableName) + " from expression: " + filter, e);
     }

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -158,6 +158,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   public List<Partition> getPartitionsByFilter(String tableName, String filter) {
     try {
       if (filter.length() <= GLUE_EXPRESSION_MAX_CHARS) {
+        LOG.error("Pushdown filters: {}", filter);
         return getPartitions(GetPartitionsRequest.builder()
               .databaseName(databaseName)
               .tableName(tableName)

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/ITTestGluePartitionPushdown.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/ITTestGluePartitionPushdown.java
@@ -115,7 +115,7 @@ public class ITTestGluePartitionPushdown {
     fileSystem.delete(new Path(tablePath), true);
   }
 
-  private void createPartitions(String[] partitions) throws ExecutionException, InterruptedException {
+  private void createPartitions(String...partitions) throws ExecutionException, InterruptedException {
     glueSync.awsGlue.createPartition(CreatePartitionRequest.builder().databaseName(DB_NAME).tableName(TABLE_NAME)
             .partitionInput(PartitionInput.builder()
                     .storageDescriptor(StorageDescriptor.builder().columns(partitionsColumn).build())
@@ -130,14 +130,14 @@ public class ITTestGluePartitionPushdown {
 
   @Test
   public void testPresentPartitionShouldReturnIt() throws ExecutionException, InterruptedException {
-    createPartitions(new String[]{"1", "b'ar"});
+    createPartitions("1", "b'ar");
     Assertions.assertEquals(1, glueSync.getPartitionsByFilter(TABLE_NAME,
             glueSync.generatePushDownFilter(Arrays.asList("1/b'ar", "2/foo", "1/b''ar"), partitionsFieldSchema)).size());
   }
 
   @Test
   public void testPresentPartitionShouldReturnAllWhenExpressionFilterLengthTooLong() throws ExecutionException, InterruptedException {
-    createPartitions(new String[]{"1", "b'ar"});
+    createPartitions("1", "b'ar");
 
     // this will generate an expression larger than GLUE_EXPRESSION_MAX_CHARS
     List<String> tooLargePartitionPredicate = new ArrayList<>();

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -85,7 +85,8 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       .defaultValue(1000)
       .markAdvanced()
       .withDocumentation("Max size limit to push down partition filters, if the estimate push down "
-          + "filters exceed this size, will directly try to fetch all partitions");
+          + "filters exceed this size, will directly try to fetch all partitions between the min/max."
+          + "In case of glue metastore, this value should be reduced because it has a filter length limit.");
 
   public static String getBucketSpec(String bucketCols, int bucketNum) {
     return "CLUSTERED BY (" + bucketCols + " INTO " + bucketNum + " BUCKETS";


### PR DESCRIPTION
### Change Logs

After few days in production it turns out glue has a hard limit of expression (= 2048 chars). This patch handle this case, by fallback to returning all existing partitions.
Also the documentation was wrong about the pushdown max size. Fixed it and added a test case

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
