### PR TITLE
[HUDI-7482] Update schema evolution docs to explicitly state allowed type promotions

### DIFF
--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -47,14 +47,14 @@ type promotions eg., 'long' to 'int'.
 
 This chart shows what the table schema will be when an incoming column type has changed (X means that it is not allowed):
 
-| Incoming Schema \ Table Schema | int    | long   | float  | double | string | bytes |
-|--------------------------------|--------|--------|--------|--------|--------|-------|
-| int                            | int    | long   | float  | double | string | X     |
-| long                           | long   | long   | float  | double | string | X     | 
-| float                          | float  | float  | float  | double | string | X     |  
-| double                         | double | double | double | double | string | X     |  
-| string                         | string | string | string | string | string | bytes | 
-| bytes                          | X      | X      | X      | X      | string | bytes |
+| Incoming Schema &#8595; \ Table Schema &#8594; | int    | long   | float  | double | string | bytes |
+|------------------------------------------------|--------|--------|--------|--------|--------|-------|
+| int                                            | int    | long   | float  | double | string | X     |
+| long                                           | long   | long   | float  | double | string | X     | 
+| float                                          | float  | float  | float  | double | string | X     |  
+| double                                         | double | double | double | double | string | X     |  
+| string                                         | string | string | string | string | string | bytes | 
+| bytes                                          | X      | X      | X      | X      | string | bytes |
 
 ## Schema Evolution on read
 

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -43,18 +43,18 @@ type promotions eg., 'long' to 'int'.
 | Demote datatype for a nested field                              | No  | No  |                                                                                                                                                                                                                                                                                               |
 | Demote datatype for a complex type (value of map or array)      | No  | No  |                                                                                                                                                                                                                                                                                               |
 
-###Type Promotions
+### Type Promotions
 
-The incoming schema will automatically have types promoted to match the table schema
+This chart shows what the table schema will be when an incoming column type has changed (X means that it is not allowed):
 
-| Incoming Schema \ Table Schema  | int   | long  | float  | double | string  | bytes   |
-|---------------------------------|-------|-------|--------|--------|---------|---------|
-| int                             |   Y   |   Y   |    Y   |    Y   |    Y    |   N     |
-| long                            |   N   |   Y   |    Y   |    Y   |    Y    |   N     | 
-| float                           |   N   |   N   |    Y   |    Y   |    Y    |   N     |  
-| double                          |   N   |   N   |    N   |    Y   |    Y    |   N     |  
-| string                          |   N   |   N   |    N   |    N   |    Y    |   Y     | 
-| bytes                           |   N   |   N   |    N   |    N   |    Y    |   Y     |
+| Incoming Schema \ Table Schema | int    | long   | float  | double | string | bytes |
+|--------------------------------|--------|--------|--------|--------|--------|-------|
+| int                            | int    | long   | float  | double | string | X     |
+| long                           | long   | long   | float  | double | string | X     | 
+| float                          | float  | float  | float  | double | string | X     |  
+| double                         | double | double | double | double | string | X     |  
+| string                         | string | string | string | string | string | bytes | 
+| bytes                          | X      | X      | X      | X      | string | bytes |
 
 ## Schema Evolution on read
 

--- a/website/versioned_docs/version-0.14.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.1/schema_evolution.md
@@ -47,14 +47,14 @@ type promotions eg., 'long' to 'int'.
 
 This chart shows what the table schema will be when an incoming column type has changed (X means that it is not allowed):
 
-| Incoming Schema \ Table Schema | int    | long   | float  | double | string | bytes |
-|--------------------------------|--------|--------|--------|--------|--------|-------|
-| int                            | int    | long   | float  | double | string | X     |
-| long                           | long   | long   | float  | double | string | X     | 
-| float                          | float  | float  | float  | double | string | X     |  
-| double                         | double | double | double | double | string | X     |  
-| string                         | string | string | string | string | string | bytes | 
-| bytes                          | X      | X      | X      | X      | string | bytes |
+| Incoming Schema &#8595; \ Table Schema &#8594; | int    | long   | float  | double | string | bytes |
+|------------------------------------------------|--------|--------|--------|--------|--------|-------|
+| int                                            | int    | long   | float  | double | string | X     |
+| long                                           | long   | long   | float  | double | string | X     | 
+| float                                          | float  | float  | float  | double | string | X     |  
+| double                                         | double | double | double | double | string | X     |  
+| string                                         | string | string | string | string | string | bytes | 
+| bytes                                          | X      | X      | X      | X      | string | bytes |
 
 ## Schema Evolution on read
 

--- a/website/versioned_docs/version-0.14.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.1/schema_evolution.md
@@ -43,18 +43,18 @@ type promotions eg., 'long' to 'int'.
 | Demote datatype for a nested field                              | No  | No  |                                                                                                                                                                                                                                                                                               |
 | Demote datatype for a complex type (value of map or array)      | No  | No  |                                                                                                                                                                                                                                                                                               |
 
-###Type Promotions
+### Type Promotions
 
-The incoming schema will automatically have types promoted to match the table schema
+This chart shows what the table schema will be when an incoming column type has changed (X means that it is not allowed):
 
-| Incoming Schema \ Table Schema  | int   | long  | float  | double | string  | bytes   |
-|---------------------------------|-------|-------|--------|--------|---------|---------|
-| int                             |   Y   |   Y   |    Y   |    Y   |    Y    |   N     |
-| long                            |   N   |   Y   |    Y   |    Y   |    Y    |   N     | 
-| float                           |   N   |   N   |    Y   |    Y   |    Y    |   N     |  
-| double                          |   N   |   N   |    N   |    Y   |    Y    |   N     |  
-| string                          |   N   |   N   |    N   |    N   |    Y    |   Y     | 
-| bytes                           |   N   |   N   |    N   |    N   |    Y    |   Y     |
+| Incoming Schema \ Table Schema | int    | long   | float  | double | string | bytes |
+|--------------------------------|--------|--------|--------|--------|--------|-------|
+| int                            | int    | long   | float  | double | string | X     |
+| long                           | long   | long   | float  | double | string | X     | 
+| float                          | float  | float  | float  | double | string | X     |  
+| double                         | double | double | double | double | string | X     |  
+| string                         | string | string | string | string | string | bytes | 
+| bytes                          | X      | X      | X      | X      | string | bytes |
 
 ## Schema Evolution on read
 


### PR DESCRIPTION
### Change Logs

Update table to clearly show how schema is evolved and manipulated based on incoming and existing schema

<img width="710" alt="image" src="https://github.com/apache/hudi/assets/26940621/72808fac-ee5d-4ff9-884e-7bda913f3c25">


### Impact

Users are clear on schema evolution

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
