### PR TITLE
[HUDI-7666] Fix serializable implementation of StorageConfiguration class

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 /**
  * Implementation of {@link StorageConfiguration} providing Hadoop's {@link Configuration}.
@@ -67,18 +68,6 @@ public class HadoopStorageConfiguration extends StorageConfiguration<Configurati
   }
 
   @Override
-  public void writeObject(ObjectOutputStream out) throws IOException {
-    out.defaultWriteObject();
-    configuration.write(out);
-  }
-
-  @Override
-  public void readObject(ObjectInputStream in) throws IOException {
-    configuration = new Configuration(false);
-    configuration.readFields(in);
-  }
-
-  @Override
   public void set(String key, String value) {
     configuration.set(key, value);
   }
@@ -94,5 +83,33 @@ public class HadoopStorageConfiguration extends StorageConfiguration<Configurati
     configuration.iterator().forEachRemaining(
         e -> stringBuilder.append(String.format("%s => %s \n", e.getKey(), e.getValue())));
     return stringBuilder.toString();
+  }
+
+  /**
+   * Serializes the storage configuration.
+   * DO NOT change the signature, as required by {@link Serializable}.
+   * This method has to be private; otherwise, serde of the object of this class
+   * in Spark does not work.
+   *
+   * @param out stream to write.
+   * @throws IOException on I/O error.
+   */
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    configuration.write(out);
+  }
+
+  /**
+   * Deserializes the storage configuration.
+   * DO NOT change the signature, as required by {@link Serializable}.
+   * This method has to be private; otherwise, serde of the object of this class
+   * in Spark does not work.
+   *
+   * @param in stream to read.
+   * @throws IOException on I/O error.
+   */
+  private void readObject(ObjectInputStream in) throws IOException {
+    configuration = new Configuration(false);
+    configuration.readFields(in);
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
@@ -22,9 +22,6 @@ package org.apache.hudi.storage;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 /**
@@ -42,25 +39,7 @@ public abstract class StorageConfiguration<T> implements Serializable {
    * @return a new copy of the storage configuration.
    */
   public abstract T newCopy();
-
-  /**
-   * Serializes the storage configuration.
-   * DO NOT change the signature, as required by {@link Serializable}.
-   *
-   * @param out stream to write.
-   * @throws IOException on I/O error.
-   */
-  public abstract void writeObject(ObjectOutputStream out) throws IOException;
-
-  /**
-   * Deserializes the storage configuration.
-   * DO NOT change the signature, as required by {@link Serializable}.
-   *
-   * @param in stream to read.
-   * @throws IOException on I/O error.
-   */
-  public abstract void readObject(ObjectInputStream in) throws IOException;
-
+  
   /**
    * Sets the configuration key-value pair.
    *

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
@@ -24,11 +24,17 @@ import org.apache.hudi.storage.StorageConfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,6 +91,21 @@ public abstract class BaseTestStorageConfiguration<T> {
   public void testGet() {
     StorageConfiguration<?> storageConf = getStorageConfiguration(getConf(prepareConfigs()));
     validateConfigs(storageConf);
+  }
+
+  @Test
+  public void testSerializability() throws IOException, ClassNotFoundException {
+    StorageConfiguration<?> storageConf = getStorageConfiguration(getConf(prepareConfigs()));
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(storageConf);
+      try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+           ObjectInputStream ois = new ObjectInputStream(bais)) {
+        StorageConfiguration<?> deserialized = (StorageConfiguration) ois.readObject();
+        assertNotNull(deserialized.get());
+        validateConfigs(deserialized);
+      }
+    }
   }
 
   private Map<String, String> prepareConfigs() {


### PR DESCRIPTION
### Change Logs

This PR fixes the bug that subclasses implementing `StorageConfiguration` cannot be properly (de)serialized in Spark.  The root cause is that the `#writeObject(ObjectOutputStream out)` and `#readObject(ObjectInputStream in)` for `Serializable` have to be `private`; they cannot be `public` or `protected`.  A new test is added, which fails without the fix and passes with the fix.

### Impact

Bug fix.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
