### PR TITLE
[HUDI-7394] Fix run script of hudi-timeline-server-bundle

### DIFF
--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>rocksdbjni</artifactId>
         </dependency>
 
+        <!-- Override the provided scope defined in hudi-common -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- Hadoop -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -192,6 +199,7 @@
                       <include>commons-io:commons-io</include>
                       <include>log4j:log4j</include>
                       <include>org.openjdk.jol:jol-core</include>
+                      <include>org.apache.avro:avro</include>
                   </includes>
                 </artifactSet>
                 <relocations combine.children="append">
@@ -206,6 +214,10 @@
                     <relocation>
                         <pattern>com.fasterxml.jackson.</pattern>
                         <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                        <pattern>org.apache.avro.</pattern>
+                        <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                     </relocation>
                 </relocations>
             </configuration>


### PR DESCRIPTION
### Change Logs

Please refer to the JIRA [HUDI-7394](https://issues.apache.org/jira/browse/HUDI-7394) for more details on this issue, detailed stack trace and how to reproduce it.


### Impact

Standalone hudi-timeline-server is able to serve timeline instant requests without throwing class conflict exceptions.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [X] Adequate tests were added if applicable
- [X] CI passed
