### PR TITLE
[HUDI-7615] Mark a few write configs with the correct sinceVersion

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -159,6 +159,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.datasource.write.payload.type")
       .defaultValue(RecordPayloadType.HOODIE_AVRO_DEFAULT.name())
       .markAdvanced()
+      .sinceVersion("1.0.0")
       .withDocumentation(RecordPayloadType.class);
 
   public static final ConfigProperty<String> RECORD_MERGER_IMPLS = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
@@ -63,6 +63,7 @@ public class KeyGeneratorOptions extends HoodieConfig {
   public static final ConfigProperty<String> KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED = ConfigProperty
       .key("hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled")
       .defaultValue("false")
+      .sinceVersion("0.10.1")
       .markAdvanced()
       .withDocumentation("When set to true, consistent value will be generated for a logical timestamp type column, "
           + "like timestamp-millis and timestamp-micros, irrespective of whether row-writer is enabled. Disabled by default so "


### PR DESCRIPTION
### Change Logs
Add since version for write configs

Following two since versions have already been marked, so no need to updated in this PR. 
[hoodie.metadata.log.compaction.enable -> 0.14.0](https://github.com/apache/hudi/blob/17ea14ab6d6a8ca7ecef2cfcdbc67b0c87f23987/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java#L95)
[hoodie.log.compaction.enable -> 0.14.0](https://github.com/apache/hudi/blob/17ea14ab6d6a8ca7ecef2cfcdbc67b0c87f23987/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java#L70)


_Describe context and summary for this change. Highlight if any code was copied._

### Impact
_Describe any public API or user-facing feature change or any performance impact._
version clarification 

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
