### PR TITLE
[HUDI-7627] ParquetSchema clip case-sensetive need be configurable

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -478,6 +478,12 @@ public class FlinkOptions extends HoodieConfig {
           + "If set true, the names of partition folders follow <partition_column_name>=<partition_value> format.\n"
           + "By default false (the names of partition folders are only partition values)");
 
+  public static final ConfigOption<Boolean> CLIP_CASE_SENSITIVE_CONTROL = ConfigOptions
+          .key("clip.parquetSchema.casesensitive")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription("Columns case-sensitive control of clipping parquetSchema according to fieldNames.");
+
   @AdvancedConfig
   public static final ConfigOption<String> KEYGEN_CLASS_NAME = ConfigOptions
       .key(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -556,6 +556,7 @@ public class HoodieTableSource implements
         this.requiredPos,
         this.conf.getString(FlinkOptions.PARTITION_DEFAULT_NAME),
         this.conf.getString(FlinkOptions.PARTITION_PATH_FIELD),
+        this.conf.getBoolean(FlinkOptions.CLIP_CASE_SENSITIVE_CONTROL),
         this.conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING),
         this.predicates,
         this.limit == NO_LIMIT_CONSTANT ? Long.MAX_VALUE : this.limit, // ParquetInputFormat always uses the limit value

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -78,6 +78,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   private final SerializableConfiguration conf;
   private final List<Predicate> predicates;
   private final long limit;
+  private boolean caseSensetive;
 
   private transient ClosableIterator<RowData> itr;
   private transient long currentReadCount;
@@ -96,6 +97,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       int[] selectedFields,
       String partDefaultName,
       String partPathField,
+      boolean caseSensetive,
       boolean hiveStylePartitioning,
       List<Predicate> predicates,
       long limit,
@@ -107,6 +109,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.limit = limit;
     this.partDefaultName = partDefaultName;
     this.partPathField = partPathField;
+    this.caseSensetive = caseSensetive;
     this.hiveStylePartitioning = hiveStylePartitioning;
     this.fullFieldNames = fullFieldNames;
     this.fullFieldTypes = fullFieldTypes;
@@ -130,7 +133,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.itr = RecordIterators.getParquetRecordIterator(
         internalSchemaManager,
         utcTimestamp,
-        true,
+        caseSensetive,
         conf.conf(),
         fullFieldNames,
         fullFieldTypes,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -333,7 +333,7 @@ public class MergeOnReadInputFormat
     return RecordIterators.getParquetRecordIterator(
         internalSchemaManager,
         this.conf.getBoolean(FlinkOptions.READ_UTC_TIMEZONE),
-        true,
+        this.conf.getBoolean(FlinkOptions.CLIP_CASE_SENSITIVE_CONTROL),
         HadoopConfigurations.getParquetConf(this.conf, hadoopConf),
         fieldNames.toArray(new String[0]),
         fieldTypes.toArray(new DataType[0]),


### PR DESCRIPTION
### Change Logs

ParquetSchema clip case-sensetive need be configurable when table set column with lowercase or uppercase.
Currently it is fixed with true should be configurable.
![1713342574768.png](https://github.com/apache/hudi/assets/10645422/c0b1cdd5-41a3-4122-b1b8-e501c93eb01e)



### Impact

none
### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
