### PR TITLE
[HUDI-7637] Make StoragePathInfo Comparable

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/storage/StoragePathInfo.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StoragePathInfo.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * with simplification based on what Hudi needs.
  */
 @PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
-public class StoragePathInfo implements Serializable {
+public class StoragePathInfo implements Serializable, Comparable<StoragePathInfo> {
   private final StoragePath path;
   private final long length;
   private final boolean isDirectory;
@@ -107,6 +107,11 @@ public class StoragePathInfo implements Serializable {
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public long getModificationTime() {
     return modificationTime;
+  }
+
+  @Override
+  public int compareTo(StoragePathInfo o) {
+    return this.getPath().compareTo(o.getPath());
   }
 
   @Override

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestStoragePathInfo.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestStoragePathInfo.java
@@ -72,6 +72,19 @@ public class TestStoragePathInfo {
   }
 
   @Test
+  public void testCompareTo() {
+    StoragePathInfo pathInfo1 = new StoragePathInfo(
+        new StoragePath(PATH1), LENGTH, false, BLOCK_REPLICATION, BLOCK_SIZE, MODIFICATION_TIME);
+    StoragePathInfo pathInfo2 = new StoragePathInfo(
+        new StoragePath(PATH1), LENGTH + 2, false, BLOCK_REPLICATION, BLOCK_SIZE, MODIFICATION_TIME + 2L);
+    StoragePathInfo pathInfo3 = new StoragePathInfo(
+        new StoragePath(PATH2), LENGTH, false, BLOCK_REPLICATION, BLOCK_SIZE, MODIFICATION_TIME);
+
+    assertEquals(0, pathInfo1.compareTo(pathInfo2));
+    assertEquals(-1, pathInfo1.compareTo(pathInfo3));
+  }
+
+  @Test
   public void testEquals() {
     StoragePathInfo pathInfo1 = new StoragePathInfo(
         new StoragePath(PATH1), LENGTH, false, BLOCK_REPLICATION, BLOCK_SIZE, MODIFICATION_TIME);


### PR DESCRIPTION
### Change Logs

As above, by comparing the path associated with the `StoragePathInfo` instance.

### Impact

Makes StoragePathInfo Comparable

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
