### PR TITLE
[HUDI-7648] Refactor MetadataPartitionType so as to enahance reuse

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -170,7 +170,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     this.dataMetaClient = HoodieTableMetaClient.builder().setConf(hadoopConf)
         .setBasePath(dataWriteConfig.getBasePath())
         .setTimeGeneratorConfig(dataWriteConfig.getTimeGeneratorConfig()).build();
-    this.enabledPartitionTypes = getEnabledPartitions(dataWriteConfig.getMetadataConfig(), dataMetaClient);
+    this.enabledPartitionTypes = getEnabledPartitions(dataWriteConfig.getProps(), dataMetaClient);
     if (writeConfig.isMetadataTableEnabled()) {
       this.metadataWriteConfig = createMetadataWriteConfig(writeConfig, failedWritesCleaningPolicy);
       try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -103,17 +103,17 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.getIndexInflightInstant;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeIndexPlan;
+import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createMetadataWriteConfig;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionLatestFileSlicesIncludingInflight;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForFunctionalIndex;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
-import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
-import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
 import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
 import static org.apache.hudi.metadata.MetadataPartitionType.FUNCTIONAL_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
+import static org.apache.hudi.metadata.MetadataPartitionType.getEnabledPartitions;
 
 /**
  * Writer implementation backed by an internal hudi table. Partition and file listing are saved within an internal MOR table
@@ -167,21 +167,15 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     this.engineContext = engineContext;
     this.hadoopConf = new SerializableConfiguration(hadoopConf);
     this.metrics = Option.empty();
-    this.enabledPartitionTypes = new ArrayList<>(4);
-
     this.dataMetaClient = HoodieTableMetaClient.builder().setConf(hadoopConf)
         .setBasePath(dataWriteConfig.getBasePath())
         .setTimeGeneratorConfig(dataWriteConfig.getTimeGeneratorConfig()).build();
-
+    this.enabledPartitionTypes = getEnabledPartitions(dataWriteConfig.getMetadataConfig(), dataMetaClient);
     if (writeConfig.isMetadataTableEnabled()) {
-      this.metadataWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(writeConfig, failedWritesCleaningPolicy);
-
+      this.metadataWriteConfig = createMetadataWriteConfig(writeConfig, failedWritesCleaningPolicy);
       try {
-        enablePartitions();
         initRegistry();
-
         initialized = initializeIfNeeded(dataMetaClient, inflightInstantTimestamp);
-
       } catch (IOException e) {
         LOG.error("Failed to initialize metadata table", e);
       }
@@ -199,28 +193,6 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       this.metadataMetaClient = metadata.getMetadataMetaClient();
     } catch (Exception e) {
       throw new HoodieException("Could not open MDT for reads", e);
-    }
-  }
-
-  /**
-   * Enable metadata table partitions based on config.
-   */
-  private void enablePartitions() {
-    final HoodieMetadataConfig metadataConfig = dataWriteConfig.getMetadataConfig();
-    if (dataWriteConfig.isMetadataTableEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(FILES)) {
-      this.enabledPartitionTypes.add(FILES);
-    }
-    if (metadataConfig.isBloomFilterIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(BLOOM_FILTERS)) {
-      this.enabledPartitionTypes.add(BLOOM_FILTERS);
-    }
-    if (metadataConfig.isColumnStatsIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(COLUMN_STATS)) {
-      this.enabledPartitionTypes.add(COLUMN_STATS);
-    }
-    if (dataWriteConfig.isRecordIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX)) {
-      this.enabledPartitionTypes.add(RECORD_INDEX);
-    }
-    if (dataMetaClient.getFunctionalIndexMetadata().isPresent()) {
-      this.enabledPartitionTypes.add(FUNCTIONAL_INDEX);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -18,30 +18,52 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
  * Partition types for metadata table.
  */
 public enum MetadataPartitionType {
-  FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-"),
-  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-"),
-  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-"),
-  RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-"),
-  FUNCTIONAL_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX, "func-index-");
+  FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-",
+      HoodieMetadataConfig::enabled,
+      (metaClient, partitionType) -> metaClient.getTableConfig().isMetadataPartitionAvailable(partitionType)),
+  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-",
+      HoodieMetadataConfig::isColumnStatsIndexEnabled,
+      (metaClient, partitionType) -> metaClient.getTableConfig().isMetadataPartitionAvailable(partitionType)),
+  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-",
+      HoodieMetadataConfig::isBloomFilterIndexEnabled,
+      (metaClient, partitionType) -> metaClient.getTableConfig().isMetadataPartitionAvailable(partitionType)),
+  RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-",
+      HoodieMetadataConfig::isRecordIndexEnabled,
+      (metaClient, partitionType) -> metaClient.getTableConfig().isMetadataPartitionAvailable(partitionType)),
+  FUNCTIONAL_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX, "func-index-",
+      metadataConfig -> false, // no config for functional index, it is created using sql
+      (metaClient, partitionType) -> metaClient.getFunctionalIndexMetadata().isPresent());
 
   // Partition path in metadata table.
   private final String partitionPath;
   // FileId prefix used for all file groups in this partition.
   private final String fileIdPrefix;
+  private final Predicate<HoodieMetadataConfig> isMetadataPartitionEnabled;
+  private final BiPredicate<HoodieTableMetaClient, MetadataPartitionType> isMetadataPartitionAvailable;
 
