### PR TITLE
[HUDI-7504] replace expensive existence check with spark options

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceCloudStorageHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceCloudStorageHelper.java
@@ -34,8 +34,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.ENABLE_EXISTS_CHECK;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.SPARK_DATASOURCE_OPTIONS;
 
 /**
@@ -53,6 +55,11 @@ public class IncrSourceCloudStorageHelper {
                                                    TypedProperties props, String fileFormat) {
     if (filepaths.isEmpty()) {
       return Option.empty();
+    }
+
+    if (getBooleanWithAltKeys(props, ENABLE_EXISTS_CHECK)) {
+      spark.conf().set("spark.sql.files.ignoreMissingFiles", "true");
+      spark.conf().set("spark.sql.files.ignoreCorruptFiles", "true");
     }
 
     DataFrameReader dfReader = getDataFrameReader(spark, props, fileFormat);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectMetadataFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectMetadataFetcher.java
@@ -18,12 +18,10 @@
 
 package org.apache.hudi.utilities.sources.helpers.gcs;
 
-import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
 import org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon;
 
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
@@ -58,15 +56,13 @@ public class GcsObjectMetadataFetcher implements Serializable {
   /**
    * @param cloudObjectMetadataDF a Dataset that contains metadata of GCS objects. Assumed to be a persisted form
    *                              of a Cloud Storage Pubsub Notification event.
-   * @param checkIfExists         Check if each file exists, before returning its full path
    * @return A {@link List} of {@link CloudObjectMetadata} containing GCS info.
    */
-  public List<CloudObjectMetadata> getGcsObjectMetadata(JavaSparkContext jsc, Dataset<Row> cloudObjectMetadataDF, boolean checkIfExists) {
-    SerializableConfiguration serializableHadoopConf = new SerializableConfiguration(jsc.hadoopConfiguration());
+  public List<CloudObjectMetadata> getGcsObjectMetadata(Dataset<Row> cloudObjectMetadataDF) {
     return cloudObjectMetadataDF
         .select("bucket", "name", "size")
         .distinct()
-        .mapPartitions(getCloudObjectMetadataPerPartition(GCS_PREFIX, serializableHadoopConf, checkIfExists), Encoders.kryo(CloudObjectMetadata.class))
+        .mapPartitions(getCloudObjectMetadataPerPartition(GCS_PREFIX), Encoders.kryo(CloudObjectMetadata.class))
         .collectAsList();
   }
 


### PR DESCRIPTION
The incremental source (for S3 and GCS) performas an existance check for the object (in the object store). This can be an expensive operation. This can be replaced with two spark session configs: `spark.sql.files.ignoreMissingFiles` and `spark.sql.files.ignoreCorruptFiles`. The documentation for the same can be found in https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#ignore-missing-files.

Of specific interest in the documentation is these lines, "Here, missing file really means the deleted file under directory after you construct the DataFrame.". This seems to be the case with the existance check in `CloudObjectsSelectorCommon.java`. Specifically, if someone wants to check for the existance of a file while the dataframe itself is being created, then this will not work.

Added a test case by simulating file deletions _after_ DataFrame is created in TestCloudObjectsSelectorCommon::ignoreMissingFiles

### Change Logs
GcsEventsHoodieIncrSource.java and S3EventsHoodieIncrSource.java
Set the two spark options in sparkSession iff `ENABLE_EXISTS_CHECK` is set in the property. The two options are `spark.sql.files.ignoreMissingFiles` and `spark.sql.files.ignoreCorruptFiles`.

CloudObjectsSelectorCommon.java:
Remove the call to `checkIfFileExists(...)` when building a URL for a file

IncrSourceCloudStorageHelper.java:
Set teh same spak options in the sparkSession. These functions do not seem to be used anywhere, but cleaning up the usage of file-existance-check regardless.

TestCloudObjectsSelectorCommon.java: New test case for the said funtionality

### Impact

None

### Risk level (write none, low medium or high below)

Low. New tests and existing tests should suffice.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
