### PR TITLE
[HUDI-7522] Support find out the conflict instants in bucket partition when bucket id multiple

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
@@ -21,18 +21,34 @@ package org.apache.hudi.index.bucket;
 import org.apache.hudi.client.utils.LazyIterableIterator;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.index.HoodieIndexUtils;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 
 import static org.apache.hudi.index.HoodieIndexUtils.tagAsNewRecordIfNeeded;
 
@@ -40,6 +56,10 @@ import static org.apache.hudi.index.HoodieIndexUtils.tagAsNewRecordIfNeeded;
  * Simple bucket index implementation, with fixed bucket number.
  */
 public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieSimpleBucketIndex.class);
+
+  private List<StoragePathInfo> fileStatusesForPartition;
 
   public HoodieSimpleBucketIndex(HoodieWriteConfig config) {
     super(config);
@@ -50,7 +70,10 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
       String partition) {
     // bucketId -> fileIds
     Map<Integer, HoodieRecordLocation> bucketIdToFileIdMapping = new HashMap<>();
-    hoodieTable.getMetaClient().reloadActiveTimeline();
+    HoodieActiveTimeline hoodieActiveTimeline = hoodieTable.getMetaClient().reloadActiveTimeline();
+    List<String> pendingInstantsStr = new ArrayList<>();
+    hoodieActiveTimeline.filterInflights().getInstants().forEach(instant -> pendingInstantsStr.add(instant.toString()));
+
     HoodieIndexUtils
         .getLatestFileSlicesForPartition(partition, hoodieTable)
         .forEach(fileSlice -> {
@@ -61,12 +84,71 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
           if (!bucketIdToFileIdMapping.containsKey(bucketId)) {
             bucketIdToFileIdMapping.put(bucketId, new HoodieRecordLocation(commitTime, fileId));
           } else {
+            // Finding the instants which conflict with the bucket id
+            Set<String> instants = findTheConflictBucketIdInPartition(hoodieTable, partition, bucketId, pendingInstantsStr);
+
             // Check if bucket data is valid
             throw new HoodieIOException("Find multiple files at partition path="
-                + partition + " belongs to the same bucket id = " + bucketId);
+                + partition + " belongs to the same bucket id = " + bucketId
+                + ", these instants need to rollback: " + instants.toString()
+                + ", you can use rollback_to_instant procedure to recovery");
           }
         });
     return bucketIdToFileIdMapping;
+  }
+
+  /**
+   * Find out the conflict files in bucket partition with bucket id
+   */
+  public HashSet<String> findTheConflictBucketIdInPartition(HoodieTable hoodieTable, String partition, int bucketId, List<String> pendingInstantsStr) {
+    HashSet<String> instants = new HashSet<>();
+    HoodieTableMetaClient metaClient = hoodieTable.getMetaClient();
+    StoragePath basePath = metaClient.getBasePathV2();
+    StoragePath partitionPath = new StoragePath(basePath.toString(), partition);
+
+    Stream<FileSlice> latestFileSlicesIncludingInflight = hoodieTable.getSliceView().getLatestFileSlicesIncludingInflight(partition);
+    List<String> pendingInstants = latestFileSlicesIncludingInflight.map(fileSlice -> fileSlice.getLatestInstantTime())
+        .filter(fileSlice -> pendingInstantsStr.contains(fileSlice))
+        .collect(Collectors.toList());
+
+    if (fileStatusesForPartition != null) {
+      fileStatusesForPartition.clear();
+    }
+
+    for (String i : pendingInstants) {
+      if (judgeInstantInPath(metaClient, partitionPath, i, bucketId)) {
+        instants.add(i);
+      }
+    }
+    return instants;
+  }
+
+  public Boolean judgeInstantInPath(HoodieTableMetaClient metaClient, StoragePath path, String instant, int bucketId) {
+    Boolean ret = false;
+    try {
+      // list filestatus only once for one partiton
+      if (fileStatusesForPartition == null) {
+        fileStatusesForPartition = metaClient.getStorage().listFiles(path);
+      }
+
+      for (StoragePathInfo status : fileStatusesForPartition) {
+        String fileName = status.getPath().getName();
+
+        try {
+          if (status.isFile() && BucketIdentifier.bucketIdFromFileId(fileName) == bucketId && fileName.contains(instant)) {
+            ret = true;
+            break;
+          }
+        } catch (NumberFormatException e) {
+          LOG.warn("file is not bucket file");
+        }
+      }
+    } catch (IOException e) {
+      LOG.warn("partition {} is not exists", path.toString());
+      ret = false;
+    }
+
+    return ret;
   }
 
   public int getBucketID(HoodieKey key) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
@@ -39,12 +40,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,8 +60,6 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieSimpleBucketIndex.class);
 
-  private List<StoragePathInfo> fileStatusesForPartition;
-
   public HoodieSimpleBucketIndex(HoodieWriteConfig config) {
     super(config);
   }
@@ -71,8 +70,7 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
     // bucketId -> fileIds
     Map<Integer, HoodieRecordLocation> bucketIdToFileIdMapping = new HashMap<>();
     HoodieActiveTimeline hoodieActiveTimeline = hoodieTable.getMetaClient().reloadActiveTimeline();