-  MetadataPartitionType(final String partitionPath, final String fileIdPrefix) {
+  MetadataPartitionType(final String partitionPath, final String fileIdPrefix,
+                        Predicate<HoodieMetadataConfig> isMetadataPartitionEnabled,
+                        BiPredicate<HoodieTableMetaClient, MetadataPartitionType> isMetadataPartitionAvailable) {
     this.partitionPath = partitionPath;
     this.fileIdPrefix = fileIdPrefix;
+    this.isMetadataPartitionEnabled = isMetadataPartitionEnabled;
+    this.isMetadataPartitionAvailable = isMetadataPartitionAvailable;
   }
 
   public String getPartitionPath() {
@@ -68,6 +90,19 @@ public enum MetadataPartitionType {
     return Arrays.stream(values())
         .map(MetadataPartitionType::getPartitionPath)
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Returns the list of metadata partition types enabled based on the metadata config and table config.
+   */
+  public static List<MetadataPartitionType> getEnabledPartitions(HoodieMetadataConfig metadataConfig, HoodieTableMetaClient metaClient) {
+    List<MetadataPartitionType> enabledTypes = new ArrayList<>(4);
+    for (MetadataPartitionType type : values()) {
+      if (type.isMetadataPartitionEnabled.test(metadataConfig) || type.isMetadataPartitionAvailable.test(metaClient, type)) {
+        enabledTypes.add(type);
+      }
+    }
+    return enabledTypes;
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieFunctionalIndexMetadata;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link MetadataPartitionType}.
+ */
+public class TestMetadataPartitionType {
+
+  @Test
+  public void testPartitionEnabledByConfigOnly() {
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+
+    // Simulate the configuration enabling FILES but the meta client not having it available (yet to initialize files partition)
+    Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(false);
+    Mockito.when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.empty());
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+
+    // Verify FILES is enabled due to config
+    assertEquals(1, enabledPartitions.size(), "Only one partition should be enabled");
+    assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by config");
+  }
+
+  @Test
+  public void testPartitionAvailableByMetaClientOnly() {
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+
+    // Simulate the meta client having RECORD_INDEX available but config not enabling it
+    Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
+    Mockito.when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.empty());
+    Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).withEnableRecordIndex(false).build();
+
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+
+    // Verify RECORD_INDEX and FILES is enabled due to availability
+    assertEquals(2, enabledPartitions.size(), "RECORD_INDEX and FILES should be available");
+    assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
+    assertTrue(enabledPartitions.contains(MetadataPartitionType.RECORD_INDEX), "RECORD_INDEX should be enabled by availability");
+  }
+
+  @Test
+  public void testNoPartitionsEnabled() {
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+
+    // Neither config nor availability allows any partitions
+    Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.empty());
+    Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(Mockito.any())).thenReturn(false);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(false).build();
+
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+
+    // Verify no partitions are enabled
+    assertTrue(enabledPartitions.isEmpty(), "No partitions should be enabled");
+  }
+
+  @Test
+  public void testFunctionalIndexPartitionEnabled() {
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+
+    // Simulate the meta client having FUNCTIONAL_INDEX available
+    Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
+    Mockito.when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.of(Mockito.mock(HoodieFunctionalIndexMetadata.class)));
+    Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.FUNCTIONAL_INDEX)).thenReturn(true);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+
+    // Verify FUNCTIONAL_INDEX and FILES is enabled due to availability
+    assertEquals(2, enabledPartitions.size(), "FUNCTIONAL_INDEX and FILES should be available");
+    assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
+    assertTrue(enabledPartitions.contains(MetadataPartitionType.FUNCTIONAL_INDEX), "FUNCTIONAL_INDEX should be enabled by availability");
+  }
+
+  @Test
+  public void testGetMetadataPartitionsNeedingWriteStatusTracking() {
+    List<MetadataPartitionType> trackingPartitions = MetadataPartitionType.getMetadataPartitionsNeedingWriteStatusTracking();
+    assertTrue(trackingPartitions.contains(MetadataPartitionType.RECORD_INDEX), "RECORD_INDEX should need write status tracking");
+    assertEquals(1, trackingPartitions.size(), "Only one partition should need write status tracking");
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -49,7 +49,7 @@ public class TestMetadataPartitionType {
     Mockito.when(metaClient.getFunctionalIndexMetadata()).thenReturn(Option.empty());
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
 
-    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify FILES is enabled due to config
     assertEquals(1, enabledPartitions.size(), "Only one partition should be enabled");
@@ -68,7 +68,7 @@ public class TestMetadataPartitionType {
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).withEnableRecordIndex(false).build();
 
-    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify RECORD_INDEX and FILES is enabled due to availability
     assertEquals(2, enabledPartitions.size(), "RECORD_INDEX and FILES should be available");
@@ -87,7 +87,7 @@ public class TestMetadataPartitionType {
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(Mockito.any())).thenReturn(false);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(false).build();
 
-    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify no partitions are enabled
     assertTrue(enabledPartitions.isEmpty(), "No partitions should be enabled");
@@ -105,7 +105,7 @@ public class TestMetadataPartitionType {
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.FUNCTIONAL_INDEX)).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
 
-    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
+    List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify FUNCTIONAL_INDEX and FILES is enabled due to availability
     assertEquals(2, enabledPartitions.size(), "FUNCTIONAL_INDEX and FILES should be available");


### PR DESCRIPTION
### Change Logs

- MetadataPartitionType` now includes predicates for checking both the enabling condition based on metadata configuration and metaClient.
- Move the `HoodieBackedTableMetadataWriter::enablePartitions` method as a static method inside the enum itself.
- Add test for the enum.

### Impact

Enhance reuse and ease of adding new metadata partitions (indexes).

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
