### PR TITLE
[HUDI-7634] Rename HoodieStorage APIs

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -94,7 +94,7 @@ public class HoodieHadoopStorage extends HoodieStorage {
   }
 
   @Override
-  public List<StoragePathInfo> listDirectEntries(StoragePath path) throws IOException {
+  public List<StoragePathInfo> listDirectory(StoragePath path) throws IOException {
     return Arrays.stream(fs.listStatus(convertToHadoopPath(path)))
         .map(HadoopFSUtils::convertToStoragePathInfo)
         .collect(Collectors.toList());
@@ -111,7 +111,7 @@ public class HoodieHadoopStorage extends HoodieStorage {
   }
 
   @Override
-  public List<StoragePathInfo> listDirectEntries(List<StoragePath> pathList) throws IOException {
+  public List<StoragePathInfo> listDirectory(List<StoragePath> pathList) throws IOException {
     return Arrays.stream(fs.listStatus(pathList.stream()
             .map(HadoopFSUtils::convertToHadoopPath)
             .toArray(Path[]::new)))
@@ -120,8 +120,8 @@ public class HoodieHadoopStorage extends HoodieStorage {
   }
 
   @Override
-  public List<StoragePathInfo> listDirectEntries(StoragePath path,
-                                                 StoragePathFilter filter)
+  public List<StoragePathInfo> listDirectory(StoragePath path,
+                                             StoragePathFilter filter)
       throws IOException {
     return Arrays.stream(fs.listStatus(
             convertToHadoopPath(path), e ->

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
@@ -34,7 +34,7 @@ public class TestHoodieHadoopStorage extends TestHoodieStorageBase {
   private static final String CONF_VALUE = "value";
 
   @Override
-  protected HoodieStorage getHoodieStorage(Object fs, Object conf) {
+  protected HoodieStorage getStorage(Object fs, Object conf) {
     return new HoodieHadoopStorage((FileSystem) fs);
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -132,7 +132,7 @@ public abstract class HoodieStorage implements Closeable {
    * @throws IOException           IO error.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract List<StoragePathInfo> listDirectEntries(StoragePath path) throws IOException;
+  public abstract List<StoragePathInfo> listDirectory(StoragePath path) throws IOException;
 
   /**
    * Lists the path info of all files under the give path recursively.
@@ -156,8 +156,8 @@ public abstract class HoodieStorage implements Closeable {
    * @throws IOException           IO error.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract List<StoragePathInfo> listDirectEntries(StoragePath path,
-                                                          StoragePathFilter filter) throws IOException;
+  public abstract List<StoragePathInfo> listDirectory(StoragePath path,
+                                                      StoragePathFilter filter) throws IOException;
 
   /**
    * Returns all the files that match the pathPattern and are not checksum files,
@@ -342,10 +342,10 @@ public abstract class HoodieStorage implements Closeable {
    * @throws IOException           IO error.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public List<StoragePathInfo> listDirectEntries(List<StoragePath> pathList) throws IOException {
+  public List<StoragePathInfo> listDirectory(List<StoragePath> pathList) throws IOException {
     List<StoragePathInfo> result = new ArrayList<>();
     for (StoragePath path : pathList) {
-      result.addAll(listDirectEntries(path));
+      result.addAll(listDirectory(path));
     }
     return result;
   }


### PR DESCRIPTION
### Change Logs

The following renaming is made to improve the readability:
- `HoodieStorage`: `#listDirectEntries` -> `#listDirectory`
- `TestHoodieStorageBase`: `#getHoodieStorage` -> `#getStorage`

### Impact

Code quality improvement.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
