### PR TITLE
[HUDI-7643] Fix test by using the right StreamSync constructor

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncUnitTests.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncUnitTests.java
@@ -141,7 +141,7 @@ public class TestStreamSyncUnitTests {
   @MethodSource("getCheckpointToResumeCases")
   void testGetCheckpointToResume(HoodieStreamer.Config cfg, HoodieCommitMetadata commitMetadata, Option<String> expectedResumeCheckpoint) throws IOException {
     HoodieSparkEngineContext hoodieSparkEngineContext = mock(HoodieSparkEngineContext.class);
-    FileSystem fs = mock(FileSystem.class);
+    HoodieStorage storage = HoodieStorageUtils.getStorage(mock(FileSystem.class));
     TypedProperties props = new TypedProperties();
     SparkSession sparkSession = mock(SparkSession.class);
     Configuration configuration = mock(Configuration.class);
@@ -152,7 +152,7 @@ public class TestStreamSyncUnitTests {
     when(commitsTimeline.lastInstant()).thenReturn(Option.of(hoodieInstant));
 
     StreamSync streamSync = new StreamSync(cfg, sparkSession, props, hoodieSparkEngineContext,
-        fs, configuration, client -> true, null,Option.empty(),null,Option.empty(),true,true);
+        storage, configuration, client -> true, null,Option.empty(),null,Option.empty(),true,true);
     StreamSync spy = spy(streamSync);
     doReturn(Option.of(commitMetadata)).when(spy).getLatestCommitMetadataWithValidCheckpointInfo(any());
 


### PR DESCRIPTION
### Change Logs

`StreamSync` constructor changed after `HoodieStorage` abstraction was introduced and the commit https://github.com/apache/hudi/commit/ca77fda51fe3036f86d4ddb8b0e58a2f160882dc was merged without rebasing. So, the master is broken. 

### Impact

Fix test and build on master.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
