### PR TITLE
[HUDI-7737] Bump Spark 3.4 version to Spark 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <http.version>4.4.1</http.version>
     <spark.version>${spark3.version}</spark.version>
     <spark2.version>2.4.4</spark2.version>
-    <spark3.version>3.4.1</spark3.version>
+    <spark3.version>3.5.1</spark3.version>
     <sparkbundle.version></sparkbundle.version>
     <flink1.18.version>1.18.0</flink1.18.version>
     <flink1.17.version>1.17.1</flink1.17.version>
@@ -167,7 +167,7 @@
     <spark31.version>3.1.3</spark31.version>
     <spark32.version>3.2.3</spark32.version>
     <spark33.version>3.3.1</spark33.version>
-    <spark34.version>3.4.1</spark34.version>
+    <spark34.version>3.4.3</spark34.version>
     <spark35.version>3.5.1</spark35.version>
     <hudi.spark.module>hudi-spark3.2.x</hudi.spark.module>
     <!-- NOTE: Different Spark versions might require different number of shared


### PR DESCRIPTION
### Change Logs

Bump Spark 3.4 version from 3.4.1 to 3.4.3

### Impact

None

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
