### PR TITLE
[MINOR] Fix Azure publishing of JUnit results

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -132,8 +132,7 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'clean install'
               options: $(MVN_OPTS_INSTALL)
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              publishJUnitResults: false
               jdkVersionOption: '1.8'
           - task: Maven@4
             displayName: UT common flink client/spark-client
@@ -141,8 +140,7 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'test'
               options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB1_MODULES),hudi-client/hudi-spark-client
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
           - task: Maven@4
@@ -168,8 +166,7 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'clean install'
               options: $(MVN_OPTS_INSTALL) -pl $(JOB2_MODULES) -am
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              publishJUnitResults: false
               jdkVersionOption: '1.8'
           - task: Maven@4
             displayName: FT client/spark-client & hudi-spark-datasource/hudi-spark
@@ -194,8 +191,7 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'clean install'
               options: $(MVN_OPTS_INSTALL) -pl $(JOB3_MODULES) -am
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              publishJUnitResults: false
               jdkVersionOption: '1.8'
           - task: Maven@4
             displayName: Java UT spark-datasource
@@ -220,8 +216,7 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'clean install'
               options: $(MVN_OPTS_INSTALL) -pl $(JOB4_MODULES) -am
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              publishJUnitResults: false
               jdkVersionOption: '1.8'
           - task: Maven@4
             displayName: Scala UT spark-datasource


### PR DESCRIPTION
### Change Logs

This PR fixes Azure publishing of JUnit results to avoid double counting the same test results.  Only the last step in a job should have the `publishJUnitResults` enabled.  Otherwise, the tests from the previous step are published again, making these tests double counted:

<img width="911" alt="Screenshot 2024-03-04 at 22 40 45" src="https://github.com/apache/hudi/assets/2497195/f59f3131-3e20-4650-964c-daf3cbcfbadb">

<img width="939" alt="Screenshot 2024-03-04 at 22 40 53" src="https://github.com/apache/hudi/assets/2497195/16026c55-0baf-443a-ba67-33141b3564d1">


### Impact

Makes test count in Azure accurate.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
