### PR TITLE
[MINOR] LSMTimeline needs to handle case for tables which has not performed first archived yet

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -158,6 +159,7 @@ public class LSMTimeline {
         LOG.warn("Error reading version file {}", versionFilePath, e);
       }
     }
+
     return allSnapshotVersions(metaClient).stream().max(Integer::compareTo).orElse(-1);
   }
 
@@ -165,6 +167,10 @@ public class LSMTimeline {
    * Returns all the valid snapshot versions.
    */
   public static List<Integer> allSnapshotVersions(HoodieTableMetaClient metaClient) throws IOException {
+    StoragePath archivedFolderPath = new StoragePath(metaClient.getArchivePath());
+    if (!metaClient.getStorage().exists(archivedFolderPath)) {
+      return Collections.emptyList();
+    }
     return metaClient.getStorage().listDirectEntries(new StoragePath(metaClient.getArchivePath()),
             getManifestFilePathFilter())
         .stream()


### PR DESCRIPTION
Found during backwards compatibility testing. Sometimes, Archiving would not have run for a Hudi table. In that case, LSMTimeline must gracefully handle instead of throwing File not found exception. 

### Change Logs

Found during backwards compatibility testing. Sometimes, Archiving would not have run for a Hudi table. In that case, LSMTimeline must gracefully handle instead of throwing File not found exception. 

### Impact

Backwards Compatibility

### Risk level (write none, low medium or high below)

None

### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
