### PR TITLE
[HUDI-7738] FileStreamReader need set Charset with UTF-8

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class is responsible to read a Process output.
@@ -40,7 +41,7 @@ public class InputStreamConsumer extends Thread {
   @Override
   public void run() {
     try {
-      InputStreamReader isr = new InputStreamReader(is);
+      InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
       BufferedReader br = new BufferedReader(isr);
       br.lines().forEach(LOG::info);
     } catch (Exception e) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -161,7 +161,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       throw new HoodieIOException("Cannot check if the properties file exist: " + filePath, ioe);
     }
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath, StandardCharsets.UTF_8 )))) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath), StandardCharsets.UTF_8))) {
       visitedFilePaths.add(filePath.toString());
       addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -42,6 +42,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
     // First try loading the external config file from class loader
     URL configFile = Thread.currentThread().getContextClassLoader().getResource(DEFAULT_PROPERTIES_FILE);
     if (configFile != null) {
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream()))) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream(), StandardCharsets.UTF_8))) {
         conf.addPropsFromStream(br, new StoragePath(configFile.toURI()));
         return conf.getProps();
       } catch (URISyntaxException e) {
@@ -160,7 +161,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       throw new HoodieIOException("Cannot check if the properties file exist: " + filePath, ioe);
     }
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath)))) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath), StandardCharsets.UTF_8))) {
       visitedFilePaths.add(filePath.toString());
       addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -42,6 +42,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
     // First try loading the external config file from class loader
     URL configFile = Thread.currentThread().getContextClassLoader().getResource(DEFAULT_PROPERTIES_FILE);
     if (configFile != null) {
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream()))) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream(), StandardCharsets.UTF_8))) {
         conf.addPropsFromStream(br, new StoragePath(configFile.toURI()));
         return conf.getProps();
       } catch (URISyntaxException e) {
@@ -160,7 +161,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       throw new HoodieIOException("Cannot check if the properties file exist: " + filePath, ioe);
     }
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath)))) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath, StandardCharsets.UTF_8 )))) {
       visitedFilePaths.add(filePath.toString());
       addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -42,7 +42,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -105,7 +104,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
     // First try loading the external config file from class loader
     URL configFile = Thread.currentThread().getContextClassLoader().getResource(DEFAULT_PROPERTIES_FILE);
     if (configFile != null) {
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream(), StandardCharsets.UTF_8))) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream()))) {
         conf.addPropsFromStream(br, new StoragePath(configFile.toURI()));
         return conf.getProps();
       } catch (URISyntaxException e) {
@@ -161,7 +160,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       throw new HoodieIOException("Cannot check if the properties file exist: " + filePath, ioe);
     }
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath), StandardCharsets.UTF_8))) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(storage.open(filePath)))) {
       visitedFilePaths.add(filePath.toString());
       addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -111,7 +112,7 @@ public class HoodieWithTimelineServer implements Serializable {
 
       System.out.println("Response Code from(" + url + ") : " + response.getStatusLine().getStatusCode());
 
-      try (BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
+      try (BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8))) {
         StringBuilder result = new StringBuilder();
         rd.lines().forEach(result::append);
         System.out.println("Got result (" + result + ")");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/TableSizeStats.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/TableSizeStats.java
@@ -55,6 +55,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -364,7 +365,7 @@ public class TableSizeStats implements Serializable {
         Option.ofNullable(hadoopConf).orElseGet(Configuration::new)
     );
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(new Path(propsPath))))) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(new Path(propsPath)), StandardCharsets.UTF_8))) {
       String line = reader.readLine();
       while (line != null) {
         filePaths.add(line);


### PR DESCRIPTION
### Change Logs

FileStreamReader need set Charset with UTF-8 but hudi not all，the pr is aim to fix it.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
