### PR TITLE
[HUDI-7517] Add ability to reset the checkpoint for kafka source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -105,7 +105,7 @@ public class KafkaOffsetGen {
       // at least 1 partition will be present.
       sb.append(ranges[0].topic() + ",");
       sb.append(Arrays.stream(ranges).map(r -> String.format("%s:%d", r.partition(), r.untilOffset()))
-          .collect(Collectors.joining(",")));
+              .collect(Collectors.joining(",")));
       return sb.toString();
     }
 
@@ -122,15 +122,14 @@ public class KafkaOffsetGen {
                                                     long numEvents,
                                                     long minPartitions) {
       // Create initial offset ranges for each 'to' partition, with default from = 0 offsets.
-      OffsetRange[] ranges = toOffsetMap.keySet().stream()
-          .map(tp -> {
-            long fromOffset = fromOffsetMap.getOrDefault(tp, 0L);
-            return OffsetRange.create(tp, fromOffset, toOffsetMap.get(tp));
-          })
+      OffsetRange[] ranges = toOffsetMap.keySet().stream().map(tp -> {
+        long fromOffset = fromOffsetMap.getOrDefault(tp, 0L);
+        return OffsetRange.create(tp, fromOffset, toOffsetMap.get(tp));
+      })
           .sorted(SORT_BY_PARTITION)
           .collect(Collectors.toList())
           .toArray(new OffsetRange[toOffsetMap.size()]);
-      LOG.info("numEvents {}, minPartitions {}, ranges {}", numEvents, minPartitions, ranges);
+      LOG.debug("numEvents {}, minPartitions {}, ranges {}", numEvents, minPartitions, ranges);
 
       // choose the actualNumEvents with min(totalEvents, numEvents)
       long actualNumEvents = Math.min(totalNewMessages(ranges), numEvents);
@@ -176,13 +175,6 @@ public class KafkaOffsetGen {
           }
         }
       }
