### PR TITLE
[HUDI-7529] Resolve hotspots in stream read

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -78,6 +78,14 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns whether the table operation is 'upsert'.
+   */
+  public static boolean isUpsertOperation(Configuration conf) {
+    WriteOperationType operationType = WriteOperationType.fromValue(conf.getString(FlinkOptions.OPERATION));
+    return operationType == WriteOperationType.UPSERT;
+  }
+
+  /**
    * Returns whether the table operation is 'bulk_insert'.
    */
   public static boolean isBulkInsertOperation(Configuration conf) {
@@ -142,8 +150,18 @@ public class OptionsResolver {
     return FilePathUtils.extractPartitionKeys(conf).length > 0;
   }
 
+  /**
+   * Returns whether the table index is bucket index.
+   */
   public static boolean isBucketIndexType(Configuration conf) {
     return conf.getString(FlinkOptions.INDEX_TYPE).equalsIgnoreCase(HoodieIndex.IndexType.BUCKET.name());
+  }
+
+  /**
+   * Returns whether it is a MERGE_ON_READ table, and updates by bucket index.
+   */
+  public static boolean isMorWithBucketIndexUpsert(Configuration conf) {
+    return isMorTable(conf) && isUpsertOperation(conf) && isBucketIndexType(conf);
   }
 
   public static HoodieIndex.BucketIndexEngineType getBucketEngineType(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/partitioner/StreamReadAppendPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/partitioner/StreamReadAppendPartitioner.java
@@ -1,0 +1,34 @@
+package org.apache.hudi.source.filedistribution.partitioner;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.api.common.functions.Partitioner;
+
+public class StreamReadAppendPartitioner implements Partitioner<Integer> {
+
+  private final int parallNum;
+
+  public StreamReadAppendPartitioner(int parallNum) {
+    this.parallNum = parallNum;
+  }
+
+  @Override
+  public int partition(Integer splitNum, int maxParallelism) {
+    return splitNum % parallNum;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/partitioner/StreamReadBucketIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/partitioner/StreamReadBucketIndexPartitioner.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.filedistribution.partitioner;
+
+import org.apache.hudi.index.bucket.BucketIdentifier;
+
+import org.apache.flink.api.common.functions.Partitioner;
+
+public class StreamReadBucketIndexPartitioner implements Partitioner<String> {
+
+  private final int parallNum;
+
+  public StreamReadBucketIndexPartitioner(int parallNum) {
+    this.parallNum = parallNum;
+  }
+
+  @Override
+  public int partition(String fileName, int maxParallelism) {
+    return BucketIdentifier.bucketIdFromFileId(fileName) % parallNum;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/selector/StreamReadAppendKeySelector.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/selector/StreamReadAppendKeySelector.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.filedistribution.selector;
+
+import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
+
+import org.apache.flink.api.java.functions.KeySelector;
+
+public class StreamReadAppendKeySelector implements KeySelector<MergeOnReadInputSplit, Integer> {
+
+  @Override
+  public Integer getKey(MergeOnReadInputSplit mergeOnReadInputSplit) throws Exception {
+    return mergeOnReadInputSplit.getSplitNumber();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/selector/StreamReadBucketIndexKeySelector.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/filedistribution/selector/StreamReadBucketIndexKeySelector.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.filedistribution.selector;
+
+import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
+
+import org.apache.flink.api.java.functions.KeySelector;
+
+public class StreamReadBucketIndexKeySelector implements KeySelector<MergeOnReadInputSplit, String> {
+
+  @Override
+  public String getKey(MergeOnReadInputSplit mergeOnReadInputSplit) throws Exception {
+    return mergeOnReadInputSplit.getFileId();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -46,6 +46,10 @@ import org.apache.hudi.source.FileIndex;
 import org.apache.hudi.source.IncrementalInputSplits;
 import org.apache.hudi.source.StreamReadMonitoringFunction;
 import org.apache.hudi.source.StreamReadOperator;
+import org.apache.hudi.source.filedistribution.partitioner.StreamReadAppendPartitioner;
+import org.apache.hudi.source.filedistribution.partitioner.StreamReadBucketIndexPartitioner;
+import org.apache.hudi.source.filedistribution.selector.StreamReadAppendKeySelector;
+import org.apache.hudi.source.filedistribution.selector.StreamReadBucketIndexKeySelector;
 import org.apache.hudi.source.prune.DataPruner;
 import org.apache.hudi.source.prune.PartitionPruners;
 import org.apache.hudi.source.prune.PrimaryKeyPruners;
@@ -204,24 +208,17 @@ public class HoodieTableSource implements
               conf, FilePathUtils.toFlinkPath(path), tableRowType, maxCompactionMemoryInBytes, partitionPruner);
           InputFormat<RowData, ?> inputFormat = getInputFormat(true);
           OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory((MergeOnReadInputFormat) inputFormat);
-          DataStream<MergeOnReadInputSplit> monitorOperatorStream = execEnv.addSource(monitoringFunction, getSourceOperatorName("split_monitor"))
+          SingleOutputStreamOperator<MergeOnReadInputSplit> monitorOperatorStream = execEnv.addSource(monitoringFunction, getSourceOperatorName("split_monitor"))
               .uid(Pipelines.opUID("split_monitor", conf))
-              .setParallelism(1)
-              .setMaxParallelism(1);
-          SingleOutputStreamOperator<RowData> source;
-          if (OptionsResolver.isAppendMode(HoodieTableSource.this.conf)) {
-            source = monitorOperatorStream
-                .transform("split_reader", typeInfo, factory)
-                .uid(Pipelines.opUID("split_reader", conf))
-                .setParallelism(conf.getInteger(FlinkOptions.READ_TASKS));
-          } else {
-            source = monitorOperatorStream
-                .keyBy(MergeOnReadInputSplit::getFileId)
-                .transform("split_reader", typeInfo, factory)
-                .uid(Pipelines.opUID("split_reader", conf))
-                .setParallelism(conf.getInteger(FlinkOptions.READ_TASKS));
-          }
-          return new DataStreamSource<>(source);
+              .setParallelism(1);
+
+          DataStream<MergeOnReadInputSplit> sourceWithKey = addFileDistributionStrategy(monitorOperatorStream);
+
+          SingleOutputStreamOperator<RowData> streamReadSource = sourceWithKey
+              .transform("split_reader", typeInfo, factory)
+              .uid(Pipelines.opUID("split_reader", conf))
+              .setParallelism(conf.getInteger(FlinkOptions.READ_TASKS));
+          return new DataStreamSource<>(streamReadSource);
         } else {
           InputFormatSourceFunction<RowData> func = new InputFormatSourceFunction<>(getInputFormat(), typeInfo);
           DataStreamSource<RowData> source = execEnv.addSource(func, asSummaryString(), typeInfo);
@@ -229,6 +226,20 @@ public class HoodieTableSource implements
         }
       }
     };
+  }
+
+  /**
+   * Specify the file distribution strategy based on different upstream writing mechanisms,
+   *  to prevent hot spot issues during stream reading.
+   */
+  private DataStream<MergeOnReadInputSplit> addFileDistributionStrategy(SingleOutputStreamOperator<MergeOnReadInputSplit> source) {
+    if (OptionsResolver.isMorWithBucketIndexUpsert(conf)) {
+      return source.partitionCustom(new StreamReadBucketIndexPartitioner(conf.getInteger(FlinkOptions.READ_TASKS)), new StreamReadBucketIndexKeySelector());
+    } else if (OptionsResolver.isAppendMode(conf)) {
+      return source.partitionCustom(new StreamReadAppendPartitioner(conf.getInteger(FlinkOptions.READ_TASKS)), new StreamReadAppendKeySelector());
+    } else {
+      return source.keyBy(MergeOnReadInputSplit::getFileId);
+    }
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

To resolve data skew issues in stream read for the following scenario.
### 1. MOR table use bucket index to upsert mode
**Before modification:**
![image](https://github.com/apache/hudi/assets/34104400/02f66f63-17bb-4fe9-9acf-eac3f3944431)

**After modification:**
![image](https://github.com/apache/hudi/assets/34104400/482b516b-e719-4992-9af7-7b4cade805fc)

**2. APPEND mode**
**Before modification:**
![image](https://github.com/apache/hudi/assets/34104400/c16216bc-c448-4ad6-93eb-e3036bd0c95d)

**After modification:**
![image](https://github.com/apache/hudi/assets/34104400/0e42020c-89e5-44d3-9673-59f1f7b8b714)

### Impact mode

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
