### PR TITLE
[HUDI-6472] fix spark sql does not ignore case

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -95,7 +95,9 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
     }
     val config = buildHoodieInsertConfig(catalogTable, sparkSession, isOverWritePartition, isOverWriteTable, partitionSpec, extraOptions, staticOverwritePartitionPathOpt)
 
-    val alignedQuery = alignQueryOutput(query, catalogTable, partitionSpec, sparkSession.sessionState.conf)
+    val optimizer = sparkSession.sessionState.optimizer
+    val optimizerPlan = optimizer.execute(query)
+    val alignedQuery = alignQueryOutput(optimizerPlan, catalogTable, partitionSpec, sparkSession.sessionState.conf)
 
     val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, mode, config, Dataset.ofRows(sparkSession, alignedQuery))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -2450,47 +2450,45 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   }
 
   test("Test query with Foldable Propagation expression") {
-    withRecordType(Seq(HoodieRecordType.AVRO))(withTempDir { tmp =>
-      Seq("cow").foreach { tableType =>
-        val tableName = generateTableName
-        // Create table
-        spark.sql(
-          s"""
-             |create table $tableName (
-             |  id int,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) using hudi
-             | location '${tmp.getCanonicalPath}/$tableName'
-             | tblproperties (
-             |  primaryKey ='id',
-             |  preCombineField = 'ts'
-             | )
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      // Create table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |  primaryKey ='id',
+           |  preCombineField = 'ts'
+           | )
        """.stripMargin)
 
-        val tableNameA = generateTableName
-        spark.sql(
-          s"""
-             |create table $tableNameA (
-             |  ID int,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) using parquet
-             | location '${tmp.getCanonicalPath}/$tableNameA'
-            """.stripMargin)
+      val tableNameA = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableNameA (
+           |  ID int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using parquet
+           | location '${tmp.getCanonicalPath}/$tableNameA'
+        """.stripMargin)
 
-        assertDoesNotThrow(
-          new Executable {
-            override def execute(): Unit = {
-              spark.sql(s"insert into table $tableName select 1 as ID, name, price, ts from $tableNameA order by ID")
-                .queryExecution.optimizedPlan
-            }
+      assertDoesNotThrow(
+        new Executable {
+          override def execute(): Unit = {
+            spark.sql(s"insert into table $tableName select 1 as ID, name, price, ts from $tableNameA order by ID")
+              .queryExecution.optimizedPlan
           }
-        )
-      }
-    })
+        }
+      )
+    }
   }
 
   test("Test various data types as partition fields") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -33,7 +33,8 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerStageSubmitted}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase.getLastCommitMetadata
 import org.apache.spark.sql.hudi.command.HoodieSparkValidateDuplicateKeyRecordMerger
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals}
+import org.junit.jupiter.api.function.Executable
 
 import java.io.File
 import java.util.concurrent.CountDownLatch
@@ -2444,6 +2445,50 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
               s"set ${DataSourceWriteOptions.INSERT_DUP_POLICY.key}=$dupPolicy"),
             dupPolicy, true)
         }
+      }
+    })
+  }
+
+  test("Test query with Foldable Propagation expression") {
+    withRecordType(Seq(HoodieRecordType.AVRO))(withTempDir { tmp =>
+      Seq("cow").foreach { tableType =>
+        val tableName = generateTableName
+        // Create table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |  primaryKey ='id',
+             |  preCombineField = 'ts'
+             | )
+       """.stripMargin)
+
+        val tableNameA = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableNameA (
+             |  ID int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using parquet
+             | location '${tmp.getCanonicalPath}/$tableNameA'
+            """.stripMargin)
+
+        assertDoesNotThrow(
+          new Executable {
+            override def execute(): Unit = {
+              spark.sql(s"insert into table $tableName select 1 as ID, name, price, ts from $tableNameA order by ID")
+                .queryExecution.optimizedPlan
+            }
+          }
+        )
       }
     })
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
@@ -376,7 +376,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
     }
   }
 
-  /* TODO [HUDI-6472]
   test("Test MergeInto When PrimaryKey And PreCombineField Of Source Table And Target Table Differ In Case Only") {
     withRecordType()(withTempDir { tmp =>
       spark.sql("set hoodie.payload.combined.schema.validate = true")
@@ -556,7 +555,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
       )
     })
   }
-*/
+
 
   test("Test only insert when source table contains history") {
     withTempDir { tmp =>

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark32PlusAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark32PlusAnalysis.scala
@@ -23,7 +23,6 @@ import org.apache.hudi.storage.StoragePath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.HoodieSpark3CatalystPlanUtils.MatchResolvedTable
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NamedRelation, ResolvedFieldName, UnresolvedAttribute, UnresolvedFieldName, UnresolvedPartitionSpec}
-import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolveExpressionByPlanChildren
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logcal.{HoodieFileSystemViewTableValuedFunction, HoodieFileSystemViewTableValuedFunctionOptionsParser, HoodieMetadataTableValuedFunction, HoodieQuery, HoodieTableChanges, HoodieTableChangesOptionsParser, HoodieTimelineTableValuedFunction, HoodieTimelineTableValuedFunctionOptionsParser}
@@ -54,6 +53,10 @@ import org.apache.spark.sql.hudi.command.{AlterHoodieTableDropPartitionCommand, 
  */
 case class HoodieSpark32PlusResolveReferences(spark: SparkSession) extends Rule[LogicalPlan]
   with SparkAdapterSupport with ProvidesHoodieConfig {
+
+  def resolveExpressionByPlanChildren(e: Expression, q: LogicalPlan): Expression = {
+    spark.sessionState.analyzer.resolveExpressionByPlanChildren(e, q)
+  }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
     case TimeTravelRelation(ResolvesToHudiTable(table), timestamp, version) =>


### PR DESCRIPTION
### Change Logs

https://github.com/apache/hudi/pull/10582
with the following changes:

- HoodieSpark32PlusAnalysis: made this change much less complex
- correct capitalization of partition column names for keygen

### Impact

allow merge into to ignore case

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
