### PR TITLE
[HUDI-7673] Fixing false positive validation failure for RLI with MDT validation tool

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -38,7 +38,6 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
-import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieWriteStat;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities;
 
+import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.async.HoodieAsyncService;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
@@ -67,6 +68,7 @@ import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.utilities.util.BloomFilterData;
 
 import com.beust.jcommander.JCommander;
@@ -79,6 +81,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.Optional;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +106,10 @@ import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
+import static org.apache.hudi.common.model.HoodieRecord.FILENAME_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.PARTITION_PATH_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBasePath;
 
@@ -542,7 +549,7 @@ public class HoodieMetadataTableValidator implements Serializable {
           }).collectAsList());
 
       try {
-        validateRecordIndex(engineContext, metaClient, metadataTableBasedContext.getTableMetadata());
+        validateRecordIndex(engineContext, metaClient);
         result.add(Pair.of(true, null));
       } catch (HoodieValidationException e) {
         LOG.error(
@@ -640,7 +647,7 @@ public class HoodieMetadataTableValidator implements Serializable {
           if (partitionCreationTimeOpt.isPresent() && !completedTimeline.containsInstant(partitionCreationTimeOpt.get())) {
             Option<HoodieInstant> lastInstant = completedTimeline.lastInstant();
             if (lastInstant.isPresent()
-                && HoodieTimeline.compareTimestamps(partitionCreationTimeOpt.get(), HoodieTimeline.GREATER_THAN, lastInstant.get().getTimestamp())) {
+                && HoodieTimeline.compareTimestamps(partitionCreationTimeOpt.get(), GREATER_THAN, lastInstant.get().getTimestamp())) {
               LOG.warn("Ignoring additional partition {}, as it was deduced to be part of a "
                   + "latest completed commit which was inflight when FS based listing was polled.", partitionFromDMT);
               actualAdditionalPartitionsInMDT.remove(partitionFromDMT);
@@ -888,10 +895,12 @@ public class HoodieMetadataTableValidator implements Serializable {
   }
 
   private void validateRecordIndex(HoodieSparkEngineContext sparkEngineContext,
-                                   HoodieTableMetaClient metaClient,
-                                   HoodieTableMetadata tableMetadata) {
+                                   HoodieTableMetaClient metaClient) {
+    if (!metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)) {
+      return;
+    }
     if (cfg.validateRecordIndexContent) {
-      validateRecordIndexContent(sparkEngineContext, metaClient, tableMetadata);
+      validateRecordIndexContent(sparkEngineContext, metaClient);
     } else if (cfg.validateRecordIndexCount) {
       validateRecordIndexCount(sparkEngineContext, metaClient);
     }
@@ -900,11 +909,15 @@ public class HoodieMetadataTableValidator implements Serializable {
   private void validateRecordIndexCount(HoodieSparkEngineContext sparkEngineContext,
                                         HoodieTableMetaClient metaClient) {
     String basePath = metaClient.getBasePathV2().toString();
+    String latestCompletedCommit = metaClient.getActiveTimeline().getCommitsAndCompactionTimeline()
+        .filterCompletedInstants().lastInstant().get().getTimestamp();
     long countKeyFromTable = sparkEngineContext.getSqlContext().read().format("hudi")
+        .option(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT().key(),latestCompletedCommit)
         .load(basePath)
-        .select(HoodieRecord.RECORD_KEY_METADATA_FIELD)
+        .select(RECORD_KEY_METADATA_FIELD)
         .count();
     long countKeyFromRecordIndex = sparkEngineContext.getSqlContext().read().format("hudi")
+        .option(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT().key(),latestCompletedCommit)
         .load(getMetadataTableBasePath(basePath))
         .select("key")
         .filter("type = 5")
@@ -921,43 +934,15 @@ public class HoodieMetadataTableValidator implements Serializable {
   }
 
   private void validateRecordIndexContent(HoodieSparkEngineContext sparkEngineContext,
-                                          HoodieTableMetaClient metaClient,
-                                          HoodieTableMetadata tableMetadata) {
+                                          HoodieTableMetaClient metaClient) {
     String basePath = metaClient.getBasePathV2().toString();
+    String latestCompletedCommit = metaClient.getActiveTimeline().getCommitsAndCompactionTimeline()
+        .filterCompletedInstants().lastInstant().get().getTimestamp();
     JavaPairRDD<String, Pair<String, String>> keyToLocationOnFsRdd =
-        sparkEngineContext.getSqlContext().read().format("hudi").load(basePath)
-            .select(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
-            .toJavaRDD()
-            .mapToPair(row -> new Tuple2<>(row.getString(row.fieldIndex(HoodieRecord.RECORD_KEY_METADATA_FIELD)),
-                Pair.of(row.getString(row.fieldIndex(HoodieRecord.PARTITION_PATH_METADATA_FIELD)),
-                    FSUtils.getFileId(row.getString(row.fieldIndex(HoodieRecord.FILENAME_METADATA_FIELD))))))
-            .cache();
+        getRecordLocationsFromFSBasedListing(sparkEngineContext, basePath, latestCompletedCommit);
 
     JavaPairRDD<String, Pair<String, String>> keyToLocationFromRecordIndexRdd =
-        sparkEngineContext.getSqlContext().read().format("hudi")
-            .load(getMetadataTableBasePath(basePath))
-            .filter("type = 5")
-            .select(functions.col("key"),
-                functions.col("recordIndexMetadata.partitionName").as("partitionName"),
-                functions.col("recordIndexMetadata.fileIdHighBits").as("fileIdHighBits"),
-                functions.col("recordIndexMetadata.fileIdLowBits").as("fileIdLowBits"),
-                functions.col("recordIndexMetadata.fileIndex").as("fileIndex"),
-                functions.col("recordIndexMetadata.fileId").as("fileId"),
-                functions.col("recordIndexMetadata.instantTime").as("instantTime"),
-                functions.col("recordIndexMetadata.fileIdEncoding").as("fileIdEncoding"))
-            .toJavaRDD()
-            .mapToPair(row -> {
-              HoodieRecordGlobalLocation location = HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(
-                  row.getString(row.fieldIndex("partitionName")),
-                  row.getInt(row.fieldIndex("fileIdEncoding")),
-                  row.getLong(row.fieldIndex("fileIdHighBits")),
-                  row.getLong(row.fieldIndex("fileIdLowBits")),
-                  row.getInt(row.fieldIndex("fileIndex")),
-                  row.getString(row.fieldIndex("fileId")),
-                  row.getLong(row.fieldIndex("instantTime")));
-              return new Tuple2<>(row.getString(row.fieldIndex("key")),
-                  Pair.of(location.getPartitionPath(), location.getFileId()));
-            });
+        getRecordLocationsFromRLI(sparkEngineContext, basePath, latestCompletedCommit);
 
     int numErrorSamples = cfg.numRecordIndexErrorSamples;
     Pair<Long, List<String>> result = keyToLocationOnFsRdd.fullOuterJoin(keyToLocationFromRecordIndexRdd, cfg.recordIndexParallelism)
@@ -1032,6 +1017,60 @@ public class HoodieMetadataTableValidator implements Serializable {
     } else {
       LOG.info("Validation of record index content succeeded: {} entries. Table: {}", countKey, cfg.basePath);
     }
+  }
+
+  @VisibleForTesting
+  JavaPairRDD<String, Pair<String, String>> getRecordLocationsFromFSBasedListing(HoodieSparkEngineContext sparkEngineContext,
+                                                                                                      String basePath,
+                                                                                                      String latestCompletedCommit) {
+    return sparkEngineContext.getSqlContext().read().format("hudi")
+        .option(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT().key(), latestCompletedCommit)
+        .load(basePath)
+        .select(RECORD_KEY_METADATA_FIELD, PARTITION_PATH_METADATA_FIELD, FILENAME_METADATA_FIELD)
+        .toJavaRDD()
+        .mapToPair(row -> new Tuple2<>(row.getString(row.fieldIndex(RECORD_KEY_METADATA_FIELD)),
+            Pair.of(row.getString(row.fieldIndex(PARTITION_PATH_METADATA_FIELD)),
+                FSUtils.getFileId(row.getString(row.fieldIndex(FILENAME_METADATA_FIELD))))))
+        .cache();
+  }
+
+  @VisibleForTesting
+  JavaPairRDD<String, Pair<String, String>> getRecordLocationsFromRLI(HoodieSparkEngineContext sparkEngineContext,
+                                                                      String basePath,
+                                                                      String latestCompletedCommit) {
+    return sparkEngineContext.getSqlContext().read().format("hudi")
+        .load(getMetadataTableBasePath(basePath))
+        .filter("type = 5")
+        .select(functions.col("key"),
+            functions.col("recordIndexMetadata.partitionName").as("partitionName"),
+            functions.col("recordIndexMetadata.fileIdHighBits").as("fileIdHighBits"),
+            functions.col("recordIndexMetadata.fileIdLowBits").as("fileIdLowBits"),
+            functions.col("recordIndexMetadata.fileIndex").as("fileIndex"),
+            functions.col("recordIndexMetadata.fileId").as("fileId"),
+            functions.col("recordIndexMetadata.instantTime").as("instantTime"),
+            functions.col("recordIndexMetadata.fileIdEncoding").as("fileIdEncoding"))
+        .toJavaRDD()
+        .map(row -> {
+          HoodieRecordGlobalLocation location = HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(
+              row.getString(row.fieldIndex("partitionName")),
+              row.getInt(row.fieldIndex("fileIdEncoding")),
+              row.getLong(row.fieldIndex("fileIdHighBits")),
+              row.getLong(row.fieldIndex("fileIdLowBits")),
+              row.getInt(row.fieldIndex("fileIndex")),
+              row.getString(row.fieldIndex("fileId")),
+              row.getLong(row.fieldIndex("instantTime")));
+          // handle false positive case. a commit was pending when FS based locations were fetched, but committed when MDT was polled.
+          if (HoodieTimeline.compareTimestamps(location.getInstantTime(), GREATER_THAN, latestCompletedCommit)) {
+            return new Tuple2<>(row, Option.empty());
+          } else {
+            return new Tuple2<>(row, Option.of(location));
+          }
+        }).filter(tuple2 -> tuple2._2.isPresent()) // filter the false positives
+        .mapToPair(tuple2 -> {
+          Tuple2<Row, Option<HoodieRecordGlobalLocation>> rowAndLocation = (Tuple2<Row, Option<HoodieRecordGlobalLocation>>) tuple2;
+          return new Tuple2<>(rowAndLocation._1.getString(rowAndLocation._1.fieldIndex("key")),
+              Pair.of(rowAndLocation._2.get().getPartitionPath(), rowAndLocation._2.get().getFileId()));
+        }).cache();
   }
 
   private String constructLocationInfoString(String recordKey, Optional<Pair<String, String>> locationOnFs,

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -258,7 +258,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     config.validateAllFileGroups = true;
 
     // lets ensure we have a pending commit when FS based polling is done. and the commit completes when MDT is polled.
-    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(jsc.hadoopConfiguration()).build();
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration())).build();
     // moving out the completed commit meta file to a temp location
     HoodieInstant lastInstant = metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().get();
     String latestCompletedCommitMetaFile = basePath + "/.hoodie/" + lastInstant.getFileName();


### PR DESCRIPTION
### Change Logs

Fixing false positive validation failure for RLI with MDT validation tool. 
When FS based record key locations are polled, we could have a pending commit. and when MDT is polled or record locations, the commit could have been completed. And so, rli validation could return additional record locations.

### Impact

Robust RLI validation with MDT validator tool.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
