### PR TITLE
[MINOR] Make ordering deterministic in small file selection

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -450,7 +450,7 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     // Bootstrap base files ("small-file targets")
     FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-1", 1024);
     FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-2", 1024);
-    FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-3", 1024);
+    FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-3", 800);
 
     FileCreateUtils.createCommit(basePath, "002");
 
@@ -469,9 +469,9 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     assertEquals(3, partitioner.numPartitions());
     assertEquals(
         Arrays.asList(
+            new BucketInfo(BucketType.UPDATE, "fg-3", partitionPath), // smallest file first
             new BucketInfo(BucketType.UPDATE, "fg-1", partitionPath),
-            new BucketInfo(BucketType.UPDATE, "fg-2", partitionPath),
-            new BucketInfo(BucketType.UPDATE, "fg-3", partitionPath)
+            new BucketInfo(BucketType.UPDATE, "fg-2", partitionPath)
         ),
         partitioner.getBucketInfos());
   }


### PR DESCRIPTION
### Change Logs

Makes the ordering deterministic to get consistent results and avoid any issues in tests

### Impact

Small file selection is consistent (mostly helps tests be consistent)

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
