### PR TITLE
[HUDI-7622] Optimize HoodieTableSource's sanity check 

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -19,10 +19,9 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
-import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
@@ -34,6 +33,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.SerializableSchema;
+import org.apache.hudi.util.SanityChecksUtil;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -87,6 +87,8 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
     setupTableOptions(conf.getString(FlinkOptions.PATH), conf);
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
     setupConfOptions(conf, context.getObjectIdentifier(), context.getCatalogTable(), schema);
+    HoodieTableMetaClient metaClient = StreamerUtil.metaClientForReader(conf, HadoopConfigurations.getHadoopConf(conf));
+    SanityChecksUtil.sanitCheck(conf, schema, metaClient);
     return new HoodieTableSource(
         SerializableSchema.create(schema),
         path,
@@ -102,9 +104,9 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
         "Option [path] should not be empty.");
     setupTableOptions(conf.getString(FlinkOptions.PATH), conf);
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
-    sanityCheck(conf, schema);
     setupConfOptions(conf, context.getObjectIdentifier(), context.getCatalogTable(), schema);
     setupSortOptions(conf, context.getConfiguration());
+    SanityChecksUtil.sanitCheck(conf, schema, null);
     return new HoodieTableSink(conf, schema);
   }
 
@@ -129,9 +131,10 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
           if (tableConfig.contains(HoodieTableConfig.TYPE) && conf.contains(FlinkOptions.TABLE_TYPE)) {
             if (!tableConfig.getString(HoodieTableConfig.TYPE).equals(conf.get(FlinkOptions.TABLE_TYPE))) {
               LOG.warn(
-                  String.format("Table type conflict : %s in %s and %s in table options. Fix the table type as to be in line with the hoodie.properties.",
-                      tableConfig.getString(HoodieTableConfig.TYPE), HoodieTableConfig.HOODIE_PROPERTIES_FILE,
-                      conf.get(FlinkOptions.TABLE_TYPE)));
+                  String.format("Table type conflict: %s is specified in %s and %s in the table %s's options. "
+                    + "Please ensure that the table type is consistent with the settings in the hoodie.properties file.",
+                    tableConfig.getString(HoodieTableConfig.TYPE), HoodieTableConfig.HOODIE_PROPERTIES_FILE,
+                    conf.get(FlinkOptions.TABLE_TYPE), tableConfig.getTableName()));
               conf.setString(FlinkOptions.TABLE_TYPE, tableConfig.getString(HoodieTableConfig.TYPE));
             }
           }
@@ -169,71 +172,6 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   //  Utilities
   // -------------------------------------------------------------------------
 
