### PR TITLE
[MINOR] Exclude slf4j-reload4j dependency from hudi-tests-common

### DIFF
--- a/hudi-tests-common/pom.xml
+++ b/hudi-tests-common/pom.xml
@@ -161,6 +161,10 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Change Logs

"slf4j-reload4j" could cause binding issue with "log4j-slf4j-impl" in some cases.

### Impact

1. Remove the binding issue;
2. Less warning noisy messages.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
