### PR TITLE
[HUDI-7578] Avoid unnecessary rewriting when copy old data from old base to new base file to improve compaction performance

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/Consumer4.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/Consumer4.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import java.io.IOException;
+
+/**
+ * Represents an operation that accepts four input arguments and returns no result.
+ * Unlike most other functional interfaces, {@code Consumer4} is expected to operate via side-effects.
+ */
+public interface Consumer4<T1, T2, T3, T4> {
+
+  /**
+   * Performs this operation on the given arguments.
+   *
+   * @param var1 the first argument
+   * @param var2 the second argument
+   * @param var3 the third argument
+   * @param var4 the forth argument
+   * @throws IOException
+   */
+  void accept(T1 var1, T2 var2, T3 var3, T4 var4) throws IOException;
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -151,7 +151,7 @@ public class HoodieMergeHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O>
     validateAndSetAndKeyGenProps(keyGeneratorOpt, config.populateMetaFields());
     // The compactor avoids heavy rewriting when copy the old record from old base file into new base file
     if (config.populateMetaFields()) {
-      LOG.info("Using update instead rewriting during compaction");
+      LOG.info("Using update instead of rewriting during compaction");
       copyOldFunc = (key, record, schema, prop) -> this.updateMetadataToOldRecord(key, record, schema, prop);
     } else {
       copyOldFunc = (key, record, schema, prop) -> this.writeToFile(key, record, schema, prop, true);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -216,6 +216,14 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
   }
 
   @Override
+  public void updateMetaFields(Schema recordSchema, MetadataValues metadataValues, Properties props) {
+    StructType structType = HoodieInternalRowUtils.getCachedSchema(recordSchema);
+    HoodieInternalRow updatableRow = wrapIntoUpdatableOverlay(this.data, structType);
+    updateMetadataValuesInternal(updatableRow, metadataValues);
+    this.data = updatableRow;
+  }
+
+  @Override
   public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) {
     StructType structType = HoodieInternalRowUtils.getCachedSchema(recordSchema);
     StructType newStructType = HoodieInternalRowUtils.getCachedSchema(newSchema);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -119,6 +119,11 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   }
 
   @Override
+  public void updateMetaFields(Schema recordSchema, MetadataValues metadataValues, Properties props) {
+    updateMetadataValuesInternal((GenericRecord) data, metadataValues);
+  }
+
+  @Override
   public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) {
     GenericRecord record = HoodieAvroUtils.rewriteRecordWithNewSchema(data, newSchema, renameCols);
     return new HoodieAvroIndexedRecord(key, record, operation, metaData);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -138,6 +138,18 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
   }
 
   @Override
+  public void updateMetaFields(Schema recordSchema, MetadataValues metadataValues, Properties props) {
+    try {
+      Option<IndexedRecord> avroRecordOpt = getData().getInsertValue(recordSchema, props);
+      GenericRecord avroRecord = (GenericRecord) avroRecordOpt.get();
+      updateMetadataValuesInternal(avroRecord, metadataValues);
+      this.data = (T) new RewriteAvroPayload(avroRecord);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to deserialize record!", e);
+    }
+  }
+
+  @Override
   public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) {
     try {
       GenericRecord oldRecord = (GenericRecord) getData().getInsertValue(recordSchema, props).get();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieEmptyRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieEmptyRecord.java
@@ -105,6 +105,11 @@ public class HoodieEmptyRecord<T> extends HoodieRecord<T> {
   }
 
   @Override
+  public void updateMetaFields(Schema recordSchema, MetadataValues metadataValues, Properties props) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) {
     throw new UnsupportedOperationException();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -404,6 +404,13 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   public abstract HoodieRecord prependMetaFields(Schema recordSchema, Schema targetSchema, MetadataValues metadataValues, Properties props);
 
   /**
+   * Update record with new meta-fields
+   *
+   * NOTE: This operation would update meta fields of current record directly
+   */
+  public abstract void updateMetaFields(Schema recordSchema, MetadataValues metadataValues, Properties props);
+
+  /**
    * Support schema evolution.
    */
   public abstract HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols);


### PR DESCRIPTION
### Change Logs
Avoid unnecessary rewriting when copy old data from old base to new base file to improve compaction performance.
See more detail in [HUDI-7578](https://issues.apache.org/jira/browse/HUDI-7578) or [issue#10978](https://github.com/apache/hudi/issues/10978).

### Impact

Improve the compact performance.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
