### PR TITLE
[HUDI-7808] Upgrade io.acryl:datahub-client from 0.8.31 to 0.8.45

### DIFF
--- a/hudi-sync/hudi-datahub-sync/pom.xml
+++ b/hudi-sync/hudi-datahub-sync/pom.xml
@@ -34,7 +34,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <datahub.version>0.8.31</datahub.version>
+    <datahub.version>0.8.45</datahub.version>
     <httpasync.version>4.1.5</httpasync.version>
   </properties>
 


### PR DESCRIPTION
### Change Logs

This PR upgrades io.acryl:datahub-client from 0.8.31 to 0.8.45 to fix security vulnerabilities.

Vulnerabilities that will be fixed with an upgrade:

INTRODUCED: 31 OCT 2022
[CVE-2022-39366](https://www.cve.org/CVERecord?id=CVE-2022-39366) 
[CWE-303](https://cwe.mitre.org/data/definitions/303.html)

|  | Issue | Score | Upgrade 
:-------------------------:|:-------------------------|:-------------------------|:-------------------------
![critical severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/c.png 'critical severity') | Incorrect Implementation of Authentication Algorithm <br/>[SNYK-JAVA-IOACRYL-3092129](https://snyk.io/vuln/SNYK-JAVA-IOACRYL-3092129) | &nbsp;&nbsp;**811**&nbsp;&nbsp; |  io.acryl:datahub-client: <br> `0.8.31` -> `0.8.45` <br> `Proof of Concept`

### Impact

Security vulnerability fix.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
