### PR TITLE
[DOCS] Update GCP config doc

### DIFF
--- a/website/docs/gcp_bigquery.md
+++ b/website/docs/gcp_bigquery.md
@@ -39,6 +39,7 @@ setting sync tool class. A few BigQuery-specific configurations are required.
 | `hoodie.gcp.bigquery.sync.dataset_location`  | Region info of the dataset; same as the GCS bucket that stores the Hudi table                                   |
 | `hoodie.gcp.bigquery.sync.source_uri`        | A wildcard path pattern pointing to the first level partition; partition key can be specified or auto-inferred. Only required for partitioned tables |
 | `hoodie.gcp.bigquery.sync.source_uri_prefix` | The common prefix of the `source_uri`, usually it's the path to the Hudi table, trailing slash does not matter. |
+| `hoodie.gcp.bigquery.sync.base_path`         | The usual basepath config for Hudi table.                                                                       |
 | `hoodie.gcp.bigquery.sync.use_bq_manifest_file` | Set to true to enable the manifest based sync                                                                |
 | `hoodie.gcp.bigquery.sync.require_partition_filter` | Introduced in Hudi version 0.14.1, this configuration accepts a BOOLEAN value, with the default being false. When enabled (set to true), you must create a partition filter (a WHERE clause) for all queries, targeting the partitioning column of a partitioned table. Queries lacking such a filter will result in an error.        |
 

--- a/website/docs/gcp_bigquery.md
+++ b/website/docs/gcp_bigquery.md
@@ -39,8 +39,9 @@ setting sync tool class. A few BigQuery-specific configurations are required.
 | `hoodie.gcp.bigquery.sync.dataset_location`  | Region info of the dataset; same as the GCS bucket that stores the Hudi table                                   |
 | `hoodie.gcp.bigquery.sync.source_uri`        | A wildcard path pattern pointing to the first level partition; partition key can be specified or auto-inferred. Only required for partitioned tables |
 | `hoodie.gcp.bigquery.sync.source_uri_prefix` | The common prefix of the `source_uri`, usually it's the path to the Hudi table, trailing slash does not matter. |
-| `hoodie.gcp.bigquery.sync.base_path`         | The usual basepath config for Hudi table.                                                                       |
 | `hoodie.gcp.bigquery.sync.use_bq_manifest_file` | Set to true to enable the manifest based sync                                                                |
+| `hoodie.gcp.bigquery.sync.require_partition_filter` | Introduced in Hudi version 0.14.1, this configuration accepts a BOOLEAN value, with the default being false. When enabled (set to true), you must create a predicate filter (a WHERE clause) for all queries, targeting the partitioning column of a partitioned table. Queries lacking such a predicate filter will result in an error.        |
+
 
 Refer to `org.apache.hudi.gcp.bigquery.BigQuerySyncConfig` for the complete configuration list.
 ### Partition Handling

--- a/website/docs/gcp_bigquery.md
+++ b/website/docs/gcp_bigquery.md
@@ -40,7 +40,7 @@ setting sync tool class. A few BigQuery-specific configurations are required.
 | `hoodie.gcp.bigquery.sync.source_uri`        | A wildcard path pattern pointing to the first level partition; partition key can be specified or auto-inferred. Only required for partitioned tables |
 | `hoodie.gcp.bigquery.sync.source_uri_prefix` | The common prefix of the `source_uri`, usually it's the path to the Hudi table, trailing slash does not matter. |
 | `hoodie.gcp.bigquery.sync.use_bq_manifest_file` | Set to true to enable the manifest based sync                                                                |
-| `hoodie.gcp.bigquery.sync.require_partition_filter` | Introduced in Hudi version 0.14.1, this configuration accepts a BOOLEAN value, with the default being false. When enabled (set to true), you must create a predicate filter (a WHERE clause) for all queries, targeting the partitioning column of a partitioned table. Queries lacking such a predicate filter will result in an error.        |
+| `hoodie.gcp.bigquery.sync.require_partition_filter` | Introduced in Hudi version 0.14.1, this configuration accepts a BOOLEAN value, with the default being false. When enabled (set to true), you must create a partition filter (a WHERE clause) for all queries, targeting the partitioning column of a partitioned table. Queries lacking such a filter will result in an error.        |
 
 
 Refer to `org.apache.hudi.gcp.bigquery.BigQuerySyncConfig` for the complete configuration list.


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
updated  `hoodie.gcp.bigquery.sync.require_partition_filter` and removed `hoodie.gcp.bigquery.sync.base_path`

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

updated https://hudi.apache.org/docs/next/gcp_bigquery
_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed

<img width="777" alt="Screenshot 2024-02-15 at 3 08 48 PM" src="https://github.com/apache/hudi/assets/5392555/37aa9a50-b265-4771-9126-ac1d971e98e8">

@xushiyan please review
