### PR TITLE
[HUDI-7356] Passing configs to file reader constructor for flexibility

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieIOException;
 
@@ -30,6 +31,7 @@ import java.io.IOException;
 
 public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory {
 
+  @Override
   public HoodieFileReader newParquetFileReader(Configuration conf, Path path) {
     conf.setIfUnset(SQLConf.PARQUET_BINARY_AS_STRING().key(), SQLConf.PARQUET_BINARY_AS_STRING().defaultValueString());
     conf.setIfUnset(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(), SQLConf.PARQUET_INT96_AS_TIMESTAMP().defaultValueString());
@@ -42,12 +44,15 @@ public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory {
     return new HoodieSparkParquetReader(conf, path);
   }
 
-  protected HoodieFileReader newHFileFileReader(Configuration conf,
+  @Override
+  protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig,
+                                                Configuration conf,
                                                 Path path,
                                                 Option<Schema> schemaOption) throws IOException {
     throw new HoodieIOException("Not support read HFile");
   }
 
+  @Override
   protected HoodieFileReader newOrcFileReader(Configuration conf, Path path) {
     throw new HoodieIOException("Not support read orc file");
   }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroFileReaderFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
@@ -29,15 +30,18 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import java.io.IOException;
 
 public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
+
+  @Override
   protected HoodieFileReader newParquetFileReader(Configuration conf, Path path) {
     return new HoodieAvroParquetReader(conf, path);
   }
 
-  protected HoodieFileReader newHFileFileReader(boolean useNativeHFileReader,
+  @Override
+  protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig,
                                                 Configuration conf,
                                                 Path path,
                                                 Option<Schema> schemaOption) throws IOException {
-    if (useNativeHFileReader) {
+    if (isUseNativeHFileReaderEnabled(hoodieConfig)) {
       return new HoodieNativeAvroHFileReader(conf, path, schemaOption);
     }
     CacheConfig cacheConfig = new CacheConfig(conf);
@@ -47,14 +51,15 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     return new HoodieHBaseAvroHFileReader(conf, path, cacheConfig);
   }
 
-  protected HoodieFileReader newHFileFileReader(boolean useNativeHFileReader,
+  @Override
+  protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig,
                                                 Configuration conf,
                                                 Path path,
                                                 FileSystem fs,
                                                 byte[] content,
                                                 Option<Schema> schemaOption)
       throws IOException {
-    if (useNativeHFileReader) {
+    if (isUseNativeHFileReaderEnabled(hoodieConfig)) {
       return new HoodieNativeAvroHFileReader(conf, content, schemaOption);
     }
     CacheConfig cacheConfig = new CacheConfig(conf);

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -84,11 +84,9 @@ public class HoodieFileReaderFactory {
                                         Option<Schema> schemaOption) throws IOException {
     switch (format) {
       case PARQUET:
-        return this.newParquetFileReader(conf, path);
+        return newParquetFileReader(conf, path);
       case HFILE:
-        boolean useNativeHFileReader =
-            hoodieConfig.getBooleanOrDefault(HoodieReaderConfig.USE_NATIVE_HFILE_READER);
-        return newHFileFileReader(useNativeHFileReader, conf, path, schemaOption);
+        return newHFileFileReader(hoodieConfig, conf, path, schemaOption);
       case ORC:
         return newOrcFileReader(conf, path);
       default:
@@ -96,15 +94,13 @@ public class HoodieFileReaderFactory {
     }
   }
 
-  public HoodieFileReader getContentReader(HoodieConfig config,
+  public HoodieFileReader getContentReader(HoodieConfig hoodieConfig,
                                            Configuration conf, Path path, HoodieFileFormat format,
                                            FileSystem fs, byte[] content,
                                            Option<Schema> schemaOption) throws IOException {
     switch (format) {
       case HFILE:
-        boolean useNativeHFileReader =
-            config.getBooleanOrDefault(HoodieReaderConfig.USE_NATIVE_HFILE_READER);
-        return newHFileFileReader(useNativeHFileReader, conf, path, fs, content, schemaOption);
+        return newHFileFileReader(hoodieConfig, conf, path, fs, content, schemaOption);
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
@@ -114,13 +110,13 @@ public class HoodieFileReaderFactory {
     throw new UnsupportedOperationException();
   }
 
-  protected HoodieFileReader newHFileFileReader(boolean useNativeHFileReader,
+  protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig,
                                                 Configuration conf, Path path,
                                                 Option<Schema> schemaOption) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  protected HoodieFileReader newHFileFileReader(boolean useNativeHFileReader,
+  protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig,
                                                 Configuration conf, Path path,
                                                 FileSystem fs,
                                                 byte[] content, Option<Schema> schemaOption)
@@ -137,5 +133,9 @@ public class HoodieFileReaderFactory {
                                                  Option<String[]> partitionFields,
                                                  Object[] partitionValues) {
     throw new UnsupportedOperationException();
+  }
+
+  protected static boolean isUseNativeHFileReaderEnabled(HoodieConfig hoodieConfig) {
+    return hoodieConfig.getBooleanOrDefault(HoodieReaderConfig.USE_NATIVE_HFILE_READER);
   }
 }


### PR DESCRIPTION
### Change Logs

Passing HoodieConfig down to newHFileReader instead of passing useBuiltInHFileReader only. So it'd be easier to add more customization directly to file reader level in the future without having to change newHFileFileReader method.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
