### PR TITLE
[HUDI-7796] Gracefully cast file system instance in Avro writers

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieAvroOrcWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieAvroOrcWriter.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.util.AvroOrcUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem;
 import org.apache.hudi.io.storage.HoodieAvroFileWriter;
@@ -35,6 +36,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -61,7 +63,8 @@ public class HoodieAvroOrcWriter implements HoodieAvroFileWriter, Closeable {
   private final Writer writer;
 
   private final Path file;
-  private final HoodieWrapperFileSystem fs;
+  private final boolean isWrapperFileSystem;
+  private final Option<HoodieWrapperFileSystem> wrapperFs;
   private final String instantTime;
   private final TaskContextSupplier taskContextSupplier;
 
@@ -74,7 +77,9 @@ public class HoodieAvroOrcWriter implements HoodieAvroFileWriter, Closeable {
 
     Configuration conf = HadoopFSUtils.registerFileSystem(file, config.getStorageConf().unwrapAs(Configuration.class));
     this.file = HoodieWrapperFileSystem.convertToHoodiePath(file, conf);
-    this.fs = (HoodieWrapperFileSystem) this.file.getFileSystem(conf);
+    FileSystem fs = this.file.getFileSystem(conf);
+    this.isWrapperFileSystem = fs instanceof HoodieWrapperFileSystem;
+    this.wrapperFs = this.isWrapperFileSystem ? Option.of((HoodieWrapperFileSystem) fs) : Option.empty();
     this.instantTime = instantTime;
     this.taskContextSupplier = taskContextSupplier;
 
@@ -104,7 +109,7 @@ public class HoodieAvroOrcWriter implements HoodieAvroFileWriter, Closeable {
 
   @Override
   public boolean canWrite() {
-    return fs.getBytesWritten(file) < maxFileSize;
+    return !isWrapperFileSystem || wrapperFs.get().getBytesWritten(file) < maxFileSize;
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

When running tests in Trino with Hudi metadata table (MDT) enabled, the `HoodieAvroHFileWriter` throws class cast exception, since Trino uses dependency injection to provide the Hadoop file system instance, which may skip the Hudi wrapper file system logic.  This PR adds new logic to gracefully cast file system instance in Avro writers to handle such cases.

```
Caused by: java.lang.ClassCastException: class io.trino.hdfs.TrinoFileSystemCache$FileSystemWrapper cannot be cast to class org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem (io.trino.hdfs.TrinoFileSystemCache$FileSystemWrapper and org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem are in unnamed module of loader 'app')
    at org.apache.hudi.io.hadoop.HoodieAvroHFileWriter.<init>(HoodieAvroHFileWriter.java:91)
    at org.apache.hudi.io.hadoop.HoodieAvroFileWriterFactory.newHFileFileWriter(HoodieAvroFileWriterFactory.java:108)
    at org.apache.hudi.io.storage.HoodieFileWriterFactory.getFileWriterByFormat(HoodieFileWriterFactory.java:70)
    at org.apache.hudi.io.storage.HoodieFileWriterFactory.getFileWriter(HoodieFileWriterFactory.java:53)
    at org.apache.hudi.io.HoodieCreateHandle.<init>(HoodieCreateHandle.java:108)
    at org.apache.hudi.io.HoodieCreateHandle.<init>(HoodieCreateHandle.java:77)
    at org.apache.hudi.io.CreateHandleFactory.create(CreateHandleFactory.java:45)
    at org.apache.hudi.execution.CopyOnWriteInsertHandler.consume(CopyOnWriteInsertHandler.java:101)
    at org.apache.hudi.execution.CopyOnWriteInsertHandler.consume(CopyOnWriteInsertHandler.java:44)
```

### Impact

Makes Hudi MDT writing in Trino tests work.  No impact on production logic in Hadoop-based implementation on Spark.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
