### PR TITLE
[HUDI-7655] Ensuring clean action executor cleans up all intended files

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -81,6 +81,8 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
       boolean deleteResult = fs.delete(deletePath, isDirectory);
       if (deleteResult) {
         LOG.debug("Cleaned file at path :" + deletePath);
+      } else {
+        throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
       }
       return deleteResult;
     } catch (FileNotFoundException fio) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.functional;
+
+import org.apache.hudi.avro.model.HoodieActionInstant;
+import org.apache.hudi.avro.model.HoodieCleanFileInfo;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.clean.CleanActionExecutor;
+import org.apache.hudi.table.action.clean.CleanPlanner;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests Clean action executor.
+ */
+public class TestCleanActionExecutor {
+
+  private static final StorageConfiguration<Configuration> CONF = getDefaultStorageConf();
+  private final HoodieEngineContext context = new HoodieLocalEngineContext(CONF);
+  private final HoodieTable<?, ?, ?, ?> mockHoodieTable = mock(HoodieTable.class);
+  private HoodieTableMetaClient metaClient;
+  private FileSystem fs;
+
+  private static String PARTITION1 = "partition1";
+
+  String earliestInstant = "20231204194919610";
+  String earliestInstantMinusThreeDays = "20231201194919610";
+
+  @BeforeEach
+  void setUp() {
+    metaClient = mock(HoodieTableMetaClient.class);
+    when(mockHoodieTable.getMetaClient()).thenReturn(metaClient);
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    when(mockHoodieTable.getStorage()).thenReturn(storage);
+    fs = mock(FileSystem.class);
+    when(storage.getFileSystem()).thenReturn(fs);
+    when(fs.getConf()).thenReturn(CONF.unwrap());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testPartialCleanFailure(boolean simulateFailedDeletion) throws IOException {
+    HoodieWriteConfig config = getCleanByCommitsConfig();
+    String fileGroup = UUID.randomUUID() + "-0";
+    HoodieBaseFile baseFile = new HoodieBaseFile(String.format("/tmp/base/%s_1-0-1_%s.parquet", fileGroup, "001"));
+    FileSystem localFs = new Path(baseFile.getPath()).getFileSystem(CONF.unwrap());
+    Path filePath = new Path(baseFile.getPath());
+    localFs.create(filePath);
+    String exceptionMsg = "throwing run time exception";
+    if (simulateFailedDeletion) {
+      when(fs.delete(filePath, false)).thenThrow(new RuntimeException(exceptionMsg));
+    } else {
+      when(fs.delete(filePath, false)).thenReturn(true);
+    }
+
+    Map<String, List<HoodieCleanFileInfo>> partitionCleanFileInfoMap = new HashMap<>();
+    List<HoodieCleanFileInfo> cleanFileInfos = Collections.singletonList(new HoodieCleanFileInfo(baseFile.getPath(), false));
+    partitionCleanFileInfoMap.put(PARTITION1, cleanFileInfos);
+    HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan(new HoodieActionInstant(earliestInstant, HoodieTimeline.COMMIT_ACTION, HoodieInstant.State.COMPLETED.name()), earliestInstantMinusThreeDays,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name(), Collections.emptyMap(), CleanPlanner.LATEST_CLEAN_PLAN_VERSION, partitionCleanFileInfoMap, Collections.emptyList(), Collections.emptyMap());
+
+    // add clean to the timeline.
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
+    when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(mockHoodieTable.getActiveTimeline()).thenReturn(activeTimeline);
+    HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "002");
+    HoodieActiveTimeline cleanTimeline = mock(HoodieActiveTimeline.class);
+    when(activeTimeline.getCleanerTimeline()).thenReturn(cleanTimeline);
+    when(cleanTimeline.getInstants()).thenReturn(Collections.singletonList(cleanInstant));
+    when(activeTimeline.getInstantDetails(cleanInstant)).thenReturn(TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+    when(activeTimeline.readCleanerInfoAsBytes(cleanInstant)).thenReturn(TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+
+    when(mockHoodieTable.getCleanTimeline()).thenReturn(cleanTimeline);
+    HoodieTimeline inflightsAndRequestedTimeline = mock(HoodieTimeline.class);
+    when(cleanTimeline.filterInflightsAndRequested()).thenReturn(inflightsAndRequestedTimeline);
+    when(inflightsAndRequestedTimeline.getInstants()).thenReturn(Collections.singletonList(cleanInstant));
+    when(activeTimeline.transitionCleanRequestedToInflight(any(), any())).thenReturn(new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "002"));
+    when(mockHoodieTable.getMetadataWriter("002")).thenReturn(Option.empty());
+
+    CleanActionExecutor cleanActionExecutor = new CleanActionExecutor(context, config, mockHoodieTable, "002");
+    if (simulateFailedDeletion) {
+      assertThrows(HoodieException.class, () -> {
+        cleanActionExecutor.execute();
+      });
+    } else {
+      HoodieCleanMetadata cleanMetadata = cleanActionExecutor.execute();
+      assertTrue(cleanMetadata.getPartitionMetadata().containsKey(PARTITION1));
+      HoodieCleanPartitionMetadata cleanPartitionMetadata = cleanMetadata.getPartitionMetadata().get(PARTITION1);
+      assertTrue(cleanPartitionMetadata.getDeletePathPatterns().contains(filePath.getName()));
+    }
+  }
+
+  private static HoodieWriteConfig getCleanByCommitsConfig() {
+    return HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .build();
+  }
+}


### PR DESCRIPTION
### Change Logs

We can't let clean action executor skip files to be deleted. Due to networking glitches, there are chances some files may not be cleaned up. As of now, clean action execution succeeds and is tracked as part of "failedDeleteFiles". But if files to be deleted does not exists or already cleaned up, we are good. but if file deletion fails due to some other exception, we can't go past the issue. It could cause data consistency issues once the commit of interest goes into archived timeline (specifically incase of replace commits). So, this patch fixes the flow, where in clean action executor will ensure all intended files will be deleted for sure. On any exception, clean execution will fail. 

### Impact

Robust clean action. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
