### PR TITLE
[HUDI-7717] Disable row writer for bulk insert if combining before insert is set

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -19,9 +19,10 @@ package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
-import org.apache.hudi.common.table.TableSchemaResolver
+import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieIndexConfig, HoodieWriteConfig}
@@ -30,9 +31,8 @@ import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode
 import org.apache.hudi.index.HoodieIndex.IndexType
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.hudi.{DataSourceWriteOptions, HoodieCLIUtils, HoodieSparkUtils}
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageSubmitted}
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.hudi.command.HoodieSparkValidateDuplicateKeyRecordMerger
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
@@ -1054,6 +1054,57 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
         }
       }
     }
+  }
+
+  test("Test combine before bulk insert") {
+    withTempDir { tmp => {
+      Seq(true, false).foreach { combineConfig => {
+        Seq(true, false).foreach { populateMetaConfig => {
+          import spark.implicits._
+
+          val tableName = generateTableName
+          val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  value double,
+               |  ts long
+               |) using hudi
+               | location '${tablePath}'
+               | tblproperties (
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts'
+               | )
+               |""".stripMargin)
+
+          val rowsWithSimilarKey = Seq((1, "a1", 10.0, 1000L), (1, "a1", 11.0, 1001L))
+          rowsWithSimilarKey.toDF("id", "name", "value", "ts")
+            .write.format("hudi")
+            // common settings
+            .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+            .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+            .option(RECORDKEY_FIELD.key, "id")
+            .option(PRECOMBINE_FIELD.key, "ts")
+            .option(HoodieWriteConfig.BULKINSERT_PARALLELISM_VALUE.key, "1")
+            // test specific settings
+            .option(OPERATION.key, WriteOperationType.BULK_INSERT.value)
+            .option(HoodieWriteConfig.COMBINE_BEFORE_INSERT.key, combineConfig.toString)
+            .option(HoodieTableConfig.POPULATE_META_FIELDS.key, populateMetaConfig.toString)
+            .mode(SaveMode.Append)
+            .save(tablePath)
+
+          val countRows = spark.sql(s"select id, name, value, ts from $tableName").count()
+          if (combineConfig) {
+            assertResult(1)(countRows)
+          } else {
+            assertResult(rowsWithSimilarKey.length)(countRows)
+          }
+        }}
+      }}
+    }}
   }
 
   test("Test bulk insert with empty dataset") {


### PR DESCRIPTION
### Change Logs

This MR fixes issue https://github.com/apache/hudi/issues/11044.
`hoodie.datasource.write.row.writer.enable` is `true` by default, and for `BULK_INSERT` operation there is a shortcut in `HoodieSparkSqlWriter.writeInternal()`, which leads to ignoring of `hoodie.combine.before.insert` parameter even it was set explicitly by user.
Added corresponding unit test, and also checked that the issue is fixed when PySpark with linked `hudi-spark-bundle` jar is used. (Made separate public repository for issues quick check if anyone would like to reuse it: https://github.com/geserdugarov/test-hudi-issues/)
The mentioned shortcut should be revisited, created separate Jira task [HUDI-7757](https://issues.apache.org/jira/browse/HUDI-7757).

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
