### PR TITLE
[HUDI-7781] Filter wrong partitions when using hoodie.datasource.write.partitions.to.delete

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -569,10 +569,6 @@ class HoodieSparkSqlWriterInternal {
    * @return Pair of(boolean, table schema), where first entry will be true only if schema conversion is required.
    */
   private def resolvePartitionWildcards(partitions: List[String], jsc: JavaSparkContext, cfg: HoodieConfig, basePath: String): List[String] = {
-    if (partitions.isEmpty) {
-      return partitions;
-    }
-
     //find out if any of the input partitions have wildcards
     //note:spark-sql may url-encode special characters (* -> %2A)
     var (wildcardPartitions, fullPartitions) = partitions.partition(partition => partition.matches(".*(\\*|%2A).*"))


### PR DESCRIPTION
### Change Logs

e.g.
When the actual partition structure is `dt=2021-12-09/hh=1`, but mistakenly config `dt=2021-12-09` in `hoodie.datasource.write.partitions.to.delete`, then, the partition `dt=2021-12-09` will be written to the metadata of replacecommit.

If we configure HMS partition synchronization at the same time, an error will always be reported:

<img width="1425" alt="image" src="https://github.com/apache/hudi/assets/37108074/6a856771-598b-4e09-bff3-a365695e8528">

### Impact

Filter wrong partitions when using `hoodie.datasource.write.partitions.to.delete`

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
