### PR TITLE
[MINOR] Remove the redundant log in HFileBootstrapIndex

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
@@ -86,7 +86,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 public class HFileBootstrapIndex extends BootstrapIndex {
 
-  protected static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
   private static final Logger LOG = LoggerFactory.getLogger(HFileBootstrapIndex.class);
 
@@ -434,7 +434,6 @@ public class HFileBootstrapIndex extends BootstrapIndex {
      * @param fileSystem File System
      */
     private static HFile.Reader createReader(String hFilePath, Configuration conf, FileSystem fileSystem) {
-      LOG.info("Opening HFile for reading :" + hFilePath);
       return HoodieHFileUtils.createHFileReader(fileSystem, new HFilePathForReader(hFilePath), new CacheConfig(conf), conf);
     }
 


### PR DESCRIPTION
### Change Logs

The log is redundant.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
