### PR TITLE
[HUDI-7727] Avoid constructAbsolutePathInHadoopPath in hudi-common module

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -149,7 +149,7 @@ public class HoodieCommitMetadata implements Serializable {
     if (getPartitionToWriteStats().get(partitionPath) != null) {
       for (HoodieWriteStat stat : getPartitionToWriteStats().get(partitionPath)) {
         if ((stat.getFileId() != null)) {
-          String fullPath = FSUtils.constructAbsolutePathInHadoopPath(basePath, stat.getPath()).toString();
+          String fullPath = FSUtils.constructAbsolutePath(basePath, stat.getPath()).toString();
           fullPaths.add(fullPath);
         }
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
@@ -367,7 +367,7 @@ public abstract class IncrementalTimelineSyncFileSystemView extends AbstractTabl
       final String partitionPath = entry.getValue().getPartitionPath();
       List<String> fullPathList = entry.getValue().getSuccessDeleteFiles()
           .stream().map(fileName -> new StoragePath(FSUtils
-              .constructAbsolutePathInHadoopPath(basePath, partitionPath).toString(), fileName).toString())
+              .constructAbsolutePath(basePath, partitionPath), fileName).toString())
           .collect(Collectors.toList());
       removeFileSlicesForPartition(timeline, instant, entry.getKey(), fullPathList);
     });


### PR DESCRIPTION
### Change Logs

As above, to remove Hadoop Path usage.

### Impact

As above.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