-  /**
-   * The sanity check.
-   *
-   * @param conf   The table options
-   * @param schema The table schema
-   */
-  private void sanityCheck(Configuration conf, ResolvedSchema schema) {
-    checkTableType(conf);
-    checkIndexType(conf);
-
-    if (!OptionsResolver.isAppendMode(conf)) {
-      checkRecordKey(conf, schema);
-    }
-    StreamerUtil.checkPreCombineKey(conf, schema.getColumnNames());
-  }
-
-  /**
-   * Validate the index type.
-   */
-  private void checkIndexType(Configuration conf) {
-    String indexType = conf.get(FlinkOptions.INDEX_TYPE);
-    if (!StringUtils.isNullOrEmpty(indexType)) {
-      HoodieIndexConfig.INDEX_TYPE.checkValues(indexType);
-    }
-  }
-
-  /**
-   * Validate the table type.
-   */
-  private void checkTableType(Configuration conf) {
-    String tableType = conf.get(FlinkOptions.TABLE_TYPE);
-    if (StringUtils.nonEmpty(tableType)) {
-      try {
-        HoodieTableType.valueOf(tableType);
-      } catch (IllegalArgumentException e) {
-        throw new HoodieValidationException("Invalid table type: " + tableType + ". Table type should be either "
-                + HoodieTableType.MERGE_ON_READ + " or " + HoodieTableType.COPY_ON_WRITE + ".");
-      }
-    }
-  }
-
-  /**
-   * Validate the record key.
-   */
-  private void checkRecordKey(Configuration conf, ResolvedSchema schema) {
-    List<String> fields = schema.getColumnNames();
-    if (!schema.getPrimaryKey().isPresent()) {
-      String[] recordKeys = conf.get(FlinkOptions.RECORD_KEY_FIELD).split(",");
-      if (recordKeys.length == 1
-          && FlinkOptions.RECORD_KEY_FIELD.defaultValue().equals(recordKeys[0])
-          && !fields.contains(recordKeys[0])) {
-        throw new HoodieValidationException("Primary key definition is required, the default primary key field "
-            + "'" + FlinkOptions.RECORD_KEY_FIELD.defaultValue() + "' does not exist in the table schema, "
-            + "use either PRIMARY KEY syntax or option '" + FlinkOptions.RECORD_KEY_FIELD.key() + "' to speciy.");
-      }
-
-      Arrays.stream(recordKeys)
-          .filter(field -> !fields.contains(field))
-          .findAny()
-          .ifPresent(f -> {
-            throw new HoodieValidationException("Field '" + f + "' specified in option "
-                + "'" + FlinkOptions.RECORD_KEY_FIELD.key() + "' does not exist in the table schema.");
-          });
-    }
-  }
 
   /**
    * Sets up the config options based on the table definition, for e.g, the table name, primary key.
@@ -318,7 +256,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
       }
     }
     boolean complexHoodieKey = pks.length > 1 || partitions.length > 1;
-    StreamerUtil.checkKeygenGenerator(complexHoodieKey, conf);
+    SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, conf);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -20,7 +20,6 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -33,7 +32,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.SerializableSchema;
-import org.apache.hudi.util.SanityChecksUtil;
+import org.apache.hudi.util.SanityChecks;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -87,8 +86,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
     setupTableOptions(conf.getString(FlinkOptions.PATH), conf);
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
     setupConfOptions(conf, context.getObjectIdentifier(), context.getCatalogTable(), schema);
-    HoodieTableMetaClient metaClient = StreamerUtil.metaClientForReader(conf, HadoopConfigurations.getHadoopConf(conf));
-    SanityChecksUtil.sanitCheck(conf, schema, metaClient);
+    SanityChecks.sanitCheck(conf, schema, true);
     return new HoodieTableSource(
         SerializableSchema.create(schema),
         path,
@@ -106,7 +104,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
     setupConfOptions(conf, context.getObjectIdentifier(), context.getCatalogTable(), schema);
     setupSortOptions(conf, context.getConfiguration());
-    SanityChecksUtil.sanitCheck(conf, schema, null);
+    SanityChecks.sanitCheck(conf, schema, false);
     return new HoodieTableSink(conf, schema);
   }
 
@@ -256,7 +254,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
       }
     }
     boolean complexHoodieKey = pks.length > 1 || partitions.length > 1;
-    SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, conf);
+    SanityChecks.checkKeygenGenerator(complexHoodieKey, conf);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -31,6 +31,7 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
+import org.apache.hudi.util.SanityChecksUtil;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.avro.Schema;
@@ -337,7 +338,7 @@ public class HoodieCatalog extends AbstractCatalog {
     }
 
     // check preCombine
-    StreamerUtil.checkPreCombineKey(conf, resolvedSchema.getColumnNames());
+    SanityChecksUtil.checkPreCombineKey(conf, resolvedSchema.getColumnNames());
 
     if (resolvedTable.isPartitioned()) {
       final String partitions = String.join(",", resolvedTable.getPartitionKeys());
@@ -346,7 +347,7 @@ public class HoodieCatalog extends AbstractCatalog {
 
       final String[] pks = conf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");
       boolean complexHoodieKey = pks.length > 1 || resolvedTable.getPartitionKeys().size() > 1;
-      StreamerUtil.checkKeygenGenerator(complexHoodieKey, conf);
+      SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, conf);
     } else {
       conf.setString(FlinkOptions.KEYGEN_CLASS_NAME.key(), NonpartitionedAvroKeyGenerator.class.getName());
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -31,7 +31,7 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
-import org.apache.hudi.util.SanityChecksUtil;
+import org.apache.hudi.util.SanityChecks;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.avro.Schema;
@@ -339,7 +339,7 @@ public class HoodieCatalog extends AbstractCatalog {
     }
 
     // check preCombine
-    SanityChecksUtil.checkPreCombineKey(conf, resolvedSchema.getColumnNames());
+    SanityChecks.checkPreCombineKey(conf, resolvedSchema.getColumnNames());
 
     if (resolvedTable.isPartitioned()) {
       final String partitions = String.join(",", resolvedTable.getPartitionKeys());
@@ -348,7 +348,7 @@ public class HoodieCatalog extends AbstractCatalog {
 
       final String[] pks = conf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");
       boolean complexHoodieKey = pks.length > 1 || resolvedTable.getPartitionKeys().size() > 1;
-      SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, conf);
+      SanityChecks.checkKeygenGenerator(complexHoodieKey, conf);
     } else {
       conf.setString(FlinkOptions.KEYGEN_CLASS_NAME.key(), NonpartitionedAvroKeyGenerator.class.getName());
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -308,6 +308,7 @@ public class HoodieCatalog extends AbstractCatalog {
     Map<String, String> options = applyOptionsHook(tablePathStr, catalogTable.getOptions());
     Configuration conf = Configuration.fromMap(options);
     conf.setString(FlinkOptions.PATH, tablePathStr);
+    conf.setString(FlinkOptions.TABLE_NAME, tablePath.getObjectName());
     ResolvedSchema resolvedSchema = resolvedTable.getResolvedSchema();
     if (!resolvedSchema.getPrimaryKey().isPresent() && !conf.containsKey(RECORD_KEY_FIELD.key())) {
       throw new CatalogException("Primary key definition is missing");
@@ -351,7 +352,7 @@ public class HoodieCatalog extends AbstractCatalog {
     } else {
       conf.setString(FlinkOptions.KEYGEN_CLASS_NAME.key(), NonpartitionedAvroKeyGenerator.class.getName());
     }
-    conf.setString(FlinkOptions.TABLE_NAME, tablePath.getObjectName());
+
     try {
       StreamerUtil.initTableIfNotExists(conf);
       // prepare the non-table-options properties

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -40,7 +40,7 @@ import org.apache.hudi.table.HoodieTableFactory;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
-import org.apache.hudi.util.SanityChecksUtil;
+import org.apache.hudi.util.SanityChecks;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.avro.Schema;
@@ -507,7 +507,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
       flinkConf.setString(FlinkOptions.PARTITION_PATH_FIELD, partitions);
       final String[] pks = flinkConf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");
       boolean complexHoodieKey = pks.length > 1 || catalogTable.getPartitionKeys().size() > 1;
-      SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, flinkConf);
+      SanityChecks.checkKeygenGenerator(complexHoodieKey, flinkConf);
     }
 
     if (!catalogTable.isPartitioned()) {
@@ -520,7 +520,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
 
     List<String> fields = new ArrayList<>();
     catalogTable.getUnresolvedSchema().getColumns().forEach(column -> fields.add(column.getName()));
-    SanityChecksUtil.checkPreCombineKey(flinkConf, fields);
+    SanityChecks.checkPreCombineKey(flinkConf, fields);
 
     try {
       StreamerUtil.initTableIfNotExists(flinkConf, hiveConf);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -40,6 +40,7 @@ import org.apache.hudi.table.HoodieTableFactory;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
+import org.apache.hudi.util.SanityChecksUtil;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.avro.Schema;
@@ -505,7 +506,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
       flinkConf.setString(FlinkOptions.PARTITION_PATH_FIELD, partitions);
       final String[] pks = flinkConf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");
       boolean complexHoodieKey = pks.length > 1 || catalogTable.getPartitionKeys().size() > 1;
-      StreamerUtil.checkKeygenGenerator(complexHoodieKey, flinkConf);
+      SanityChecksUtil.checkKeygenGenerator(complexHoodieKey, flinkConf);
     }
 
     if (!catalogTable.isPartitioned()) {
@@ -520,7 +521,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
 
     List<String> fields = new ArrayList<>();
     catalogTable.getUnresolvedSchema().getColumns().forEach(column -> fields.add(column.getName()));
-    StreamerUtil.checkPreCombineKey(flinkConf, fields);
+    SanityChecksUtil.checkPreCombineKey(flinkConf, fields);
 
     try {
       StreamerUtil.initTableIfNotExists(flinkConf, hiveConf);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -484,6 +484,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
 
   private void initTableIfNotExists(ObjectPath tablePath, CatalogTable catalogTable) {
     Configuration flinkConf = Configuration.fromMap(catalogTable.getOptions());
+    flinkConf.setString(FlinkOptions.TABLE_NAME, tablePath.getObjectName());
     final String avroSchema = AvroSchemaConverter.convertToSchema(
         catalogTable.getSchema().toPersistedRowDataType().getLogicalType(),
         AvroSchemaUtils.getAvroRecordQualifiedName(tablePath.getObjectName())).toString();
@@ -516,8 +517,6 @@ public class HoodieHiveCatalog extends AbstractCatalog {
     if (!flinkConf.getOptional(PATH).isPresent()) {
       flinkConf.setString(PATH, inferTablePath(tablePath, catalogTable));
     }
-
-    flinkConf.setString(FlinkOptions.TABLE_NAME, tablePath.getObjectName());
 
     List<String> fields = new ArrayList<>();
     catalogTable.getUnresolvedSchema().getColumns().forEach(column -> fields.add(column.getName()));

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecks.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecks.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
@@ -41,23 +42,22 @@ import java.util.stream.Collectors;
 /**
  * Utilities for HoodieTableFactory sanity check.
  */
