### PR TITLE
[HUDI-7438] Add GitHub action to check Azure CI report

### DIFF
--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -25,7 +25,6 @@ on:
 
 permissions:
   issues: read
-  pull_requests: read
 
 jobs:
   check-azure-ci-report:

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -20,6 +20,8 @@ name: Azure CI
 on:
   pull_request:
     types: [ opened, reopened, synchronize, edited ]
+  pull_request_review:
+    types: [ submitted, edited, dismissed ]
   issue_comment:
     types: [ created, edited, deleted ]
 

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Get last commit hash
         id: last_commit
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -43,7 +43,7 @@ jobs:
             core.setOutput("last_commit_hash", lastCommitHash);
 
       - name: Check Azure CI report in PR comment
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Azure CI
 
 on:

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -34,6 +34,7 @@ jobs:
         id: last_commit
         uses: actions/github-script@v5
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const pr = context.payload.pull_request;
             const lastCommitHash = pr.head.sha;
@@ -44,6 +45,7 @@ jobs:
       - name: Check Azure CI report in PR comment
         uses: actions/github-script@v5
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const lastCommitHash = '${{ steps.last_commit.outputs.last_commit_hash }}'
             const botUsername = 'hudi-bot';
@@ -86,3 +88,5 @@ jobs:
               core.setFailed("Azure CI report does not seem to be ready yet.");
               return false;
             }
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   check-azure-ci-report:
-    if: "!contains(github.event.pull_request.body, 'HOTFIX: SKIP CI')"
+    if: "!contains(github.event.pull_request.body, 'HOTFIX: SKIP AZURE CI')"
     runs-on: ubuntu-latest
     steps:
       - name: Get last commit hash

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -24,6 +24,7 @@ on:
     types: [ created, edited, deleted ]
 
 permissions:
+  pull-requests: read
   issues: read
 
 jobs:

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -20,8 +20,6 @@ name: Azure CI
 on:
   pull_request:
     types: [ opened, reopened, synchronize, edited ]
-  pull_request_review:
-    types: [ submitted, edited, dismissed ]
   issue_comment:
     types: [ created, edited, deleted ]
 
@@ -31,6 +29,7 @@ permissions:
 
 jobs:
   check-azure-ci-report:
+    if: "!contains(github.event.pull_request.body, 'HOTFIX: SKIP CI')"
     runs-on: ubuntu-latest
     steps:
       - name: Get last commit hash

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -18,8 +18,6 @@
 name: Azure CI
 
 on:
-  pull_request:
-    types: [ opened, reopened, synchronize, edited ]
   issue_comment:
     types: [ created, edited, deleted ]
 

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -10,9 +10,6 @@ jobs:
   check-azure-ci-report:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Get last commit hash
         id: last_commit
         uses: actions/github-script@v5
@@ -30,7 +27,6 @@ jobs:
           script: |
             const lastCommitHash = '${{ steps.last_commit.outputs.last_commit_hash }}'
             const botUsername = 'hudi-bot';
-            const contentToCheck = 'specific content';
             
             const issueNumber = context.payload.pull_request.number;
             const comments = await github.rest.issues.listComments({
@@ -66,7 +62,7 @@ jobs:
                 return false;
               }
             } else {
-              console.log(`PR comments do not contain Azure CI report.`);
-              core.setFailed("PR comments do not contain Azure CI report.");
+              console.log(`Azure CI report does not seem to be ready yet.`);
+              core.setFailed("Azure CI report does not seem to be ready yet.");
               return false;
             }

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -24,7 +24,8 @@ on:
     types: [ created, edited, deleted ]
 
 permissions:
-  contents: read
+  issues: read
+  pull_requests: read
 
 jobs:
   check-azure-ci-report:

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -23,6 +23,9 @@ on:
   issue_comment:
     types: [ created, edited, deleted ]
 
+permissions:
+  contents: read
+
 jobs:
   check-azure-ci-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -1,0 +1,72 @@
+name: Azure CI
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
+  issue_comment:
+    types: [ created, edited, deleted ]
+
+jobs:
+  check-azure-ci-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get last commit hash
+        id: last_commit
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const lastCommitHash = pr.head.sha;
+            console.log(`Last commit hash: ${lastCommitHash}`);
+            // Set the output variable to be used in subsequent step
+            core.setOutput("last_commit_hash", lastCommitHash);
+
+      - name: Check Azure CI report in PR comment
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const lastCommitHash = '${{ steps.last_commit.outputs.last_commit_hash }}'
+            const botUsername = 'hudi-bot';
+            const contentToCheck = 'specific content';
+            
+            const issueNumber = context.payload.pull_request.number;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            
+            // Find the last comment from hudi-bot containing the Azure CI report
+            const botComments = comments.data.filter(comment => comment.user.login === botUsername);
+            const lastComment = botComments.pop();
+            
+            if (lastComment) {
+              const reportPrefix = '${lastCommitHash} Azure: '
+              const successReportString = '${reportPrefix}[SUCCESS]'
+              const failureReportString = '${reportPrefix}[FAILURE]'
+              if (lastComment.body.includes(reportPrefix)) {
+                if (lastComment.body.includes(successReportString)) {
+                  console.log(`Azure CI succeeded on the latest commit of the PR.`);
+                  return true;
+                } else if (lastComment.body.includes(failureReportString)) {
+                  console.log(`Azure CI failed on the latest commit of the PR.`);
+                  core.setFailed("Azure CI failed on the latest commit of the PR.");
+                  return false;
+                } else {
+                  console.log(`Azure CI is in progress on the latest commit of the PR.`);
+                  core.setFailed("Azure CI is in progress on the latest commit of the PR.");
+                  return false;
+                }
+              } else {
+                console.log(`No Azure CI report on the latest commit of the PR.`);
+                core.setFailed("No Azure CI report on the latest commit of the PR.");
+                return false;
+              }
+            } else {
+              console.log(`PR comments do not contain Azure CI report.`);
+              core.setFailed("PR comments do not contain Azure CI report.");
+              return false;
+            }


### PR DESCRIPTION
### Change Logs

This PR adds the GitHub action to check Azure CI report.  The action fails if Azure CI does not pass.

The action checks the last `hudi-bot` comment to look for the Azure CI report on the latest commit of the PR.

In case the check blocks merging unnecessarily, e.g., for hotfix, you can add this magic phrase, `HOTFIX: SKIP AZURE CI`, in the PR description to skip the Azure CI report check.


### Impact

Enforces Azure CI check.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
