### PR TITLE
[HUDI-7580] Fix order of fields when records inserted out of order

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -315,11 +315,11 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
              | partitioned by(price)
              | location '$basePath'
        """.stripMargin)
-        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
-        spark.sql(s"insert into $tableName values(2, 'a2', 100, 200000)")
-        checkAnswer(s"select id, name, ts, price from $tableName")(
-          Seq(1, "a1", 10, 1000),
-          Seq(2, "a2", 100, 200000)
+        spark.sql(s"insert into $tableName (id, name, ts, price) values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName (id, name, ts, price) values(2, 'a2', 100, 200000)")
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 1000, 10),
+          Seq(2, "a2", 200000, 100)
         )
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -294,6 +294,37 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test Insert Into Table with partition field not in the end") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        val tableName = "rides"
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price int,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = 'mor',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(price)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 100, 200000)")
+        checkAnswer(s"select id, name, ts, price from $tableName")(
+          Seq(1, "a1", 10, 1000),
+          Seq(2, "a2", 100, 200000)
+        )
+      }
+    }
+  }
+
   test("Test Insert Into with multi partition") {
     withRecordType()(withTempDir { tmp =>
       val tableName = generateTableName


### PR DESCRIPTION
### Change Logs

Fix order of fields when records inserted out of order.

### Impact

Bug fix, no public api change.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
