### PR TITLE
[HUDI-7386] add builder to filegroup reader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderBuilder.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+public class HoodieFileGroupReaderBuilder {
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -111,23 +111,24 @@ public class HoodieFileGroupReaderTestUtils {
         Schema schema,
         boolean shouldUseRecordPosition
     ) {
-      return new HoodieFileGroupReader<>(
-          readerContext,
-          hadoopConf,
-          basePath,
-          latestCommitTime,
-          fileSlice,
-          schema,
-          schema,
-          props,
-          tableConfig,
-          start,
-          length,
-          shouldUseRecordPosition,
-          1024 * 1024 * 1000,
-          basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME,
-          ExternalSpillableMap.DiskMapType.ROCKS_DB,
-          false);
+      return HoodieFileGroupReader.builder()
+          .withReaderContext(readerContext)
+          .withHadoopConf(hadoopConf)
+          .withTablePath(basePath)
+          .withLatestCommitTime(latestCommitTime)
+          .withFileSlice(fileSlice)
+          .withDataSchema(schema)
+          .withRequestedSchema(schema)
+          .withTypedProperties(props)
+          .withTableConfig(tableConfig)
+          .withStart(start)
+          .withLength(length)
+          .withUseRecordPosition(shouldUseRecordPosition)
+          .withMaxMemorySizeInBytes(1024 * 1024 * 1000)
+          .withSpillableMapBasePath(basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME)
+          .withDiskMapType(ExternalSpillableMap.DiskMapType.ROCKS_DB)
+          .withBitCaskDiskMapCompressionEnabled(false)
+          .build();
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Add builder so we can have more params

### Impact

Mistakes will be made when there are so many params for the fg reader.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
