### PR TITLE
[MINOR] Fix BUG: HoodieLogFormatWriter: unable to close output stream for log…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -278,7 +278,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
         try {
           LOG.warn("running logformatwriter hook");
           if (output != null) {
-            close();
+            closeStream();
           }
         } catch (Exception e) {
           LOG.warn("unable to close output stream for log file " + logFile, e);


### PR DESCRIPTION
Fix BUG: HoodieLogFormatWriter: unable to close output stream for log file HoodieLogFile{xxx}

This happens sometimes when users try to shutdown Hudi programs manually (and then YARN containers receive SIG_TERM), causing shutdown hooks to run.

* due to java.lang.IllegalStateException: Shutdown in progress, cause: when `org.apache.hudi.common.table.log.HoodieLogFormatWriter.close` tries to `removeShutdownHook`, hooks were already removed by JVM when triggered (i.e., hooks == null), so JVM would throw this exception

Relevant error logs:
```
24/04/09 23:01:10 ERROR CoarseGrainedExecutorBackend: RECEIVED SIGNAL TERM
24/04/09 23:01:10 WARN HoodieLogFormatWriter: unable to close output stream for log file HoodieLogFile{pathStr='/path/to/table/.4f261267-ce71-4e70-bdc2-f8b993e6eb10-0_20240409223056647.log.1_0-184283-2228331', fileLen=23013}
java.lang.IllegalStateException: Shutdown in progress
	at java.lang.ApplicationShutdownHooks.remove(ApplicationShutdownHooks.java:82)
	at java.lang.Runtime.removeShutdownHook(Runtime.java:231)
	at org.apache.hudi.common.table.log.HoodieLogFormatWriter.close(HoodieLogFormatWriter.java:240)
	at org.apache.hudi.common.table.log.HoodieLogFormatWriter$1.run(HoodieLogFormatWriter.java:284)
```

### Change Logs

When close output streams in a shutdown hook, no need to remove itself from registered shutdown hooks.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
