### PR TITLE
[HUDI-7600] Shutdown ExecutorService when HiveMetastoreBasedLockProvider is closed

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -154,6 +154,7 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
         lock = null;
       }
       Hive.closeCurrent();
+      executor.shutdown();
     } catch (Exception e) {
       LOG.error(generateLogStatement(org.apache.hudi.common.lock.LockState.FAILED_TO_RELEASE, generateLogSuffixString()));
     }


### PR DESCRIPTION
### Change Logs

Shutdown ExecutorService when HiveMetastoreBasedLockProvider is closed

### Impact

When we submitted a clustering job with table with HMS lock, the jvm could not exit. 
The reason is that this thread pool did not exit.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
