### PR TITLE
[MINOR] Cleanup FileSystemViewManager code

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -115,6 +115,9 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
     super.init(metaClient, visibleActiveTimeline);
   }
 
+  /**
+   * Visible for testing
+   */
   public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
       FileStatus[] fileStatuses) {
     init(metaClient, visibleActiveTimeline);
@@ -421,7 +424,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   /**
    * Get the latest file slices for a given partition including the inflight ones.
    *
-   * @param partitionPath
+   * @param partitionPath The partition path of interest
    * @return Stream of latest {@link FileSlice} in the partition path.
    */
   public Stream<FileSlice> fetchLatestFileSlicesIncludingInflight(String partitionPath) {


### PR DESCRIPTION
### Change Logs

Cleaning up `FileSystemViewManager#createViewManager` related code  that is passing around a `SerializableConfiguration` (HadoopConf) that is never used.

Added a doctstring to indicate that in `#init` function in `HoodieTableFileSystemView` is used for tests.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [X] Adequate tests were added if applicable
- [ ] CI passed
