### PR TITLE
[HUDI-7635] Add default block size and openSeekable APIs to HoodieStorage

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -44,7 +44,6 @@ import org.apache.hudi.hadoop.fs.inline.InLineFileSystem;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StorageSchemes;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -597,24 +596,6 @@ public class FSUtils {
    */
   public static String getDFSFullPartitionPath(FileSystem fs, Path fullPartitionPath) {
     return fs.getUri() + fullPartitionPath.toUri().getRawPath();
-  }
-
-  /**
-   * This is due to HUDI-140 GCS has a different behavior for detecting EOF during seek().
-   *
-   * @param fs fileSystem instance.
-   * @return true if the inputstream or the wrapped one is of type GoogleHadoopFSInputStream
-   */
-  public static boolean isGCSFileSystem(FileSystem fs) {
-    return fs.getScheme().equals(StorageSchemes.GCS.getScheme());
-  }
-
-  /**
-   * Chdfs will throw {@code IOException} instead of {@code EOFException}. It will cause error in isBlockCorrupted().
-   * Wrapped by {@code BoundedFsDataInputStream}, to check whether the desired offset is out of the file size in advance.
-   */
-  public static boolean isCHDFileSystem(FileSystem fs) {
-    return StorageSchemes.CHDFS.getScheme().equals(fs.getScheme());
   }
 
   public static Configuration registerFileSystem(Path file, Configuration conf) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
@@ -172,7 +172,7 @@ public class HadoopFSUtils {
                                                        int bufferSize) {
     FSDataInputStream fsDataInputStream = null;
     try {
-      fsDataInputStream = fs.open(new Path(filePath.toUri()), bufferSize);
+      fsDataInputStream = fs.open(convertToHadoopPath(filePath), bufferSize);
     } catch (IOException e) {
       throw new HoodieIOException("Exception creating input stream from file: " + filePath, e);
     }
@@ -183,11 +183,11 @@ public class HadoopFSUtils {
     }
 
     if (isCHDFileSystem(fs)) {
-      return new BoundedFsDataInputStream(fs, new Path(filePath.toUri()), fsDataInputStream);
+      return new BoundedFsDataInputStream(fs, convertToHadoopPath(filePath), fsDataInputStream);
     }
 
     if (fsDataInputStream.getWrappedStream() instanceof FSInputStream) {
-      return new TimedFSDataInputStream(new Path(filePath.toUri()), new FSDataInputStream(
+      return new TimedFSDataInputStream(convertToHadoopPath(filePath), new FSDataInputStream(
           new BufferedFSInputStream((FSInputStream) fsDataInputStream.getWrappedStream(), bufferSize)));
     }
 
@@ -213,14 +213,14 @@ public class HadoopFSUtils {
     // b. fsDataInputStream.getWrappedStream() not an instanceof FSInputStream, but an instance of FSDataInputStream.
     // (a) is handled in the first if block and (b) is handled in the second if block. If not, we fallback to original fsDataInputStream
     if (fsDataInputStream.getWrappedStream() instanceof FSInputStream) {
-      return new TimedFSDataInputStream(new Path(filePath.toUri()), new FSDataInputStream(
+      return new TimedFSDataInputStream(convertToHadoopPath(filePath), new FSDataInputStream(
           new BufferedFSInputStream((FSInputStream) fsDataInputStream.getWrappedStream(), bufferSize)));
     }
 
     if (fsDataInputStream.getWrappedStream() instanceof FSDataInputStream
         && ((FSDataInputStream) fsDataInputStream.getWrappedStream()).getWrappedStream() instanceof FSInputStream) {
       FSInputStream inputStream = (FSInputStream) ((FSDataInputStream) fsDataInputStream.getWrappedStream()).getWrappedStream();
-      return new TimedFSDataInputStream(new Path(filePath.toUri()),
+      return new TimedFSDataInputStream(convertToHadoopPath(filePath),
           new FSDataInputStream(new BufferedFSInputStream(inputStream, bufferSize)));
     }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -20,6 +20,8 @@
 package org.apache.hudi.storage.hadoop;
 
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.hadoop.fs.HadoopSeekableDataInputStream;
+import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathFilter;
@@ -64,6 +66,11 @@ public class HoodieHadoopStorage extends HoodieStorage {
   }
 
   @Override
+  public int getDefaultBlockSize(StoragePath path) {
+    return (int) fs.getDefaultBlockSize(convertToHadoopPath(path));
+  }
+
+  @Override
   public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
     return fs.create(convertToHadoopPath(path), overwrite);
   }
@@ -71,6 +78,12 @@ public class HoodieHadoopStorage extends HoodieStorage {
   @Override
   public InputStream open(StoragePath path) throws IOException {
     return fs.open(convertToHadoopPath(path));
+  }
+
+  @Override
+  public SeekableDataInputStream openSeekable(StoragePath path, int bufferSize) throws IOException {
+    return new HadoopSeekableDataInputStream(
+        HadoopFSUtils.getFSDataInputStream(fs, path, bufferSize));
   }
 
   @Override

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -24,6 +24,7 @@ import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.SeekableDataInputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,12 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract String getScheme();
+
+  /**
+   * @return the default block size.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public abstract int getDefaultBlockSize(StoragePath path);
 
   /**
    * Returns a URI which identifies this HoodieStorage.
@@ -81,6 +88,17 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract InputStream open(StoragePath path) throws IOException;
+
+  /**
+   * Opens an SeekableDataInputStream at the indicated path with seeks supported.
+   *
+   * @param path       the file to open.
+   * @param bufferSize buffer size to use.
+   * @return the InputStream to read from.
+   * @throws IOException IO error.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public abstract SeekableDataInputStream openSeekable(StoragePath path, int bufferSize) throws IOException;
 
   /**
    * Appends to an existing file (optional operation).
@@ -330,6 +348,18 @@ public abstract class HoodieStorage implements Closeable {
       create(path, false).close();
       return true;
     }
+  }
+
+  /**
+   * Opens an SeekableDataInputStream at the indicated path with seeks supported.
+   *
+   * @param path the file to open.
+   * @return the InputStream to read from.
+   * @throws IOException IO error.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public SeekableDataInputStream openSeekable(StoragePath path) throws IOException {
+    return openSeekable(path, getDefaultBlockSize(path));
   }
 
   /**

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -175,6 +175,7 @@ public abstract class TestHoodieStorageBase {
   private void validateSeekableDataInputStream(SeekableDataInputStream seekableStream,
                                                byte[] expectedData) throws IOException {
     List<Integer> positionList = new ArrayList<>();
+    // Adding these positions for testing non-contiguous and backward seeks
     positionList.add(1);
     positionList.add(expectedData.length / 2);
     positionList.add(expectedData.length - 1);

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.io.storage;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.util.IOUtils;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -36,6 +37,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -146,6 +148,46 @@ public abstract class TestHoodieStorageBase {
     assertTrue(storage.createDirectory(path4));
     validatePathInfo(storage, path4, EMPTY_BYTES, true);
     assertTrue(storage.createDirectory(path4));
+  }
+
+  @Test
+  public void testSeekable() throws IOException {
+    HoodieStorage storage = getHoodieStorage();
+    StoragePath path = new StoragePath(getTempDir(), "testSeekable/1.file");
+    assertFalse(storage.exists(path));
+    byte[] data = new byte[] {2, 42, 49, (byte) 158, (byte) 233, 66, 9, 34, 79};
+
+    // By default, create overwrites the file
+    try (OutputStream stream = storage.create(path)) {
+      stream.write(data);
+      stream.flush();
+    }
+
+    try (SeekableDataInputStream seekableStream = storage.openSeekable(path)) {
+      validateSeekableDataInputStream(seekableStream, data);
+    }
+
+    try (SeekableDataInputStream seekableStream = storage.openSeekable(path, 2)) {
+      validateSeekableDataInputStream(seekableStream, data);
+    }
+  }
+
+  private void validateSeekableDataInputStream(SeekableDataInputStream seekableStream,
+                                               byte[] expectedData) throws IOException {
+    List<Integer> positionList = new ArrayList<>();
+    positionList.add(1);
+    positionList.add(expectedData.length / 2);
+    positionList.add(expectedData.length - 1);
+    for (int i = 0; i < expectedData.length; i++) {
+      positionList.add(i);
+    }
+
+    assertEquals(0, seekableStream.getPos());
+    for (Integer pos : positionList) {
+      seekableStream.seek(pos);
+      assertEquals(pos, (int) seekableStream.getPos());
+      assertEquals(expectedData[pos], seekableStream.readByte());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR adds `getDefaultBlockSize` and `openSeekable` APIs to `HoodieStorage` and implements these APIs in `HoodieHadoopStorage`.  The implementation follows the same logic of creating seekable input stream for log file reading, and `openSeekable` will be used by the log reading logic.

A few util methods are moved from `FSUtils` and `HoodieLogFileReader` classes to `HadoopFSUtils`class.

### Impact

Supports seekable input stream and log reading with `HoodieStorage`.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
