### PR TITLE
[HUDI-7767][0.x] Revert Spark 3.3 and 3.4 upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,8 +166,8 @@
     <spark30.version>3.0.2</spark30.version>
     <spark31.version>3.1.3</spark31.version>
     <spark32.version>3.2.3</spark32.version>
-    <spark33.version>3.3.4</spark33.version>
-    <spark34.version>3.4.3</spark34.version>
+    <spark33.version>3.3.1</spark33.version>
+    <spark34.version>3.4.1</spark34.version>
     <spark35.version>3.5.1</spark35.version>
     <hudi.spark.module>hudi-spark3.2.x</hudi.spark.module>
     <!-- NOTE: Different Spark versions might require different number of shared


### PR DESCRIPTION
### Change Logs

As above, to avoid read failure on Spark 3.3.4 and 3.4.3.  HUDI-7769 as a follow-up to fix this.

### Impact

Bug fix to avoid regression.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
