### PR TITLE
[HUDI-7440] Verify field exist in schema before fetching the value

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -27,7 +27,6 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
@@ -198,12 +197,13 @@ public class HoodieRealtimeRecordReaderUtils {
         Writable[] recordValues = new Writable[schema.getFields().size()];
         int recordValueIndex = 0;
         for (Schema.Field field : schema.getFields()) {
-          // TODO Revisit Avro exception handling in future
           Object fieldValue = null;
-          try {
+          if (record.getSchema().getField(field.name()) != null) {
             fieldValue = record.get(field.name());
-          } catch (AvroRuntimeException e) {
-            LOG.debug("Field:" + field.name() + "not found in Schema:" + schema);
+          } else {
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Field:" + field.name() + "not found in Schema:" + schema);
+            }
           }
           recordValues[recordValueIndex++] = avroToArrayWritable(fieldValue, field.schema(), supportTimestamp);
         }


### PR DESCRIPTION
### Change Logs
- Avro 1.10 throws ```AvroRuntimeException``` when field is not present in the schema. 
- Since reader schema doesn't contain all fields present in the table. This causes exceptions to be thrown for all fields which are not present in the schema.
- To fix, Verify the field before trying to fetch the value

### Impact

- Catching exception and printing log introduces performance impact for MoR RT tables 
- SELECT query on 3TB TPCDS RT Table with ~40 columns and 10K row updates
- took ```429739 ms```
- with fix ```20689 ms```

### Risk level (write none, low medium or high below)
_low_

### Documentation Update

_N/A_


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
