### PR TITLE
[HUDI-7397] Adding support to purge pending clustering instant

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -472,6 +472,18 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     return clusteringMetadata;
   }
 
+  public boolean purgePendingClustering(String clusteringInstant) {
+    HoodieTable<?, I, ?, T> table = createTable(config, context.getHadoopConf().get());
+    HoodieTimeline pendingClusteringTimeline = table.getActiveTimeline().filterPendingReplaceTimeline();
+    HoodieInstant inflightInstant = HoodieTimeline.getReplaceCommitInflightInstant(clusteringInstant);
+    if (pendingClusteringTimeline.containsInstant(inflightInstant)) {
+      table.rollbackInflightClustering(inflightInstant, commitToRollback -> getPendingRollbackInfo(table.getMetaClient(), commitToRollback, false), true);
+      table.getMetaClient().reloadActiveTimeline();
+      return true;
+    }
+    return false;
+  }
+
   protected abstract void validateClusteringCommit(HoodieWriteMetadata<O> clusteringMetadata, String clusteringCommitTime, HoodieTable table);
 
   protected abstract HoodieWriteMetadata<O> convertToOutputMetadata(HoodieWriteMetadata<T> writeMetadata);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1198,6 +1198,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     return tableServiceClient.cluster(clusteringInstant, shouldComplete);
   }
 
+  public boolean purgePendingClustering(String clusteringInstant) {
+    HoodieTable table = createTable(config, context.getHadoopConf().get());
+    preWrite(clusteringInstant, WriteOperationType.CLUSTER, table.getMetaClient());
+    return tableServiceClient.purgePendingClustering(clusteringInstant);
+  }
+
   /**
    * Schedule table services such as clustering, compaction & cleaning.
    *

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -627,8 +627,23 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    */
   public void rollbackInflightClustering(HoodieInstant inflightInstant,
                                          Function<String, Option<HoodiePendingRollbackInfo>> getPendingRollbackInstantFunc) {
+    rollbackInflightClustering(inflightInstant, getPendingRollbackInstantFunc, false);
+  }
+
+  /**
+   * Rollback inflight clustering instant to requested clustering instant
+   *
+   * @param inflightInstant               Inflight clustering instant
+   * @param getPendingRollbackInstantFunc Function to get rollback instant
+   */
+  public void rollbackInflightClustering(HoodieInstant inflightInstant,
+                                         Function<String, Option<HoodiePendingRollbackInfo>> getPendingRollbackInstantFunc, boolean deleteInstants) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     rollbackInflightInstant(inflightInstant, getPendingRollbackInstantFunc);
+    if (deleteInstants) {
+      // above rollback would still keep requested in the timeline. so, lets delete it if if are looking to purge the pending clustering fully.
+      getActiveTimeline().deletePending(new HoodieInstant(HoodieInstant.State.REQUESTED, inflightInstant.getAction(), inflightInstant.getTimestamp()));
+    }
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -45,6 +45,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.apache.hudi.utilities.UtilHelpers.EXECUTE;
+import static org.apache.hudi.utilities.UtilHelpers.PURGE_PENDING_INSTANT;
 import static org.apache.hudi.utilities.UtilHelpers.SCHEDULE;
 import static org.apache.hudi.utilities.UtilHelpers.SCHEDULE_AND_EXECUTE;
 
@@ -192,6 +193,10 @@ public class HoodieClusteringJob {
           LOG.info("Running Mode: [" + EXECUTE + "]; Do cluster");
           return doCluster(jsc);
         }
