### PR TITLE
Fix a bug in the HoodieBaseListData.isEmpty() empty-check logic

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieBaseListData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieBaseListData.java
@@ -53,7 +53,7 @@ public abstract class HoodieBaseListData<T> {
 
   protected boolean isEmpty() {
     if (lazy) {
-      return data.asLeft().findAny().isPresent();
+      return !data.asLeft().findAny().isPresent();
     } else {
       return data.asRight().isEmpty();
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListData.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListData.java
@@ -27,12 +27,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestHoodieListData {
 
@@ -71,5 +74,24 @@ class TestHoodieListData {
     HoodieData<Integer> listData = HoodieListData.eager(
         IntStream.rangeClosed(0, 100).boxed().collect(Collectors.toList()));
     assertEquals(1, listData.getNumPartitions());
+  }
+
+  @Test
+  public void testIsEmpty() {
+    // HoodieListData bearing eager execution semantic
+    HoodieData<Integer> listData = HoodieListData.eager(
+            IntStream.rangeClosed(0, 100).boxed().collect(Collectors.toList()));
+    assertFalse(listData.isEmpty());
+
+    HoodieData<Integer> emptyListData = HoodieListData.eager(Collections.emptyList());
+    assertTrue(emptyListData.isEmpty());
+
+    // HoodieListData bearing lazy execution semantic
+    listData = HoodieListData.lazy(
+            IntStream.rangeClosed(0, 100).boxed().collect(Collectors.toList()));
+    assertFalse(listData.isEmpty());
+
+    emptyListData = HoodieListData.lazy(Collections.emptyList());
+    assertTrue(emptyListData.isEmpty());
   }
 }


### PR DESCRIPTION
### Change Logs

There is an obvious logical error in HoodieBaseListData.isEmpty(). When the internal data structure is Stream<T>, there is a logical error in determining whether it is empty.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [1] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [1] Change Logs and Impact were stated clearly
- [1] Adequate tests were added if applicable
- [1] CI passed
