### PR TITLE
[HUDI-7770] Parse partition path from hudi directory for bootstrap tables

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -483,6 +483,10 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
   protected def getPartitionColumnsAsInternalRow(file: StoragePathInfo): InternalRow =
     getPartitionColumnsAsInternalRowInternal(file, metaClient.getBasePathV2, shouldExtractPartitionValuesFromPartitionPath)
 
+  protected def getPartitionColumnValuesAsInternalRow(file: StoragePathInfo): InternalRow =
+    getPartitionColumnsAsInternalRowInternal(file,
+      metaClient.getBasePathV2, extractPartitionValuesFromPartitionPath = true)
+
   protected def getPartitionColumnsAsInternalRowInternal(file: StoragePathInfo, basePath: StoragePath,
                                                          extractPartitionValuesFromPartitionPath: Boolean): InternalRow = {
     if (extractPartitionValuesFromPartitionPath) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -481,25 +481,19 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    */
 
   protected def getPartitionColumnsAsInternalRow(file: StoragePathInfo): InternalRow =
-    getPartitionColumnsAsInternalRowInternal(file,
-      new Path(metaClient.getBasePathV2.toUri), shouldExtractPartitionValuesFromPartitionPath)
+    getPartitionColumnsAsInternalRowInternal(file, metaClient.getBasePathV2, shouldExtractPartitionValuesFromPartitionPath)
 
-  protected def getPartitionColumnValuesAsInternalRow(file: StoragePathInfo): InternalRow =
-    getPartitionColumnsAsInternalRowInternal(file,
-      new Path(metaClient.getBasePathV2.toUri), extractPartitionValuesFromPartitionPath = true)
-
-  protected def getPartitionColumnsAsInternalRowInternal(file: StoragePathInfo, basePath: Path,
+  protected def getPartitionColumnsAsInternalRowInternal(file: StoragePathInfo, basePath: StoragePath,
                                                          extractPartitionValuesFromPartitionPath: Boolean): InternalRow = {
     if (extractPartitionValuesFromPartitionPath) {
-      val baseStoragePath = convertToStoragePath(basePath)
-      val tablePathWithoutScheme = baseStoragePath.getPathWithoutSchemeAndAuthority
+      val tablePathWithoutScheme = basePath.getPathWithoutSchemeAndAuthority
       val partitionPathWithoutScheme = file.getPath.getParent.getPathWithoutSchemeAndAuthority
       val relativePath = tablePathWithoutScheme.toUri.relativize(partitionPathWithoutScheme.toUri).toString
       val timeZoneId = conf.get("timeZone", sparkSession.sessionState.conf.sessionLocalTimeZone)
       val rowValues = HoodieSparkUtils.parsePartitionColumnValues(
         partitionColumns,
         relativePath,
-        baseStoragePath,
+        basePath,
         tableStructSchema,
         timeZoneId,
         sparkAdapter.getSparkParsePartitionUtil,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -99,8 +99,6 @@ abstract class BaseHoodieBootstrapRelation(override val sqlContext: SQLContext,
 
   private lazy val skeletonSchema = HoodieSparkUtils.getMetaSchema
 
-  private lazy val bootstrapBasePath = new Path(metaClient.getTableConfig.getBootstrapBasePath.get)
-
   override lazy val mandatoryFields: Seq[String] = Seq.empty
 
   protected def getFileSlices(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[FileSlice] = {
@@ -115,8 +113,8 @@ abstract class BaseHoodieBootstrapRelation(override val sqlContext: SQLContext,
     fileSlices.map { fileSlice =>
       val baseFile = fileSlice.getBaseFile.get()
       if (baseFile.getBootstrapBaseFile.isPresent) {
-        val partitionValues = getPartitionColumnsAsInternalRowInternal(baseFile.getBootstrapBaseFile.get.getPathInfo,
-          bootstrapBasePath, extractPartitionValuesFromPartitionPath = isPartitioned)
+        val partitionValues = getPartitionColumnsAsInternalRowInternal(baseFile.getPathInfo,
+          metaClient.getBasePathV2, extractPartitionValuesFromPartitionPath = isPartitioned)
         val dataFile = createPartitionedFile(
           partitionValues, baseFile.getBootstrapBaseFile.get.getPathInfo.getPath,
           0, baseFile.getBootstrapBaseFile.get().getFileLen)


### PR DESCRIPTION
### Change Logs

Parse using the hudi path instead of the bootstrap base path incase the path has changed due to timestampkeygen etc.

### Impact

partition parsing is correct for bootstrap and easier to maintain

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
