### PR TITLE
[HUDI-7706] Improve validation in PARTITION_STATS index test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_INSERT_INTO_OPERATION
 import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.common.util.hash.PartitionIndexID
+import org.apache.hudi.metadata.HoodieTableMetadataUtil
+
 import org.apache.spark.sql.functions.{col, from_json}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
@@ -676,19 +679,25 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
             s"select * from hudi_metadata('$identifier') where type=3"
           )
           assert(result4DF.count() == 3)
-          checkAnswer(spark.sql(s"select ColumnStatsMetadata.minValue.member1.value from hudi_metadata('$identifier') where type=3").collect())(
-            Seq(1000),
-            Seq(2000),
-            Seq(3000)
+          // TODO(HUDI-7705): use partition column name to generate the prefix after the bug fix
+          val columnNameKeyPrefix = "XV1ds8/f890="
+          checkAnswer(s"select key, ColumnStatsMetadata.minValue.member1.value from hudi_metadata('$identifier') where type=3")(
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=10"), 1000),
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=20"), 2000),
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=30"), 3000)
           )
-          checkAnswer(spark.sql(s"select ColumnStatsMetadata.maxValue.member1.value from hudi_metadata('$identifier') where type=3").collect())(
-            Seq(2000),
-            Seq(3000),
-            Seq(4000)
+          checkAnswer(s"select key, ColumnStatsMetadata.maxValue.member1.value from hudi_metadata('$identifier') where type=3")(
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=10"), 2000),
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=20"), 3000),
+            Seq(columnNameKeyPrefix + getPartitionIndexKey("ts=30"), 4000)
           )
         }
       }
     }
     spark.sessionState.conf.unsetConf(SPARK_SQL_INSERT_INTO_OPERATION.key)
+  }
+
+  def getPartitionIndexKey(partitionPath: String): String = {
+    new PartitionIndexID(HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionPath)).asBase64EncodedString
   }
 }


### PR DESCRIPTION
### Change Logs

This PR adds the validation of the record keys of the PARTITION_STATS index records in MDT when verifying the data in the PARTITION_STATS index, to make the validation robust.

### Impact

Test improvement.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
