### PR TITLE
[HUDI-7658] Add time to meta sync failure log

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1046,7 +1046,7 @@ public class StreamSync implements Serializable, Closeable {
     long timeMs = metaSyncTimeNanos / 1000000L;
     String timeString = String.format("and took %d s %d ms ", timeMs / 1000L, timeMs % 1000L);
     if (metaSyncException.isPresent()) {
-      LOG.error("[MetaSync] SyncTool class {} failed with exception {} {}" + timeString, impl.trim(), metaSyncException.get(), timeString);
+      LOG.error("[MetaSync] SyncTool class {} failed with exception {} {}", impl.trim(), metaSyncException.get(), timeString);
       failedMetaSyncs.put(impl, metaSyncException.get());
     } else {
       LOG.info("[MetaSync] SyncTool class {} completed successfully {}", impl.trim(), timeString);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1046,10 +1046,10 @@ public class StreamSync implements Serializable, Closeable {
     long timeMs = metaSyncTimeNanos / 1000000L;
     String timeString = String.format("and took %d s %d ms ", timeMs / 1000L, timeMs % 1000L);
     if (metaSyncException.isPresent()) {
-      LOG.error("[MetaSync] SyncTool class {} failed with exception {} " + timeString, impl.trim(), metaSyncException.get());
+      LOG.error("[MetaSync] SyncTool class {} failed with exception {} {}" + timeString, impl.trim(), metaSyncException.get(), timeString);
       failedMetaSyncs.put(impl, metaSyncException.get());
     } else {
-      LOG.info("[MetaSync] SyncTool class {} completed successfully " + timeString, impl.trim());
+      LOG.info("[MetaSync] SyncTool class {} completed successfully {}", impl.trim(), timeString);
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1044,11 +1044,12 @@ public class StreamSync implements Serializable, Closeable {
     long metaSyncTimeNanos = syncContext != null ? syncContext.stop() : 0;
     metrics.updateStreamerMetaSyncMetrics(getSyncClassShortName(impl), metaSyncTimeNanos);
     long timeMs = metaSyncTimeNanos / 1000000L;
+    String timeString = String.format("and took %d s %d ms ", timeMs / 1000L, timeMs % 1000L);
     if (metaSyncException.isPresent()) {
-      LOG.error("[MetaSync] SyncTool class {} failed with exception {} and took {} s {} ms ", impl.trim(), metaSyncException.get(), timeMs / 1000L, timeMs % 1000L);
+      LOG.error("[MetaSync] SyncTool class {} failed with exception {} " + timeString, impl.trim(), metaSyncException.get());
       failedMetaSyncs.put(impl, metaSyncException.get());
     } else {
-      LOG.info("[MetaSync] SyncTool class {} completed successfully and took {} s {} ms ", impl.trim(), timeMs / 1000L, timeMs % 1000L);
+      LOG.info("[MetaSync] SyncTool class {} completed successfully " + timeString, impl.trim());
     }
   }
 


### PR DESCRIPTION
### Change Logs

log the time taken when meta sync fails

### Impact

more consistent logging between success an failure

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
