### PR TITLE
[HUDI-7462] Refactor checkTopicCheckpoint in KafkaOffsetGen for reusability

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -59,6 +59,7 @@ import static org.apache.hudi.common.util.ConfigUtils.checkRequiredProperties;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getLongWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils.checkTopicCheckpoint;
 
 /**
  * Source to read data from Kafka, incrementally.
@@ -68,16 +69,14 @@ public class KafkaOffsetGen {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaOffsetGen.class);
   private static final String METRIC_NAME_KAFKA_DELAY_COUNT = "kafkaDelayCount";
   private static final Comparator<OffsetRange> SORT_BY_PARTITION = Comparator.comparing(OffsetRange::partition);
-
   public static final String KAFKA_CHECKPOINT_TYPE_TIMESTAMP = "timestamp";
 
-  /**
-   * kafka checkpoint Pattern.
-   * Format: topic_name,partition_num:offset,partition_num:offset,....
-   */
-  private static final Pattern PATTERN = Pattern.compile(".*,.*:.*");
-
   public static class CheckpointUtils {
+    /**
+     * kafka checkpoint Pattern.
+     * Format: topic_name,partition_num:offset,partition_num:offset,....
+     */
+    private static final Pattern PATTERN = Pattern.compile(".*,.*:.*");
 
     /**
      * Reconstruct checkpoint from timeline.
@@ -209,6 +208,11 @@ public class KafkaOffsetGen {
 
     public static long totalNewMessages(OffsetRange[] ranges) {
       return Arrays.stream(ranges).mapToLong(OffsetRange::count).sum();
+    }
+
+    public static boolean checkTopicCheckpoint(Option<String> lastCheckpointStr) {
+      Matcher matcher = PATTERN.matcher(lastCheckpointStr.get());
+      return matcher.matches();
     }
   }
 
@@ -423,11 +427,6 @@ public class KafkaOffsetGen {
   public boolean checkTopicExists(KafkaConsumer consumer)  {
     Map<String, List<PartitionInfo>> result = consumer.listTopics();
     return result.containsKey(topicName);
-  }
-
-  public static boolean checkTopicCheckpoint(Option<String> lastCheckpointStr) {
-    Matcher matcher = PATTERN.matcher(lastCheckpointStr.get());
-    return matcher.matches();
   }
 
   public String getTopicName() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -75,7 +75,7 @@ public class KafkaOffsetGen {
    * kafka checkpoint Pattern.
    * Format: topic_name,partition_num:offset,partition_num:offset,....
    */
-  private final Pattern pattern = Pattern.compile(".*,.*:.*");
+  private static final Pattern PATTERN = Pattern.compile(".*,.*:.*");
 
   public static class CheckpointUtils {
 
@@ -425,8 +425,8 @@ public class KafkaOffsetGen {
     return result.containsKey(topicName);
   }
 
-  private boolean checkTopicCheckpoint(Option<String> lastCheckpointStr) {
-    Matcher matcher = pattern.matcher(lastCheckpointStr.get());
+  public static boolean checkTopicCheckpoint(Option<String> lastCheckpointStr) {
+    Matcher matcher = PATTERN.matcher(lastCheckpointStr.get());
     return matcher.matches();
   }
 


### PR DESCRIPTION
### Change Logs
Refactoring checkTopicCheckpoint in KafkaOffsetGen for reusability by making it as public static, useful for validating source related checkpoints. 

### Impact

no major impact, this pr just exposes an existing function

### Risk level (write none, low medium or high below)

low

### Documentation Update
NA 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
