### PR TITLE
[HUDI-8184] Fix Hudi CLI 'version' command to return Hudi version

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -29,12 +29,14 @@
   <properties>
     <jar.mainclass>org.apache.hudi.cli.Main</jar.mainclass>
     <main.basedir>${project.parent.basedir}</main.basedir>
+    <hudi.version>${project.parent.version}</hudi.version>
   </properties>
 
   <build>
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+        <filtering>true</filtering>
       </resource>
     </resources>
     <pluginManagement>

--- a/hudi-cli/src/main/resources/application.yml
+++ b/hudi-cli/src/main/resources/application.yml
@@ -21,3 +21,7 @@ spring:
     history:
       enabled: true
       name: hoodie-cmd.log
+    command:
+      version:
+        template: "classpath:version.txt"
+

--- a/hudi-cli/src/main/resources/version.txt
+++ b/hudi-cli/src/main/resources/version.txt
@@ -1,0 +1,1 @@
+${hudi.version}

--- a/pom.xml
+++ b/pom.xml
@@ -699,6 +699,7 @@
               <exclude>**/*.log</exclude>
               <exclude>**/*.sqltemplate</exclude>
               <exclude>**/compose_env</exclude>
+              <exclude>**/main/resources/version.txt</exclude>
               <exclude>**/*NOTICE*</exclude>
               <exclude>**/*LICENSE*</exclude>
               <exclude>**/dependency-reduced-pom.xml</exclude>


### PR DESCRIPTION
### Change Logs
Hudi Cli version command output empty string. Adding property files to output the version number according with the hudi parent project version. 

### Impact
Will cause confusion for client without knowing the version number

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
