### PR TITLE
[HUDI-7452] Repartition row dataset in S3/GCS based on task size

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -21,18 +21,19 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
-
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-
 import org.apache.spark.sql.RowFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness {
@@ -103,5 +104,27 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertEquals(1, result.get().count());
     Row expected = RowFactory.create("some data", null);
     Assertions.assertEquals(Collections.singletonList(expected), result.get().collectAsList());
+  }
+
+  @Test
+  public void loadDatasetWithSchemaAndRepartition() {
+    TypedProperties props = new TypedProperties();
+    TestCloudObjectsSelectorCommon.class.getClassLoader().getResource("schema/sample_data_schema.avsc");
+    String schemaFilePath = TestCloudObjectsSelectorCommon.class.getClassLoader().getResource("schema/sample_data_schema.avsc").getPath();
+    props.put("hoodie.deltastreamer.schemaprovider.source.schema.file", schemaFilePath);
+    props.put("hoodie.deltastreamer.schema.provider.class.name", FilebasedSchemaProvider.class.getName());
+    props.put("hoodie.deltastreamer.source.cloud.data.partition.fields.from.path", "country,state");
+    // Setting this config so that dataset repartition happens inside `loadAsDataset`
+    props.put("hoodie.streamer.source.cloud.data.partition.max.size", "1");
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata("src/test/resources/data/partitioned/country=US/state=CA/data.json", 1000),
+        new CloudObjectMetadata("src/test/resources/data/partitioned/country=US/state=TX/data.json", 1000),
+        new CloudObjectMetadata("src/test/resources/data/partitioned/country=IND/state=TS/data.json", 1000)
+    );
+    Option<Dataset<Row>> result = CloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, props, "json", Option.of(new FilebasedSchemaProvider(props, jsc)));
+    Assertions.assertTrue(result.isPresent());
+    List<Row> expected = Arrays.asList(RowFactory.create("some data", "US", "CA"), RowFactory.create("some data", "US", "TX"), RowFactory.create("some data", "IND", "TS"));
+    List<Row> actual = result.get().collectAsList();
+    Assertions.assertEquals(new HashSet<>(expected), new HashSet<>(actual));
   }
 }

--- a/hudi-utilities/src/test/resources/data/partitioned/country=IND/state=TS/data.json
+++ b/hudi-utilities/src/test/resources/data/partitioned/country=IND/state=TS/data.json
@@ -1,0 +1,1 @@
+{"data": "some data"}

--- a/hudi-utilities/src/test/resources/data/partitioned/country=US/state=TX/data.json
+++ b/hudi-utilities/src/test/resources/data/partitioned/country=US/state=TX/data.json
@@ -1,0 +1,1 @@
+{"data": "some data"}


### PR DESCRIPTION
### Change Logs

In our current code we are doing a coalesce which just decreases the partitions but doesn't increase them, adding a function known as `coalesceOrRepartition` which does coalesce or repartition depending on the rdd partitions and the numPartitions calculated using the task/partition size. 

### Impact

Improvement in S3/GCS sources to increase/decrease  parallelism based on partition size. 

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
