### PR TITLE
[HUDI-7739] Shudown asyncDetectorExecutor in AsyncTimelineServerBasedDetectionStrategy

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/conflict/detection/TimelineServerBasedDetectionStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/conflict/detection/TimelineServerBasedDetectionStrategy.java
@@ -60,4 +60,6 @@ public abstract class TimelineServerBasedDetectionStrategy implements EarlyConfl
                                            String basePath, Long maxAllowableHeartbeatIntervalInMs,
                                            HoodieStorage storage, Object markerHandler,
                                            Set<HoodieInstant> completedCommits);
+
+  public abstract void stop();
 }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -88,7 +88,7 @@ public class RequestHandler {
   private final MarkerHandler markerHandler;
   private final InstantStateHandler instantStateHandler;
   private final Registry metricsRegistry = Registry.getRegistry("TimelineService");
-  private ScheduledExecutorService asyncResultService = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService asyncResultService;
 
   public RequestHandler(Javalin app, StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
                         HoodieEngineContext hoodieEngineContext, HoodieStorage storage,
@@ -111,7 +111,9 @@ public class RequestHandler {
       this.instantStateHandler = null;
     }
     if (timelineServiceConfig.async) {
-      asyncResultService = Executors.newSingleThreadScheduledExecutor();
+      this.asyncResultService = Executors.newSingleThreadScheduledExecutor();
+    } else {
+      this.asyncResultService = null;
     }
   }
 
@@ -201,6 +203,9 @@ public class RequestHandler {
   public void stop() {
     if (markerHandler != null) {
       markerHandler.stop();
+    }
+    if (asyncResultService != null) {
+      asyncResultService.shutdown();
     }
   }
 

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
@@ -128,6 +128,9 @@ public class MarkerHandler extends Handler {
     }
     dispatchingExecutorService.shutdownNow();
     batchingExecutorService.shutdownNow();
+    if (earlyConflictDetectionStrategy != null) {
+      earlyConflictDetectionStrategy.stop();
+    }
   }
 
   /**

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
@@ -83,4 +83,10 @@ public class AsyncTimelineServerBasedDetectionStrategy extends TimelineServerBas
       resolveMarkerConflict(basePath, markerDir, markerName);
     }
   }
+
+  public void stop() {
+    if (asyncDetectorExecutor != null) {
+      asyncDetectorExecutor.shutdown();
+    }
+  }
 }


### PR DESCRIPTION
### Change Logs

Shudown asyncDetectorExecutor in AsyncTimelineServerBasedDetectionStrategy

### Impact

In order for the JVM to exit normally，when:
- `"hoodie.write.concurrency.early.conflict.detection.enable": "true"`
- `"hoodie.write.markers.type": "TIMELINE_SERVER_BASED"`

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
