### PR TITLE
[HUDI-7788] Fixing exception handling in AverageRecordSizeUtils

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
@@ -29,7 +29,6 @@ import org.apache.hudi.storage.StoragePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -80,9 +79,9 @@ public class AverageRecordSizeUtils {
               break;
             }
           }
-        } catch (IOException ioe) {
+        } catch (Throwable t) {
           // make this fail safe.
-          LOG.error("Error trying to compute average bytes/record ", ioe);
+          LOG.error("Error trying to compute average bytes/record ", t);
         }
       }
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,6 +45,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.model.HoodieFileFormat.HOODIE_LOG;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.config.HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,6 +91,24 @@ public class TestAverageRecordSizeUtils {
     commitsTimeline.setInstants(instants);
 
     assertEquals(expectedSize, AverageRecordSizeUtils.averageBytesPerRecord(mockTimeline, writeConfig));
+  }
+
+  @Test
+  public void testErrorHandling() {
+    int recordSize = 10000;
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
+        .build(false);
+    HoodieDefaultTimeline commitsTimeline = new HoodieDefaultTimeline();
+    List<HoodieInstant> instants = Collections.singletonList(
+        new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
+
+    when(mockTimeline.getInstants()).thenReturn(instants);
+    when(mockTimeline.getReverseOrderedInstants()).then(i -> instants.stream());
+    // Simulate a case where the instant details are absent
+    commitsTimeline.setInstants(new ArrayList<>());
+
+    assertEquals(recordSize, AverageRecordSizeUtils.averageBytesPerRecord(mockTimeline, writeConfig));
   }
 
   private static String getBaseFileName(String instantTime) {


### PR DESCRIPTION
### Change Logs

PR targeting master https://github.com/apache/hudi/pull/11289
This PR targets `branch-0.x` with the same changes.

This PR makes the exception handling in `AverageRecordSizeUtils` more robust by catching the `Throwable` instead of `IOException`.

### Impact

Robust exception handling in `AverageRecordSizeUtils`

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