-public class SanityChecksUtil {
+public class SanityChecks {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SanityChecksUtil.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SanityChecks.class);
 
   /**
    * The sanity check.
-   * If the metaClient is not null, it means that this is a table source sanity check and the source table has
-   * already been initialized.
    *
-   * @param conf   The table options
-   * @param schema The table schema
-   * @param metaClient  The table meta client
+   * @param conf  The table options
+   * @param schema  The table schema
+   * @param checkMetaData  Weather to check metadata
    */
-  public static void sanitCheck(Configuration conf, ResolvedSchema schema, HoodieTableMetaClient metaClient) {
+  public static void sanitCheck(Configuration conf, ResolvedSchema schema, Boolean checkMetaData) {
     checkTableType(conf);
     List<String> schemaFields = schema.getColumnNames();
-    if (metaClient != null) {
+    if (checkMetaData) {
+      HoodieTableMetaClient metaClient = StreamerUtil.metaClientForReader(conf, HadoopConfigurations.getHadoopConf(conf));
       List<String> latestTablefields = StreamerUtil.getLatestTableFields(metaClient);
       if (latestTablefields != null) {
         checkSchema(conf, schemaFields, latestTablefields);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecksUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecksUtil.java
@@ -101,6 +101,9 @@ public class SanityChecksUtil {
    * Validate the index type.
    */
   public static void checkIndexType(Configuration conf) {
+    if (OptionsResolver.isAppendMode(conf)) {
+      return;
+    }
     String indexType = conf.get(FlinkOptions.INDEX_TYPE);
     if (!StringUtils.isNullOrEmpty(indexType)) {
       try {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecksUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/SanityChecksUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.mortbay.log.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for HoodieTableFactory sanity check.
+ */
+public class SanityChecksUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SanityChecksUtil.class);
+
+  /**
+   * The sanity check.
+   * If the metaClient is not null, it means that this is a table source sanity check and the source table has
+   * already been initialized.
+   *
+   * @param conf   The table options
+   * @param schema The table schema
+   * @param metaClient  The table meta client
+   */
+  public static void sanitCheck(Configuration conf, ResolvedSchema schema, HoodieTableMetaClient metaClient) {
+    checkTableType(conf);
+    List<String> schemaFields = schema.getColumnNames();
+    if (metaClient != null) {
+      List<String> latestTablefields = StreamerUtil.getLatestTableFields(metaClient);
+      if (latestTablefields != null) {
+        checkSchema(conf, schemaFields, latestTablefields);
+        checkRecordKey(conf, latestTablefields);
+      }
+    } else {
+      if (!schema.getPrimaryKey().isPresent()) {
+        checkRecordKey(conf, schemaFields);
+      }
+      checkIndexType(conf);
+      checkPreCombineKey(conf, schema.getColumnNames());
+    }
+    Log.info("The sanity check for table " + conf.getString(FlinkOptions.TABLE_NAME) + " was successful.");
+  }
+
+  /**
+   * Validate the table type.
+   */
+  public static void checkTableType(Configuration conf) {
+    try {
+      HoodieTableType.valueOf(conf.get(FlinkOptions.TABLE_TYPE));
+    } catch (IllegalArgumentException e) {
+      throw new HoodieValidationException("Invalid table type in the table " + conf.getString(FlinkOptions.TABLE_NAME)
+         + ". Table type should be either " + HoodieTableType.MERGE_ON_READ + " or " + HoodieTableType.COPY_ON_WRITE + ".");
+    }
+  }
+
+  /**
+   * Validate the table schema.
+   */
+  public static void checkSchema(Configuration conf, List<String> fields, List<String> lastestTableFields) {
+    if (lastestTableFields != null) {
+      List<String> missingFields = fields.stream().filter(field -> !lastestTableFields.contains(field)).collect(Collectors.toList());
+      if (!missingFields.isEmpty()) {
+        throw new HoodieValidationException("Column(s) [" + String.join(", ", missingFields) + "] does not exist in the table " + conf.getString(FlinkOptions.TABLE_NAME) + ".");
+      }
+    }
+  }
+
+  /**
+   * Validate the index type.
+   */
+  public static void checkIndexType(Configuration conf) {
+    String indexType = conf.get(FlinkOptions.INDEX_TYPE);
+    if (!StringUtils.isNullOrEmpty(indexType)) {
+      try {
+        HoodieIndexConfig.INDEX_TYPE.checkValues(indexType);
+      } catch (IllegalArgumentException e) {
+        throw new HoodieValidationException("Invalid table index in the table " + conf.getString(FlinkOptions.TABLE_NAME) + " : " + e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Validate the record key(s).
+   */
+  public static void checkRecordKey(Configuration conf,List<String> existingFields) {
+    if (OptionsResolver.isAppendMode(conf)) {
+      return;
+    }
+    String[] recordKeys = conf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");
+    final List<String> expColumns = Arrays.stream(recordKeys)
+        .filter(key -> !existingFields.contains(key))
+        .collect(Collectors.toList());
+
+    if (!expColumns.isEmpty()) {
+      if (expColumns.size() == 1 && FlinkOptions.RECORD_KEY_FIELD.defaultValue().equals(expColumns.get(0))) {
+        throw new HoodieValidationException("Record key definition is required in the table " + conf.getString(FlinkOptions.TABLE_NAME)
+           + ", the default primary key field '" + FlinkOptions.RECORD_KEY_FIELD.defaultValue() + "' does not exist, "
+           + "use either PRIMARY KEY syntax or option '" + FlinkOptions.RECORD_KEY_FIELD.key() + "' to speciy.");
+      } else {
+        throw new HoodieValidationException("Record Key(s) [" + String.join(", ", expColumns) + "] specified in option "
+           + FlinkOptions.RECORD_KEY_FIELD.key() + " does not exist in the table "
+           + conf.getString(FlinkOptions.TABLE_NAME) + ".");
+      }
+    }
+  }
+
+  /**
+   * Validate pre_combine key.
+   */
+  public static void checkPreCombineKey(Configuration conf, List<String> fields) {
+    String preCombineField = conf.get(FlinkOptions.PRECOMBINE_FIELD);
+    if (!fields.contains(preCombineField)) {
+      if (OptionsResolver.isDefaultHoodieRecordPayloadClazz(conf)) {
+        throw new HoodieValidationException("Option '" + FlinkOptions.PRECOMBINE_FIELD.key()
+           + "' is required for payload class: " + DefaultHoodieRecordPayload.class.getName()
+           + " in the table " + conf.getString(FlinkOptions.TABLE_NAME) + ".");
+      }
+      if (preCombineField.equals(FlinkOptions.PRECOMBINE_FIELD.defaultValue())) {
+        conf.setString(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE);
+      } else if (!preCombineField.equals(FlinkOptions.NO_PRE_COMBINE)) {
+        throw new HoodieValidationException("Field " + preCombineField + " does not exist in the table "
+           + conf.getString(FlinkOptions.TABLE_NAME) + ".Please check '" + FlinkOptions.PRECOMBINE_FIELD.key() + "' option.");
+      }
+    }
+  }
+
+  /**
+   * Validate keygen generator.
+   */
+  public static void checkKeygenGenerator(boolean isComplexHoodieKey, Configuration conf) {
+    if (isComplexHoodieKey && FlinkOptions.isDefaultValueDefined(conf, FlinkOptions.KEYGEN_CLASS_NAME)) {
+      conf.setString(FlinkOptions.KEYGEN_CLASS_NAME, ComplexAvroKeyGenerator.class.getName());
+      LOG.info("Table option [{}] is reset to {}  in the table {}, because record key or partition path has two or more fields",
+          FlinkOptions.KEYGEN_CLASS_NAME.key(), ComplexAvroKeyGenerator.class.getName(), conf.getString(FlinkOptions.TABLE_NAME));
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -498,9 +498,9 @@ public class StreamerUtil {
     return null;
   }
 
-  public static List<String> getLatestTableFields(HoodieTableMetaClient metaClient) {
+  public static List<String> getLatestTableFields(HoodieTableMetaClient metaClient, boolean includeMetadataFields) {
     try {
-      Schema schema = getTableAvroSchema(metaClient, false);
+      Schema schema = getTableAvroSchema(metaClient, includeMetadataFields);
       return schema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
     } catch (Exception e) {
       LOG.warn("Error while resolving the latest table schema, will return null.", e);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -30,7 +30,7 @@ import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator;
 import org.apache.hudi.util.AvroSchemaConverter;
-import org.apache.hudi.util.SanityChecksUtil;
+import org.apache.hudi.util.SanityChecks;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.SchemaBuilder;
 import org.apache.hudi.utils.TestConfigurations;
@@ -280,17 +280,17 @@ public class TestHoodieTableFactory {
     // Queried column is consistent with the metadata, No exception will be thrown
     List<String> lastestTableFields = Arrays.asList(new String[]{"f0", "f1", "f2", "ts"});
     List<String> fieldsTest1 = Arrays.asList(new String[]{"f0", "f1", "f2", "ts"});
-    assertDoesNotThrow(() -> SanityChecksUtil.checkSchema(this.conf, fieldsTest1, lastestTableFields));
+    assertDoesNotThrow(() -> SanityChecks.checkSchema(this.conf, fieldsTest1, lastestTableFields));
     List<String> fieldsTest3 = Arrays.asList(new String[]{"f0", "f1", "ts"});
-    assertDoesNotThrow(() -> SanityChecksUtil.checkSchema(this.conf, fieldsTest3, lastestTableFields));
+    assertDoesNotThrow(() -> SanityChecks.checkSchema(this.conf, fieldsTest3, lastestTableFields));
 
     // Case mismatch will throw HoodieValidationException exception
     List<String> fieldsTest2 = Arrays.asList(new String[]{"f0", "f1", "F2", "ts"});
-    assertThrows(HoodieValidationException.class, () -> SanityChecksUtil.checkSchema(this.conf, fieldsTest2, lastestTableFields));
+    assertThrows(HoodieValidationException.class, () -> SanityChecks.checkSchema(this.conf, fieldsTest2, lastestTableFields));
 
     // Columns that do not exist will throw HoodieValidationException exception
     List<String> fieldsTest4 = Arrays.asList(new String[]{"f0", "f1", "f2", "f3", "ts"});
-    assertThrows(HoodieValidationException.class, () -> SanityChecksUtil.checkSchema(this.conf, fieldsTest4, lastestTableFields));
+    assertThrows(HoodieValidationException.class, () -> SanityChecks.checkSchema(this.conf, fieldsTest4, lastestTableFields));
   }
 
   @Test
@@ -298,17 +298,17 @@ public class TestHoodieTableFactory {
     // The configuration column(s) for RECORD_KEY_FIELD is consistent with the metadata, and no exception will be thrown.
     List<String> fields = Arrays.asList(new String[]{"f0", "f1", "f2", "ts"});
     this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "f0");
-    assertDoesNotThrow(() -> SanityChecksUtil.checkRecordKey(this.conf, fields));
+    assertDoesNotThrow(() -> SanityChecks.checkRecordKey(this.conf, fields));
     this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "f0,f1");
-    assertDoesNotThrow(() -> SanityChecksUtil.checkRecordKey(this.conf, fields));
+    assertDoesNotThrow(() -> SanityChecks.checkRecordKey(this.conf, fields));
 
     // Case mismatch will throw HoodieValidationException exception
     this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "F0");
-    assertThrows(HoodieValidationException.class, () -> SanityChecksUtil.checkRecordKey(this.conf, fields));
+    assertThrows(HoodieValidationException.class, () -> SanityChecks.checkRecordKey(this.conf, fields));
 
     // Columns that do not exist will throw HoodieValidationException exception
     this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "xxxx");
-    assertThrows(HoodieValidationException.class, () -> SanityChecksUtil.checkRecordKey(this.conf, fields));
+    assertThrows(HoodieValidationException.class, () -> SanityChecks.checkRecordKey(this.conf, fields));
   }
 
   @Test


### PR DESCRIPTION
### Change Logs


Existing exceptions cannot know which table and which specific columns the exception is.
![image](https://github.com/apache/hudi/assets/34104400/6a3ee776-692d-4849-8759-f9162b818653)


**Modify as follows：**

1. Printing wrong columns name and table name in exception for MergeOnReadTableState#getRequiredPositions，and advance the exception from the operator execution stage to the operator initialization stage

**check columns**
<img width="746" alt="image" src="https://github.com/apache/hudi/assets/34104400/7e5ffa74-8abe-40a4-b940-307c7070d4d5">


**check pks**
<img width="718" alt="image" src="https://github.com/apache/hudi/assets/34104400/f2a211fc-cd48-4fe2-9312-50de7caf4a4d">

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
