### PR TITLE
[MINOR] Publish test results from the containerized job to Azure

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -261,7 +261,20 @@ stages:
               command: 'run'
               arguments: >
                 -i docker.io/apachehudi/hudi-ci-bundle-validation-base:$(Build.BuildId)
+                -v $(Build.ArtifactStagingDirectory)/surefire-reports:/app/target/surefire-reports
                 /bin/bash -c "mvn clean install $(MVN_OPTS_INSTALL) -Phudi-platform-service -Pthrift-gen-source
-                && mvn test  $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB5_UT_MODULES)
                 && mvn test  $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB5_UT_MODULES)
-                && grep \"testcase\" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'\"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100"
+                && mkdir -p /app/target/surefire-reports
+                && find . -type f -name "TEST-*.xml" -exec mv {} /app/target/surefire-reports \;
+                && echo "All surefire report files:"
+                && ls -l /app/target/surefire-reports
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              searchFolder: '$(Build.ArtifactStagingDirectory)'
+              failTaskOnFailedTests: true
+          - script: |
+              grep "testcase" surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
+            displayName: Top 100 long-running testcases


### PR DESCRIPTION
### Change Logs

This PR makes the last module running the containerized job in Azure CI to publish the test results to Azure for accurate reporting.

### Impact

Makes test report in Azure accurate.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
