### PR TITLE
[HUDI-7514] Update Manifest file after the parquet writer closed in LSMTimelineWriter

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/LSMTimelineWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/LSMTimelineWriter.java
@@ -124,9 +124,13 @@ public class LSMTimelineWriter {
           exceptionHandler.ifPresent(handler -> handler.accept(e));
         }
       }
-      updateManifest(filePath.getName());
     } catch (Exception e) {
       throw new HoodieCommitException("Failed to write commits", e);
+    }
+    try {
+      updateManifest(filePath.getName());
+    } catch (Exception e) {
+      throw new HoodieCommitException("Failed to update archiving manifest", e);
     }
   }
 


### PR DESCRIPTION
### Change Logs

In LSMTimelineWriter we should wait for the parquet writer closed and then update the manifest and version file.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
