### PR TITLE
[HUDI-7718] Use source profile in HoodieIncrSource

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -67,6 +67,7 @@ import static org.apache.hudi.utilities.config.CloudSourceConfig.SPARK_DATASOURC
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_IGNORE_KEY_PREFIX;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_IGNORE_KEY_SUBSTRING;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_KEY_PREFIX;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.coalesceOrRepartition;
 import static org.apache.spark.sql.functions.input_file_name;
 import static org.apache.spark.sql.functions.split;
 
@@ -271,17 +272,6 @@ public class CloudObjectsSelectorCommon {
     }
     dataset = coalesceOrRepartition(dataset, numPartitions);
     return Option.of(dataset);
-  }
-
-  private static Dataset<Row> coalesceOrRepartition(Dataset dataset, int numPartitions) {
-    int existingNumPartitions = dataset.rdd().getNumPartitions();
-    LOG.info(String.format("existing number of partitions=%d, required number of partitions=%d", existingNumPartitions, numPartitions));
-    if (existingNumPartitions < numPartitions) {
-      dataset = dataset.repartition(numPartitions);
-    } else {
-      dataset = dataset.coalesce(numPartitions);
-    }
-    return dataset;
   }
 
   public static Option<Dataset<Row>> loadAsDataset(SparkSession spark, List<CloudObjectMetadata> cloudObjectMetadata, TypedProperties props, String fileFormat) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -251,6 +251,17 @@ public class IncrSourceHelper {
     return null;
   }
 
+  public static Dataset<Row> coalesceOrRepartition(Dataset dataset, int numPartitions) {
+    int existingNumPartitions = dataset.rdd().getNumPartitions();
+    LOG.info(String.format("existing number of partitions=%d, required number of partitions=%d", existingNumPartitions, numPartitions));
+    if (existingNumPartitions < numPartitions) {
+      dataset = dataset.repartition(numPartitions);
+    } else {
+      dataset = dataset.coalesce(numPartitions);
+    }
+    return dataset;
+  }
+
   /**
    * Kafka reset offset strategies.
    */


### PR DESCRIPTION
### Change Logs

Similar to `KafkaSource`, the source profile populated in `StreamContext` can be used for better parallelism and instead of using a static value for numInstantsPerFetch, a dynamic value generated based on heuristics can be used. This PR needs to be merged after [https://github.com/apache/hudi/pull/10918] 

### Impact

A new constructor added for HoodieIncrSource for emitting metrics related to source parallelism and source bytes ingested. 

### Risk level (write none, low medium or high below)

Medium 

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
