### PR TITLE
[HUDI-7775] Remove unused APIs in HoodieStorage

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -294,7 +294,7 @@ public class OrcUtils extends FileFormatUtils {
     // Since we are only interested in saving metadata to the footer, the schema, blocksizes and other
     // parameters are not important.
     Schema schema = HoodieAvroUtils.getRecordKeySchema();
-    OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(storage.unwrapConfAs(Configuration.class))
+    OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(storage.getConf().unwrapAs(Configuration.class))
         .fileSystem((FileSystem) storage.getFileSystem())
         .setSchema(AvroOrcUtils.createOrcSchema(schema));
     try (Writer writer = OrcFile.createWriter(convertToHadoopPath(filePath), writerOptions)) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -221,12 +221,6 @@ public class HoodieHadoopStorage extends HoodieStorage {
   }
 
   @Override
-  public StoragePath makeQualified(StoragePath path) {
-    return convertToStoragePath(
-        fs.makeQualified(convertToHadoopPath(path)));
-  }
-
-  @Override
   public Object getFileSystem() {
     return fs;
   }
@@ -234,11 +228,6 @@ public class HoodieHadoopStorage extends HoodieStorage {
   @Override
   public StorageConfiguration<Configuration> getConf() {
     return new HadoopStorageConfiguration(fs.getConf());
-  }
-
-  @Override
-  public Configuration unwrapConf() {
-    return fs.getConf();
   }
 
   @Override

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -39,8 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.apache.hudi.storage.StorageConfiguration.castConfiguration;
-
 /**
  * Provides I/O APIs on files and directories on storage.
  * The APIs are mainly based on {@code org.apache.hadoop.fs.FileSystem} class.
@@ -253,15 +251,6 @@ public abstract class HoodieStorage implements Closeable {
   public abstract boolean deleteFile(StoragePath path) throws IOException;
 
   /**
-   * Qualifies a path to one which uses this storage and, if relative, made absolute.
-   *
-   * @param path to qualify.
-   * @return Qualified path.
-   */
-  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract StoragePath makeQualified(StoragePath path);
-
-  /**
    * @return the underlying file system instance if exists.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
@@ -272,12 +261,6 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract StorageConfiguration<?> getConf();
-
-  /**
-   * @return the underlying configuration instance.
-   */
-  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract Object unwrapConf();
 
   /**
    * @return the raw storage.
@@ -436,15 +419,5 @@ public abstract class HoodieStorage implements Closeable {
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public List<StoragePathInfo> globEntries(StoragePath pathPattern) throws IOException {
     return globEntries(pathPattern, e -> true);
-  }
-
-  /**
-   * @param clazz class of U.
-   * @param <U>   type to return.
-   * @return the underlying configuration cast to type {@link U}.
-   */
-  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public final <U> U unwrapConfAs(Class<U> clazz) {
-    return castConfiguration(unwrapConf(), clazz);
   }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -325,15 +325,6 @@ public abstract class TestHoodieStorageBase {
   }
 
   @Test
-  public void testMakeQualified() {
-    HoodieStorage storage = getStorage();
-    StoragePath path = new StoragePath("/tmp/testMakeQualified/1.file");
-    assertEquals(
-        new StoragePath("file:/tmp/testMakeQualified/1.file"),
-        storage.makeQualified(path));
-  }
-
-  @Test
   public void testGetFileSystem() {
     Object conf = getConf();
     Object fs = getFileSystem(conf);


### PR DESCRIPTION
### Change Logs

PR targeting master: https://github.com/apache/hudi/pull/11255
This PR targeting `branch-0.x` contains the same changes as the above.

As above.

### Impact

Simplifies `HoodieStorage` APIs.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
