### PR TITLE
[HUDI-7569] [RLI] Fix wrong result generated by query

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -162,7 +162,10 @@ class RecordLevelIndexSupport(spark: SparkSession,
       case inQuery: In =>
         var validINQuery = true
         inQuery.value match {
-          case _: AttributeReference =>
+          case attribute: AttributeReference =>
+            if (!attributeMatchesRecordKey(attribute.name)) {
+              validINQuery = false
+            }
           case _ => validINQuery = false
         }
         var literals: List[String] = List.empty


### PR DESCRIPTION
Record level index speeds up queries (when appropriate config properties are enabled) by pruning files based on metadata's RLI partition entries. The current implementation can prune files only when the query predicate has a EqalTo (i.e '=') OR In filters/expressions on the record-key column.

However, the logic to detect if a 'In' query predicate references a record-key column is buggy. This can result in wrong results when the query predicate is a `In` expression ona  column other than record-key column. This seems like a serious bug that needs to be fixed.

This PR fixes this problem and adds a unit test for the same.

### Change Logs

The changes introduced are:
RecordLevelIndexSupport.scala: The method `filterQueryWithRecordKey(...)` is where the bug exists. The switch-case for `In` expression was not filtering out expressions that are based on non-record-key columns. Fixed it correctly.

TestRecordLevelIndexWithSQL.scala: Adds a unit test that clearly shows the problem with wrong results and the changes in this PR that fixes the wrong result issue.

### Impact

Bug fix

### Risk level (write none, low medium or high below)

None

### Documentation Update

None. No new configs are user visible options/changes added

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
