### PR TITLE
[HUDI-7636] Make StoragePath Serializable

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/storage/StoragePath.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StoragePath.java
@@ -23,6 +23,9 @@ import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.PublicAPIMethod;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,12 +36,11 @@ import java.net.URISyntaxException;
  * The APIs are mainly based on {@code org.apache.hadoop.fs.Path} class.
  */
 @PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
-// StoragePath
 public class StoragePath implements Comparable<StoragePath>, Serializable {
   public static final char SEPARATOR_CHAR = '/';
   public static final char COLON_CHAR = ':';
   public static final String SEPARATOR = "" + SEPARATOR_CHAR;
-  private final URI uri;
+  private URI uri;
   private transient volatile StoragePath cachedParent;
   private transient volatile String cachedName;
   private transient volatile String uriString;
@@ -305,5 +307,13 @@ public class StoragePath implements Comparable<StoragePath>, Serializable {
       return SEPARATOR;
     }
     return path.substring(0, indexOfLastSlash);
+  }
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.writeObject(uri);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    uri = (URI) in.readObject();
   }
 }


### PR DESCRIPTION
### Change Logs

As above, by using the custom implementation of `writeObject` and `readObject`.

### Impact

Custom serde to save time.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
