### PR TITLE
[HUDI-7415] Support OLAP engine query from origin table avoid empty result in default

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -174,7 +174,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       .withDocumentation("The spark version used when syncing with a metastore.");
   public static final ConfigProperty<String> META_SYNC_SNAPSHOT_WITH_TABLE_NAME = ConfigProperty
           .key("hoodie.meta.sync.sync_snapshot_with_table_name")
-          .defaultValue("false")
+          .defaultValue("true")
           .markAdvanced()
           .sinceVersion("0.14.0")
           .withDocumentation("sync meta info to origin table if enable");


### PR DESCRIPTION
### Change Logs

<html>
<body>
<!--StartFragment--><p>OLAP query need support read data from origin table by default，for example，query from olap engine such as starrocks presto，we can only read data in ro/rt sub table and get empty data from origin table，this is not fitable：</p>
<p>query mor table with starrocks as:</p>
<p>MySQL <span class="error">[(none)]</span>&gt; select * from hudi_catalog_01.hudi_test.test_mor_hudi_22_rt;</p>
<div class="table-wrap">

_hoodie_commit_time | _hoodie_commit_seqno | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name
-- | -- | -- | -- | --
20230522100703567 | 20230522100703567_0_0 | 1 | partition=de | f14492ed-b672-4f60-8e86-6359790feb2a-0_0-17-2013_20230522101 row in set (2.11 sec)


</div>
<p>MySQL <span class="error">[(none)]</span>&gt; select * from hudi_catalog_01.hudi_test.test_mor_hudi_22;<br />Empty set (1.23 sec)</p><!--EndFragment-->
</body>
</html>

In default would not sync origin table partitions metadata to hive metastore


![1708070785272.png](https://github.com/apache/hudi/assets/10645422/411b779a-a616-4460-82cc-cef41d174595)




### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
