### PR TITLE
[HUDI-7531] Consider pending clustering when scheduling a new clustering plan

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
@@ -55,7 +55,7 @@ public class PreferWriterConflictResolutionStrategy
                                                     Option<HoodieInstant> lastSuccessfulInstant) {
     HoodieActiveTimeline activeTimeline = metaClient.reloadActiveTimeline();
     if ((REPLACE_COMMIT_ACTION.equals(currentInstant.getAction())
-        && ClusteringUtils.isClusteringCommit(metaClient, currentInstant))
+        && ClusteringUtils.isClusteringInstant(activeTimeline, currentInstant))
         || COMPACTION_ACTION.equals(currentInstant.getAction())) {
       return getCandidateInstantsForTableServicesCommits(activeTimeline, currentInstant);
     } else {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -58,7 +58,7 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseActionExecutor
   protected Option<HoodieClusteringPlan> createClusteringPlan() {
     LOG.info("Checking if clustering needs to be run on " + config.getBasePath());
     Option<HoodieInstant> lastClusteringInstant =
-        table.getActiveTimeline().getLastCompleteOrPendingClusteringInstant();
+        table.getActiveTimeline().getLastClusteringInstant();
 
     int commitsSinceLastClustering = table.getActiveTimeline().getCommitsTimeline().filterCompletedInstants()
         .findInstantsAfter(lastClusteringInstant.map(HoodieInstant::getTimestamp).orElse("0"), Integer.MAX_VALUE)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -57,7 +57,8 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseActionExecutor
 
   protected Option<HoodieClusteringPlan> createClusteringPlan() {
     LOG.info("Checking if clustering needs to be run on " + config.getBasePath());
-    Option<HoodieInstant> lastClusteringInstant = table.getActiveTimeline().getLastClusterCommit();
+    Option<HoodieInstant> lastClusteringInstant =
+        table.getActiveTimeline().getLastCompleteOrPendingClusteringInstant();
 
     int commitsSinceLastClustering = table.getActiveTimeline().getCommitsTimeline().filterCompletedInstants()
         .findInstantsAfter(lastClusteringInstant.map(HoodieInstant::getTimestamp).orElse("0"), Integer.MAX_VALUE)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -188,7 +188,7 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
         if (!instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
           return true;
         }
-        return !ClusteringUtils.isPendingClusteringInstant(table.getMetaClient(), instant);
+        return !ClusteringUtils.isClusteringInstant(table.getActiveTimeline(), instant);
       }).map(HoodieInstant::getTimestamp)
           .collect(Collectors.toList());
       if ((instantTimeToRollback != null) && !inflights.isEmpty()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -71,7 +71,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
       // rollback pending clustering instants first before other instants (See HUDI-3362)
       List<HoodieInstant> pendingClusteringInstantsToRollback = table.getActiveTimeline().filterPendingReplaceTimeline()
               // filter only clustering related replacecommits (Not insert_overwrite related commits)
-              .filter(instant -> ClusteringUtils.isPendingClusteringInstant(table.getMetaClient(), instant))
+              .filter(instant -> ClusteringUtils.isClusteringInstant(table.getActiveTimeline(), instant))
               .getReverseOrderedInstants()
               .filter(instant -> HoodieActiveTimeline.GREATER_THAN.test(instant.getTimestamp(), savepointToRestoreTimestamp))
               .collect(Collectors.toList());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
@@ -230,7 +230,7 @@ public class IncrementalQueryAnalyzer {
       timeline = timeline.filter(instant -> !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION));
     }
     if (skipClustering) {
-      timeline = timeline.filter(instant -> !ClusteringUtils.isClusteringInstant(instant, oriTimeline));
+      timeline = timeline.filter(instant -> !ClusteringUtils.isCompletedClusteringInstant(instant, oriTimeline));
     }
     return timeline;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.common.table.timeline;
 
-import org.apache.hudi.common.model.HoodieCommitMetadata;
-import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -31,7 +29,6 @@ import org.apache.hudi.exception.HoodieException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -515,19 +512,8 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   public Option<HoodieInstant> getLastCompleteOrPendingClusteringInstant() {
     return Option.fromJavaOptional(getCommitsTimeline().filter(s -> s.getAction().equalsIgnoreCase(HoodieTimeline.REPLACE_COMMIT_ACTION))
         .getReverseOrderedInstants()
-        .filter(i -> {
-          if (i.isCompleted()) {
-            try {
-              HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(i, this);
-              return metadata.getOperationType().equals(WriteOperationType.CLUSTER);
-            } catch (IOException e) {
-              LOG.warn("Unable to read commit metadata for " + i + " due to " + e.getMessage());
-              return false;
-            }
-          } else {
-            return ClusteringUtils.isClusteringInstant(this, i);
-          }
-        }).findFirst());
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i))
+        .findFirst());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -509,7 +509,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
-  public Option<HoodieInstant> getLastCompleteOrPendingClusteringInstant() {
+  public Option<HoodieInstant> getLastClusteringInstant() {
     return Option.fromJavaOptional(getCommitsTimeline().filter(s -> s.getAction().equalsIgnoreCase(HoodieTimeline.REPLACE_COMMIT_ACTION))
         .getReverseOrderedInstants()
         .filter(i -> ClusteringUtils.isClusteringInstant(this, i))

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -525,7 +525,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
               return false;
             }
           } else {
-            return ClusteringUtils.isPendingClusteringInstant(this, i);
+            return ClusteringUtils.isClusteringInstant(this, i);
           }
         }).findFirst());
   }