-    List<String> pendingInstantsStr = new ArrayList<>();
-    hoodieActiveTimeline.filterInflights().getInstants().forEach(instant -> pendingInstantsStr.add(instant.toString()));
+    Set<String> pendingInstants = hoodieActiveTimeline.filterInflights().getInstantsAsStream().map(HoodieInstant::getTimestamp).collect(Collectors.toSet());
 
     HoodieIndexUtils
         .getLatestFileSlicesForPartition(partition, hoodieTable)
@@ -85,70 +83,63 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
             bucketIdToFileIdMapping.put(bucketId, new HoodieRecordLocation(commitTime, fileId));
           } else {
             // Finding the instants which conflict with the bucket id
-            Set<String> instants = findTheConflictBucketIdInPartition(hoodieTable, partition, bucketId, pendingInstantsStr);
+            List<String> instants = findConflictInstantsInPartition(hoodieTable, partition, bucketId, pendingInstants);
 
             // Check if bucket data is valid
             throw new HoodieIOException("Find multiple files at partition path="
-                + partition + " belongs to the same bucket id = " + bucketId
+                + partition + " that belong to the same bucket id = " + bucketId
                 + ", these instants need to rollback: " + instants.toString()
-                + ", you can use rollback_to_instant procedure to recovery");
+                + ", you can use 'rollback_to_instant' procedure to revert the conflicts.");
           }
         });
     return bucketIdToFileIdMapping;
   }
 
   /**
-   * Find out the conflict files in bucket partition with bucket id
+   * Find out the conflict files in bucket partition with bucket id.
    */
-  public HashSet<String> findTheConflictBucketIdInPartition(HoodieTable hoodieTable, String partition, int bucketId, List<String> pendingInstantsStr) {
-    HashSet<String> instants = new HashSet<>();
+  public List<String> findConflictInstantsInPartition(HoodieTable hoodieTable, String partition, int bucketId, Set<String> pendingInstants) {
+    List<String> instants = new ArrayList<>();
     HoodieTableMetaClient metaClient = hoodieTable.getMetaClient();
-    StoragePath basePath = metaClient.getBasePathV2();
-    StoragePath partitionPath = new StoragePath(basePath.toString(), partition);
+    StoragePath partitionPath = new StoragePath(metaClient.getBasePathV2(), partition);
+
+    List<StoragePathInfo> filesInPartition = listFilesFromPartition(metaClient, partitionPath);
 
     Stream<FileSlice> latestFileSlicesIncludingInflight = hoodieTable.getSliceView().getLatestFileSlicesIncludingInflight(partition);
-    List<String> pendingInstants = latestFileSlicesIncludingInflight.map(fileSlice -> fileSlice.getLatestInstantTime())
-        .filter(fileSlice -> pendingInstantsStr.contains(fileSlice))
+    List<String> candidates = latestFileSlicesIncludingInflight.map(FileSlice::getLatestInstantTime)
+        .filter(pendingInstants::contains)
         .collect(Collectors.toList());
 
-    if (fileStatusesForPartition != null) {
-      fileStatusesForPartition.clear();
-    }
-
-    for (String i : pendingInstants) {
-      if (judgeInstantInPath(metaClient, partitionPath, i, bucketId)) {
+    for (String i : candidates) {
+      if (hasPendingDataFilesForInstant(filesInPartition, i, bucketId)) {
         instants.add(i);
       }
     }
     return instants;
   }
 
-  public Boolean judgeInstantInPath(HoodieTableMetaClient metaClient, StoragePath path, String instant, int bucketId) {
-    Boolean ret = false;
+  private static List<StoragePathInfo> listFilesFromPartition(HoodieTableMetaClient metaClient, StoragePath partitionPath) {
     try {
-      // list filestatus only once for one partiton
-      if (fileStatusesForPartition == null) {
-        fileStatusesForPartition = metaClient.getStorage().listFiles(path);
-      }
-
-      for (StoragePathInfo status : fileStatusesForPartition) {
-        String fileName = status.getPath().getName();
-
-        try {
-          if (status.isFile() && BucketIdentifier.bucketIdFromFileId(fileName) == bucketId && fileName.contains(instant)) {
-            ret = true;
-            break;
-          }
-        } catch (NumberFormatException e) {
-          LOG.warn("file is not bucket file");
-        }
-      }
+      return metaClient.getStorage().listFiles(partitionPath);
     } catch (IOException e) {
-      LOG.warn("partition {} is not exists", path.toString());
-      ret = false;
+      // ignore the exception though
+      return Collections.emptyList();
     }
+  }
 
-    return ret;
+  public Boolean hasPendingDataFilesForInstant(List<StoragePathInfo> filesInPartition, String instant, int bucketId) {
+    for (StoragePathInfo status : filesInPartition) {
+      String fileName = status.getPath().getName();
+
+      try {
+        if (status.isFile() && BucketIdentifier.bucketIdFromFileId(fileName) == bucketId && fileName.contains(instant)) {
+          return true;
+        }
+      } catch (NumberFormatException e) {
+        LOG.warn("File is not bucket file");
+      }
+    }
+    return false;
   }
 
   public int getBucketID(HoodieKey key) {


### PR DESCRIPTION
### Change Logs

Relate to the issue: https://github.com/apache/hudi/issues/7216
occur bucket id multiple, only need delete the parition next write can success，but did not delete partition currently，add a config to implement it.

### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
