### PR TITLE
[HUDI-7675]Don't set default value for primary key when get schema from hms

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HiveSchemaUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HiveSchemaUtils.java
@@ -68,8 +68,8 @@ public class HiveSchemaUtils {
     allCols.addAll(hiveTable.getPartitionKeys());
 
     String pkConstraintName = hiveTable.getParameters().get(TableOptionProperties.PK_CONSTRAINT_NAME);
-    String pkColumnStr = hiveTable.getParameters().getOrDefault(FlinkOptions.RECORD_KEY_FIELD.key(), FlinkOptions.RECORD_KEY_FIELD.defaultValue());
-    List<String> pkColumns = StringUtils.split(pkColumnStr, ",");
+    String pkColumnStr = hiveTable.getParameters().get(FlinkOptions.RECORD_KEY_FIELD.key());
+    List<String> pkColumns = pkColumnStr == null ? new ArrayList<>() : StringUtils.split(pkColumnStr, ",");
 
     String[] colNames = new String[allCols.size()];
     DataType[] colTypes = new DataType[allCols.size()];
@@ -88,7 +88,7 @@ public class HiveSchemaUtils {
     org.apache.flink.table.api.Schema.Builder builder = org.apache.flink.table.api.Schema.newBuilder().fromFields(colNames, colTypes);
     if (!StringUtils.isNullOrEmpty(pkConstraintName)) {
       builder.primaryKeyNamed(pkConstraintName, pkColumns);
-    } else {
+    } else if (!pkColumns.isEmpty()) {
       builder.primaryKey(pkColumns);
     }
 


### PR DESCRIPTION
### Change Logs

Don't set default value for primary key when get schema from hms.



### Impact

```
The main method caused an error: org.apache.flink.table.api.ValidationException: Invalid primary key 'PK_uuid'. Column 'uuid' does not exist.
	at org.apache.flink.table.catalog.DefaultSchemaResolver.validatePrimaryKey(DefaultSchemaResolver.java:337)
```

### Risk level (write none, low medium or high below)


### Documentation Update



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
