### PR TITLE
[WIP] [HUDI-7524] Ensure existing hoodie.properties are not overwritten with HoodieTableMetaClient creation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
@@ -446,6 +447,9 @@ public class HoodieTableConfig extends HoodieConfig {
     }
     HoodieConfig hoodieConfig = new HoodieConfig(properties);
     Path propertyPath = new Path(metadataFolder, HOODIE_PROPERTIES_FILE);
+    if (fs.exists(propertyPath)) {
+      throw new HoodieException("hoodie.properties already exists");
+    }
     try (OutputStream outputStream = fs.create(propertyPath)) {
       if (!hoodieConfig.contains(NAME)) {
         throw new IllegalArgumentException(NAME.key() + " property needs to be specified");


### PR DESCRIPTION
### Change Logs

org.apache.hudi.common.table.HoodieTableMetaClient#initTableAndGetMetaClient can overwrite a existing `hoodie.properties` today. The jira ensures that an error is thrown if the file already exists.

### Impact

`org.apache.hudi.common.table.HoodieTableMetaClient#initTableAndGetMetaClient` would now throw error if hoodie.properties already exists. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
