### PR TITLE
[HUDI-7694] Unify bijection-avro dependency version

### DIFF
--- a/hudi-examples/hudi-examples-flink/pom.xml
+++ b/hudi-examples/hudi-examples-flink/pom.xml
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>bijection-avro_${scala.binary.version}</artifactId>
-            <version>0.9.7</version>
+            <version>${bijection-avro.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -337,7 +337,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>bijection-avro_${scala.binary.version}</artifactId>
-      <version>0.9.7</version>
+      <version>${bijection-avro.version}</version>
     </dependency>
 
     <!-- Kafka -->

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -619,7 +619,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>bijection-avro_${scala.binary.version}</artifactId>
-      <version>0.9.3</version>
+      <version>${bijection-avro.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
     <hudi.spark.common.modules.1>hudi-spark3-common</hudi.spark.common.modules.1>
     <hudi.spark.common.modules.2>hudi-spark3.2plus-common</hudi.spark.common.modules.2>
     <avro.version>1.8.2</avro.version>
+    <bijection-avro.version>0.9.7</bijection-avro.version>
     <caffeine.version>2.9.1</caffeine.version>
     <commons.io.version>2.11.0</commons.io.version>
     <scala11.version>2.11.12</scala11.version>


### PR DESCRIPTION
### Change Logs

This PR unifies `bijection-avro` dependency version in the repo and upgrades the dependency version in `hudi-integ-test-bundle` (there is no reason to use a different version).  Also note that `bijection-avro:0.9.7` supports Scala 2.13, which makes Scala 2.13 support easier.

### Impact

Dependency management improvement.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
