### PR TITLE
[MINOR] Disable hdfs for hudi-utilities tests

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlFileBasedSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlFileBasedSource.java
@@ -63,7 +63,7 @@ public class TestSqlFileBasedSource extends UtilitiesTestBase {
 
   @BeforeAll
   public static void initClass() throws Exception {
-    UtilitiesTestBase.initTestServices(true, true, false);
+    UtilitiesTestBase.initTestServices(false, true, false);
     FileSystem fs = UtilitiesTestBase.fs;
     UtilitiesTestBase.Helpers.copyToDFS(
         "streamer-config/sql-file-based-source.sql", fs,

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractDFSSourceTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractDFSSourceTestBase.java
@@ -60,7 +60,7 @@ public abstract class AbstractDFSSourceTestBase extends UtilitiesTestBase {
 
   @BeforeAll
   public static void initClass() throws Exception {
-    UtilitiesTestBase.initTestServices(true, false, false);
+    UtilitiesTestBase.initTestServices(false, false, false);
   }
 
   @BeforeEach


### PR DESCRIPTION
### Change Logs

Tests in hudi-utilities module cause serious flaky failures for Azure CI tests.
This is one of the steps that we try to stabilize the Azure CI test.

### Impact

Removing one of the sources of instabilities.

### Risk level (write none, low medium or high below)

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
