### PR TITLE
[MINOR] [DOCS] changes to redshift & starrocks compat matrix

### DIFF
--- a/website/docs/sql_queries.md
+++ b/website/docs/sql_queries.md
@@ -344,10 +344,8 @@ The current default supported version of Hudi is 0.10.0 ~ 0.13.1, and has not be
 
 ## StarRocks
 
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version
-2.2.0. Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.io/en-us/latest/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.
 
 ## ClickHouse
 
@@ -386,20 +384,20 @@ Following tables show whether a given query is supported on specific query engin
 
 ### Merge-On-Read tables
 
-| Query Engine        |Snapshot Queries|Incremental Queries|Read Optimized Queries|
-|---------------------|--------|-----------|--------------|
-| **Hive**            |Y|Y|Y|
-| **Spark SQL**       |Y|Y|Y|
-| **Spark Datasource** |Y|Y|Y|
-| **Flink SQL**       |Y|Y|Y|
-| **PrestoDB**        |Y|N|Y|
-| **AWS Athena**      |Y|N|Y|
-| **Big Query**       |Y|N|Y|
-| **Trino**           |N|N|Y|
-| **Impala**          |N|N|Y|
-| **Redshift Spectrum** |N|N|N|
-| **Doris**           |Y|N|Y|
-| **StarRocks**       |N|N|N|
-| **ClickHouse**      |N|N|N|
+| Query Engine        | Snapshot Queries |Incremental Queries| Read Optimized Queries |
+|---------------------|------------------|-----------|------------------------|
+| **Hive**            | Y                |Y| Y                      |
+| **Spark SQL**       | Y                |Y| Y                      |
+| **Spark Datasource** | Y                |Y| Y                      |
+| **Flink SQL**       | Y                |Y| Y                      |
+| **PrestoDB**        | Y                |N| Y                      |
+| **AWS Athena**      | Y                |N| Y                      |
+| **Big Query**       | Y                |N| Y                      |
+| **Trino**           | N                |N| Y                      |
+| **Impala**          | N                |N| Y                      |
+| **Redshift Spectrum** | N                |N| Y                      |
+| **Doris**           | Y                |N| Y                      |
+| **StarRocks**       | Y                |N| Y                      |
+| **ClickHouse**      | N                |N| N                      |
 
 