@@ -534,7 +534,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   public Option<HoodieInstant> getLastPendingClusterInstant() {
     return  Option.fromJavaOptional(filterPendingReplaceTimeline()
         .getReverseOrderedInstants()
-        .filter(i -> ClusteringUtils.isPendingClusteringInstant(this, i)).findFirst());
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i)).findFirst());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -398,7 +398,7 @@ public interface HoodieTimeline extends Serializable {
   /**
    * get the most recent cluster commit if present
    */
-  public Option<HoodieInstant> getLastCompleteOrPendingClusteringInstant();
+  public Option<HoodieInstant> getLastClusteringInstant();
 
   /**
    * get the most recent pending cluster commit if present

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -397,9 +397,8 @@ public interface HoodieTimeline extends Serializable {
 
   /**
    * get the most recent cluster commit if present
-   *
    */
-  public Option<HoodieInstant> getLastClusterCommit();
+  public Option<HoodieInstant> getLastCompleteOrPendingClusteringInstant();
 
   /**
    * get the most recent pending cluster commit if present

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -76,7 +76,7 @@ public class ClusteringUtils {
 
   /**
    * Checks if the requested, inflight, or completed instant of replacecommit action
-   * is a clustering instant, by checking whether the requested instant contains
+   * is a clustering operation, by checking whether the requested instant contains
    * a clustering plan.
    *
    * @param timeline       Hudi timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -75,15 +75,22 @@ public class ClusteringUtils {
   }
 
   /**
-   * Checks if the replacecommit is clustering commit.
+   * Checks if the requested, inflight, or completed instant of replacecommit action
+   * is a clustering instant, by checking whether the requested instant contains
+   * a clustering plan.
+   *
+   * @param timeline       Hudi timeline.
+   * @param replaceInstant the instant of replacecommit action to check.
+   * @return whether the instant is a clustering operation.
    */
-  public static boolean isClusteringCommit(HoodieTableMetaClient metaClient, HoodieInstant pendingReplaceInstant) {
-    return getClusteringPlan(metaClient, pendingReplaceInstant).isPresent();
+  public static boolean isClusteringInstant(HoodieTimeline timeline, HoodieInstant replaceInstant) {
+    return getClusteringPlan(timeline, replaceInstant).isPresent();
   }
 
   /**
    * Get requested replace metadata from timeline.
-   * @param timeline used to get the bytes stored in the requested replace instant in the timeline
+   *
+   * @param timeline              used to get the bytes stored in the requested replace instant in the timeline
    * @param pendingReplaceInstant can be in any state, because it will always be converted to requested state
    * @return option of the replace metadata if present, else empty
    * @throws IOException
@@ -238,16 +245,8 @@ public class ClusteringUtils {
 
   public static List<HoodieInstant> getPendingClusteringInstantTimes(HoodieTableMetaClient metaClient) {
     return metaClient.getActiveTimeline().filterPendingReplaceTimeline().getInstantsAsStream()
-            .filter(instant -> isPendingClusteringInstant(metaClient, instant))
-            .collect(Collectors.toList());
-  }
-
-  public static boolean isPendingClusteringInstant(HoodieTableMetaClient metaClient, HoodieInstant instant) {
-    return getClusteringPlan(metaClient, instant).isPresent();
-  }
-
-  public static boolean isPendingClusteringInstant(HoodieTimeline timeline, HoodieInstant instant) {
-    return getClusteringPlan(timeline, instant).isPresent();
+        .filter(instant -> isClusteringInstant(metaClient.getActiveTimeline(), instant))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -301,9 +300,11 @@ public class ClusteringUtils {
   }
 
   /**
-   * Returns whether the given instant {@code instant} is with clustering operation.
+   * @param instant  Hudi instant to check.
+   * @param timeline Hudi timeline.
+   * @return whether the given {@code instant} is a completed clustering operation.
    */
-  public static boolean isClusteringInstant(HoodieInstant instant, HoodieTimeline timeline) {
+  public static boolean isCompletedClusteringInstant(HoodieInstant instant, HoodieTimeline timeline) {
     if (!instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
       return false;
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -133,7 +133,9 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     String clusterTime1 = "1";
     HoodieInstant requestedInstant = createRequestedReplaceInstant(partitionPath1, clusterTime1, fileIds1);
     HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant, Option.empty());
+    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), requestedInstant));
     HoodieClusteringPlan requestedClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, requestedInstant).get().getRight();
