### PR TITLE
[HUDI-7672] Fix the Hive server scratch dir for tests in hudi-utilities

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -138,7 +138,6 @@ public class UtilitiesTestBase {
 
   public static void initTestServices(boolean needsHdfs, boolean needsHive, boolean needsZookeeper) throws Exception {
     hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
-    hadoopConf.set("hive.exec.scratchdir", System.getenv("java.io.tmpdir") + "/hive");
 
     if (needsHdfs) {
       hdfsTestService = new HdfsTestService(hadoopConf);
@@ -152,6 +151,7 @@ public class UtilitiesTestBase {
     }
     storage = HoodieStorageUtils.getStorage(fs);
 
+    hadoopConf.set("hive.exec.scratchdir", basePath + "/.tmp/hive");
     if (needsHive) {
       hiveTestService = new HiveTestService(hadoopConf);
       hiveServer = hiveTestService.start();


### PR DESCRIPTION
### Change Logs

Currently a `null/hive/${user}` dir would be left over when the tests finished, which introduces some permission access issues for Azure CI test reports.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
