### PR TITLE
[HUDI-7528] Fixing RowCustomColumnsSortPartitioner to use repartition instead of coalesce

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
@@ -51,7 +51,7 @@ public class RowCustomColumnsSortPartitioner implements BulkInsertPartitioner<Da
   public Dataset<Row> repartitionRecords(Dataset<Row> records, int outputSparkPartitions) {
     return records
         .sort(Arrays.stream(sortColumnNames).map(Column::new).toArray(Column[]::new))
-        .coalesce(outputSparkPartitions);
+        .repartition(outputSparkPartitions);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
@@ -139,10 +139,10 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieSparkClientT
         .build();
 
     testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(sortColumns, config),
-        records, true, true, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
+        records, true, false, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
 
     testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(config),
-        records, true, true, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
+        records, true, false, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
   }
 
   private void testBulkInsertInternalPartitioner(BulkInsertPartitioner partitioner,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.RowCustomColumnsSortPartitioner;
 import org.apache.hudi.keygen.ComplexKeyGenerator;
 import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
@@ -197,6 +198,34 @@ public class TestHoodieDatasetBulkInsertHelper extends HoodieSparkClientTestBase
     Dataset<Row> trimmedOutput = result.drop(HoodieRecord.PARTITION_PATH_METADATA_FIELD).drop(HoodieRecord.RECORD_KEY_METADATA_FIELD)
         .drop(HoodieRecord.FILENAME_METADATA_FIELD).drop(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD).drop(HoodieRecord.COMMIT_TIME_METADATA_FIELD);
     assertTrue(dataset.except(trimmedOutput).count() == 0);
+  }
+
+  @Test
+  public void testRowCustomSortPartitioner() {
+    List<Row> rows = DataSourceTestUtils.generateRandomRows(100);
+    Map<String, String> props = getPropsAllSet("_row_key");
+    props.put(HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS.key(), "ts");
+    HoodieWriteConfig config = getConfigBuilder(schemaStr).withProps(props)
+        .withPopulateMetaFields(false).build();
+    Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+    RowCustomColumnsSortPartitioner partitioner = new RowCustomColumnsSortPartitioner(config);
+    Dataset<Row> output = partitioner.repartitionRecords(dataset, 1);
+    output.cache();
+
+    assertEquals(output.count(), 100);
+    assertEquals(output.rdd().getNumPartitions(), 1);
+
+    output = partitioner.repartitionRecords(dataset.repartition(5), 3);
+    output.cache();
+
+    assertEquals(output.count(), 100);
+    assertEquals(output.rdd().getNumPartitions(), 3);
+
+    // higher value of output spark partitions.
+    output = partitioner.repartitionRecords(dataset.repartition(3), 6);
+    output.cache();
+    assertEquals(output.count(), 100);
+    assertEquals(output.rdd().getNumPartitions(), 6);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

Fixing RowCustomColumnsSortPartitioner to use repartition instead of coalesce. w/ coalesce, chances that user defined shuffle parallelism may not be honored. 

### Impact

User defined shuffle parallelism will be honored with RowCustomColumnsSortPartitioner

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
