### PR TITLE
[HUDI-7450] Fix offset computation bug when allocedEvents > actualNumEvents

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -166,12 +166,12 @@ public class KafkaOffsetGen {
           if (toOffset == range.untilOffset()) {
             exhaustedPartitions.add(range.partition());
           }
-          allocedEvents += toOffset - range.fromOffset();
           // We need recompute toOffset if allocedEvents larger than actualNumEvents.
-          if (allocedEvents > actualNumEvents) {
+          if (allocedEvents + (toOffset - range.fromOffset()) > actualNumEvents) {
             long offsetsToAdd = Math.min(eventsPerPartition, (actualNumEvents - allocedEvents));
-            toOffset = Math.min(range.untilOffset(), toOffset + offsetsToAdd);
+            toOffset = Math.min(range.untilOffset(), range.fromOffset() + offsetsToAdd);
           }
+          allocedEvents = allocedEvents + (toOffset - range.fromOffset());
           OffsetRange thisRange = OffsetRange.create(range.topicPartition(), range.fromOffset(), toOffset);
           finalRanges.add(thisRange);
           ranges[i] = OffsetRange.create(range.topicPartition(), range.fromOffset() + thisRange.count(), range.untilOffset());


### PR DESCRIPTION
### Change Logs

When allocedEvents in the offset computation function exceeds the  actualNumEvents that can be ingested in this round, there is a bug in the way the endOffset or toOffset is calculated leading to invalid offset ranges exception as re-produced in the unit test, this change fixes this bug.

### Impact

No impact to existing users, this is a bug fix for kafka sources.

### Risk level (write none, low medium or high below)

Medium. 

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
