### PR TITLE
[HUDI-7799] Optimize the access modifier of AbstractHoodieLogRecordReader#processNextRecord

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -789,7 +789,7 @@ public abstract class AbstractHoodieLogRecordReader {
    *
    * @param hoodieRecord Hoodie Record to process
    */
-  public abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
+  protected abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
 
   /**
    * Process next deleted record.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -239,7 +239,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
   }
 
   @Override
-  public <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
+  protected <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
     String key = newRecord.getRecordKey();
     HoodieRecord<T> prevRecord = records.get(key);
     if (prevRecord != null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -72,7 +72,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
   }
 
   @Override
-  public <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
+  protected <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
     // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
     //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
     //       it since these records will be put into queue of BoundedInMemoryExecutor.


### PR DESCRIPTION
### Change Logs

AbstractHoodieLogRecordReader#processNextRecord access modifier is wrong and should be changed from public to protected.

reason:
processNextRecord is used to process HoodieRecord inside the class. Derived classes implement this abstract member method. The access modifier should not be public. For example, the derived class HoodieMergedLogRecordScanner implements processNextRecord, which is used to merge HoodieRecord.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [1] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [1] Change Logs and Impact were stated clearly
- [1] Adequate tests were added if applicable
- [1] CI passed