+    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), inflightInstant));
     HoodieClusteringPlan inflightClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, inflightInstant).get().getRight();
     assertEquals(requestedClusteringPlan, inflightClusteringPlan);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -514,7 +514,7 @@ public class StreamerUtil {
   public static boolean isWriteCommit(HoodieTableType tableType, HoodieInstant instant, HoodieTimeline timeline) {
     return tableType == HoodieTableType.MERGE_ON_READ
         ? !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION) // not a compaction
-        : !ClusteringUtils.isClusteringInstant(instant, timeline);   // not a clustering
+        : !ClusteringUtils.isCompletedClusteringInstant(instant, timeline);   // not a clustering
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1903,8 +1903,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
             metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get,
             (commitToRollback: String) => new SparkRDDWriteClient(context, writeConfig)
               .getTableServiceClient.getPendingRollbackInfo(table.getMetaClient, commitToRollback, false))
-          val requestedClustering = metaClient.reloadActiveTimeline
-            .filter(e => !e.getAction.equals(HoodieTimeline.ROLLBACK_ACTION)).lastInstant.get
+          val requestedClustering = metaClient.reloadActiveTimeline.getCommitsTimeline.lastInstant.get
           assertTrue(requestedClustering.isRequested)
           assertEquals(
             requestedClustering,
@@ -1914,8 +1913,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
         new SparkRDDWriteClient(context, writeConfig)
           .scheduleClustering(org.apache.hudi.common.util.Option.of(Map[String, String]()))
         assertEquals(lastInstant.getTimestamp,
-          metaClient.reloadActiveTimeline.filter(
-            e => !e.getAction.equals(HoodieTimeline.ROLLBACK_ACTION)).lastInstant.get.getTimestamp)
+          metaClient.reloadActiveTimeline.getCommitsTimeline.lastInstant.get.getTimestamp)
       }
     }
     val timeline = metaClient.reloadActiveTimeline

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1852,7 +1852,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       .setConf(hadoopConf)
       .build()
 
-    assertTrue(metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.isEmpty)
+    assertTrue(metaClient.getActiveTimeline.getLastClusteringInstant.isEmpty)
 
     var lastClustering: HoodieInstant = null
     for (i <- 1 until 4) {
@@ -1872,14 +1872,14 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
         lastClustering = lastInstant
         assertEquals(
           lastClustering,
-          metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get)
+          metaClient.getActiveTimeline.getLastClusteringInstant.get)
       } else {
         assertTrue(TimelineUtils.getCommitMetadata(lastInstant, metaClient.getActiveTimeline)
           .getOperationType.equals(WriteOperationType.INSERT_OVERWRITE))
         assertFalse(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline, lastInstant))
         assertEquals(
           lastClustering,
-          metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get)
+          metaClient.getActiveTimeline.getLastClusteringInstant.get)
       }
       if (i == 1) {
         val writeConfig = HoodieWriteConfig.newBuilder()
@@ -1895,12 +1895,12 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
           assertTrue(inflightClustering.isInflight)
           assertEquals(
             inflightClustering,
-            metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get)
+            metaClient.getActiveTimeline.getLastClusteringInstant.get)
         }
         if (firstClusteringState == HoodieInstant.State.REQUESTED) {
           val table = HoodieSparkTable.create(writeConfig, context)
           table.rollbackInflightClustering(
-            metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get,
+            metaClient.getActiveTimeline.getLastClusteringInstant.get,
             new java.util.function.Function[String, Option[HoodiePendingRollbackInfo]] {
               override def apply(commitToRollback: String): Option[HoodiePendingRollbackInfo] = {
                 new SparkRDDWriteClient(context, writeConfig).getTableServiceClient
@@ -1911,7 +1911,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
           assertTrue(requestedClustering.isRequested)
           assertEquals(
             requestedClustering,
-            metaClient.getActiveTimeline.getLastCompleteOrPendingClusteringInstant.get)
+            metaClient.getActiveTimeline.getLastClusteringInstant.get)
         }
         // This should not schedule any new clustering
         new SparkRDDWriteClient(context, writeConfig)


### PR DESCRIPTION
### Change Logs

This PR fixes the regression introduced by #9755, by still considering pending clustering when scheduling a new clustering plan.

Refactoring of `ClusteringUtils` methods is also done to avoid confusion:
- Consolidates `#isClusteringCommit`, `#isPendingClusteringInstant` into `#isClusteringInstant` to check if a requested, inflight, or completed instant of replacecommit action is a clustering operation.
- Renames `#isClusteringInstant` to `#isCompletedClusteringInstant`

The tests are added to guard the fix, so that before the fix the test fails, and after the fix, the test succeeds.

### Impact

Bug fix.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
