### PR TITLE
[HUDI-7423] Support table type name incase-sensitive when create table in sparksql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -155,7 +155,8 @@ object HoodieOptionConfig {
   def mapSqlOptionsToTableConfigs(options: Map[String, String]): Map[String, String] = {
     options.map { case (k, v) =>
       if (sqlOptionKeyToTableConfigKey.contains(k)) {
-        sqlOptionKeyToTableConfigKey(k) -> sqlOptionValueToHoodieConfigValue.getOrElse(v, v)
+        // support table type incase-sensitive
+        sqlOptionKeyToTableConfigKey(k) -> sqlOptionValueToHoodieConfigValue.getOrElse(v.toLowerCase, v)
       } else {
         k -> v
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -84,6 +84,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            |""".stripMargin
       )
 
+      // check result after insert and merge data into target table
       checkAnswer(s"select id, name, dt, day, hour from $targetTable limit 10")(
         Seq("1", "aa", 123, "2024-02-19", 10),
         Seq("2", "bb", 456, "2024-02-19", 10)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -40,6 +40,57 @@ import java.util.concurrent.CountDownLatch
 
 class TestInsertTable extends HoodieSparkSqlTestBase {
 
+  test("Test table type name incase-sensitive test") {
+    withRecordType()(withTempDir { tmp =>
+      val targetTable = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+
+      spark.sql(
+        s"""
+           |create table ${targetTable} (
+           |  `id` string,
+           |  `name` string,
+           |  `dt` bigint,
+           |  `day` STRING,
+           |  `hour` INT
+           |) using hudi
+           |tblproperties (
+           |  'primaryKey' = 'id',
+           |  'type' = 'MOR',
+           |  'preCombineField'='dt',
+           |  'hoodie.index.type' = 'BUCKET',
+           |  'hoodie.bucket.index.hash.field' = 'id',
+           |  'hoodie.bucket.index.num.buckets'=512
+           | )
+             partitioned by (`day`,`hour`)
+             location '${tablePath}'
+             """.stripMargin)
+
+      spark.sql(
+        s"""
+           |insert into ${targetTable}
+           |select '1' as id, 'aa' as name, 123 as dt, '2024-02-19' as `day`, 10 as `hour`
+           |""".stripMargin)
+
+      spark.sql(
+        s"""
+           |merge into ${targetTable} as target
+           |using (
+           |select '2' as id, 'bb' as name, 456 as dt, '2024-02-19' as `day`, 10 as `hour`
+           |) as source
+           |on target.id = source.id
+           |when matched then update set *
+           |when not matched then insert *
+           |""".stripMargin
+      )
+
+      checkAnswer(s"select id, name, dt, day, hour from $targetTable limit 10")(
+        Seq("1", "aa", 123, "2024-02-19", 10),
+        Seq("2", "bb", 456, "2024-02-19", 10)
+      )
+    })
+  }
+
   test("Test Insert Into with values") {
     withRecordType()(withTempDir { tmp =>
       val tableName = generateTableName


### PR DESCRIPTION
### Change Logs

Support table type name incase-sensitive when create table in sparksql.

When many user create table would set table.type = MOR/Mor/Cow/COW according to Hudi document，like：




CREATE TABLE `hudi_test`.`hudi_test29` (
  `app_id` STRING COMMENT '应用id',
  `message_id` STRING COMMENT '消息id',
  `dt` INT,
  `from` STRING,
  `day` STRING COMMENT '日期分区',
  `hour` INT COMMENT '小时分区'
)using hudi
tblproperties (
  'primaryKey' = 'app_id,message_id',
  'type' = 'MOR',
  'preCombineField'='dt',
  'hoodie.index.type' = 'BUCKET',
  'hoodie.bucket.index.hash.field' = 'app_id,message_id',
  'hoodie.bucket.index.num.buckets'=256,
  'hoodie.datasource.hive_sync.table.strategy'='RT'
)
PARTITIONED BY (`day`,`hour`);




it would occur error as: 

java.lang.IllegalArgumentException: No enum constant org.apache.hudi.common.model.HoodieTableType.MOR
    at java.lang.Enum.valueOf(Enum.java:238)
    at org.apache.hudi.common.model.HoodieTableType.valueOf(HoodieTableType.java:30)
    at org.apache.hudi.common.table.HoodieTableMetaClient$PropertyBuilder.setTableType(HoodieTableMetaClient.java:833)
    at org.apache.hudi.common.table.HoodieTableMetaClient$PropertyBuilder.fromProperties(HoodieTableMetaClient.java:1009)
    at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.initHoodieTable(HoodieCatalogTable.scala:219)
    at org.apache.spark.sql.hudi.command.CreateHoodieTableCommand.run(CreateHoodieTableCommand.scala:70)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:80)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:78)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:89)
    at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:110)
    at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$5(SQLExecution.scala:103)

It is not friendly to user which must set table=mor/cow for users. So it is better make the config incase-sensitive to users

### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
