### PR TITLE
[HUDI-7761] Make the ManifestWriter Extendable

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
@@ -48,7 +48,7 @@ public class BigQuerySchemaResolver {
     this.tableSchemaResolverSupplier = tableSchemaResolverSupplier;
   }
 
-  static BigQuerySchemaResolver getInstance() {
+  public static BigQuerySchemaResolver getInstance() {
     return INSTANCE;
   }
 

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 /**
  * Extracts the BigQuery schema from a Hudi table.
  */
-class BigQuerySchemaResolver {
+public class BigQuerySchemaResolver {
   private static final BigQuerySchemaResolver INSTANCE = new BigQuerySchemaResolver(TableSchemaResolver::new);
 
   private final Function<HoodieTableMetaClient, TableSchemaResolver> tableSchemaResolverSupplier;

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
@@ -54,7 +54,7 @@ public class ManifestFileWriter {
   private final HoodieTableMetaClient metaClient;
   private final boolean useFileListingFromMetadata;
 
-  private ManifestFileWriter(HoodieTableMetaClient metaClient, boolean useFileListingFromMetadata) {
+  protected ManifestFileWriter(HoodieTableMetaClient metaClient, boolean useFileListingFromMetadata) {
     this.metaClient = metaClient;
     this.useFileListingFromMetadata = useFileListingFromMetadata;
   }
@@ -64,7 +64,7 @@ public class ManifestFileWriter {
    */
   public synchronized void writeManifestFile(boolean useAbsolutePath) {
     try {
-      List<String> baseFiles = fetchLatestBaseFilesForAllPartitions(metaClient, useFileListingFromMetadata, useAbsolutePath)
+      List<String> baseFiles = fetchLatestBaseFilesForAllPartitions(useAbsolutePath)
           .collect(Collectors.toList());
       if (baseFiles.isEmpty()) {
         LOG.warn("No base file to generate manifest file.");
@@ -86,8 +86,7 @@ public class ManifestFileWriter {
   }
 
   @VisibleForTesting
-  public static Stream<String> fetchLatestBaseFilesForAllPartitions(HoodieTableMetaClient metaClient,
-      boolean useFileListingFromMetadata, boolean useAbsolutePath) {
+  public Stream<String> fetchLatestBaseFilesForAllPartitions(boolean useAbsolutePath) {
     try {
       StorageConfiguration storageConf = metaClient.getStorageConf();
       HoodieLocalEngineContext engContext = new HoodieLocalEngineContext(storageConf);

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestManifestFileWriter.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestManifestFileWriter.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS;
-import static org.apache.hudi.sync.common.util.ManifestFileWriter.fetchLatestBaseFilesForAllPartitions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,7 +50,7 @@ public class TestManifestFileWriter extends HoodieCommonTestHarness {
     // Generate 10 files under each partition
     createTestDataForPartitionedTable(metaClient, 10);
     ManifestFileWriter manifestFileWriter = ManifestFileWriter.builder().setMetaClient(metaClient).build();
-    assertEquals(30, fetchLatestBaseFilesForAllPartitions(metaClient, false, false).count());
+    assertEquals(30, manifestFileWriter.fetchLatestBaseFilesForAllPartitions(false).count());
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

- Change the visibility of private constructor to make it possible to extend and pluing custom manifest writer classes.
- Make fetchLatestFilesForAllPartitions method in ManifestWriter to be non-static to avoid sharing multiple local variables with the inherited class.
- Change the visibility of BigQuerySchemaResolver so that it can be instantiaed outside the hudi repository.

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed