### PR TITLE
[HUDI-7582] Fix functional index lookup

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkFunctionalIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkFunctionalIndex.java
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-package org.apache.hudi.index.functional;
+package org.apache.hudi;
 
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.index.functional.HoodieFunctionalIndex;
 
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.functions;
@@ -44,69 +45,69 @@ public class HoodieSparkFunctionalIndex implements HoodieFunctionalIndex<Column,
    * NOTE: This is not an exhaustive list of spark-sql functions. Only the common date/timestamp and string functions have been added.
    * Add more functions as needed. However, keep the key should match the exact spark-sql function name in lowercase.
    */
-  private static final Map<String, SparkFunction> SPARK_FUNCTION_MAP = CollectionUtils.createImmutableMap(
+  public static final Map<String, SparkFunction> SPARK_FUNCTION_MAP = CollectionUtils.createImmutableMap(
       // Date/Timestamp functions
-      Pair.of("date_format", (columns, options) -> {
+      Pair.of(SPARK_DATE_FORMAT, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("DATE_FORMAT requires 1 column");
         }
         return functions.date_format(columns.get(0), options.get("format"));
       }),
-      Pair.of("day", (columns, options) -> {
+      Pair.of(SPARK_DAY, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("DAY requires 1 column");
         }
         return functions.dayofmonth(columns.get(0));
       }),
-      Pair.of("year", (columns, options) -> {
+      Pair.of(SPARK_YEAR, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("YEAR requires 1 column");
         }
         return functions.year(columns.get(0));
       }),
-      Pair.of("month", (columns, options) -> {
+      Pair.of(SPARK_MONTH, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("MONTH requires 1 column");
         }
         return functions.month(columns.get(0));
       }),
-      Pair.of("hour", (columns, options) -> {
+      Pair.of(SPARK_HOUR, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("HOUR requires 1 column");
         }
         return functions.hour(columns.get(0));
       }),
-      Pair.of("from_unixtime", (columns, options) -> {
+      Pair.of(SPARK_FROM_UNIXTIME, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("FROM_UNIXTIME requires 1 column");
         }
         return functions.from_unixtime(columns.get(0), options.get("format"));
       }),
-      Pair.of("unix_timestamp", (columns, options) -> {
+      Pair.of(SPARK_UNIX_TIMESTAMP, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("UNIX_TIMESTAMP requires 1 column");
         }
         return functions.unix_timestamp(columns.get(0), options.get("format"));
       }),
-      Pair.of("to_date", (columns, options) -> {
+      Pair.of(SPARK_TO_DATE, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("TO_DATE requires 1 column");
         }
         return functions.to_date(columns.get(0));
       }),
-      Pair.of("to_timestamp", (columns, options) -> {
+      Pair.of(SPARK_TO_TIMESTAMP, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("TO_TIMESTAMP requires 1 column");
         }
         return functions.to_timestamp(columns.get(0));
       }),
-      Pair.of("date_add", (columns, options) -> {
+      Pair.of(SPARK_DATE_ADD, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("DATE_ADD requires 1 column");
         }
         return functions.date_add(columns.get(0), Integer.parseInt(options.get("days")));
       }),
-      Pair.of("date_sub", (columns, options) -> {
+      Pair.of(SPARK_DATE_SUB, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("DATE_SUB requires 1 column");
         }
@@ -114,73 +115,73 @@ public class HoodieSparkFunctionalIndex implements HoodieFunctionalIndex<Column,
       }),
 
       // String functions
-      Pair.of("concat", (columns, options) -> {
+      Pair.of(SPARK_CONCAT, (columns, options) -> {
         if (columns.size() < 2) {
           throw new IllegalArgumentException("CONCAT requires at least 2 columns");
         }
         return functions.concat(columns.toArray(new Column[0]));
       }),
-      Pair.of("substring", (columns, options) -> {
+      Pair.of(SPARK_SUBSTRING, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("SUBSTRING requires 1 column");
         }
         return functions.substring(columns.get(0), Integer.parseInt(options.get("pos")), Integer.parseInt(options.get("len")));
       }),
-      Pair.of("lower", (columns, options) -> {
+      Pair.of(SPARK_LOWER, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("LOWER requires 1 column");
         }
         return functions.lower(columns.get(0));
       }),
-      Pair.of("upper", (columns, options) -> {
+      Pair.of(SPARK_UPPER, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("UPPER requires 1 column");
         }
         return functions.upper(columns.get(0));
       }),
-      Pair.of("trim", (columns, options) -> {
+      Pair.of(SPARK_TRIM, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("TRIM requires 1 column");
         }
         return functions.trim(columns.get(0));
       }),
-      Pair.of("ltrim", (columns, options) -> {
+      Pair.of(SPARK_LTRIM, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("LTRIM requires 1 column");
         }
         return functions.ltrim(columns.get(0));
       }),
-      Pair.of("rtrim", (columns, options) -> {
+      Pair.of(SPARK_RTRIM, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("RTRIM requires 1 column");
         }
         return functions.rtrim(columns.get(0));
       }),
-      Pair.of("length", (columns, options) -> {
+      Pair.of(SPARK_LENGTH, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("LENGTH requires 1 column");
         }
         return functions.length(columns.get(0));
       }),
-      Pair.of("regexp_replace", (columns, options) -> {
+      Pair.of(SPARK_REGEXP_REPLACE, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("REGEXP_REPLACE requires 1 column");
         }
         return functions.regexp_replace(columns.get(0), options.get("pattern"), options.get("replacement"));
       }),
-      Pair.of("regexp_extract", (columns, options) -> {
+      Pair.of(SPARK_REGEXP_EXTRACT, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("REGEXP_EXTRACT requires 1 column");
         }
         return functions.regexp_extract(columns.get(0), options.get("pattern"), Integer.parseInt(options.get("idx")));
       }),
-      Pair.of("split", (columns, options) -> {
+      Pair.of(SPARK_SPLIT, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("SPLIT requires 1 column");
         }
         return functions.split(columns.get(0), options.get("pattern"));
       }),
-      Pair.of("identity", (columns, options) -> {
+      Pair.of(SPARK_IDENTITY, (columns, options) -> {
         if (columns.size() != 1) {
           throw new IllegalArgumentException("IDENTITY requires 1 column");
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -38,7 +38,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.index.functional.HoodieFunctionalIndex;
-import org.apache.hudi.index.functional.HoodieSparkFunctionalIndex;
+import org.apache.hudi.HoodieSparkFunctionalIndex;
 import org.apache.hudi.metrics.DistributedRegistry;
 import org.apache.hudi.metrics.MetricsReporterType;
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/functional/TestHoodieSparkFunctionalIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/functional/TestHoodieSparkFunctionalIndex.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.index.functional;
 
+import org.apache.hudi.HoodieSparkFunctionalIndex;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
 import org.apache.spark.sql.Column;

--- a/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
@@ -30,6 +30,31 @@ import java.util.List;
  * @param <T> The target type after applying the transformation. Represents the type of the indexed value.
  */
 public interface HoodieFunctionalIndex<S, T> extends Serializable {
+
+  public static final String SPARK_DATE_FORMAT = "date_format";
+  public static final String SPARK_DAY = "day";
+  public static final String SPARK_MONTH = "month";
+  public static final String SPARK_YEAR = "year";
+  public static final String SPARK_HOUR = "hour";
+  public static final String SPARK_FROM_UNIXTIME = "from_unixtime";
+  public static final String SPARK_UNIX_TIMESTAMP = "unix_timestamp";
+  public static final String SPARK_TO_DATE = "to_date";
+  public static final String SPARK_TO_TIMESTAMP = "to_timestamp";
+  public static final String SPARK_DATE_ADD = "date_add";
+  public static final String SPARK_DATE_SUB = "date_sub";
+  public static final String SPARK_CONCAT = "concat";
+  public static final String SPARK_SUBSTRING = "substring";
+  public static final String SPARK_UPPER = "upper";
+  public static final String SPARK_LOWER = "lower";
+  public static final String SPARK_TRIM = "trim";
+  public static final String SPARK_LTRIM = "ltrim";
+  public static final String SPARK_RTRIM = "rtrim";
+  public static final String SPARK_LENGTH = "length";
+  public static final String SPARK_REGEXP_REPLACE = "regexp_replace";
+  public static final String SPARK_REGEXP_EXTRACT = "regexp_extract";
+  public static final String SPARK_SPLIT = "split";
+  public static final String SPARK_IDENTITY = "identity";
+
   /**
    * Get the name of the index.
    *

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -156,7 +156,7 @@ object DataSourceReadOptions {
 
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty
     .key("hoodie.enable.data.skipping")
-    .defaultValue(false)
+    .defaultValue(true)
     .markAdvanced()
     .sinceVersion("0.10.0")
     .withDocumentation("Enables data-skipping allowing queries to leverage indexes to reduce the search space by " +

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -156,7 +156,7 @@ object DataSourceReadOptions {
 
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty
     .key("hoodie.enable.data.skipping")
-    .defaultValue(true)
+    .defaultValue(false)
     .markAdvanced()
     .sinceVersion("0.10.0")
     .withDocumentation("Enables data-skipping allowing queries to leverage indexes to reduce the search space by " +

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -45,7 +45,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
 import scala.collection.JavaConverters._
-import scala.collection.convert.ImplicitConversions.`map AsScala`
 import scala.collection.{JavaConverters, mutable}
 
 class FunctionalIndexSupport(spark: SparkSession,
@@ -139,7 +138,7 @@ class FunctionalIndexSupport(spark: SparkSession,
         val targetColumnName = expr.references.head.name
         // Check if the expression string contains any of the function names
         val exprString = expr.toString
-        SPARK_FUNCTION_MAP.keys
+        SPARK_FUNCTION_MAP.asScala.keys
           .find(exprString.contains)
           .map(functionName => functionName -> targetColumnName)
       } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -352,7 +352,7 @@ case class HoodieFileIndex(spark: SparkSession,
     } else if (functionalIndex.isIndexAvailable && !queryFilters.isEmpty) {
       val prunedFileNames = getPrunedFileNames(prunedPartitionsAndFileSlices)
       val shouldReadInMemory = functionalIndex.shouldReadInMemory(this, queryReferencedColumns)
-      val indexDf = functionalIndex.loadFunctionalIndexDataFrame("", shouldReadInMemory)
+      val indexDf = functionalIndex.loadFunctionalIndexDataFrame("func_index_idx_datestr", shouldReadInMemory)
       Some(getCandidateFiles(indexDf, queryFilters, prunedFileNames))
     } else if (!columnStatsIndex.isIndexAvailable || queryFilters.isEmpty || queryReferencedColumns.isEmpty) {
       validateConfig()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -172,18 +172,17 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
   test("Test Create Functional Index") {
     if (HoodieSparkUtils.gteqSpark3_2) {
       withTempDir { tmp =>
-        Seq("cow").foreach { tableType =>
+        Seq("cow", "mor").foreach { tableType =>
           val databaseName = "default"
           val tableName = generateTableName
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
-          spark.sql("set hoodie.metadata.enable=true")
           spark.sql(
             s"""
                |create table $tableName (
                |  id int,
                |  name string,
-               |  ts long,
-               |  price int
+               |  price double,
+               |  ts long
                |) using hudi
                | options (
                |  primaryKey ='id',
@@ -192,23 +191,37 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
                |  hoodie.metadata.record.index.enable = 'true',
                |  hoodie.datasource.write.recordkey.field = 'id'
                | )
-               | partitioned by(price)
+               | partitioned by(ts)
                | location '$basePath'
        """.stripMargin)
-          spark.sql(s"insert into $tableName (id, name, ts, price) values(1, 'a1', 1000, 10)")
-          spark.sql(s"insert into $tableName (id, name, ts, price) values(2, 'a2', 200000, 100)")
-          spark.sql(s"insert into $tableName (id, name, ts, price) values(3, 'a3', 2000000000, 1000)")
+          spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+          spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+          spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
 
           var metaClient = HoodieTableMetaClient.builder()
             .setBasePath(basePath)
             .setConf(spark.sessionState.newHadoopConf())
             .build()
 
+          assert(metaClient.getTableConfig.isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX))
+
+          val sqlParser: ParserInterface = spark.sessionState.sqlParser
+          val analyzer: Analyzer = spark.sessionState.analyzer
+
+          var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
+          var resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].table, databaseName, tableName)
+
           var createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
+          logicalPlan = sqlParser.parsePlan(createIndexSql)
+
+          resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+          assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+          assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
 
           spark.sql(createIndexSql)
-          spark.sql(s"select key, type, ColumnStatsMetadata from hudi_metadata('$tableName') where type = 3").show(false)
-
           metaClient = HoodieTableMetaClient.builder()
             .setBasePath(basePath)
             .setConf(spark.sessionState.newHadoopConf())
@@ -218,8 +231,23 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
-          spark.sql(s"select id, name, price, ts, from_unixtime(ts, 'yyyy-MM-dd') from $tableName").show(false)
-          spark.sql(s"select id, name, price, ts, from_unixtime(ts, 'yyyy-MM-dd') from $tableName where from_unixtime(ts, 'yyyy-MM-dd') < '2033-05-18'").show(false)
+          // Verify one can create more than one functional index
+          createIndexSql = s"create index name_lower on $tableName using column_stats(ts) options(func='identity')"
+          spark.sql(createIndexSql)
+          metaClient = HoodieTableMetaClient.builder()
+            .setBasePath(basePath)
+            .setConf(spark.sessionState.newHadoopConf())
+            .build()
+          functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
+          assertEquals(2, functionalIndexMetadata.getIndexDefinitions.size())
+          assertEquals("func_index_name_lower", functionalIndexMetadata.getIndexDefinitions.get("func_index_name_lower").getIndexName)
+
+          // Ensure that both the indexes are tracked correctly in metadata partition config
+          val mdtPartitions = metaClient.getTableConfig.getMetadataPartitions
+          assert(mdtPartitions.contains("func_index_name_lower") && mdtPartitions.contains("func_index_idx_datestr"))
+
+          // [HUDI-7472] After creating functional index, the existing MDT partitions should still be available
+          assert(metaClient.getTableConfig.isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX))
         }
       }
     }
@@ -290,6 +318,61 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         val mdtPartitions = metaClient.getTableConfig.getMetadataPartitions
         assertTrue(mdtPartitions.contains("func_index_name_lower") && mdtPartitions.contains("func_index_idx_datestr"))
       })
+    }
+  }
+
+  test("Test Create Functional Index With Data Skipping") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        Seq("cow").foreach { tableType =>
+          val databaseName = "default"
+          val tableName = generateTableName
+          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql("set hoodie.metadata.enable=true")
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  ts long,
+               |  price int
+               |) using hudi
+               | options (
+               |  primaryKey ='id',
+               |  type = '$tableType',
+               |  preCombineField = 'ts'
+               | )
+               | partitioned by(price)
+               | location '$basePath'
+       """.stripMargin)
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(1, 'a1', 1000, 10)")
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(2, 'a2', 200000, 100)")
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(3, 'a3', 2000000000, 1000)")
+
+          var metaClient = HoodieTableMetaClient.builder()
+            .setBasePath(basePath)
+            .setConf(spark.sessionState.newHadoopConf())
+            .build()
+
+          var createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
+
+          spark.sql(createIndexSql)
+          spark.sql(s"select key, type, ColumnStatsMetadata from hudi_metadata('$tableName') where type = 3").show(false)
+
+          metaClient = HoodieTableMetaClient.builder()
+            .setBasePath(basePath)
+            .setConf(spark.sessionState.newHadoopConf())
+            .build()
+          assertTrue(metaClient.getFunctionalIndexMetadata.isPresent)
+          var functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
+          assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
+          assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
+
+          checkAnswer(s"select id, name, price, ts, from_unixtime(ts, 'yyyy-MM-dd') from $tableName where from_unixtime(ts, 'yyyy-MM-dd') < '1970-01-03'")(
+            Seq(1, "a1", 10, 1000, "1970-01-01")
+          )
+        }
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -329,6 +329,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           val tableName = generateTableName
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
           spark.sql("set hoodie.metadata.enable=true")
+          spark.sql("set hoodie.enable.data.skipping=true")
           spark.sql(
             s"""
                |create table $tableName (

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -172,17 +172,18 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
   test("Test Create Functional Index") {
     if (HoodieSparkUtils.gteqSpark3_2) {
       withTempDir { tmp =>
-        Seq("cow", "mor").foreach { tableType =>
+        Seq("cow").foreach { tableType =>
           val databaseName = "default"
           val tableName = generateTableName
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql("set hoodie.metadata.enable=true")
           spark.sql(
             s"""
                |create table $tableName (
                |  id int,
                |  name string,
-               |  price double,
-               |  ts long
+               |  ts long,
+               |  price int
                |) using hudi
                | options (
                |  primaryKey ='id',
@@ -191,37 +192,23 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
                |  hoodie.metadata.record.index.enable = 'true',
                |  hoodie.datasource.write.recordkey.field = 'id'
                | )
-               | partitioned by(ts)
+               | partitioned by(price)
                | location '$basePath'
        """.stripMargin)
-          spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
-          spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
-          spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(1, 'a1', 1000, 10)")
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(2, 'a2', 200000, 100)")
+          spark.sql(s"insert into $tableName (id, name, ts, price) values(3, 'a3', 2000000000, 1000)")
 
           var metaClient = HoodieTableMetaClient.builder()
             .setBasePath(basePath)
             .setConf(spark.sessionState.newHadoopConf())
             .build()
 
-          assert(metaClient.getTableConfig.isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX))
-
-          val sqlParser: ParserInterface = spark.sessionState.sqlParser
-          val analyzer: Analyzer = spark.sessionState.analyzer
-
-          var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
-          var resolvedLogicalPlan = analyzer.execute(logicalPlan)
-          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].table, databaseName, tableName)
-
           var createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
-          logicalPlan = sqlParser.parsePlan(createIndexSql)
-
-          resolvedLogicalPlan = analyzer.execute(logicalPlan)
-          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
-          assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
-          assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
-          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
 
           spark.sql(createIndexSql)
+          spark.sql(s"select key, type, ColumnStatsMetadata from hudi_metadata('$tableName') where type = 3").show(false)
+
           metaClient = HoodieTableMetaClient.builder()
             .setBasePath(basePath)
             .setConf(spark.sessionState.newHadoopConf())
@@ -231,23 +218,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
-          // Verify one can create more than one functional index
-          createIndexSql = s"create index name_lower on $tableName using column_stats(ts) options(func='identity')"
-          spark.sql(createIndexSql)
-          metaClient = HoodieTableMetaClient.builder()
-            .setBasePath(basePath)
-            .setConf(spark.sessionState.newHadoopConf())
-            .build()
-          functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
-          assertEquals(2, functionalIndexMetadata.getIndexDefinitions.size())
-          assertEquals("func_index_name_lower", functionalIndexMetadata.getIndexDefinitions.get("func_index_name_lower").getIndexName)
-
-          // Ensure that both the indexes are tracked correctly in metadata partition config
-          val mdtPartitions = metaClient.getTableConfig.getMetadataPartitions
-          assert(mdtPartitions.contains("func_index_name_lower") && mdtPartitions.contains("func_index_idx_datestr"))
-
-          // [HUDI-7472] After creating functional index, the existing MDT partitions should still be available
-          assert(metaClient.getTableConfig.isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX))
+          spark.sql(s"select id, name, price, ts, from_unixtime(ts, 'yyyy-MM-dd') from $tableName").show(false)
+          spark.sql(s"select id, name, price, ts, from_unixtime(ts, 'yyyy-MM-dd') from $tableName where from_unixtime(ts, 'yyyy-MM-dd') < '2033-05-18'").show(false)
         }
       }
     }


### PR DESCRIPTION
### Change Logs

The read path for functional index leads to a NPE which causes file-pruning to be skipped entirely. This PR fixes the issue as follows:
1. Parse query filter to extrat function name and target column
2. Check functional index definiton and if there is an index, then use that to skip files.

### Impact

Correct data skipping with functional index.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