-      // We need to ensure every partition is part of returned offset ranges even if we are not consuming any new msgs (for instance, if its already caught up).
-      // as this will be tracked as the checkpoint, we need to ensure all partitions are part of final ranges.
-      fromOffsetMap.entrySet()
-          .stream()
-          .filter((kv) -> !finalRanges.containsKey(kv.getKey()))
-          .forEach((kv) -> finalRanges.put(kv.getKey(), Collections.singletonList(OffsetRange.create(kv.getKey(), kv.getValue(), kv.getValue()))));
-
       OffsetRange[] sortedRangeArray = finalRanges.values().stream().flatMap(Collection::stream)
           .sorted(SORT_BY_PARTITION).toArray(OffsetRange[]::new);
       if (actualNumEvents == 0) {
@@ -291,7 +283,7 @@ public class KafkaOffsetGen {
       }
       List<PartitionInfo> partitionInfoList = fetchPartitionInfos(consumer, topicName);
       Set<TopicPartition> topicPartitions = partitionInfoList.stream()
-          .map(x -> new TopicPartition(x.topic(), x.partition())).collect(Collectors.toSet());
+              .map(x -> new TopicPartition(x.topic(), x.partition())).collect(Collectors.toSet());
 
       if (KAFKA_CHECKPOINT_TYPE_TIMESTAMP.equals(kafkaCheckpointType) && isValidTimestampCheckpointType(checkpointOpt)) {
         checkpointOpt = getOffsetsByTimestamp(consumer, partitionInfoList, topicPartitions, topicName, Long.parseLong(checkpointOpt.get()));
@@ -321,7 +313,7 @@ public class KafkaOffsetGen {
     }
     return CheckpointUtils.computeOffsetRanges(fromOffsets, toOffsets, numEvents, minPartitions);
   }
-
+  
   /**
    * Fetch partition infos for given topic.
    *
@@ -359,7 +351,7 @@ public class KafkaOffsetGen {
    * @return a map of Topic partitions to offsets.
    */
   private Map<TopicPartition, Long> fetchValidOffsets(KafkaConsumer consumer,
-                                                      Option<String> lastCheckpointStr, Set<TopicPartition> topicPartitions) {
+                                                        Option<String> lastCheckpointStr, Set<TopicPartition> topicPartitions) {
     Map<TopicPartition, Long> earliestOffsets = consumer.beginningOffsets(topicPartitions);
     Map<TopicPartition, Long> checkpointOffsets = CheckpointUtils.strToOffsets(lastCheckpointStr.get());
     boolean isCheckpointOutOfBounds = checkpointOffsets.entrySet().stream()
@@ -419,8 +411,8 @@ public class KafkaOffsetGen {
                                                String topicName, Long timestamp) {
 
     Map<TopicPartition, Long> topicPartitionsTimestamp = partitionInfoList.stream()
-        .map(x -> new TopicPartition(x.topic(), x.partition()))
-        .collect(Collectors.toMap(Function.identity(), x -> timestamp));
+                                                    .map(x -> new TopicPartition(x.topic(), x.partition()))
+                                                    .collect(Collectors.toMap(Function.identity(), x -> timestamp));
 
     Map<TopicPartition, Long> earliestOffsets = consumer.beginningOffsets(topicPartitions);
     Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestamp = consumer.offsetsForTimes(topicPartitionsTimestamp);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -40,8 +40,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.streaming.kafka010.KafkaTestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -61,21 +61,21 @@ import static org.mockito.Mockito.when;
  */
 abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarness {
   protected static final String TEST_TOPIC_PREFIX = "hoodie_test_";
+  protected static KafkaTestUtils testUtils;
 
   protected final HoodieIngestionMetrics metrics = mock(HoodieIngestionMetrics.class);
   protected final Option<SourceProfileSupplier> sourceProfile = Option.of(mock(SourceProfileSupplier.class));
 
   protected SchemaProvider schemaProvider;
-  protected KafkaTestUtils testUtils;
 
-  @BeforeEach
-  public void initClass() {
+  @BeforeAll
+  public static void initClass() {
     testUtils = new KafkaTestUtils();
     testUtils.setup();
   }
 
-  @AfterEach
-  public void cleanupClass() {
+  @AfterAll
+  public static void cleanupClass() {
     testUtils.teardown();
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -40,8 +40,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.streaming.kafka010.KafkaTestUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -61,21 +61,21 @@ import static org.mockito.Mockito.when;
  */
 abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarness {
   protected static final String TEST_TOPIC_PREFIX = "hoodie_test_";
-  protected static KafkaTestUtils testUtils;
 
   protected final HoodieIngestionMetrics metrics = mock(HoodieIngestionMetrics.class);
   protected final Option<SourceProfileSupplier> sourceProfile = Option.of(mock(SourceProfileSupplier.class));
 
   protected SchemaProvider schemaProvider;
+  protected KafkaTestUtils testUtils;
 
-  @BeforeAll
-  public static void initClass() {
+  @BeforeEach
+  public void initClass() {
     testUtils = new KafkaTestUtils();
     testUtils.setup();
   }
 
-  @AfterAll
-  public static void cleanupClass() {
+  @AfterEach
+  public void cleanupClass() {
     testUtils.teardown();
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
@@ -165,17 +165,6 @@ public class TestCheckpointUtils {
     assertEquals(0, ranges[1].fromOffset());
     assertEquals(100, ranges[1].untilOffset());
 
-    // minPartitions < number of topic partitions
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1, 2}, new long[] {0, 0, 0}),
-        makeOffsetMap(new int[] {0, 1, 2}, new long[] {1000, 1000, 1000}), 300, 2);
-    assertEquals(3, ranges.length);
-    assertEquals(0, ranges[0].fromOffset());
-    assertEquals(100, ranges[0].untilOffset());
-    assertEquals(0, ranges[1].fromOffset());
-    assertEquals(100, ranges[1].untilOffset());
-    assertEquals(0, ranges[1].fromOffset());
-    assertEquals(100, ranges[1].untilOffset());
-
     // 1 TopicPartition to N offset ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
         makeOffsetMap(new int[] {0}, new long[] {1000}), 300, 3);
@@ -187,21 +176,18 @@ public class TestCheckpointUtils {
     assertEquals(200, ranges[2].fromOffset());
     assertEquals(300, ranges[2].untilOffset());
 
-
-    // minPartitions is 2x of number of topic partitions
+    // N skewed TopicPartitions to M offset ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {0, 0}),
-        makeOffsetMap(new int[] {0, 1}, new long[] {100, 500}), 600, 4);
-    assertEquals(5, ranges.length);
+        makeOffsetMap(new int[] {0, 1}, new long[] {100, 500}), 600, 3);
+    assertEquals(4, ranges.length);
     assertEquals(0, ranges[0].fromOffset());
     assertEquals(100, ranges[0].untilOffset());
     assertEquals(0, ranges[1].fromOffset());
-    assertEquals(150, ranges[1].untilOffset());
-    assertEquals(150, ranges[2].fromOffset());
-    assertEquals(300, ranges[2].untilOffset());
-    assertEquals(300, ranges[3].fromOffset());
-    assertEquals(450, ranges[3].untilOffset());
-    assertEquals(450, ranges[4].fromOffset());
-    assertEquals(500, ranges[4].untilOffset());
+    assertEquals(200, ranges[1].untilOffset());
+    assertEquals(200, ranges[2].fromOffset());
+    assertEquals(400, ranges[2].untilOffset());
+    assertEquals(400, ranges[3].fromOffset());
+    assertEquals(500, ranges[3].untilOffset());
 
     // range inexact multiple of minPartitions
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
@@ -234,7 +220,7 @@ public class TestCheckpointUtils {
 
     // all empty ranges, do not ignore empty ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}),
-        makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}), 600, 0);
+        makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}), 600, 3);
     assertEquals(0, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(2, ranges.length);
     assertEquals(0, ranges[0].partition());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -31,8 +31,8 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.spark.streaming.kafka010.KafkaTestUtils;
 import org.apache.spark.streaming.kafka010.OffsetRange;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -52,17 +52,17 @@ import static org.mockito.Mockito.mock;
 public class TestKafkaOffsetGen {
 
   private final String testTopicName = "hoodie_test_" + UUID.randomUUID();
-  private static KafkaTestUtils testUtils;
   private HoodieIngestionMetrics metrics = mock(HoodieIngestionMetrics.class);
+  private KafkaTestUtils testUtils;
 
-  @BeforeAll
-  public static void setup() throws Exception {
+  @BeforeEach
+  public void setup() throws Exception {
     testUtils = new KafkaTestUtils();
     testUtils.setup();
   }
 
-  @AfterAll
-  public static void teardown() throws Exception {
+  @AfterEach
+  public void teardown() throws Exception {
     testUtils.teardown();
   }
 
@@ -188,32 +188,6 @@ public class TestKafkaOffsetGen {
     assertEquals(400, nextOffsetRanges[0].untilOffset());
     assertEquals(249, nextOffsetRanges[1].fromOffset());
     assertEquals(399, nextOffsetRanges[1].untilOffset());
-
-    // try w/ 1 partition already exhausted. both partitions need to be returned as part of offset ranges
-    lastCheckpointString = testTopicName + ",0:400,1:500";
-    kafkaOffsetGen.commitOffsetToKafka(lastCheckpointString);
-    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
-    assertEquals(3, nextOffsetRanges.length);
-    assertEquals(400, nextOffsetRanges[0].fromOffset());
-    assertEquals(450, nextOffsetRanges[0].untilOffset());
-    assertEquals(450, nextOffsetRanges[1].fromOffset());
-    assertEquals(500, nextOffsetRanges[1].untilOffset());
-    assertEquals(0, nextOffsetRanges[1].partition());
-    assertEquals(500, nextOffsetRanges[2].fromOffset());
-    assertEquals(500, nextOffsetRanges[2].untilOffset());
-    assertEquals(1, nextOffsetRanges[2].partition());
-
-    // if there is just 1 msg to consume from just 1 partition.
-    lastCheckpointString = testTopicName + ",0:499,1:500";
-    kafkaOffsetGen.commitOffsetToKafka(lastCheckpointString);
-    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
-    assertEquals(2, nextOffsetRanges.length);
-    assertEquals(499, nextOffsetRanges[0].fromOffset());
-    assertEquals(500, nextOffsetRanges[0].untilOffset());
-    assertEquals(0, nextOffsetRanges[0].partition());
-    assertEquals(500, nextOffsetRanges[1].fromOffset());
-    assertEquals(500, nextOffsetRanges[1].untilOffset());
-    assertEquals(1, nextOffsetRanges[1].partition());
 
     // committed offsets are not present for the consumer group
     kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("group", "string"));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -132,12 +132,11 @@ public class TestKafkaOffsetGen {
     KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs(autoOffsetResetConfig, "string"));
 
     OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.of(resetCheckpoint), 500, metrics);
-    if(autoOffsetResetConfig.equals("latest")) {
+    if (autoOffsetResetConfig.equals("latest")) {
       assertEquals(1, nextOffsetRanges.length);
       assertEquals(1000, nextOffsetRanges[0].fromOffset());
       assertEquals(1000, nextOffsetRanges[0].untilOffset());
-    }
-    else {
+    } else {
       assertEquals(1, nextOffsetRanges.length);
       assertEquals(0, nextOffsetRanges[0].fromOffset());
       assertEquals(500, nextOffsetRanges[0].untilOffset());


### PR DESCRIPTION
### Change Logs
adding support to reset checkpoints for kafka source. if the resume checkpoint is of the format: `topic-name:reset-timestamp` then it is considered as a reset checpoint, and ingestion starts afresh.

this will be used in cases where one might want to bootstrap data from one source and then switch to a new source and start ingesting from the earliest or latest offset (we need to reset so that the old checkpoint is not used) 

### Impact
no impact on existing projects

### Risk level (write none, low medium or high below)
none

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
