### PR TITLE
[HUDI-7688] Stop retry inflate if encounter InterruptedIOException

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -39,6 +39,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -312,6 +313,10 @@ public abstract class HoodieLogBlock {
       inputStream.seek(this.getBlockContentLocation().get().getContentPositionInLogFile());
       inputStream.readFully(content.get(), 0, content.get().length);
       inputStream.seek(this.getBlockContentLocation().get().getBlockEndPos());
+    } catch (InterruptedIOException e) {
+      // Stop retry inflate if encounters InterruptedIOException
+      Thread.currentThread().interrupt();
+      throw new HoodieIOException("Thread is interrupted while inflating.", e);
     } catch (IOException e) {
       // TODO : fs.open() and return inputstream again, need to pass FS configuration
       // because the inputstream might close/timeout for large number of log blocks to be merged


### PR DESCRIPTION
### Change Logs

Stop retry inflate if encounter InterruptedIOException to avoid StackOverFlow error.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
