### PR TITLE
[HUDI-7718] Use source profile in HoodieIncrSource

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -28,8 +28,11 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.config.HoodieIncrSourceConfig;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.QueryInfo;
+import org.apache.hudi.utilities.streamer.SourceProfile;
+import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.hudi.utilities.streamer.StreamContext;
 
 import org.apache.spark.api.java.JavaSparkContext;
@@ -59,6 +62,7 @@ import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.utilities.UtilHelpers.createRecordMerger;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.coalesceOrRepartition;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.generateQueryInfo;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 
@@ -68,6 +72,7 @@ public class HoodieIncrSource extends RowSource {
   public static final Set<String> HOODIE_INCR_SOURCE_READ_OPT_KEYS =
       CollectionUtils.createImmutableSet(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key());
   private final Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter;
+  private Option<HoodieIngestionMetrics> metricsOption;
 
   public static class Config {
 
@@ -142,29 +147,29 @@ public class HoodieIncrSource extends RowSource {
   public HoodieIncrSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
                           StreamContext streamContext) {
     super(props, sparkContext, sparkSession, streamContext);
-
+    this.snapshotLoadQuerySplitter = SnapshotLoadQuerySplitter.getInstance(props);
+    this.metricsOption = Option.empty();
     for (Object key : props.keySet()) {
       String keyString = key.toString();
       if (HOODIE_INCR_SOURCE_READ_OPT_KEYS.contains(keyString)) {
         readOpts.put(keyString, props.getString(key.toString()));
       }
     }
+  }
 
-    this.snapshotLoadQuerySplitter = SnapshotLoadQuerySplitter.getInstance(props);
+  public HoodieIncrSource(
+      TypedProperties props,
+      JavaSparkContext sparkContext,
+      SparkSession sparkSession,
+      HoodieIngestionMetrics metricsOption,
+      StreamContext streamContext) {
+    this(props, sparkContext, sparkSession, streamContext);
+    this.metricsOption = Option.ofNullable(metricsOption);
   }
 
   @Override
   public Pair<Option<Dataset<Row>>, String> fetchNextBatch(Option<String> lastCkptStr, long sourceLimit) {
-
     checkRequiredConfigProperties(props, Collections.singletonList(HoodieIncrSourceConfig.HOODIE_SRC_BASE_PATH));
-
-    /*
-     * DataSourceUtils.checkRequiredProperties(props, Arrays.asList(Config.HOODIE_SRC_BASE_PATH,
-     * Config.HOODIE_SRC_PARTITION_FIELDS)); List<String> partitionFields =
-     * props.getStringList(Config.HOODIE_SRC_PARTITION_FIELDS, ",", new ArrayList<>()); PartitionValueExtractor
-     * extractor = DataSourceUtils.createPartitionExtractor(props.getString( Config.HOODIE_SRC_PARTITION_EXTRACTORCLASS,
-     * Config.DEFAULT_HOODIE_SRC_PARTITION_EXTRACTORCLASS));
-     */
     String srcPath = getStringWithAltKeys(props, HoodieIncrSourceConfig.HOODIE_SRC_BASE_PATH);
     int numInstantsPerFetch = getIntWithAltKeys(props, HoodieIncrSourceConfig.NUM_INSTANTS_PER_FETCH);
     boolean readLatestOnMissingCkpt = getBooleanWithAltKeys(
@@ -182,6 +187,12 @@ public class HoodieIncrSource extends RowSource {
     Option<String> beginInstant =
         lastCkptStr.isPresent() ? lastCkptStr.get().isEmpty() ? Option.empty() : lastCkptStr : Option.empty();
 
+    // If source profile exists, use the numInstants from source profile.
+    if (getLatestSourceProfile().isPresent()) {
+      int numInstantsFromSourceProfile = getLatestSourceProfile().get().getSourceSpecificContext();
+      LOG.info("Overriding numInstantsPerFetch from source profile numInstantsFromSourceProfile {} , numInstantsPerFetchThroughConfig {}", numInstantsFromSourceProfile, numInstantsPerFetch);
+      numInstantsPerFetch = numInstantsFromSourceProfile;
+    }
     HollowCommitHandling handlingMode = getHollowCommitHandleMode(props);
     QueryInfo queryInfo = generateQueryInfo(sparkContext, srcPath,
         numInstantsPerFetch, beginInstant, missingCheckpointStrategy, handlingMode,
@@ -243,7 +254,17 @@ public class HoodieIncrSource extends RowSource {
     // Remove Hoodie meta columns except partition path from input source
     String[] colsToDrop = shouldDropMetaFields ? HoodieRecord.HOODIE_META_COLUMNS.stream().toArray(String[]::new) :
         HoodieRecord.HOODIE_META_COLUMNS.stream().filter(x -> !x.equals(HoodieRecord.PARTITION_PATH_METADATA_FIELD)).toArray(String[]::new);
-    final Dataset<Row> src = source.drop(colsToDrop);
+    Dataset<Row> sourceWithMetaColumnsDropped = source.drop(colsToDrop);
+    final Dataset<Row> src = getLatestSourceProfile().map(sourceProfile -> {
+      metricsOption.ifPresent(metrics -> metrics.updateStreamerSourceBytesToBeIngestedInSyncRound(sourceProfile.getMaxSourceBytes()));
+      metricsOption.ifPresent(metrics -> metrics.updateStreamerSourceParallelism(sourceProfile.getSourcePartitions()));
+      return coalesceOrRepartition(sourceWithMetaColumnsDropped, sourceProfile.getSourcePartitions());
+    }).orElse(sourceWithMetaColumnsDropped);
     return Pair.of(Option.of(src), queryInfo.getEndInstant());
+  }
+
+  // Try to fetch the latestSourceProfile, this ensures the profile is refreshed if it's no longer valid.
+  private Option<SourceProfile<Integer>> getLatestSourceProfile() {
+    return sourceProfileSupplier.map(SourceProfileSupplier::getSourceProfile);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -72,7 +72,7 @@ public class HoodieIncrSource extends RowSource {
   public static final Set<String> HOODIE_INCR_SOURCE_READ_OPT_KEYS =
       CollectionUtils.createImmutableSet(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key());
   private final Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter;
-  private Option<HoodieIngestionMetrics> metricsOption;
+  private final Option<HoodieIngestionMetrics> metricsOption;
 
   public static class Config {
 
@@ -146,15 +146,7 @@ public class HoodieIncrSource extends RowSource {
 
   public HoodieIncrSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
                           StreamContext streamContext) {
-    super(props, sparkContext, sparkSession, streamContext);
-    this.snapshotLoadQuerySplitter = SnapshotLoadQuerySplitter.getInstance(props);
-    this.metricsOption = Option.empty();
-    for (Object key : props.keySet()) {
-      String keyString = key.toString();
-      if (HOODIE_INCR_SOURCE_READ_OPT_KEYS.contains(keyString)) {
-        readOpts.put(keyString, props.getString(key.toString()));
-      }
-    }
+    this(props, sparkContext, sparkSession, null, streamContext);
   }
 
   public HoodieIncrSource(
@@ -163,7 +155,14 @@ public class HoodieIncrSource extends RowSource {
       SparkSession sparkSession,
       HoodieIngestionMetrics metricsOption,
       StreamContext streamContext) {
-    this(props, sparkContext, sparkSession, streamContext);
+    super(props, sparkContext, sparkSession, streamContext);
+    for (Object key : props.keySet()) {
+      String keyString = key.toString();
+      if (HOODIE_INCR_SOURCE_READ_OPT_KEYS.contains(keyString)) {
+        readOpts.put(keyString, props.getString(key.toString()));
+      }
+    }
+    this.snapshotLoadQuerySplitter = SnapshotLoadQuerySplitter.getInstance(props);
     this.metricsOption = Option.ofNullable(metricsOption);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -80,6 +80,7 @@ import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_IGNORE_KEY_PREFIX;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_IGNORE_KEY_SUBSTRING;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_KEY_PREFIX;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.coalesceOrRepartition;
 import static org.apache.spark.sql.functions.input_file_name;
 import static org.apache.spark.sql.functions.split;
 
@@ -330,17 +331,6 @@ public class CloudObjectsSelectorCommon {
     }
     dataset = coalesceOrRepartition(dataset, numPartitions);
     return Option.of(dataset);
-  }
-
-  private static Dataset<Row> coalesceOrRepartition(Dataset dataset, int numPartitions) {
-    int existingNumPartitions = dataset.rdd().getNumPartitions();
-    LOG.info(String.format("existing number of partitions=%d, required number of partitions=%d", existingNumPartitions, numPartitions));
-    if (existingNumPartitions < numPartitions) {
-      dataset = dataset.repartition(numPartitions);
-    } else {
-      dataset = dataset.coalesce(numPartitions);
-    }
-    return dataset;
   }
 
   private static boolean isCoalesceRequired(TypedProperties properties, Schema sourceSchema) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -266,6 +266,17 @@ public class IncrSourceHelper {
     return null;
   }
 
+  public static Dataset<Row> coalesceOrRepartition(Dataset dataset, int numPartitions) {
+    int existingNumPartitions = dataset.rdd().getNumPartitions();
+    LOG.info(String.format("existing number of partitions=%d, required number of partitions=%d", existingNumPartitions, numPartitions));
+    if (existingNumPartitions < numPartitions) {
+      dataset = dataset.repartition(numPartitions);
+    } else {
+      dataset = dataset.coalesce(numPartitions);
+    }
+    return dataset;
+  }
+
   /**
    * Kafka reset offset strategies.
    */

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -42,10 +42,13 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.config.HoodieIncrSourceConfig;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.TestSnapshotQuerySplitterImpl;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
+import org.apache.hudi.utilities.streamer.SourceProfile;
+import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 
 import org.apache.avro.Schema;
 import org.apache.spark.SparkConf;
@@ -53,13 +56,17 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
@@ -68,10 +75,15 @@ import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.RAW_TRIPS_TEST_NAME;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
@@ -83,6 +95,8 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
   private HoodieTestDataGenerator dataGen;
   private HoodieTableMetaClient metaClient;
   private HoodieTableType tableType = COPY_ON_WRITE;
+  private final Option<SourceProfileSupplier> sourceProfile = Option.of(mock(SourceProfileSupplier.class));
+  private final HoodieIngestionMetrics metrics = mock(HoodieIngestionMetrics.class);
 
   @BeforeEach
   public void setUp() throws IOException {
@@ -100,9 +114,22 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, props);
   }
 
+  @Test
+  public void testCreateSource() {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty("hoodie.deltastreamer.source.hoodieincr.path", basePath());
+    properties.setProperty("hoodie.deltastreamer.source.hoodieincr.missing.checkpoint.strategy", READ_UPTO_LATEST_COMMIT.name());
+    // Validate constructor with metrics.
+    HoodieIncrSource incrSource = new HoodieIncrSource(properties, jsc(), spark(), metrics, new DefaultStreamContext(new DummySchemaProvider(HoodieTestDataGenerator.AVRO_SCHEMA), sourceProfile));
+    assertEquals(Source.SourceType.ROW, incrSource.getSourceType());
+    // Validate constructor without metrics.
+    incrSource = new HoodieIncrSource(properties, jsc(), spark(), new DefaultStreamContext(new DummySchemaProvider(HoodieTestDataGenerator.AVRO_SCHEMA), sourceProfile));
+    assertEquals(Source.SourceType.ROW, incrSource.getSourceType());
+  }
+
   @ParameterizedTest
-  @EnumSource(HoodieTableType.class)
-  public void testHoodieIncrSource(HoodieTableType tableType) throws IOException {
+  @MethodSource("getArgumentsForHoodieIncrSource")
+  public void testHoodieIncrSource(HoodieTableType tableType, boolean useSourceProfile) throws IOException {
     this.tableType = tableType;
     metaClient = getHoodieMetaClient(storageConf(), basePath());
     HoodieWriteConfig writeConfig = getConfigBuilder(basePath(), metaClient)
@@ -112,6 +139,12 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(false).build())
         .build();
+
+    if (useSourceProfile) {
+      when(sourceProfile.get().getSourceProfile()).thenReturn(new TestSourceProfile(Long.MAX_VALUE, 4, 500));
+    } else {
+      when(sourceProfile.get().getSourceProfile()).thenReturn(null);
+    }
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
       Pair<String, List<HoodieRecord>> inserts = writeRecords(writeClient, INSERT, null, "100");
@@ -139,7 +172,21 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
       // insert new batch and ensure the checkpoint moves
       readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_LATEST, Option.of(inserts5.getKey()), 100, inserts6.getKey());
+
+      if (useSourceProfile) {
+        verify(metrics, times(5)).updateStreamerSourceBytesToBeIngestedInSyncRound(Long.MAX_VALUE);
+        verify(metrics, times(5)).updateStreamerSourceParallelism(4);
+      }
     }
+  }
+
+  private static Stream<Arguments> getArgumentsForHoodieIncrSource() {
+    return Stream.of(
+        Arguments.of(COPY_ON_WRITE, true),
+        Arguments.of(MERGE_ON_READ, true),
+        Arguments.of(COPY_ON_WRITE, false),
+        Arguments.of(MERGE_ON_READ, false)
+    );
   }
 
   @ParameterizedTest
@@ -379,7 +426,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     snapshotCheckPointImplClassOpt.map(className ->
         properties.setProperty(SnapshotLoadQuerySplitter.Config.SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME, className));
     TypedProperties typedProperties = new TypedProperties(properties);
-    HoodieIncrSource incrSource = new HoodieIncrSource(typedProperties, jsc(), spark(), new DefaultStreamContext(new DummySchemaProvider(HoodieTestDataGenerator.AVRO_SCHEMA), Option.empty()));
+    HoodieIncrSource incrSource = new HoodieIncrSource(typedProperties, jsc(), spark(), metrics, new DefaultStreamContext(new DummySchemaProvider(HoodieTestDataGenerator.AVRO_SCHEMA), sourceProfile));
 
     // read everything until latest
     Pair<Option<Dataset<Row>>, String> batchCheckPoint = incrSource.fetchNextBatch(checkpointToPull, 500);
@@ -432,6 +479,34 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     @Override
     public Schema getSourceSchema() {
       return schema;
+    }
+  }
+
+  static class TestSourceProfile implements SourceProfile<Integer> {
+
+    private final long maxSourceBytes;
+    private final int sourcePartitions;
+    private final int numInstantsPerFetch;
+
+    public TestSourceProfile(long maxSourceBytes, int sourcePartitions, int numInstantsPerFetch) {
+      this.maxSourceBytes = maxSourceBytes;
+      this.sourcePartitions = sourcePartitions;
+      this.numInstantsPerFetch = numInstantsPerFetch;
+    }
+
+    @Override
+    public long getMaxSourceBytes() {
+      return maxSourceBytes;
+    }
+
+    @Override
+    public int getSourcePartitions() {
+      return sourcePartitions;
+    }
+
+    @Override
+    public Integer getSourceSpecificContext() {
+      return numInstantsPerFetch;
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Similar to KafkaSource, the source profile populated in StreamContext can be used for better parallelism and instead of using a static value for numInstantsPerFetch, a dynamic value generated based on heuristics can be used. This PR needs to be merged after [https://github.com/https://github.com/apache/hudi/pull/10918]

Try to fetch the latestSourceProfile always, this ensures the profile is refreshed if it's no longer valid. The implementation of source profile takes care when a profile needs to be refreshed or re-computed again.

### Impact

A new constructor added for HoodieIncrSource for emitting metrics related to source parallelism and source bytes ingested.


### Risk level (write none, low medium or high below)

Medium

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
