### PR TITLE
[HUDI-7430] Fix empty schema issue for compactor

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -276,7 +276,7 @@ public class HoodieCompactor {
     }
   }
 
-  String getSchemaFromLatestInstant() throws Exception {
+  protected String getSchemaFromLatestInstant() throws Exception {
     TableSchemaResolver schemaUtil = new TableSchemaResolver(metaClient);
     Schema schema = schemaUtil.getTableAvroSchema(false);
     return schema.toString();
@@ -288,7 +288,7 @@ public class HoodieCompactor {
     }
   }
 
-  String getSchema() throws Exception {
+  protected String getSchema() throws Exception {
     if (StringUtils.isNullOrEmpty(cfg.schemaFile)) {
       return getSchemaFromLatestInstant();
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 
 public class TestHoodieCompactor {
   @TempDir
@@ -116,7 +117,7 @@ public class TestHoodieCompactor {
     HoodieCompactor compactor = new HoodieCompactor(jsc, config);
 
     HoodieCompactor spyCompactor = Mockito.spy(compactor);
-    Mockito.doReturn(TRIP_EXAMPLE_SCHEMA).when(spyCompactor).getSchemaFromLatestInstant();
+    doReturn(TRIP_EXAMPLE_SCHEMA).when(spyCompactor).getSchemaFromLatestInstant();
     String schemaStr = spyCompactor.getSchema();
     assertEquals(TRIP_EXAMPLE_SCHEMA, schemaStr);
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
@@ -24,12 +24,12 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,23 +43,32 @@ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAM
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestHoodieCompactor extends UtilitiesTestBase {
+public class TestHoodieCompactor {
   @TempDir
   protected static java.nio.file.Path sharedTempDir;
   protected static Configuration hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
   private final FileSystem fs;
-  private final JavaSparkContext jsc;
+  private JavaSparkContext jsc;
   private String base;
   private String schemaFile;
+  private String basePath;
 
   public TestHoodieCompactor() throws IOException {
     fs = FileSystem.getLocal(hadoopConf);
-    jsc = UtilHelpers.buildSparkContext(TestHoodieCompactor.class + "-hoodie", "local[4]");
     basePath = sharedTempDir.toUri().toString();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (null != jsc) {
+      jsc.close();
+    }
   }
 
   @BeforeEach
   public void setUp() throws Exception {
+    jsc = UtilHelpers.buildSparkContext(
+        TestHoodieCompactor.class + "-hoodie", "local[4]");
     base = basePath + "base";
     schemaFile = basePath + "schema.avro";
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Properties;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieCompactor extends UtilitiesTestBase {
+  @TempDir
+  protected static java.nio.file.Path sharedTempDir;
+  protected static Configuration hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
+  private final FileSystem fs;
+  private final JavaSparkContext jsc;
+  private String base;
+  private String schemaFile;
+
+  public TestHoodieCompactor() throws IOException {
+    fs = FileSystem.getLocal(hadoopConf);
+    jsc = UtilHelpers.buildSparkContext(TestHoodieCompactor.class + "-hoodie", "local[4]");
+    basePath = sharedTempDir.toUri().toString();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    base = basePath + "base";
+    schemaFile = basePath + "schema.avro";
+
+    HoodieWriteConfig writeConfig = getWriteConfig(base);
+    Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
+        .setTableType(HoodieTableType.MERGE_ON_READ)
+        .setPayloadClass(HoodieAvroPayload.class)
+        .fromProperties(writeConfig.getProps())
+        .build();
+    HoodieTableMetaClient.initTableAndGetMetaClient(
+        jsc.hadoopConfiguration(), base, metaClientProps);
+  }
+
+  public static HoodieWriteConfig getWriteConfig(String basePath) {
+    return HoodieWriteConfig.newBuilder()
+        .forTable("compactor_test_table")
+        .withPath(basePath)
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .build();
+  }
+
+  public static void writeSchema(FileSystem fs, String path, String schema) throws IOException {
+    PrintStream os = new PrintStream(fs.create(new Path(path), false), true);
+    os.println(schema);
+    os.flush();
+    os.close();
+  }
+
+  @Test
+  public void testGetSchemaWithSchemaFile() throws Exception {
+    HoodieCompactor.Config config = new HoodieCompactor.Config();
+    config.basePath = base;
+    config.schemaFile = schemaFile;
+    HoodieCompactor compactor = new HoodieCompactor(jsc, config);
+    writeSchema(fs, schemaFile, TRIP_EXAMPLE_SCHEMA);
+
+    String schemaStr = compactor.getSchema();
+    assertTrue(schemaStr.startsWith(TRIP_EXAMPLE_SCHEMA));
+  }
+
+  @Test
+  public void testGetSchemaWithoutSchemaFile() throws Exception {
+    HoodieCompactor.Config config = new HoodieCompactor.Config();
+    config.basePath = base;
+    HoodieCompactor compactor = new HoodieCompactor(jsc, config);
+
+    HoodieCompactor spyCompactor = Mockito.spy(compactor);
+    Mockito.doReturn(TRIP_EXAMPLE_SCHEMA).when(spyCompactor).getSchemaFromLatestInstant();
+    String schemaStr = spyCompactor.getSchema();
+    assertEquals(TRIP_EXAMPLE_SCHEMA, schemaStr);
+  }
+}
+

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieCompactor.java
@@ -114,9 +114,8 @@ public class TestHoodieCompactor {
   public void testGetSchemaWithoutSchemaFile() throws Exception {
     HoodieCompactor.Config config = new HoodieCompactor.Config();
     config.basePath = base;
-    HoodieCompactor compactor = new HoodieCompactor(jsc, config);
 
-    HoodieCompactor spyCompactor = Mockito.spy(compactor);
+    HoodieCompactor spyCompactor = Mockito.spy(new HoodieCompactor(jsc, config));
     doReturn(TRIP_EXAMPLE_SCHEMA).when(spyCompactor).getSchemaFromLatestInstant();
     String schemaStr = spyCompactor.getSchema();
     assertEquals(TRIP_EXAMPLE_SCHEMA, schemaStr);

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
     <junit.vintage.version>5.7.2</junit.vintage.version>
     <junit.platform.version>1.7.2</junit.platform.version>
-    <mockito.jupiter.version>3.9.0</mockito.jupiter.version>
+    <mockito.jupiter.version>3.3.3</mockito.jupiter.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.7.36</slf4j.version>
     <joda.version>2.9.9</joda.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
     <junit.vintage.version>5.7.2</junit.vintage.version>
     <junit.platform.version>1.7.2</junit.platform.version>
-    <mockito.jupiter.version>3.3.3</mockito.jupiter.version>
+    <mockito.jupiter.version>3.9.0</mockito.jupiter.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.7.36</slf4j.version>
     <joda.version>2.9.9</joda.version>


### PR DESCRIPTION
### Change Logs

The input schema string is empty.
We try to get it form schema file or instants.

### Impact

Fixed the bug.

### Risk level (write none, low medium or high below)

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
