### PR TITLE
[HUDI-7822] Resolve the conflicts between mixed hdfs and local path in Flink tests

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
@@ -273,6 +273,7 @@ public class TestHoodieCatalog {
 
     // validate key generator for partitioned table
     HoodieTableMetaClient metaClient = createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())),
         catalog.inferTablePath(catalogPathStr, tablePath));
     String keyGeneratorClassName = metaClient.getTableConfig().getKeyGeneratorClassName();
     assertEquals(keyGeneratorClassName, SimpleAvroKeyGenerator.class.getName());
@@ -290,6 +291,7 @@ public class TestHoodieCatalog {
 
     catalog.createTable(singleKeyMultiplePartitionPath, singleKeyMultiplePartitionTable, false);
     metaClient = createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())),
         catalog.inferTablePath(catalogPathStr, singleKeyMultiplePartitionPath));
     keyGeneratorClassName = metaClient.getTableConfig().getKeyGeneratorClassName();
     assertThat(keyGeneratorClassName, is(ComplexAvroKeyGenerator.class.getName()));
@@ -307,6 +309,7 @@ public class TestHoodieCatalog {
 
     catalog.createTable(multipleKeySinglePartitionPath, multipleKeySinglePartitionTable, false);
     metaClient = createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())),
         catalog.inferTablePath(catalogPathStr, singleKeyMultiplePartitionPath));
     keyGeneratorClassName = metaClient.getTableConfig().getKeyGeneratorClassName();
     assertThat(keyGeneratorClassName, is(ComplexAvroKeyGenerator.class.getName()));
@@ -324,7 +327,9 @@ public class TestHoodieCatalog {
 
     catalog.createTable(nonPartitionPath, nonPartitionCatalogTable, false);
 
-    metaClient = createMetaClient(catalog.inferTablePath(catalogPathStr, nonPartitionPath));
+    metaClient = createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())),
+        catalog.inferTablePath(catalogPathStr, nonPartitionPath));
     keyGeneratorClassName = metaClient.getTableConfig().getKeyGeneratorClassName();
     assertEquals(keyGeneratorClassName, NonpartitionedAvroKeyGenerator.class.getName());
   }
@@ -433,7 +438,8 @@ public class TestHoodieCatalog {
     String tablePathStr = catalog.inferTablePath(catalogPathStr, tablePath);
     Configuration flinkConf = TestConfigurations.getDefaultConf(tablePathStr);
     HoodieTableMetaClient metaClient = HoodieTestUtils
-        .createMetaClient(new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(flinkConf)), tablePathStr);
+        .createMetaClient(
+            new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(flinkConf)), tablePathStr);
     TestData.writeData(TestData.DATA_SET_INSERT, flinkConf);
     assertTrue(catalog.partitionExists(tablePath, partitionSpec));
 


### PR DESCRIPTION
### Change Logs
Resolve the conflicts for which may be mixed hdfs and local path together

```
org.apache.flink.table.catalog.exceptions.CatalogException: Catalog hudi path /var/folders/k1/65gcjk_92ws2bjh3ftpz33fc0000gp/T/junit845658121822910144 does not exist.

	at org.apache.hudi.table.catalog.HoodieCatalog.open(HoodieCatalog.java:122)
	at org.apache.hudi.table.catalog.TestHoodieCatalog.beforeEach(TestHoodieCatalog.java:167)
```

### Impact

It can use hdfs and local path to run test case.

The tempdir is creatd by local path. But hoodiecatalog may use hdfs path if the hadoop env exist 

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
