### PR TITLE
[HUDI-7640] Uses UUID as temporary file suffix for HoodieStorage.createImmutableFileInPath

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Provides I/O APIs on files and directories on storage.
@@ -45,7 +46,6 @@ import java.util.List;
 @PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
 public abstract class HoodieStorage implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(HoodieStorage.class);
-  public static final String TMP_PATH_POSTFIX = ".tmp";
 
   /**
    * @return the scheme of the storage.
@@ -249,8 +249,11 @@ public abstract class HoodieStorage implements Closeable {
    * empty, will first write the content to a temp file if {needCreateTempFile} is
    * true, and then rename it back after the content is written.
    *
-   * @param path    file path.
-   * @param content content to be stored.
+   * <p>CAUTION: if this method is invoked in multi-threads for concurrent write of the same file,
+   * an existence check of the file is recommended.
+   *
+   * @param path    File path.
+   * @param content Content to be stored.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final void createImmutableFileInPath(StoragePath path,
@@ -267,7 +270,7 @@ public abstract class HoodieStorage implements Closeable {
 
       if (content.isPresent() && needTempFile) {
         StoragePath parent = path.getParent();
-        tmpPath = new StoragePath(parent, path.getName() + TMP_PATH_POSTFIX);
+        tmpPath = new StoragePath(parent, path.getName() + "." + UUID.randomUUID());
         fsout = create(tmpPath, false);
         fsout.write(content.get());
       }


### PR DESCRIPTION
### Change Logs

Always use UUID as the temporary file suffix so that the method can be thread-safe.
This is required by #10886 

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
