### PR TITLE
[HUDI-7783] Fix connection leak in FileSystemBasedLockProvider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -96,6 +96,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     synchronized (LOCK_FILE_NAME) {
       try {
         fs.delete(this.lockFile, true);
+        fs.close();
       } catch (IOException e) {
         throw new HoodieLockException(generateLogStatement(LockState.FAILED_TO_RELEASE), e);
       }


### PR DESCRIPTION
### Change Logs

if fs.hdfs.impl.disable.cache is true，FileSystemBasedLockProvider memory would increase all the time to oom due to FileSystem Cache is too large，so we should close fs in close method to aviod memory leak.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
