### PR TITLE
[HUDI-8218] Change the properties to be loaded from both default path and environment variable

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -111,8 +111,9 @@ public class ConfigGroups {
             + "job configurations/tunings, so all the jobs on your cluster can utilize it. "
             + "It also works with Spark SQL DML/DDL, and helps avoid having to pass configs "
             + "inside the SQL statements.\n\n"
-            + "Hudi always loads the configuration file under default directory `file:/etc/hudi/conf` "
-            + "to set the default configs. You can specify another configuration "
+            + "Hudi always loads the configuration file under default directory "
+            + "`file:/etc/hudi/conf`, if exists, to set the default configs. "
+            + "Besides, you can specify another configuration "
             + "directory location by setting the `HUDI_CONF_DIR` environment variable. "
             + "The configs stored in `HUDI_CONF_DIR/hudi-defaults.conf` are loaded, "
             + "overriding any configs already set by the config file in the default directory.";

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -111,9 +111,11 @@ public class ConfigGroups {
             + "job configurations/tunings, so all the jobs on your cluster can utilize it. "
             + "It also works with Spark SQL DML/DDL, and helps avoid having to pass configs "
             + "inside the SQL statements.\n\n"
-            + "By default, Hudi would load the configuration file under `/etc/hudi/conf` "
-            + "directory. You can specify a different configuration directory location by "
-            + "setting the `HUDI_CONF_DIR` environment variable.";
+            + "Hudi always loads the configuration file under default directory `file:/etc/hudi/conf` "
+            + "to set the default configs. You can specify another configuration "
+            + "directory location by setting the `HUDI_CONF_DIR` environment variable. "
+            + "The configs stored in `HUDI_CONF_DIR/hudi-defaults.conf` are loaded, "
+            + "overriding any configs already set by the config file in the default directory.";
         break;
       case SPARK_DATASOURCE:
         description = "These configs control the Hudi Spark Datasource, "

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -117,15 +117,14 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       }
     }
     // Try loading the external config file from local file system
+    try {
+      conf.addPropsFromFile(DEFAULT_PATH);
+    } catch (Exception e) {
+      LOG.warn("Cannot load default config file: " + DEFAULT_PATH, e);
+    }
     Option<StoragePath> defaultConfPath = getConfPathFromEnv();
     if (defaultConfPath.isPresent()) {
       conf.addPropsFromFile(defaultConfPath.get());
-    } else {
-      try {
-        conf.addPropsFromFile(DEFAULT_PATH);
-      } catch (Exception e) {
-        LOG.warn("Cannot load default config file: " + DEFAULT_PATH, e);
-      }
     }
     return conf.getProps();
   }


### PR DESCRIPTION

### Change Logs

This PR changes config properties in the Hudi streamer to be always loaded from environment variable first and then from the config file specified by the environment variable for any overrides.

### Impact

No Major Impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

HUDI-8223

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
