### PR TITLE
[HUDI-7535] Add metrics for sourceParallelism and Refresh profile in S3/GCS

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -64,5 +64,7 @@ public abstract class HoodieIngestionMetrics implements Serializable {
 
   public abstract void updateStreamerSourceParallelism(int sourceParallelism);
 
+  public abstract void updateStreamerSourceBytesToBeIngestedInSyncRound(long sourceBytesToBeIngested);
+
   public abstract void shutdown();
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -62,5 +62,7 @@ public abstract class HoodieIngestionMetrics implements Serializable {
 
   public abstract void updateStreamerSourceNewMessageCount(String sourceMetricName, long sourceNewMessageCount);
 
+  public abstract void updateStreamerSourceParallelism(int sourceParallelism);
+
   public abstract void shutdown();
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.CloudDataFetcher;
 import org.apache.hudi.utilities.sources.helpers.CloudObjectIncrCheckpoint;
@@ -112,24 +113,29 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
   private final QueryRunner queryRunner;
   private final Option<SchemaProvider> schemaProvider;
   private final Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter;
-
   private static final Logger LOG = LoggerFactory.getLogger(GcsEventsHoodieIncrSource.class);
 
-  public GcsEventsHoodieIncrSource(TypedProperties props, JavaSparkContext jsc, SparkSession spark,
-                                   SchemaProvider schemaProvider) {
-
+  public GcsEventsHoodieIncrSource(
+      TypedProperties props,
+      JavaSparkContext jsc,
+      SparkSession spark,
+      SchemaProvider schemaProvider,
+      HoodieIngestionMetrics metrics) {
     this(props, jsc, spark,
-        new CloudDataFetcher(props, jsc, spark),
+        new CloudDataFetcher(props, jsc, spark, metrics),
         new QueryRunner(spark, props),
         new DefaultStreamContext(schemaProvider, Option.empty())
     );
   }
 
-  public GcsEventsHoodieIncrSource(TypedProperties props, JavaSparkContext jsc, SparkSession spark,
-                                   StreamContext streamContext) {
-
+  public GcsEventsHoodieIncrSource(
+      TypedProperties props,
+      JavaSparkContext jsc,
+      SparkSession spark,
+      HoodieIngestionMetrics metrics,
+      StreamContext streamContext) {
     this(props, jsc, spark,
-        new CloudDataFetcher(props, jsc, spark),
+        new CloudDataFetcher(props, jsc, spark, metrics),
         new QueryRunner(spark, props),
         streamContext
     );

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -84,11 +84,14 @@ public abstract class KafkaSource<T> extends Source<T> {
       SourceProfile<Long> kafkaSourceProfile = sourceProfileSupplier.get().getSourceProfile();
       offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, kafkaSourceProfile.getSourceSpecificContext(),
           kafkaSourceProfile.getSourcePartitions(), metrics);
+      metrics.updateStreamerSourceParallelism(kafkaSourceProfile.getSourcePartitions());
+      metrics.updateStreamerSourceBytesToBeIngestedInSyncRound(kafkaSourceProfile.getMaxSourceBytes());
       LOG.info("About to read maxEventsInSyncRound {} of size {} bytes in {} partitions from Kafka for topic {} with offsetRanges {}",
           kafkaSourceProfile.getSourceSpecificContext(), kafkaSourceProfile.getMaxSourceBytes(),
           kafkaSourceProfile.getSourcePartitions(), offsetGen.getTopicName(), offsetRanges);
     } else {
       long minPartitions = getLongWithAltKeys(props, KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS);
+      metrics.updateStreamerSourceParallelism(minPartitions);
       offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       LOG.info("About to read sourceLimit {} in {} spark partitions from kafka for topic {} with offset ranges {}",
           sourceLimit, minPartitions, offsetGen.getTopicName(),

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -90,7 +90,7 @@ public abstract class KafkaSource<T> extends Source<T> {
           kafkaSourceProfile.getSourceSpecificContext(), kafkaSourceProfile.getMaxSourceBytes(),
           kafkaSourceProfile.getSourcePartitions(), offsetGen.getTopicName(), offsetRanges);
     } else {
-      long minPartitions = getLongWithAltKeys(props, KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS);
+      int minPartitions = (int) getLongWithAltKeys(props, KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS);
       metrics.updateStreamerSourceParallelism(minPartitions);
       offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       LOG.info("About to read sourceLimit {} in {} spark partitions from kafka for topic {} with offset ranges {}",

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.CloudDataFetcher;
 import org.apache.hudi.utilities.sources.helpers.CloudObjectIncrCheckpoint;
@@ -72,21 +73,23 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
       TypedProperties props,
       JavaSparkContext sparkContext,
       SparkSession sparkSession,
+      HoodieIngestionMetrics metrics,
       SchemaProvider schemaProvider) {
     this(props, sparkContext, sparkSession, new QueryRunner(sparkSession, props),
-        new CloudDataFetcher(props, sparkContext, sparkSession), new DefaultStreamContext(schemaProvider, Option.empty()));
+        new CloudDataFetcher(props, sparkContext, sparkSession, metrics), new DefaultStreamContext(schemaProvider, Option.empty()));
   }
 
   public S3EventsHoodieIncrSource(
       TypedProperties props,
       JavaSparkContext sparkContext,
       SparkSession sparkSession,
+      HoodieIngestionMetrics metrics,
       StreamContext streamContext) {
     this(props, sparkContext, sparkSession, new QueryRunner(sparkSession, props),
-        new CloudDataFetcher(props, sparkContext, sparkSession), streamContext);
+        new CloudDataFetcher(props, sparkContext, sparkSession, metrics), streamContext);
   }
 
-  public S3EventsHoodieIncrSource(
+  S3EventsHoodieIncrSource(
       TypedProperties props,
       JavaSparkContext sparkContext,
       SparkSession sparkSession,

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -73,8 +73,8 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
       TypedProperties props,
       JavaSparkContext sparkContext,
       SparkSession sparkSession,
-      HoodieIngestionMetrics metrics,
-      SchemaProvider schemaProvider) {
+      SchemaProvider schemaProvider,
+      HoodieIngestionMetrics metrics) {
     this(props, sparkContext, sparkSession, new QueryRunner(sparkSession, props),
         new CloudDataFetcher(props, sparkContext, sparkSession, metrics), new DefaultStreamContext(schemaProvider, Option.empty()));
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
@@ -165,6 +165,12 @@ public class HoodieStreamerMetrics extends HoodieIngestionMetrics {
     }
   }
 
+  public void updateStreamerSourceBytesToBeIngestedInSyncRound(long sourceBytesToBeIngested) {
+    if (writeConfig.isMetricsOn()) {
+      metrics.registerGauge(getMetricsName("deltastreamer", "sourceBytesToBeIngestedInSyncRound"), sourceBytesToBeIngested);
+    }
+  }
+
   @Override
   public void shutdown() {
     if (metrics != null) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
@@ -159,6 +159,13 @@ public class HoodieStreamerMetrics extends HoodieIngestionMetrics {
   }
 
   @Override
+  public void updateStreamerSourceParallelism(int sourceParallelism) {
+    if (writeConfig.isMetricsOn()) {
+      metrics.registerGauge(getMetricsName("deltastreamer", "sourceParallelism"), sourceParallelism);
+    }
+  }
+
+  @Override
   public void shutdown() {
     if (metrics != null) {
       metrics.shutdown();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -300,6 +300,7 @@ public abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarne
     InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(), 900);
     assertEquals(500, fetch1.getBatch().get().count());
     verify(metrics, times(2)).updateStreamerSourceParallelism(4);
+    verify(metrics, times(2)).updateStreamerSourceBytesToBeIngestedInSyncRound(Long.MAX_VALUE);
   }
 
   static class TestSourceProfile implements SourceProfile<Long> {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -55,6 +55,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -297,6 +299,7 @@ public abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarne
     sendMessagesToKafka(topic, 1000, 2);
     InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(), 900);
     assertEquals(500, fetch1.getBatch().get().count());
+    verify(metrics, times(2)).updateStreamerSourceParallelism(4);
   }
 
   static class TestSourceProfile implements SourceProfile<Long> {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -88,7 +88,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -110,6 +110,8 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
   @Mock
   CloudObjectsSelectorCommon cloudObjectsSelectorCommon;
   @Mock
+  HoodieIngestionMetrics metrics;
+  @Mock
   SourceProfileSupplier sourceProfileSupplier;
 
   protected Option<SchemaProvider> schemaProvider;
@@ -294,18 +296,22 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50L, exptected4, typedProperties);
     // Verify the partitions being passed in getCloudObjectDataDF are correct.
     ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> argumentCaptorForMetrics = ArgumentCaptor.forClass(Integer.class);
     verify(cloudObjectsSelectorCommon, atLeastOnce()).loadAsDataset(any(), any(), any(), eq(schemaProvider), argumentCaptor.capture());
+    verify(metrics, atLeastOnce()).updateStreamerSourceParallelism(argumentCaptorForMetrics.capture());
+    List<Integer> numPartitions;
     if (snapshotCheckPoint.equals("1") || snapshotCheckPoint.equals("2")) {
-      Assertions.assertEquals(Arrays.asList(12, 3, 1), argumentCaptor.getAllValues());
+      numPartitions = Arrays.asList(12, 3, 1);
     } else {
-      Assertions.assertEquals(Arrays.asList(23, 1), argumentCaptor.getAllValues());
+      numPartitions = Arrays.asList(23, 1);
     }
+    Assertions.assertEquals(numPartitions, argumentCaptor.getAllValues());
+    Assertions.assertEquals(numPartitions, argumentCaptorForMetrics.getAllValues());
   }
 
   @Test
   public void testCreateSource() throws IOException {
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
-    HoodieIngestionMetrics metrics = mock(HoodieIngestionMetrics.class);
     Source gcsSource = UtilHelpers.createSource(GcsEventsHoodieIncrSource.class.getName(), typedProperties, jsc(), spark(), metrics,
         new DefaultStreamContext(schemaProvider.orElse(null), Option.of(sourceProfileSupplier)));
     assertEquals(Source.SourceType.ROW, gcsSource.getSourceType());
@@ -340,7 +346,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
                              TypedProperties typedProperties) {
 
     GcsEventsHoodieIncrSource incrSource = new GcsEventsHoodieIncrSource(typedProperties, jsc(),
-        spark(), new CloudDataFetcher(typedProperties, jsc(), spark(), cloudObjectsSelectorCommon), queryRunner,
+        spark(), new CloudDataFetcher(typedProperties, jsc(), spark(), metrics, cloudObjectsSelectorCommon), queryRunner,
         new DefaultStreamContext(schemaProvider.orElse(null), Option.of(sourceProfileSupplier)));
 
     Pair<Option<Dataset<Row>>, String> dataAndCheckpoint = incrSource.fetchNextBatch(checkpointToPull, sourceLimit);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -75,7 +75,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,6 @@ import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
### Change Logs

Previous PR -> https://github.com/apache/hudi/pull/10861 
Publish metrics for source parallelism for Kafka, S3/GCS sources.


### Impact

No impact, only change in metrics.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
