### PR TITLE
[HUDI-7668] Add and rename APIs in StorageConfiguration

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
@@ -80,7 +80,7 @@ public class HadoopFSUtils {
   }
 
   public static <T> FileSystem getFs(Path path, StorageConfiguration<T> storageConf, boolean newCopy) {
-    T conf = newCopy ? storageConf.newCopy() : storageConf.unwrap();
+    T conf = newCopy ? storageConf.unwrapCopy() : storageConf.unwrap();
     ValidationUtils.checkArgument(conf instanceof Configuration);
     return getFs(path, (Configuration) conf);
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
@@ -80,7 +80,7 @@ public class HadoopFSUtils {
   }
 
   public static <T> FileSystem getFs(Path path, StorageConfiguration<T> storageConf, boolean newCopy) {
-    T conf = newCopy ? storageConf.newCopy() : storageConf.get();
+    T conf = newCopy ? storageConf.newCopy() : storageConf.unwrap();
     ValidationUtils.checkArgument(conf instanceof Configuration);
     return getFs(path, (Configuration) conf);
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
@@ -58,7 +58,12 @@ public class HadoopStorageConfiguration extends StorageConfiguration<Configurati
   }
 
   @Override
-  public Configuration get() {
+  public StorageConfiguration<Configuration> newInstance() {
+    return new HadoopStorageConfiguration(this);
+  }
+
+  @Override
+  public Configuration unwrap() {
     return configuration;
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HadoopStorageConfiguration.java
@@ -54,7 +54,7 @@ public class HadoopStorageConfiguration extends StorageConfiguration<Configurati
   }
 
   public HadoopStorageConfiguration(HadoopStorageConfiguration configuration) {
-    this.configuration = configuration.newCopy();
+    this.configuration = configuration.unwrapCopy();
   }
 
   @Override
@@ -68,7 +68,7 @@ public class HadoopStorageConfiguration extends StorageConfiguration<Configurati
   }
 
   @Override
-  public Configuration newCopy() {
+  public Configuration unwrapCopy() {
     return new Configuration(configuration);
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
@@ -31,9 +31,14 @@ import java.io.Serializable;
  */
 public abstract class StorageConfiguration<T> implements Serializable {
   /**
+   * @return a new {@link StorageConfiguration} instance with a new copy of the configuration.
+   */
+  public abstract StorageConfiguration<T> newInstance();
+
+  /**
    * @return the storage configuration.
    */
-  public abstract T get();
+  public abstract T unwrap();
 
   /**
    * @return a new copy of the storage configuration.
@@ -107,5 +112,18 @@ public abstract class StorageConfiguration<T> implements Serializable {
     return value.isPresent()
         ? Enum.valueOf(defaultValue.getDeclaringClass(), value.get())
         : defaultValue;
+  }
+
+  /**
+   * Sets a property key with a value in the configuration, if the property key
+   * does not already exist.
+   *
+   * @param key   property key.
+   * @param value property value.
+   */
+  public final void setIfUnset(String key, String value) {
+    if (getString(key).isEmpty()) {
+      set(key, value);
+    }
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StorageConfiguration.java
@@ -31,19 +31,20 @@ import java.io.Serializable;
  */
 public abstract class StorageConfiguration<T> implements Serializable {
   /**
-   * @return a new {@link StorageConfiguration} instance with a new copy of the configuration.
+   * @return a new {@link StorageConfiguration} instance with a new copy of
+   * the configuration of type {@link T}.
    */
   public abstract StorageConfiguration<T> newInstance();
 
   /**
-   * @return the storage configuration.
+   * @return the underlying configuration of type {@link T}.
    */
   public abstract T unwrap();
 
   /**
-   * @return a new copy of the storage configuration.
+   * @return a new copy of the underlying configuration of type {@link T}.
    */
-  public abstract T newCopy();
+  public abstract T unwrapCopy();
   
   /**
    * Sets the configuration key-value pair.

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
@@ -70,14 +70,14 @@ public abstract class BaseTestStorageConfiguration<T> {
   protected abstract T getConf(Map<String, String> mapping);
 
   @Test
-  public void testConstructorNewInstanceUnwrapNewCopy() {
+  public void testConstructorNewInstanceUnwrapCopy() {
     T conf = getConf(EMPTY_MAP);
     StorageConfiguration<T> storageConf = getStorageConfiguration(conf);
     StorageConfiguration<T> newStorageConf = storageConf.newInstance();
     assertNotSame(storageConf, newStorageConf);
     assertNotSame(storageConf.unwrap(), newStorageConf.unwrap());
     assertSame(storageConf.unwrap(), storageConf.unwrap());
-    assertNotSame(storageConf.unwrap(), storageConf.newCopy());
+    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopy());
   }
 
   @Test

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
@@ -47,11 +47,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public abstract class BaseTestStorageConfiguration<T> {
   private static final Map<String, String> EMPTY_MAP = new HashMap<>();
   private static final String KEY_STRING = "hudi.key.string";
+  private static final String KEY_STRING_OTHER = "hudi.key.string.other";
   private static final String KEY_BOOLEAN = "hudi.key.boolean";
   private static final String KEY_LONG = "hudi.key.long";
   private static final String KEY_ENUM = "hudi.key.enum";
   private static final String KEY_NON_EXISTENT = "hudi.key.non_existent";
   private static final String VALUE_STRING = "string_value";
+  private static final String VALUE_STRING_1 = "string_value_1";
   private static final String VALUE_BOOLEAN = "true";
   private static final String VALUE_LONG = "12309120";
   private static final String VALUE_ENUM = TestEnum.ENUM2.toString();
@@ -68,11 +70,14 @@ public abstract class BaseTestStorageConfiguration<T> {
   protected abstract T getConf(Map<String, String> mapping);
 
   @Test
-  public void testConstructorGetNewCopy() {
+  public void testConstructorNewInstanceUnwrapNewCopy() {
     T conf = getConf(EMPTY_MAP);
     StorageConfiguration<T> storageConf = getStorageConfiguration(conf);
-    assertSame(storageConf.get(), storageConf.get());
-    assertNotSame(storageConf.get(), storageConf.newCopy());
+    StorageConfiguration<T> newStorageConf = storageConf.newInstance();
+    assertNotSame(storageConf, newStorageConf);
+    assertNotSame(storageConf.unwrap(), newStorageConf.unwrap());
+    assertSame(storageConf.unwrap(), storageConf.unwrap());
+    assertNotSame(storageConf.unwrap(), storageConf.newCopy());
   }
 
   @Test
@@ -85,6 +90,11 @@ public abstract class BaseTestStorageConfiguration<T> {
     storageConf.set(KEY_BOOLEAN, VALUE_BOOLEAN);
     assertEquals(Option.of(VALUE_STRING), storageConf.getString(KEY_STRING));
     assertTrue(storageConf.getBoolean(KEY_BOOLEAN, false));
+
+    storageConf.setIfUnset(KEY_STRING, VALUE_STRING + "_1");
+    storageConf.setIfUnset(KEY_STRING_OTHER, VALUE_STRING_1);
+    assertEquals(Option.of(VALUE_STRING), storageConf.getString(KEY_STRING));
+    assertEquals(Option.of(VALUE_STRING_1), storageConf.getString(KEY_STRING_OTHER));
   }
 
   @Test
@@ -102,7 +112,7 @@ public abstract class BaseTestStorageConfiguration<T> {
       try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
            ObjectInputStream ois = new ObjectInputStream(bais)) {
         StorageConfiguration<?> deserialized = (StorageConfiguration) ois.readObject();
-        assertNotNull(deserialized.get());
+        assertNotNull(deserialized.unwrap());
         validateConfigs(deserialized);
       }
     }


### PR DESCRIPTION
### Change Logs

This PR makes the following changes:
- Adds `StorageConfiguration#newInstance` to create a new `StorageConfiguration` instance with a new copy of the configuration.
- Adds `StorageConfiguration#setIfUnset` to set a property key with a value in the configuration, if the property key does not already exist.
- Renames `StorageConfiguration#get` to `StorageConfiguration#unwrap` for readability.
- Renames `StorageConfiguration#newCopy` to `StorageConfiguration#unwrapCopy` for readability.

### Impact

New APIs to facilitate integration of `StorageConfiguration`.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
