### PR TITLE
[HUDI-7685] Fix delete partition instant commit in partition TTL

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/DeletePartitionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/DeletePartitionUtils.java
@@ -19,7 +19,7 @@
 package org.apache.hudi.client.utils;
 
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
-import org.apache.hudi.exception.HoodieDeletePartitionException;
+import org.apache.hudi.exception.HoodieDeletePartitionPendingTableServiceException;
 import org.apache.hudi.table.HoodieTable;
 
 import java.util.ArrayList;
@@ -67,7 +67,7 @@ public class DeletePartitionUtils {
         .forEach(x -> instantsOfOffendingPendingTableServiceAction.add(x.getRight().getTimestamp()));
 
     if (instantsOfOffendingPendingTableServiceAction.size() > 0) {
-      throw new HoodieDeletePartitionException("Failed to drop partitions. "
+      throw new HoodieDeletePartitionPendingTableServiceException("Failed to drop partitions. "
           + "Please ensure that there are no pending table service actions (clustering/compaction) for the partitions to be deleted: " + partitionsToDrop + ". "
           + "Instant(s) of offending pending table service action: "
           + instantsOfOffendingPendingTableServiceAction.stream().distinct().collect(Collectors.toList()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieDeletePartitionPendingTableServiceException.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieDeletePartitionPendingTableServiceException.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.exception;
+
+public class HoodieDeletePartitionPendingTableServiceException extends HoodieDeletePartitionException {
+
+  public HoodieDeletePartitionPendingTableServiceException(String msg) {
+    super(msg);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByCreationTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByCreationTimeStrategy.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * KeepByTimeStrategy will return expired partitions by their lastCommitTime.
+ * KeepByTimeStrategy will return expired partitions by their create time.
  */
 public class KeepByCreationTimeStrategy extends KeepByTimeStrategy {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByTimeStrategy.java
@@ -103,7 +103,7 @@ public class KeepByTimeStrategy extends PartitionTTLStrategy {
    * @param referenceTime last commit time or creation time for partition
    */
   protected boolean isPartitionExpired(String referenceTime) {
-    String expiredTime = instantTimePlusMillis(fixInstantTimeCompatibility(referenceTime), ttlInMilis);
+    String expiredTime = instantTimePlusMillis(referenceTime, ttlInMilis);
     return fixInstantTimeCompatibility(instantTime).compareTo(expiredTime) > 0;
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
@@ -74,6 +74,18 @@ public class DataSourceTestUtils {
     return toReturn;
   }
 
+  public static List<Row> generateRandomRowsByPartition(int count, String partition) {
+    List<Row> toReturn = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      Object[] values = new Object[3];
+      values[0] = HoodieTestDataGenerator.genPseudoRandomUUID(RANDOM).toString();
+      values[1] = partition;
+      values[2] = new Date().getTime();
+      toReturn.add(RowFactory.create(values));
+    }
+    return toReturn;
+  }
+
   public static List<Row> generateUpdates(List<Row> records, int count) {
     List<Row> toReturn = new ArrayList<>();
     for (int i = 0; i < count; i++) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterPartitionTTL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterPartitionTTL.scala
@@ -1,0 +1,94 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL
+import org.apache.hudi.common.model.HoodieFileFormat
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.{fixInstantTimeCompatibility, instantTimePlusMillis}
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.config.{HoodieTTLConfig, HoodieWriteConfig}
+import org.apache.hudi.table.action.ttl.strategy.KeepByTimeStrategy
+import org.apache.hudi.testutils.DataSourceTestUtils
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Test
+import org.apache.hudi.table.HoodieTable
+
+
+/**
+ * The origin PartitionTTLStrategy calculate the expire time by DAYs, it's too long for test.
+ * Override the method isPartitionExpired to calculate expire time by minutes.
+ * @param hoodieTable
+ * @param instantTime
+ */
+class HoodieSparkSqlWriterTestStrategy(hoodieTable: HoodieTable[_, _, _, _], instantTime: String)
+  extends KeepByTimeStrategy(hoodieTable, instantTime) {
+  override def isPartitionExpired(referenceTime: String): Boolean = {
+    val expiredTime = instantTimePlusMillis(referenceTime, ttlInMilis / 24 / 60)
+    fixInstantTimeCompatibility(instantTime).compareTo(expiredTime) > 0
+  }
+}
+
+class TestHoodieSparkSqlWriterPartitionTTL extends HoodieSparkWriterTestBase {
+
+  /**
+   *  Test partition ttl with HoodieSparkSqlWriter.
+   */
+  @Test
+  def testSparkSqlWriterWithPartitionTTL(): Unit = {
+    val hoodieFooTableName = "hoodie_foo_tbl"
+    val fooTableModifier = Map("path" -> tempBasePath,
+      HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+      HoodieWriteConfig.BASE_FILE_FORMAT.key -> HoodieFileFormat.PARQUET.name,
+      DataSourceWriteOptions.TABLE_TYPE.key -> MOR_TABLE_TYPE_OPT_VAL,
+      HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key -> "4",
+      DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+      HoodieTableConfig.POPULATE_META_FIELDS.key() -> "true",
+      HoodieTTLConfig.INLINE_PARTITION_TTL.key() -> "true",
+      HoodieTTLConfig.DAYS_RETAIN.key() -> "1",
+      HoodieTTLConfig.PARTITION_TTL_STRATEGY_CLASS_NAME.key() -> "org.apache.hudi.HoodieSparkSqlWriterTestStrategy"
+    )
+
+    val schema = DataSourceTestUtils.getStructTypeExampleSchema
+    val structType = AvroConversionUtils.convertAvroSchemaToStructType(schema)
+    val recordsForPart1 = DataSourceTestUtils.generateRandomRowsByPartition(100, "part1")
+    val recordsSeqForPart1 = convertRowListToSeq(recordsForPart1)
+    val part1DF = spark.createDataFrame(sc.parallelize(recordsSeqForPart1), structType)
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier, part1DF)
+
+    // Wait for part1 expires.
+    Thread.sleep(60 * 1000)
+    val recordsForPart2 = DataSourceTestUtils.generateRandomRowsByPartition(100, "part2")
+    val recordsSeqForPart2 = convertRowListToSeq(recordsForPart2)
+    val part2DF = spark.createDataFrame(sc.parallelize(recordsSeqForPart2), structType)
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier, part2DF)
+
+    val timeline = HoodieTestUtils.createMetaClient(tempBasePath).getActiveTimeline
+    assert(timeline.getCompletedReplaceTimeline.getInstants.size() > 0)
+    val replaceInstant = timeline.getCompletedReplaceTimeline.getInstants.get(0)
+    val replaceMetadata = TimelineMetadataUtils.deserializeReplaceCommitMetadata(timeline.getInstantDetails(replaceInstant).get())
+    assert(replaceMetadata.getPartitionToReplaceFileIds.containsKey("part1"))
+  }
+
+}


### PR DESCRIPTION
### Change Logs

After cherry pick https://github.com/apache/hudi/pull/9723, I find the delete partition instant can‘t be committed. 

Auto commit in HoodieSparkSqlWriter is disabled, while SparkDeletePartitionCommitActionExecutor calls commitOnAutoCommit to commit the instant.

DataSourceUtils -> createHoodieConfig
https://github.com/apache/hudi/blob/d286ae44c0fc4562a48d99ec40b4ce2a4fc198ea/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java#L189-L190

SparkDeletePartitionCommitActionExecutor -> commitOnAutoCommit
https://github.com/apache/hudi/blob/d286ae44c0fc4562a48d99ec40b4ce2a4fc198ea/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java#L180-L189

### Impact

none

### Risk level (write none, low medium or high below)

none
### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
