### PR TITLE
[HUDI-7428] Support Netease Object Storage protocol for Hudi

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
@@ -56,6 +56,7 @@ public class TestStorageSchemes {
     assertFalse(StorageSchemes.isAtomicCreationSupported("jfs"));
     assertFalse(StorageSchemes.isAtomicCreationSupported("bos"));
     assertFalse(StorageSchemes.isAtomicCreationSupported("ks3"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("nos"));
     assertFalse(StorageSchemes.isAtomicCreationSupported("ofs"));
     assertFalse(StorageSchemes.isAtomicCreationSupported("oci"));
     assertFalse(StorageSchemes.isAtomicCreationSupported("tos"));

--- a/hudi-io/src/main/java/org/apache/hudi/storage/StorageSchemes.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StorageSchemes.java
@@ -69,6 +69,8 @@ public enum StorageSchemes {
   OBS("obs", null, null),
   // Kingsoft Standard Storage ks3
   KS3("ks3", null, null),
+  // Netease Object Storage nos
+  NOS("nos", null, null),
   // JuiceFileSystem
   JFS("jfs", null, null),
   // Baidu Object Storage


### PR DESCRIPTION
### Change Logs

Currently Hudi not support NOS（Netease Object Storage），so add protocol to support it. https://issues.apache.org/jira/browse/HUDI-7428

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
