### PR TITLE
[HUDI-6884] hudi-cli should generate correct HoodieTimeGeneratorConfig

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieCLI.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieCLI.java
@@ -39,6 +39,7 @@ public class HoodieCLI {
 
   public static Configuration conf;
   public static ConsistencyGuardConfig consistencyGuardConfig = ConsistencyGuardConfig.newBuilder().build();
+  public static HoodieTimeGeneratorConfig timeGeneratorConfig;
   public static FileSystem fs;
   public static CLIState state = CLIState.INIT;
   public static String basePath;
@@ -56,6 +57,10 @@ public class HoodieCLI {
 
   public static void setConsistencyGuardConfig(ConsistencyGuardConfig config) {
     consistencyGuardConfig = config;
+  }
+
+  public static void setTimeGeneratorConfig(HoodieTimeGeneratorConfig config) {
+    timeGeneratorConfig = config;
   }
 
   private static void setTableMetaClient(HoodieTableMetaClient tableMetadata) {
@@ -88,8 +93,7 @@ public class HoodieCLI {
   public static void refreshTableMetadata() {
     setTableMetaClient(HoodieTableMetaClient.builder().setConf(HoodieCLI.conf).setBasePath(basePath).setLoadActiveTimelineOnLoad(false)
         .setConsistencyGuardConfig(HoodieCLI.consistencyGuardConfig)
-        // TODO [HUDI-6884] Generate HoodieTimeGeneratorConfig from props user set
-        .setTimeGeneratorConfig(HoodieTimeGeneratorConfig.defaultConfig(basePath))
+        .setTimeGeneratorConfig(timeGeneratorConfig == null ? HoodieTimeGeneratorConfig.defaultConfig(basePath) : timeGeneratorConfig)
         .setLayoutVersion(Option.of(layoutVersion)).build());
   }
 

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -22,6 +22,7 @@ import org.apache.hudi.cli.HoodieCLI;
 import org.apache.hudi.cli.HoodiePrintHelper;
 import org.apache.hudi.cli.HoodieTableHeaderFields;
 import org.apache.hudi.cli.TableHeader;
+import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -30,6 +31,7 @@ import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimeGeneratorType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -85,12 +87,24 @@ public class TableCommand {
       @ShellOption(value = {"--maxWaitIntervalMs"}, defaultValue = "300000",
           help = "Max wait time for eventual consistency") final Integer maxConsistencyIntervalMs,
       @ShellOption(value = {"--maxCheckIntervalMs"}, defaultValue = "7",
-          help = "Max checks for eventual consistency") final Integer maxConsistencyChecks)
+          help = "Max checks for eventual consistency") final Integer maxConsistencyChecks,
+      @ShellOption(value = {"--timeGeneratorType"}, defaultValue = "WAIT_TO_ADJUST_SKEW",
+          help = "Time generator type, which is used to generate globally monotonically increasing timestamp") final String timeGeneratorType,
+      @ShellOption(value = {"--maxExpectedClockSkewMs"}, defaultValue = "200",
+          help = "The max expected clock skew time for WaitBasedTimeGenerator in ms") final Long maxExpectedClockSkewMs,
+      @ShellOption(value = {"--useDefaultLockProvider"}, defaultValue = "false",
+          help = "Use org.apache.hudi.client.transaction.lock.InProcessLockProvider") final boolean useDefaultLockProvider)
       throws IOException {
     HoodieCLI
         .setConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(eventuallyConsistent)
             .withInitialConsistencyCheckIntervalMs(initialConsistencyIntervalMs)
             .withMaxConsistencyCheckIntervalMs(maxConsistencyIntervalMs).withMaxConsistencyChecks(maxConsistencyChecks)
+            .build());
+    HoodieCLI
+        .setTimeGeneratorConfig(HoodieTimeGeneratorConfig.newBuilder().withPath(path)
+            .withTimeGeneratorType(TimeGeneratorType.valueOf(timeGeneratorType))
+            .withMaxExpectedClockSkewMs(maxExpectedClockSkewMs)
+            .withDefaultLockProvider(useDefaultLockProvider)
             .build());
     HoodieCLI.initConf();
     HoodieCLI.connectTo(path, layoutVersion);
@@ -144,7 +158,8 @@ public class TableCommand {
         .setTimelineLayoutVersion(layoutVersion)
         .initTable(HoodieCLI.conf, path);
     // Now connect to ensure loading works
-    return connect(path, layoutVersion, false, 0, 0, 0);
+    return connect(path, layoutVersion, false, 0, 0, 0,
+        "WAIT_TO_ADJUST_SKEW", 200L, true);
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
@@ -323,7 +323,8 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
         .addTableHeaderField(HoodieTableHeaderFields.HEADER_DELTA_FILES_UNSCHEDULED);
 
     // Test show with partition path '2016/03/15'
-    new TableCommand().connect(partitionedTablePath, null, false, 0, 0, 0);
+    new TableCommand().connect(partitionedTablePath, null, false, 0, 0, 0,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     Object partitionedTable = shell.evaluate(() -> "show fsview latest --partitionPath " + partitionPath);
     assertTrue(ShellEvaluationResultUtil.isSuccess(partitionedTable));
 
@@ -336,7 +337,8 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     assertEquals(partitionedExpected, partitionedResults);
 
     // Test show for non-partitioned table
-    new TableCommand().connect(nonpartitionedTablePath, null, false, 0, 0, 0);
+    new TableCommand().connect(nonpartitionedTablePath, null, false, 0, 0, 0,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     Object nonpartitionedTable = shell.evaluate(() -> "show fsview latest");
     assertTrue(ShellEvaluationResultUtil.isSuccess(nonpartitionedTable));
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
@@ -96,7 +96,8 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf()).setBasePath(tablePath).build();
     assertFalse(metaClient.getTableConfig().getMetadataPartitions().isEmpty());
 
-    new TableCommand().connect(tablePath, null, false, 0, 0, 0);
+    new TableCommand().connect(tablePath, null, false, 0, 0, 0,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     Object result = shell.evaluate(() -> "metadata delete");
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
@@ -91,7 +91,8 @@ public class ITTestBootstrapCommand extends HoodieCLIIntegrationTestBase {
     assertTrue(ShellEvaluationResultUtil.isSuccess(resultForBootstrapRun));
 
     // Connect & check Hudi table exist
-    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     metaClient = HoodieCLI.getTableMetaClient();
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should have 1 commit.");
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
@@ -113,7 +113,8 @@ public class ITTestHDFSParquetImportCommand extends HoodieCLIIntegrationTestBase
     assertTrue(Files.exists(Paths.get(metaPath)), "Hoodie table not exist.");
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     metaClient = HoodieCLI.getTableMetaClient();
 
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should only 1 commit.");
@@ -137,7 +138,8 @@ public class ITTestHDFSParquetImportCommand extends HoodieCLIIntegrationTestBase
     dataImporter.dataImport(jsc, 0);
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     metaClient = HoodieCLI.getTableMetaClient();
 
     // check if insert instant exist

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
@@ -320,7 +320,8 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
   }
 
   private void connectTableAndReloadMetaClient(String tablePath) throws IOException {
-    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 0, 0, 0);
+    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 0, 0, 0,
+        "WAIT_TO_ADJUST_SKEW", 200L, false);
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
   }
 


### PR DESCRIPTION
### Change Logs

Currently, we build HoodieTimeGeneratorConfig with default configuration, instead we should respect props users set.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
