### PR TITLE
[MINOR] Fix operation total io should not exceed the target io limit

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/strategy/BoundedIOCompactionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/strategy/BoundedIOCompactionStrategy.java
@@ -44,10 +44,10 @@ public class BoundedIOCompactionStrategy extends CompactionStrategy {
     for (HoodieCompactionOperation op : operations) {
       long opIo = op.getMetrics().get(TOTAL_IO_MB).longValue();
       targetIORemaining -= opIo;
-      finalOperations.add(op);
-      if (targetIORemaining <= 0) {
+      if (targetIORemaining < 0) {
         return finalOperations;
       }
+      finalOperations.add(op);
     }
     return finalOperations;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -82,11 +82,11 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
     assertTrue(returned.size() < operations.size(), "BoundedIOCompaction should have resulted in fewer compactions");
-    assertEquals(2, returned.size(), "BoundedIOCompaction should have resulted in 2 compactions being chosen");
+    assertEquals(1, returned.size(), "BoundedIOCompaction should have resulted in 2 compactions being chosen");
     // Total size of all the log files
     Long returnedSize = returned.stream().map(s -> s.getMetrics().get(BoundedIOCompactionStrategy.TOTAL_IO_MB))
         .map(Double::longValue).reduce(Long::sum).orElse(0L);
-    assertEquals(610, (long) returnedSize,
+    assertEquals(390, (long) returnedSize,
         "Should chose the first 2 compactions which should result in a total IO of 610 MB");
   }
 


### PR DESCRIPTION
### Change Logs

Fix the operations' io check. For example, operations contain a list with io `[200, 100, 500]`, the target io is `400`. In previous way, the result io is 800 which exceeds the target io. It's not reasonable.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
