### PR TITLE
[HUDI-7438] Add write permission of commit statuses in Azure CI check

### DIFF
--- a/.github/workflows/azure_ci_check.yml
+++ b/.github/workflows/azure_ci_check.yml
@@ -22,6 +22,7 @@ on:
     types: [ created, edited, deleted ]
 
 permissions:
+  statuses: write
   pull-requests: read
   issues: read
 


### PR DESCRIPTION
### Change Logs

This PR adds the write permission of commit statuses in the GitHub action of  Azure CI check, to test if the permission is allowed on master for `issue_comment` events.  The PR has to be landed on master for validation.

### Impact

none

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
