### PR TITLE
[HUDI-7513] Add jackson-module-scala to spark bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,7 @@
               <include>org.apache.htrace:htrace-core4</include>
               <!-- afterburner module for jackson performance -->
               <include>com.fasterxml.jackson.module:jackson-module-afterburner</include>
+              <include>com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}</include>
               <!-- native HFile reader uses protobuf -->
               <include>com.google.protobuf:protobuf-java</include>
             </includes>


### PR DESCRIPTION
### Change Logs

#10097 we relocated "com.fasterxml.jackson.module", 

https://github.com/apache/hudi/blob/2dcdd311245b38c0a9884338d6333212a730d310/pom.xml#L582-L586

this changes the package path of *jackson-module-scala_${scala.binary.version}*.

When we do spark stream read, we will get `ClassNotFoundException: org.apache.hudi.com.fasterxml.jackson.module.scala.DefaultScalaModule$`

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
