### PR TITLE
[HUDI-7749] Bump Spark version 3.3.1 to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <spark30.version>3.0.2</spark30.version>
     <spark31.version>3.1.3</spark31.version>
     <spark32.version>3.2.3</spark32.version>
-    <spark33.version>3.3.1</spark33.version>
+    <spark33.version>3.3.4</spark33.version>
     <spark34.version>3.4.3</spark34.version>
     <spark35.version>3.5.1</spark35.version>
     <hudi.spark.module>hudi-spark3.2.x</hudi.spark.module>


### PR DESCRIPTION
### Change Logs

Bump Spark version 3.3.1 to 3.3.4. This includes fix for a data correctness issue as described in https://issues.apache.org/jira/browse/SPARK-44805

### Impact

Spark patch version upgrade for 3.3.x.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
