### PR TITLE
[MINOR] Add PR description validation on documentation updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ _If medium or high, explain what verification was done to mitigate the risks._
 
 ### Documentation Update
 
-_Describe any necessary documentation update if there is any new feature, config, or user-facing change_
+_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "N/A"._
 
 - _The config description must be updated if new configs are added or the default value of the configs are changed_
 - _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ _If medium or high, explain what verification was done to mitigate the risks._
 
 ### Documentation Update
 
-_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "N/A"._
+_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._
 
 - _The config description must be updated if new configs are added or the default value of the configs are changed_
 - _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the

--- a/scripts/pr_compliance.py
+++ b/scripts/pr_compliance.py
@@ -389,21 +389,29 @@ class ValidateBody:
 #Generate the validator for the current template.
 #needs to be manually updated
 def make_default_validator(body, debug=False):
-    changelogs = ParseSectionData("CHANGELOGS",
+    changelogs = ParseSectionData("CHANGE_LOGS",
         "### Change Logs",
         {"_Describe context and summary for this change. Highlight if any code was copied._"})
     impact = ParseSectionData("IMPACT",
         "### Impact",
         {"_Describe any public API or user-facing feature change or any performance impact._"})
-    risklevel = RiskLevelData("RISKLEVEL",
+    risklevel = RiskLevelData("RISK_LEVEL",
         "### Risk level",
         {"_If medium or high, explain what verification was done to mitigate the risks._"})
+    docsUpdate = ParseSectionData("DOCUMENTATION_UPDATE",
+        "### Documentation Update",
+        {"_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
+        "",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed_",
+        "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
+        "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
+        "  changes to the website._"})
     checklist = ParseSectionData("CHECKLIST",
         "### Contributor's checklist",
         {})
-    parseSections = ParseSections([changelogs, impact, risklevel, checklist])
+    parseSections = ParseSections([changelogs, impact, risklevel, docsUpdate, checklist])
 
-    return ValidateBody(body, "CHANGELOGS", parseSections, debug)
+    return ValidateBody(body, "CHANGE_LOGS", parseSections, debug)
 
 
 #takes a list of strings and returns a string of those lines separated by \n
@@ -466,6 +474,21 @@ def test_body():
     good_risklevel = template_risklevel.copy()
     good_risklevel[1] = "none"
 
+    template_docs_update = [
+        "### Documentation Update",
+        "",
+        "_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
+        "",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed_",
+        "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
+        "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
+        "  changes to the website._",
+        ""
+    ]
+
+    good_docs_update = template_docs_update.copy()
+    good_docs_update[1] = "update docs"
+
     template_checklist = [
         "### Contributor's checklist",
         "",
@@ -476,10 +499,10 @@ def test_body():
     ]
 
     #list of sections that when combined form a valid body
-    good_sections = [good_changelogs, good_impact, good_risklevel, template_checklist]
+    good_sections = [good_changelogs, good_impact, good_risklevel, good_docs_update, template_checklist]
 
     #list of sections that when combined form the template
-    template_sections = [template_changelogs, template_impact, template_risklevel, template_checklist]
+    template_sections = [template_changelogs, template_impact, template_risklevel, template_docs_update, template_checklist]
 
     tests_passed = True
     #Test section not filled out
@@ -530,9 +553,6 @@ def test_body():
     print("*****")
     
     return tests_passed
-
-
-
 
 
 if __name__ == '__main__':

--- a/scripts/pr_compliance.py
+++ b/scripts/pr_compliance.py
@@ -402,7 +402,7 @@ def make_default_validator(body, debug=False):
         "### Documentation Update",
         {"_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
         "",
-        "- _The config description must be updated if new configs are added or the default value of the configs are changed_",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"N/A\"._",
         "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
         "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
         "  changes to the website._"})
@@ -479,7 +479,7 @@ def test_body():
         "",
         "_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
         "",
-        "- _The config description must be updated if new configs are added or the default value of the configs are changed_",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"N/A\"._",
         "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
         "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
         "  changes to the website._",

--- a/scripts/pr_compliance.py
+++ b/scripts/pr_compliance.py
@@ -402,7 +402,7 @@ def make_default_validator(body, debug=False):
         "### Documentation Update",
         {"_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
         "",
-        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"N/A\"._",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"none\"._",
         "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
         "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
         "  changes to the website._"})
@@ -479,7 +479,7 @@ def test_body():
         "",
         "_Describe any necessary documentation update if there is any new feature, config, or user-facing change_",
         "",
-        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"N/A\"._",
+        "- _The config description must be updated if new configs are added or the default value of the configs are changed. If not, put \"none\"._",
         "- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the",
         "  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make",
         "  changes to the website._",


### PR DESCRIPTION
### Change Logs

As above, to make PR description validation strict.

No information in the "Documentation Update" section in the PR description will trigger PR validation failure:

<img width="1394" alt="Screenshot 2024-03-02 at 16 30 05" src="https://github.com/apache/hudi/assets/2497195/bf8e2cee-355c-4f55-9b01-9c6ba2dd78f6">

### Impact

As above.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