--- a/website/versioned_docs/version-0.12.0/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.0/query_engine_setup.md
@@ -127,7 +127,5 @@ Please refer to [Redshift Spectrum Integration with Apache Hudi](https://docs.aw
 for more details.
 
 ## StarRocks
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version 2.2.0.
-Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.com/en-us/2.2/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.

--- a/website/versioned_docs/version-0.12.0/querying_data.md
+++ b/website/versioned_docs/version-0.12.0/querying_data.md
@@ -306,4 +306,6 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 |**PrestoDB**|Y|N|Y|
 |**Trino**|N|N|Y|
 |**Impala**|N|N|Y|
+|**Redshift Spectrum**|N|N|Y|
+|**StarRocks**|Y|N|Y|
 

--- a/website/versioned_docs/version-0.12.1/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.1/query_engine_setup.md
@@ -127,7 +127,5 @@ Please refer to [Redshift Spectrum Integration with Apache Hudi](https://docs.aw
 for more details.
 
 ## StarRocks
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version 2.2.0.
-Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.io/en-us/2.2/data_source/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.

--- a/website/versioned_docs/version-0.12.1/querying_data.md
+++ b/website/versioned_docs/version-0.12.1/querying_data.md
@@ -306,4 +306,6 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 |**PrestoDB**|Y|N|Y|
 |**Trino**|N|N|Y|
 |**Impala**|N|N|Y|
+|**Redshift Spectrum**|N|N|Y|
+|**StarRocks**|Y|N|Y|
 

--- a/website/versioned_docs/version-0.12.2/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.2/query_engine_setup.md
@@ -136,7 +136,5 @@ The current default supported version of Hudi is 0.10.0 and has not been tested 
 :::
 
 ## StarRocks
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version 2.2.0. 
-Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported. 
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.com/en-us/2.2/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.

--- a/website/versioned_docs/version-0.12.2/querying_data.md
+++ b/website/versioned_docs/version-0.12.2/querying_data.md
@@ -324,4 +324,6 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 |**PrestoDB**|Y|N|Y|
 |**Trino**|N|N|Y|
 |**Impala**|N|N|Y|
+|**Redshift Spectrum**|N|N|Y|
+|**StarRocks**|Y|N|Y|
 

--- a/website/versioned_docs/version-0.12.3/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.3/query_engine_setup.md
@@ -136,7 +136,5 @@ The current default supported version of Hudi is 0.10.0 and has not been tested 
 :::
 
 ## StarRocks
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version 2.2.0. 
-Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported. 
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.com/en-us/2.2/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.

--- a/website/versioned_docs/version-0.12.3/querying_data.md
+++ b/website/versioned_docs/version-0.12.3/querying_data.md
@@ -324,4 +324,5 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 |**PrestoDB**|Y|N|Y|
 |**Trino**|N|N|Y|
 |**Impala**|N|N|Y|
-
+|**Redshift Spectrum**|N|N|Y|
+|**StarRocks**|Y|N|Y|

--- a/website/versioned_docs/version-0.13.0/query_engine_setup.md
+++ b/website/versioned_docs/version-0.13.0/query_engine_setup.md
@@ -136,7 +136,5 @@ The current default supported version of Hudi is 0.10.0 and has not been tested 
 :::
 
 ## StarRocks
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version 2.2.0. 
-Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported. 
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.com/en-us/2.2/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.

--- a/website/versioned_docs/version-0.13.0/querying_data.md
+++ b/website/versioned_docs/version-0.13.0/querying_data.md
@@ -324,4 +324,5 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 |**PrestoDB**|Y|N|Y|
 |**Trino**|N|N|Y|
 |**Impala**|N|N|Y|
-
+|**Redshift Spectrum**|N|N|Y|
+|**StarRocks**|Y|N|Y|

--- a/website/versioned_docs/version-0.13.1/querying_data.md
+++ b/website/versioned_docs/version-0.13.1/querying_data.md
@@ -435,11 +435,8 @@ will be supported in the future.
 
 ## StarRocks
 
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version
-2.2.0. Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer
-to [StarRocks Hudi external table](https://docs.starrocks.io/en-us/latest/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.
 
 ## ClickHouse
 
@@ -482,16 +479,16 @@ Note that `Read Optimized` queries are not applicable for COPY_ON_WRITE tables.
 
 ### Merge-On-Read tables
 
-|Query Engine|Snapshot Queries|Incremental Queries|Read Optimized Queries|
-|------------|--------|-----------|--------------|
-|**Hive**|Y|Y|Y|
-|**Spark SQL**|Y|Y|Y|
-|**Spark Datasource**|Y|Y|Y|
-|**Flink SQL**|Y|Y|Y|
-|**PrestoDB**|Y|N|Y|
-|**Trino**|N|N|Y|
-|**Impala**|N|N|Y|
-| **Redshift Spectrum** |N|N|N|
-| **Doris**             |N|N|N|
-| **StarRocks**         |N|N|N|
+| Query Engine           | Snapshot Queries |Incremental Queries| Read Optimized Queries |
+|------------------------|-----------------|-----------|------------------------|
+| **Hive**               |Y|Y|Y|
+| **Spark SQL**          |Y|Y|Y|
+| **Spark Datasource**   |Y|Y|Y|
+| **Flink SQL**          |Y|Y|Y|
+| **PrestoDB**           |Y|N|Y|
+| **Trino**              |N|N|Y|
+| **Impala**             |N|N|Y|
+| **Redshift Spectrum**  |N|N|Y|
+| **Doris**              |N|N|N|
+| **StarRocks**          |Y|N|Y|
 | **ClickHouse**         |N|N|N|

--- a/website/versioned_docs/version-0.14.0/sql_queries.md
+++ b/website/versioned_docs/version-0.14.0/sql_queries.md
@@ -339,10 +339,8 @@ will be supported in the future.
 
 ## StarRocks
 
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version
-2.2.0. Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.io/en-us/latest/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.
 
 ## ClickHouse
 
@@ -381,20 +379,20 @@ Following tables show whether a given query is supported on specific query engin
 
 ### Merge-On-Read tables
 
-| Query Engine        |Snapshot Queries|Incremental Queries|Read Optimized Queries|
-|---------------------|--------|-----------|--------------|
-| **Hive**            |Y|Y|Y|
-| **Spark SQL**       |Y|Y|Y|
-| **Spark Datasource** |Y|Y|Y|
-| **Flink SQL**       |Y|Y|Y|
-| **PrestoDB**        |Y|N|Y|
-| **AWS Athena**      |Y|N|Y|
-| **Big Query**       |Y|N|Y|
-| **Trino**           |N|N|Y|
-| **Impala**          |N|N|Y|
-| **Redshift Spectrum** |N|N|N|
-| **Doris**           |N|N|N|
-| **StarRocks**       |N|N|N|
-| **ClickHouse**      |N|N|N|
+| Query Engine        | Snapshot Queries |Incremental Queries| Read Optimized Queries |
+|---------------------|------------------|-----------|------------------------|
+| **Hive**            | Y                |Y| Y                      |
+| **Spark SQL**       | Y                |Y| Y                      |
+| **Spark Datasource** | Y                |Y| Y                      |
+| **Flink SQL**       | Y                |Y| Y                      |
+| **PrestoDB**        | Y                |N| Y                      |
+| **AWS Athena**      | Y                |N| Y                      |
+| **Big Query**       | Y                |N| Y                      |
+| **Trino**           | N                |N| Y                      |
+| **Impala**          | N                |N| Y                      |
+| **Redshift Spectrum** | N                |N| Y                      |
+| **Doris**           | N                |N| N                      |
+| **StarRocks**       | Y                |N| Y                      |
+| **ClickHouse**      | N                |N| N                      |
 
 

--- a/website/versioned_docs/version-0.14.1/sql_queries.md
+++ b/website/versioned_docs/version-0.14.1/sql_queries.md
@@ -347,10 +347,8 @@ will be supported in the future.
 
 ## StarRocks
 
-Copy on Write tables in Apache Hudi 0.10.0 and above can be queried via StarRocks external tables from StarRocks version
-2.2.0. Only snapshot queries are supported currently. In future releases Merge on Read tables will also be supported.
-Please refer to [StarRocks Hudi external table](https://docs.starrocks.io/en-us/latest/using_starrocks/External_table#hudi-external-table)
-for more details on the setup.
+For Copy-on-Write tables StarRocks provides support for Snapshot queries and for Merge-on-Read tables, StarRocks provides support for Snapshot and Read Optimized queries.
+Please refer [StarRocks docs](https://docs.starrocks.io/docs/data_source/catalog/hudi_catalog/) for more details.
 
 ## ClickHouse
 
@@ -389,20 +387,20 @@ Following tables show whether a given query is supported on specific query engin
 
 ### Merge-On-Read tables
 
-| Query Engine        |Snapshot Queries|Incremental Queries|Read Optimized Queries|
-|---------------------|--------|-----------|--------------|
-| **Hive**            |Y|Y|Y|
-| **Spark SQL**       |Y|Y|Y|
-| **Spark Datasource** |Y|Y|Y|
-| **Flink SQL**       |Y|Y|Y|
-| **PrestoDB**        |Y|N|Y|
-| **AWS Athena**      |Y|N|Y|
-| **Big Query**       |Y|N|Y|
-| **Trino**           |N|N|Y|
-| **Impala**          |N|N|Y|
-| **Redshift Spectrum** |N|N|N|
-| **Doris**           |N|N|N|
-| **StarRocks**       |N|N|N|
-| **ClickHouse**      |N|N|N|
+| Query Engine        | Snapshot Queries |Incremental Queries| Read Optimized Queries |
+|---------------------|------------------|-----------|------------------------|
+| **Hive**            | Y                |Y| Y                      |
+| **Spark SQL**       | Y                |Y| Y                      |
+| **Spark Datasource** | Y                |Y| Y                      |
+| **Flink SQL**       | Y                |Y| Y                      |
+| **PrestoDB**        | Y                |N| Y                      |
+| **AWS Athena**      | Y                |N| Y                      |
+| **Big Query**       | Y                |N| Y                      |
+| **Trino**           | N                |N| Y                      |
+| **Impala**          | N                |N| Y                      |
+| **Redshift Spectrum** | N                |N| Y                      |
+| **Doris**           | N                |N| N                      |
+| **StarRocks**       | Y                |N| Y                      |
+| **ClickHouse**      | N                |N| N                      |
 
 


### PR DESCRIPTION
Refer: https://github.com/apache/hudi/pull/10202

### Change Logs

Update SQL Queries compatibility matrix 
Redshift spectrum support Hudi MOR RO tables but doesn't support Snapshot and Incremental queries.
StarRocks support MOR RO and Snapshot queries, but doesn't support Incremental queries.
Made some cosmetic changes that intellij suggested.

### Impact

Doc update.

### Risk level (write none, low medium or high below)

MINOR Doc update.

### Documentation Update

Doc update.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable - `npm run build` and `npm run serve` ran successfully
- [NA] CI passed - CI runs after raising PR
