### PR TITLE
[HUDI-7786] Fix roaring bitmap dependency in hudi-integ-test-bundle

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -97,7 +97,6 @@
                   <include>org.jetbrains.kotlin:kotlin-stdlib-common</include>
                   <include>org.jetbrains:annotations</include>
                   <include>org.jetbrains.kotlin:kotlin-stdlib-jdk7</include>
-
                   <include>org.eclipse.jetty:jetty-server</include>
                   <include>org.eclipse.jetty:jetty-http</include>
                   <include>org.eclipse.jetty:jetty-util</include>
@@ -114,7 +113,7 @@
                   <include>org.eclipse.jetty.websocket:websocket-servlet</include>
                   <include>org.mortbay.jetty:jetty</include>
                   <include>org.mortbay.jetty:jetty-util</include>
-
+                  <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>com.beust:jcommander</include>
@@ -277,6 +276,10 @@
                 <relocation>
                   <pattern>com.uber.m3.</pattern>
                   <shadedPattern>org.apache.hudi.com.uber.m3.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.roaringbitmap.</pattern>
+                  <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
                 </relocation>
               </relocations>
               <filters>


### PR DESCRIPTION
### Change Logs

Fixing roaring bit map dep for integ test bundle

### Impact

Fixing roaring bit map dep for integ test bundle

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
