### PR TITLE
[HUDI-7564] Revert hive sync inconsistency and add docs for it

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -480,7 +480,9 @@ trait ProvidesHoodieConfig extends Logging {
       hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS, props.getString(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key))
     }
     hiveSyncConfig.setDefaultValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS, classOf[MultiPartKeysValueExtractor].getName)
-    hiveSyncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE.defaultValue())
+    // This is hardcoded to true to ensure consistency as Spark syncs TIMESTAMP types as TIMESTAMP by default
+    // via Spark's externalCatalog API, which is used by AlterHoodieTableCommand.
+    hiveSyncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, "true")
     if (hiveSyncConfig.useBucketSync())
       hiveSyncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC,
         HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key),

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -90,7 +90,8 @@ public class HiveSyncConfigHolder {
       .defaultValue("false")
       .markAdvanced()
       .withDocumentation("‘INT64’ with original type TIMESTAMP_MICROS is converted to hive ‘timestamp’ type. "
-          + "Disabled by default for backward compatibility.");
+          + "Disabled by default for backward compatibility. \n"
+          + "NOTE: On Spark entrypoints, this is defaulted to TRUE");
   public static final ConfigProperty<String> HIVE_TABLE_PROPERTIES = ConfigProperty
       .key("hoodie.datasource.hive_sync.table_properties")
       .noDefaultValue()


### PR DESCRIPTION
### Change Logs

Reverting the hive-sync support_timestamp inconsistency as described in https://github.com/apache/hudi/pull/10951#issuecomment-2034230672.

TLDR, this inconsistency was introduced to ensure that hive-sync's behaviour is inline with Spark's externalCatalog table schema sync, which is used in AlterTableHoodieCommand.

Hive-sync is used to create the _ro and _rt tables of MOR.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

Updated the config description for `hoodie.datasource.hive_sync.support_timestamp` to document that this is an intended inconsistency.


### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
