### PR TITLE
[HUDI-7759] Remove Hadoop dependencies in hudi-common module

### DIFF
--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -189,24 +189,6 @@
       <artifactId>rocksdbjni</artifactId>
     </dependency>
 
-    <!-- Hadoop -->
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -126,6 +127,7 @@ public class TestPriorityBasedFileSystemView {
   }
 
   @Test
+  @Disabled
   public void testBadRequestExceptionWithPrimary() {
     final TestLogAppender appender = new TestLogAppender();
     final Logger logger = (Logger) LogManager.getLogger(PriorityBasedFileSystemView.class);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -127,7 +126,6 @@ public class TestPriorityBasedFileSystemView {
   }
 
   @Test
-  @Disabled
   public void testBadRequestExceptionWithPrimary() {
     final TestLogAppender appender = new TestLogAppender();
     final Logger logger = (Logger) LogManager.getLogger(PriorityBasedFileSystemView.class);
@@ -769,7 +767,7 @@ public class TestPriorityBasedFileSystemView {
 
     @Override
     public void append(LogEvent event) {
-      log.add(event);
+      log.add(event.toImmutable());
     }
 
     public List<LogEvent> getLog() {


### PR DESCRIPTION
### Change Logs

As above.

### Impact

`hudi-common` is Hadoop-independent.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
