### PR TITLE
[HUDI-7699] Support STS external ids and configurable session names in the AWS StsAssumeRoleCredentialsProvider

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/credentials/HoodieConfigAWSAssumedRoleCredentialsProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/credentials/HoodieConfigAWSAssumedRoleCredentialsProvider.java
@@ -41,9 +41,12 @@ public class HoodieConfigAWSAssumedRoleCredentialsProvider implements AwsCredent
 
   public HoodieConfigAWSAssumedRoleCredentialsProvider(Properties props) {
     String roleArn = props.getProperty(HoodieAWSConfig.AWS_ASSUME_ROLE_ARN.key());
+    String externalId = props.getProperty(HoodieAWSConfig.AWS_ASSUME_ROLE_EXTERNAL_ID.key());
+    String sessionName = props.getProperty(HoodieAWSConfig.AWS_ASSUME_ROLE_SESSION_NAME.key());
     AssumeRoleRequest req = AssumeRoleRequest.builder()
           .roleArn(roleArn)
-          .roleSessionName("hoodie")
+          .roleSessionName(sessionName)
+          .externalId(externalId)
           .build();
     StsClient stsClient = StsClient.builder().build();
 

--- a/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
@@ -73,8 +73,22 @@ public class HoodieAWSConfig extends HoodieConfig {
           .key("hoodie.aws.role.arn")
           .noDefaultValue()
           .markAdvanced()
-          .sinceVersion("0.13.2")
+          .sinceVersion("0.15.0")
           .withDocumentation("AWS Role ARN to assume");
+
+  public static final ConfigProperty<String> AWS_ASSUME_ROLE_SESSION_NAME = ConfigProperty
+          .key("hoodie.aws.role.session.name")
+          .defaultValue("hoodie")
+          .markAdvanced()
+          .sinceVersion("0.15.0")
+          .withDocumentation("Session name to use when assuming the AWS Role");
+
+  public static final ConfigProperty<String> AWS_ASSUME_ROLE_EXTERNAL_ID = ConfigProperty
+          .key("hoodie.aws.role.external.id")
+          .noDefaultValue()
+          .markAdvanced()
+          .sinceVersion("0.15.0")
+          .withDocumentation("External ID use when assuming the AWS Role");
 
   public static final ConfigProperty<String> AWS_GLUE_ENDPOINT = ConfigProperty
           .key("hoodie.aws.glue.endpoint")
@@ -114,6 +128,14 @@ public class HoodieAWSConfig extends HoodieConfig {
     return getString(AWS_ASSUME_ROLE_ARN);
   }
 
+  public String getAWSAssumeRoleExternalID() {
+    return getString(AWS_ASSUME_ROLE_EXTERNAL_ID);
+  }
+
+  public String getAWSAssumeRoleSessionName() {
+    return getString(AWS_ASSUME_ROLE_SESSION_NAME);
+  }
+
   public static class Builder {
 
     private final HoodieAWSConfig awsConfig = new HoodieAWSConfig();
@@ -147,6 +169,16 @@ public class HoodieAWSConfig extends HoodieConfig {
 
     public HoodieAWSConfig.Builder withAssumeRoleARN(String assumeRoleARN) {
       awsConfig.setValue(AWS_ASSUME_ROLE_ARN, assumeRoleARN);
+      return this;
+    }
+
+    public HoodieAWSConfig.Builder withAssumeRoleExternalID(String assumeRoleExternalID) {
+      awsConfig.setValue(AWS_ASSUME_ROLE_EXTERNAL_ID, assumeRoleExternalID);
+      return this;
+    }
+
+    public HoodieAWSConfig.Builder withAssumeRoleSessionName(String assumeRoleSessionName) {
+      awsConfig.setValue(AWS_ASSUME_ROLE_SESSION_NAME, assumeRoleSessionName);
       return this;
     }
 


### PR DESCRIPTION
### Change Logs

See issue [HUDI-7699](https://issues.apache.org/jira/browse/HUDI-7699).

[HUDI-6695](https://issues.apache.org/jira/browse/HUDI-6695) (#9260) added a AWS credentials provider to support assuming a role when syncing to Glue.

We use Hudi in a multi-tenant environment, and our customers give us delegated access to their Glue catalog.  In this multi-tenant setup it is important to use [an external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) to improve security when assuming IAM roles.

Furthermore, the STS session name is currently hard-coded to "hoodie".  It is helpful for us to have configurable session names so we have better tracability of what entities are creating STS sessions in the cloud.

Currently, the assumed role is configured with the `hoodie.aws.role.arn` config property.  I would like to add the following extra optional config properties, which will be used by the `HoodieConfigAWSAssumedRoleCredentialsProvider`:

- `hoodie.aws.role.external.id`
- `hoodie.aws.role.session.name`


### Impact

No impact to any existing way of using Hudi.  It only adds more configurability to an existing feature.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None.  The new configuration options need to be documented, but I believe that is done automatically from the config code (someone please confirm this!)

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
