### PR TITLE
[HUDI-7703] Clean plan to exclude partitions with no deleting file

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -138,6 +138,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
         cleanOps.putAll(cleanOpsWithPartitionMeta.entrySet().stream()
+            .filter(e -> !e.getValue().getValue().isEmpty())
             .collect(Collectors.toMap(Map.Entry::getKey, e -> CleanerUtils.convertToHoodieCleanFileInfoList(e.getValue().getValue()))));
 
         partitionsToDelete.addAll(cleanOpsWithPartitionMeta.entrySet().stream().filter(entry -> entry.getValue().getKey()).map(Map.Entry::getKey)


### PR DESCRIPTION
### Change Logs

![Screenshot 2024-04-10 at 2 59 57 PM](https://github.com/apache/hudi/assets/2701446/d9e1836e-ba25-457b-948f-5d726db5b9ce)

Exclude partitions with no deleting files for clean plan.

### Impact

Remove unnecessary info in  the clean plan - minor optimization to reduce cleaner memory footprint.

### Risk level

Low.

### Documentation Update

NA.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
