### PR TITLE
[MINOR] Disable release candidate validation by default

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -25,7 +25,6 @@ on:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master') && !contains(github.ref, 'branch-0.x') }}
 
 env:
   MVN_ARGS: -e -ntp -B -V -Dgpg.skip -Djacoco.skip -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=5

--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -67,7 +67,7 @@ jobs:
             sparkProfile: 'spark'
             sparkRuntime: 'spark2.4.8'
           - scalaProfile: 'scala-2.11'
-            flinkProfile: 'flink1.11'
+            flinkProfile: 'flink1.14'
             sparkProfile: 'spark2.4'
             sparkRuntime: 'spark2.4.8'
     steps:

--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   validate-release-candidate-bundles:
     runs-on: ubuntu-latest
+    if: false
     env:
       HUDI_VERSION: 0.14.1
       STAGING_REPO_NUM: 1123

--- a/packaging/bundle-validation/README.md
+++ b/packaging/bundle-validation/README.md
@@ -57,7 +57,7 @@ to `base/` and the image should only be used for development only and not be pus
 The bundle validation on a release candidate is specified in the Github Action job `validate-release-candidate-bundles`
 in `.github/workflows/bot.yml`. By default, this is disabled.
 
-To enable the bundle validation on a particular release candidate, makes the following changes to the job by fipping the
+To enable the bundle validation on a particular release candidate, makes the following changes to the job by flipping the
 flag and adding the release candidate version and staging repo number:
 
 ```shell

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -421,6 +421,8 @@ Set up a few environment variables to simplify Maven commands that follow. This 
       ```shell
       ./scripts/release/validate_staged_bundles.sh orgapachehudi-<stage_repo_number> ${RELEASE_VERSION}-rc${RC_NUM} 2>&1 | tee -a /tmp/validate_staged_bundles_output.txt
       ```
+   9. Run the release candidate bundle validation in GitHub Action by following the instruction in
+      ["Running Bundle Validation on a Release Candidate"](packaging/bundle-validation/README.md).
 
 ## Checklist to proceed to the next step
 


### PR DESCRIPTION
### Change Logs

As above.  Release candidate validation should only be enabled on demand by opening a PR on a release branch.

Other minor changes:

- change from #11341 to fix the flink version in the release validation
- fixes a typo in the bundle validation readme
- adds instruction in the release guide to run the bundle validation



### Impact

No impact on production code.

### Risk level

none

### Documentation Update

Updates release process doc.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
