### PR TITLE
[MINOR] Optimize print write error msg in StreamWriteOperatorCoordinator#doCommit

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -576,12 +576,17 @@ public class StreamWriteOperatorCoordinator
       }
     } else {
       LOG.error("Error when writing. Errors/Total=" + totalErrorRecords + "/" + totalRecords);
-      LOG.error("The first 100 error messages");
-      writeResults.stream().filter(WriteStatus::hasErrors).limit(100).forEach(ws -> {
-        LOG.error("Global error for partition path {} and fileID {}: {}",
-            ws.getGlobalError(), ws.getPartitionPath(), ws.getFileId());
+      LOG.error("The first 10 files with write errors:");
+      writeResults.stream().filter(WriteStatus::hasErrors).limit(10).forEach(ws -> {
+        if (ws.getGlobalError() != null) {
+          LOG.error("Global error for partition path {} and fileID {}: {}",
+              ws.getPartitionPath(), ws.getFileId(), ws.getGlobalError());
+        }
         if (ws.getErrors().size() > 0) {
-          ws.getErrors().forEach((key, value) -> LOG.trace("Error for key:" + key + " and value " + value));
+          LOG.error("The first 100 records-level errors for partition path {} and fileID {}:",
+              ws.getPartitionPath(), ws.getFileId());
+          ws.getErrors().entrySet().stream().limit(100).forEach(entry -> LOG.error("Error for key: "
+              + entry.getKey() + " and Exception: " + entry.getValue().getMessage()));
         }
       });
       // Rolls back instant


### PR DESCRIPTION
### Change Logs
refer to
https://issues.apache.org/jira/browse/HUDI-7477

<img width="674" alt="c614086e1752d4c9d33bb56ca28bce26" src="https://github.com/apache/hudi/assets/34104400/320a81eb-432a-444d-8cec-57ef8b588d92">

Before modification:
1. The semantics are unclear. In fact, it is not the first 100 error messages， but the first10 file errors.
2. The printing positions of partition and global exception are reversed. 
And if there is no global exception, there is no need to print null.
4. Row-level exceptions. Although they are printed in the trace,  the online data traffic is usually very large,  so it is not wise to print them all.

So, I modified it to print the first 10 files with write exceptions
Then print global exceptions and row-level exceptions as needed,  and if there are row-level exceptions,  only print the first 100 exceptions.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
