### PR TITLE
[HUDI-7583] Read log block header only for the schema and instant time

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -389,7 +389,10 @@ public class TableSchemaResolver {
    * @return
    */
   public static MessageType readSchemaFromLogFile(FileSystem fs, Path path) throws IOException {
-    try (Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null)) {
+    // We only need to read the schema from the log block header,
+    // so we read the block lazily to avoid reading block content
+    // containing the records
+    try (Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null, true, false)) {
       HoodieDataBlock lastBlock = null;
       while (reader.hasNext()) {
         HoodieLogBlock block = reader.next();

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -2835,7 +2835,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     }
   }
 
-  private static HoodieDataBlock getDataBlock(HoodieLogBlockType dataBlockType, List<IndexedRecord> records,
+  public static HoodieDataBlock getDataBlock(HoodieLogBlockType dataBlockType, List<IndexedRecord> records,
                                               Map<HeaderMetadataType, String> header) {
     return getDataBlock(dataBlockType, records.stream().map(HoodieAvroIndexedRecord::new).collect(Collectors.toList()), header, new Path("dummy_path"));
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -19,13 +19,33 @@
 package org.apache.hudi.common.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.internal.schema.HoodieSchemaException;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroSchemaConverter;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.functional.TestHoodieLogFormat.getDataBlock;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK;
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getSimpleSchema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,6 +54,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests {@link TableSchemaResolver}.
  */
 public class TestTableSchemaResolver {
+
+  @TempDir
+  public java.nio.file.Path tempDir;
 
   @Test
   public void testRecreateSchemaWhenDropPartitionColumns() {
@@ -64,5 +87,38 @@ public class TestTableSchemaResolver {
     } catch (HoodieSchemaException e) {
       assertTrue(e.getMessage().contains("Partial partition fields are still in the schema"));
     }
+  }
+
+  @Test
+  public void testReadSchemaFromLogFile() throws IOException, URISyntaxException, InterruptedException {
+    String testDir = initTestDir("read_schema_from_log_file");
+    Path partitionPath = new Path(testDir, "partition1");
+    Schema expectedSchema = getSimpleSchema();
+    Path logFilePath = writeLogFile(partitionPath, expectedSchema);
+    assertEquals(
+        new AvroSchemaConverter().convert(expectedSchema),
+        TableSchemaResolver.readSchemaFromLogFile(
+            logFilePath.getFileSystem(new Configuration()), logFilePath));
+  }
+
+  private String initTestDir(String folderName) throws IOException {
+    java.nio.file.Path basePath = tempDir.resolve(folderName);
+    java.nio.file.Files.createDirectories(basePath);
+    return basePath.toString();
+  }
+
+  private Path writeLogFile(Path partitionPath, Schema schema) throws IOException, URISyntaxException, InterruptedException {
+    FileSystem fs = partitionPath.getFileSystem(new Configuration());
+    HoodieLogFormat.Writer writer =
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withFileExtension(HoodieLogFile.DELTA_EXTENSION)
+            .withFileId("test-fileid1").withDeltaCommit("100").withFs(fs).build();
+    List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, "100");
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
+    HoodieDataBlock dataBlock = getDataBlock(AVRO_DATA_BLOCK, records, header);
+    writer.appendBlock(dataBlock);
+    writer.close();
+    return writer.getLogFile().getPath();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1175,7 +1175,7 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
         Schema readerSchema = converter.convert(messageType);
         reader =
-            HoodieLogFormat.newReader(fs, new HoodieLogFile(logFilePathStr), readerSchema);
+            HoodieLogFormat.newReader(fs, new HoodieLogFile(logFilePathStr), readerSchema, true, false);
         // read the avro blocks
         if (reader.hasNext()) {
           HoodieLogBlock block = reader.next();


### PR DESCRIPTION
### Change Logs

The `TableSchemaResolver` reads the schema from the log block.  The current way of instantiating log reader does not lazily read the content, causing the whole block content to be read, which is unnecessary.  During clustering, when clustering rewrites a file group that contains log files, it requires deriving the schema from the file group in the current logic.  Such logic happens in all paralleled threads on each file group on the Spark driver, causing OOM on the driver.

This PR fixes the `TableSchemaResolver` and `HoodieMetadataTableValidator` to read the log blocker header only for the schema and instant time, and avoid reading block content to reduce the memory requirement.

A test is added for reading the log file.  The memory usage is manually verified.

I have created follow-ups to improve the relevant logic in deriving schema and clustering: [HUDI-7584](https://issues.apache.org/jira/browse/HUDI-7584), [HUDI-7585](https://issues.apache.org/jira/browse/HUDI-7585), [HUDI-7586](https://issues.apache.org/jira/browse/HUDI-7586).

Relevant code before the fix:
`TableSchemaResolver`:
```
  public static MessageType readSchemaFromLogFile(FileSystem fs, Path path) throws IOException {
    try (Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null)) {
      HoodieDataBlock lastBlock = null;
      while (reader.hasNext()) {
        HoodieLogBlock block = reader.next();
        if (block instanceof HoodieDataBlock) {
          lastBlock = (HoodieDataBlock) block;
        }
      }
      return lastBlock != null ? new AvroSchemaConverter().convert(lastBlock.getSchema()) : null;
    }
  }
```
`HoodieLogFormat.Reader`:
```
  static HoodieLogFormat.Reader newReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema)
      throws IOException {
    return new HoodieLogFileReader(fs, logFile, readerSchema, HoodieLogFileReader.DEFAULT_BUFFER_SIZE, false);
  }
```

Call stack in clustering:
<img width="629" alt="Screenshot 2024-04-09 at 15 33 16" src="https://github.com/apache/hudi/assets/2497195/ecc18f9b-56d9-4910-933f-7c353cd63fff">

### Impact

Fixes OOM and reduces memory usage.

Before fix (log block content is loaded):
<img width="1295" alt="Screenshot 2024-04-09 at 13 00 14" src="https://github.com/apache/hudi/assets/2497195/edb719e1-f13e-41b2-8cb5-f75829c40d20">

After fix (log block content is empty):
<img width="1334" alt="Screenshot 2024-04-09 at 12 58 57" src="https://github.com/apache/hudi/assets/2497195/b27462dc-4590-47dd-b177-b4abc1455881">


### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
