### PR TITLE
[HUDI-7763] Fix that multiple jmx reporter can exist if metadata enables

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieJmxMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieJmxMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.NetworkTestUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import org.junit.jupiter.api.AfterEach;
@@ -34,6 +35,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.when;
 
 /**
@@ -79,5 +82,56 @@ public class TestHoodieJmxMetrics {
     metrics.registerGauge("jmx_metric2", 123L);
     assertEquals("123", metrics.getRegistry().getGauges()
         .get("jmx_metric2").getValue().toString());
+  }
+
+  @Test
+  public void testMultipleJmxReporterServer() {
+    String ports = "9889-9890";
+    clearInvocations(metricsConfig);
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
+    when(metricsConfig.getJmxHost()).thenReturn("localhost");
+    when(metricsConfig.getJmxPort()).thenReturn(ports);
+    when(metricsConfig.getBasePath()).thenReturn("s3://test" + UUID.randomUUID());
+    hoodieMetrics = new HoodieMetrics(writeConfig, storageConf);
+    metrics = hoodieMetrics.getMetrics();
+
+    clearInvocations(metricsConfig);
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
+    when(metricsConfig.getJmxHost()).thenReturn("localhost");
+    when(metricsConfig.getJmxPort()).thenReturn(ports);
+    when(metricsConfig.getBasePath()).thenReturn("s3://test2" + UUID.randomUUID());
+
+    hoodieMetrics = new HoodieMetrics(writeConfig, storageConf);
+    Metrics metrics2 = hoodieMetrics.getMetrics();
+
+    metrics.registerGauge("jmx_metric3", 123L);
+    assertEquals("123", metrics.getRegistry().getGauges()
+        .get("jmx_metric3").getValue().toString());
+
+    metrics2.registerGauge("jmx_metric4", 123L);
+    assertEquals("123", metrics2.getRegistry().getGauges()
+        .get("jmx_metric4").getValue().toString());
+  }
+
+  @Test
+  public void testMultipleJmxReporterServerFailedForOnePort() {
+    String ports = "9891";
+    clearInvocations(metricsConfig);
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
+    when(metricsConfig.getJmxHost()).thenReturn("localhost");
+    when(metricsConfig.getJmxPort()).thenReturn(ports);
+    when(metricsConfig.getBasePath()).thenReturn("s3://test" + UUID.randomUUID());
+    hoodieMetrics = new HoodieMetrics(writeConfig, storageConf);
+    metrics = hoodieMetrics.getMetrics();
+
+    clearInvocations(metricsConfig);
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
+    when(metricsConfig.getJmxHost()).thenReturn("localhost");
+    when(metricsConfig.getJmxPort()).thenReturn(ports);
+    when(metricsConfig.getBasePath()).thenReturn("s3://test2" + UUID.randomUUID());
+
+    assertThrows(HoodieException.class, () -> {
+      hoodieMetrics = new HoodieMetrics(writeConfig, storageConf);
+    });
   }
 }


### PR DESCRIPTION
### Change Logs
- allows initializing jmxReporter on multiple ports 

### Impact

metrics - JmxReporter

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
