### PR TITLE
[HUDI-7446] Enable CI on PRs targeting branch-0.x and branch-0.x

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - 'release-*'
+      - branch-0.x
   pull_request:
     paths-ignore:
       - '**.bmp'
@@ -20,10 +21,11 @@ on:
     branches:
       - master
       - 'release-*'
+      - branch-0.x
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master') }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master') && !contains(github.ref, 'branch-0.x') }}
 
 env:
   MVN_ARGS: -e -ntp -B -V -Dgpg.skip -Djacoco.skip -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=5

--- a/.github/workflows/pr_compliance.yml
+++ b/.github/workflows/pr_compliance.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, edited, reopened, synchronize]
     branches:
       - master
+      - branch-0.x
 
 jobs:
   validate-pr:

--- a/.github/workflows/scheduled_workflow.yml
+++ b/.github/workflows/scheduled_workflow.yml
@@ -46,7 +46,7 @@ jobs:
           script: |
             // Cron schedule may not be reliable so giving buffer time to avoid missing recent PRs
             const since = new Date(new Date().getTime() - (900 * 1000)).toISOString();
-            const query = `repo:${context.repo.owner}/${context.repo.repo} type:pr state:open base:master updated:>=${since}`;
+            const query = `repo:${context.repo.owner}/${context.repo.repo} type:pr state:open updated:>=${since}`;
             const openPrs = await github.paginate(github.rest.search.issuesAndPullRequests, {
               q: query,
               sort: 'updated',
@@ -61,12 +61,19 @@ jobs:
             for (const pr of openPrs) {
               console.log(`*** Processing PR: ${pr.title}, URL: ${pr.html_url}`);
             
-              if (!pr.body.includes('HOTFIX: SKIP AZURE CI')) {
-                const { data: pullRequest } = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number
-                });
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+            
+              const targetBase = pullRequest.base.ref;
+              console.log(`Target base branch: ${targetBase}`);
+            
+              // Check Azure CI and create commit status (targeting "master", "release*", or "branch-0.x" branch)
+              const targetBaseRegex = /^(master|release.*|branch-0\.x)$/;
+              if (targetBaseRegex.test(targetBase)
+                && !pr.body.includes('HOTFIX: SKIP AZURE CI')) {
                 const latestCommitHash = pullRequest.head.sha;
             
                 // Create commit status based on Azure CI report to PR


### PR DESCRIPTION
### Change Logs

HOTFIX: SKIP AZURE CI
script update only

This PR adjusts the GitHub workflows to run and check CI on PR targeting branch-0.x and branch-0.x itself.

### Impact

As above to run tests for branch-0.x.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