+        case PURGE_PENDING_INSTANT: {
+          LOG.info("Running Mode: [" + PURGE_PENDING_INSTANT + "];");
+          return doPurgePendingInstant(jsc);
+        }
         default: {
           LOG.error("Unsupported running mode [" + cfg.runningMode + "], quit the job directly");
           return -1;
@@ -280,6 +285,15 @@ public class HoodieClusteringJob {
       clean(client);
       return UtilHelpers.handleErrors(metadata.get(), instantTime.get());
     }
+  }
+
+  private int doPurgePendingInstant(JavaSparkContext jsc) throws Exception {
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    String schemaStr = UtilHelpers.getSchemaFromLatestInstant(metaClient);
+    try (SparkRDDWriteClient<HoodieRecordPayload> client = UtilHelpers.createHoodieClient(jsc, cfg.basePath, schemaStr, cfg.parallelism, Option.empty(), props)) {
+      client.purgePendingClustering(cfg.clusteringInstantTime);
+    }
+    return 0;
   }
 
   private void clean(SparkRDDWriteClient<?> client) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -122,6 +122,7 @@ public class UtilHelpers {
   public static final String EXECUTE = "execute";
   public static final String SCHEDULE = "schedule";
   public static final String SCHEDULE_AND_EXECUTE = "scheduleandexecute";
+  public static final String PURGE_PENDING_INSTANT = "purge_pending_instant";
 
   private static final Logger LOG = LoggerFactory.getLogger(UtilHelpers.class);
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
@@ -25,42 +25,34 @@ import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.testutils.HoodieClientTestUtils;
 import org.apache.hudi.utilities.HoodieClusteringJob;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Properties;
 
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.utilities.UtilHelpers.PURGE_PENDING_INSTANT;
+import static org.apache.hudi.utilities.testutils.UtilitiesTestBase.Helpers.deleteFileFromDfs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases for {@link HoodieClusteringJob}.
  */
 public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
+
   @Test
   public void testHoodieClusteringJobWithClean() throws Exception {
     String tableBasePath = basePath + "/asyncClustering";
     Properties props = getPropertiesForKeyGen(true);
-    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
-        .forTable("asyncClustering")
-        .withPath(tableBasePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
-        .withParallelism(2, 2)
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
-        .withAutoCommit(false)
-        .withClusteringConfig(HoodieClusteringConfig.newBuilder()
-          .withInlineClustering(false)
-          .withScheduleInlineClustering(false)
-          .withAsyncClustering(false).build())
-        .withStorageConfig(HoodieStorageConfig.newBuilder()
-          .logFileMaxSize(1024).build())
-        .withCleanConfig(HoodieCleanConfig.newBuilder()
-          .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
-          .withAutoClean(false).withAsyncClean(false).build())
-        .build();
+    HoodieWriteConfig config = getWriteConfig(tableBasePath);
     props.putAll(config.getProps());
     Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
@@ -68,7 +60,7 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
         .fromProperties(props)
         .build();
 
-    metaClient =  HoodieTableMetaClient.initTableAndGetMetaClient(jsc.hadoopConfiguration(), tableBasePath, metaClientProps);
+    metaClient = HoodieTableMetaClient.initTableAndGetMetaClient(jsc.hadoopConfiguration(), tableBasePath, metaClientProps);
     client = new SparkRDDWriteClient(context, config);
 
     writeData(false, client.createNewInstantTime(), 100, true);
@@ -92,6 +84,58 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     HoodieOfflineJobTestBase.TestHelpers.assertNCleanCommits(1, tableBasePath, fs);
   }
 
+  @Test
+  public void testPurgePendingInstants() throws Exception {
+    String tableBasePath = basePath + "/purgePendingClustering";
+    Properties props = getPropertiesForKeyGen(true);
+    HoodieWriteConfig config = getWriteConfig(tableBasePath);
+    props.putAll(config.getProps());
+    Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
+        .setTableType(HoodieTableType.COPY_ON_WRITE)
+        .setPayloadClass(HoodieAvroPayload.class)
+        .fromProperties(props)
+        .build();
+
+    metaClient = HoodieTableMetaClient.initTableAndGetMetaClient(jsc.hadoopConfiguration(), tableBasePath, metaClientProps);
+    client = new SparkRDDWriteClient(context, config);
+
+    writeData(false, client.createNewInstantTime(), 100, true);
+    writeData(false, client.createNewInstantTime(), 100, true);
+
+    // offline clustering execute without clean
+    HoodieClusteringJob hoodieCluster =
+        init(tableBasePath, true, "scheduleAndExecute", false);
+    hoodieCluster.cluster(0);
+    HoodieOfflineJobTestBase.TestHelpers.assertNClusteringCommits(1, tableBasePath, fs);
+    HoodieOfflineJobTestBase.TestHelpers.assertNCleanCommits(0, tableBasePath, fs);
+
+    // remove the completed instant from timeline and trigger purge of pending clustering instant.
+    HoodieInstant latestClusteringInstant = metaClient.getActiveTimeline()
+        .filterCompletedInstantsOrRewriteTimeline().getCompletedReplaceTimeline().getInstants().get(0);
+    String completedFilePath = tableBasePath + "/" + METAFOLDER_NAME + "/" + latestClusteringInstant.getFileName();
+    deleteFileFromDfs(fs, completedFilePath);
+
+    // trigger purge.
+    hoodieCluster =
+        getClusteringConfigForPurge(tableBasePath, true, PURGE_PENDING_INSTANT, false, latestClusteringInstant.getTimestamp());
+    hoodieCluster.cluster(0);
+    // validate that there are no clustering commits in timeline.
+    HoodieOfflineJobTestBase.TestHelpers.assertNClusteringCommits(0, tableBasePath, fs);
+
+    // validate that no records match the clustering instant.
+    String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
+    for (int i = 0; i < fullPartitionPaths.length; i++) {
+      fullPartitionPaths[i] = String.format("%s/%s/*", tableBasePath, dataGen.getPartitionPaths()[i]);
+    }
+    assertEquals(0, HoodieClientTestUtils.read(jsc, tableBasePath, sqlContext, fs, fullPartitionPaths).filter("_hoodie_commit_time = " + latestClusteringInstant.getTimestamp()).count(),
+        "Must not contain any records w/ clustering instant time");
+  }
+
+  private void deleteCommitMetaFile(String instantTime, String suffix) throws IOException {
+    String targetPath = basePath + "/" + METAFOLDER_NAME + "/" + instantTime + suffix;
+    deleteFileFromDfs(fs, targetPath);
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
@@ -99,6 +143,14 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
   private HoodieClusteringJob init(String tableBasePath, boolean runSchedule, String scheduleAndExecute, boolean isAutoClean) {
     HoodieClusteringJob.Config clusterConfig = buildHoodieClusteringUtilConfig(tableBasePath, runSchedule, scheduleAndExecute, isAutoClean);
     clusterConfig.configs.add(String.format("%s=%s", "hoodie.datasource.write.row.writer.enable", "false"));
+    return new HoodieClusteringJob(jsc, clusterConfig);
+  }
+
+  private HoodieClusteringJob getClusteringConfigForPurge(String tableBasePath, boolean runSchedule, String scheduleAndExecute, boolean isAutoClean,
+                                                          String pendingInstant) {
+    HoodieClusteringJob.Config clusterConfig = buildHoodieClusteringUtilConfig(tableBasePath, runSchedule, scheduleAndExecute, isAutoClean);
+    clusterConfig.configs.add(String.format("%s=%s", "hoodie.datasource.write.row.writer.enable", "false"));
+    clusterConfig.clusteringInstantTime = pendingInstant;
     return new HoodieClusteringJob(jsc, clusterConfig);
   }
 
@@ -113,4 +165,25 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     config.configs.add(String.format("%s=%s", HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), 1));
     return config;
   }
+
+  private HoodieWriteConfig getWriteConfig(String tableBasePath) {
+    return HoodieWriteConfig.newBuilder()
+        .forTable("asyncClustering")
+        .withPath(tableBasePath)
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withParallelism(2, 2)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .withAutoCommit(false)
+        .withClusteringConfig(HoodieClusteringConfig.newBuilder()
+            .withInlineClustering(false)
+            .withScheduleInlineClustering(false)
+            .withAsyncClustering(false).build())
+        .withStorageConfig(HoodieStorageConfig.newBuilder()
+            .logFileMaxSize(1024).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
+            .withAutoClean(false).withAsyncClean(false).build())
+        .build();
+  }
+
 }


### PR DESCRIPTION
### Change Logs

- Adding support to purge pending clustering instant. 

### Impact

If a user made some mistake on clustering params and wishes to completely purge a pending clustering, we do not have any support for that. Adding support to purge a pending clustering and rolling it back fully. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
