### PR TITLE
[HUDI-7788] Fixing exception handling in AverageRecordSizeUtils

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
@@ -29,7 +29,6 @@ import org.apache.hudi.storage.StoragePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -80,9 +79,9 @@ public class AverageRecordSizeUtils {
               break;
             }
           }
-        } catch (IOException ioe) {
+        } catch (Throwable t) {
           // make this fail safe.
-          LOG.error("Error trying to compute average bytes/record ", ioe);
+          LOG.error("Error trying to compute average bytes/record ", t);
         }
       }
     }


### PR DESCRIPTION
### Change Logs

This PR makes the exception handling in `AverageRecordSizeUtils` more robust by catching the `Throwable` instead of `IOException`.

### Impact

Robust exception handling in `AverageRecordSizeUtils`

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
