### PR TITLE
[WIP] Get Hudi 1.x reader to read 0.14+ writer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
@@ -319,12 +319,14 @@ public class CompletionTimeQueryView implements AutoCloseable, Serializable {
     this.metaClient.getActiveTimeline()
         .filterCompletedInstants().getInstantsAsStream()
         .forEach(instant -> setCompletionTime(instant.getTimestamp(), instant.getCompletionTime()));
-    // then load the archived instants.
-    HoodieArchivedTimeline.loadInstants(metaClient,
-        new HoodieArchivedTimeline.StartTsFilter(this.cursorInstant),
-        HoodieArchivedTimeline.LoadMode.TIME,
-        r -> true,
-        this::readCompletionTime);
+    if (LSMTimeline.isSupportingLayout(metaClient)) {
+      // then load the archived instants.
+      HoodieArchivedTimeline.loadInstants(metaClient,
+              new HoodieArchivedTimeline.StartTsFilter(this.cursorInstant),
+              HoodieArchivedTimeline.LoadMode.TIME,
+              r -> true,
+              this::readCompletionTime);
+    }
   }
 
   private void readCompletionTime(String instantTime, GenericRecord record) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.model.HoodieLSMTimelineManifest;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.ArchivedInstantReadSchemas;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
@@ -292,5 +293,9 @@ public class LSMTimeline {
    */
   public static StoragePathFilter getManifestFilePathFilter() {
     return path -> path.getName().startsWith(MANIFEST_FILE_PREFIX) && !path.getName().endsWith(TEMP_FILE_SUFFIX);
+  }
+
+  public static boolean isSupportingLayout(HoodieTableMetaClient metaClient) {
+    return metaClient.getTableConfig().getTableVersion().versionCode() > HoodieTableVersion.SIX.versionCode();
   }
 }


### PR DESCRIPTION
### Change Logs

When deploying 1.x, readers will be upgraded first. This PR is to ensure 1.x Reader be able to  correctly read 0.14+ datasets.
This is a WIP, Will update this PR with more fixes. 


### Impact

Make 1.x reader interoperable with 0.14+

### Risk level (write none, low medium or high below)

Low

### Documentation Update
None so far.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
