### PR TITLE
[HUDI-7686] Add tests on the util methods for type cast of configuration instances

### DIFF
--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
@@ -76,14 +76,20 @@ public abstract class BaseTestStorageConfiguration<T> {
     StorageConfiguration<T> storageConf = getStorageConfiguration(conf);
     StorageConfiguration<T> newStorageConf = storageConf.newInstance();
     Class unwrapperConfClass = storageConf.unwrap().getClass();
-    assertNotSame(storageConf, newStorageConf);
+    assertNotSame(storageConf, newStorageConf,
+        "storageConf.newInstance() should return a different StorageConfiguration instance.");
     validateConfigs(newStorageConf);
-    assertNotSame(storageConf.unwrap(), newStorageConf.unwrap());
-    assertSame(storageConf.unwrap(), storageConf.unwrap());
-    assertSame(storageConf.unwrap(), storageConf.unwrapAs(unwrapperConfClass));
-    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopy());
+    assertNotSame(storageConf.unwrap(), newStorageConf.unwrap(),
+        "storageConf.newInstance() should contain a new copy of the underlying configuration instance.");
+    assertSame(storageConf.unwrap(), storageConf.unwrap(),
+        "storageConf.unwrap() should return the same underlying configuration instance.");
+    assertSame(storageConf.unwrap(), storageConf.unwrapAs(unwrapperConfClass),
+        "storageConf.unwrapAs(unwrapperConfClass) should return the same underlying configuration instance.");
+    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopy(),
+        "storageConf.unwrapCopy() should return a new copy of the underlying configuration instance.");
     validateConfigs(getStorageConfiguration(storageConf.unwrapCopy()));
-    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopyAs(unwrapperConfClass));
+    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopyAs(unwrapperConfClass),
+        "storageConf.unwrapCopyAs(unwrapperConfClass) should return a new copy of the underlying configuration instance.");
     validateConfigs(getStorageConfiguration((T) storageConf.unwrapCopyAs(unwrapperConfClass)));
     assertThrows(
         IllegalArgumentException.class,

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/BaseTestStorageConfiguration.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -71,13 +72,25 @@ public abstract class BaseTestStorageConfiguration<T> {
 
   @Test
   public void testConstructorNewInstanceUnwrapCopy() {
-    T conf = getConf(EMPTY_MAP);
+    T conf = getConf(prepareConfigs());
     StorageConfiguration<T> storageConf = getStorageConfiguration(conf);
     StorageConfiguration<T> newStorageConf = storageConf.newInstance();
+    Class unwrapperConfClass = storageConf.unwrap().getClass();
     assertNotSame(storageConf, newStorageConf);
+    validateConfigs(newStorageConf);
     assertNotSame(storageConf.unwrap(), newStorageConf.unwrap());
     assertSame(storageConf.unwrap(), storageConf.unwrap());
+    assertSame(storageConf.unwrap(), storageConf.unwrapAs(unwrapperConfClass));
     assertNotSame(storageConf.unwrap(), storageConf.unwrapCopy());
+    validateConfigs(getStorageConfiguration(storageConf.unwrapCopy()));
+    assertNotSame(storageConf.unwrap(), storageConf.unwrapCopyAs(unwrapperConfClass));
+    validateConfigs(getStorageConfiguration((T) storageConf.unwrapCopyAs(unwrapperConfClass)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> storageConf.unwrapAs(Integer.class));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> storageConf.unwrapCopyAs(Integer.class));
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR adds tests on the new util methods in `StorageConfiguration` and `HoodieStorage` class to return underlying configuration instance with the specified type.

### Impact

Tests on the util methods.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
