### PR TITLE
[HUDI-7435] Remove shaded of codahale metrics in flink bundle

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -195,10 +195,6 @@
                   <shadedPattern>${flink.bundle.shade.prefix}com.beust.jcommander.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.codahale.metrics.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}com.codahale.metrics.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.commons.codec.</pattern>
                   <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.codec.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Change Logs

Remove shaded of codahale metrics in flink bundle

See https://github.com/apache/hudi/pull/9118#issuecomment-1926124497

We need to remove shaded of com.codahale.metrics to register metrics to flink. This change was tested in inner version.

### Impact

Remove shaded of codahale metrics in flink bundle, now we can register write metrics to flink correctly.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NONE

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
