### PR TITLE
[HUDI-7564] Fix HiveSyncConfig inconsistency

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -480,7 +480,7 @@ trait ProvidesHoodieConfig extends Logging {
       hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS, props.getString(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key))
     }
     hiveSyncConfig.setDefaultValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS, classOf[MultiPartKeysValueExtractor].getName)
-    hiveSyncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, "true")
+    hiveSyncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE.defaultValue())
     if (hiveSyncConfig.useBucketSync())
       hiveSyncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC,
         HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key),


### PR DESCRIPTION
### Change Logs

Please refer to the jira ticket [HUDI-7564](https://issues.apache.org/jira/browse/HUDI-7564) for a more detailed explanation.

When investigating an error thrown by Trino/Presto queries involving Timestamp types:

```log
2024-04-02 17:32:21 (UTC+8) INFO - Clear session property for connection.
2024-04-02 17:32:21 (UTC+8) ERROR- Task Execution failed with CommonException: Query failed (#20240402_093220_06724_cg4jg): Expected field to be long, actual timestamp(9) (field 0) 
```

We realised that there is a config inconsistency shown that indirectly causes the error thrown above. Trino/Presto requires that `TIMESTAMP` types to be synced to HMS as `LONG` types. 

This should be the default behaviour as:
```properties
hoodie.datasource.hive_sync.support_timestamp=false
```

However, we realised that the default behaviour is overwritten by `buildHiveSyncConfig` when performing inserts via **Spark**, breaking our assumptions.

This PR fixes this inconsistency.

**TLDR:** 
Fix inconsistency
```
hoodie.datasource.hive_sync.support_timestamp = false  (HiveSyncConfigHolder - default)
hoodie.datasource.hive_sync.support_timestamp = true   (ProvidesHoodieConfig#buildHiveSyncConfig )
```

### Impact

No impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
