### PR TITLE
[MINOR] Added configurations of Hudi table, file-based SQL source, Hudi error table, and timestamp key generator to configuration listing

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
@@ -21,6 +21,7 @@ package org.apache.hudi.config;
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -30,7 +31,7 @@ import java.util.Arrays;
 @ConfigClassProperty(name = "Error table Configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
     description = "Configurations that are required for Error table configs")
-public class HoodieErrorTableConfig {
+public class HoodieErrorTableConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ERROR_TABLE_ENABLED = ConfigProperty
       .key("hoodie.errortable.enable")
       .defaultValue(false)

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -30,6 +30,7 @@ public class ConfigGroups {
    * {@link ConfigGroups#getDescription}.
    */
   public enum Names {
+    TABLE_CONFIG("Hudi Table Config"),
     ENVIRONMENT_CONFIG("Environment Config"),
     SPARK_DATASOURCE("Spark Datasource Configs"),
     FLINK_SQL("Flink Sql Configs"),
@@ -98,6 +99,9 @@ public class ConfigGroups {
   public static String getDescription(Names names) {
     String description;
     switch (names) {
+      case TABLE_CONFIG:
+        description = "Basic Hudi Table configuration parameters.";
+        break;
       case ENVIRONMENT_CONFIG:
         description = "Hudi supports passing configurations via a configuration file "
             + "`hudi-default.conf` in which each line consists of a key and a value "

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TimestampKeyGeneratorConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TimestampKeyGeneratorConfig.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
         + "the partition field. The field values are interpreted as timestamps and not just "
         + "converted to string while generating partition path value for records. Record key is "
         + "same as before where it is chosen by field name.")
-public class TimestampKeyGeneratorConfig {
+public class TimestampKeyGeneratorConfig extends HoodieConfig {
   private static final String TIMESTAMP_KEYGEN_CONFIG_PREFIX = "hoodie.keygen.timebased.";
   @Deprecated
   private static final String OLD_TIMESTAMP_KEYGEN_CONFIG_PREFIX = "hoodie.deltastreamer.keygen.timebased.";

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.common.table;
 
 import org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex;
+import org.apache.hudi.common.config.ConfigClassProperty;
+import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.OrderedProperties;
@@ -50,6 +52,8 @@ import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -75,13 +79,12 @@ import static org.apache.hudi.common.util.ConfigUtils.fetchConfigs;
 import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
-/**
- * Configurations on the Hoodie Table like type of ingestion, storage formats, hive table name etc Configurations are loaded from hoodie.properties, these properties are usually set during
- * initializing a path as hoodie base path and never changes during the lifetime of a hoodie table.
- *
- * @see HoodieTableMetaClient
- * @since 0.3.0
- */
+@Immutable
+@ConfigClassProperty(name = "Hudi Table Basic Configs",
+    groupName = ConfigGroups.Names.TABLE_CONFIG,
+    description = "Configurations of the Hudi Table like type of ingestion, storage formats, hive table name etc."
+        + " Configurations are loaded from hoodie.properties, these properties are usually set during"
+        + " initializing a path as hoodie base path and never changes during the lifetime of a hoodie table.")
 public class HoodieTableConfig extends HoodieConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieTableConfig.class);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/SqlFileBasedSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/SqlFileBasedSourceConfig.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.config;
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +34,7 @@ import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
     groupName = ConfigGroups.Names.HUDI_STREAMER,
     subGroupName = ConfigGroups.SubGroupNames.DELTA_STREAMER_SOURCE,
     description = "Configurations controlling the behavior of File-based SQL Source in Hudi Streamer.")
-public class SqlFileBasedSourceConfig {
+public class SqlFileBasedSourceConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> SOURCE_SQL_FILE = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.sql.file")


### PR DESCRIPTION
### Change Logs

Not all configurations are presented on [All configurations](https://hudi.apache.org/docs/configurations) page. This MR adds list of basic Hudi table configurations, and also some missed configurations of file-based SQL source, Hudi error table, and timestamp key generator.

### Impact

Change only the list of all configurations on Hudi site.

### Risk level (write none, low medium or high below)

None

### Documentation Update

Corresponding MR with updates to the `current` version of docs - https://github.com/apache/hudi/pull/11058.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
