### PR TITLE
[HUDI-7817] Use Jackson Core instead of org.codehaus.jackson for JSON encoding

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/JsonEncoder.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/JsonEncoder.java
@@ -19,6 +19,10 @@
 
 package org.apache.hudi.avro;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Encoder;
@@ -27,10 +31,6 @@ import org.apache.avro.io.parsing.JsonGrammarGenerator;
 import org.apache.avro.io.parsing.Parser;
 import org.apache.avro.io.parsing.Symbol;
 import org.apache.avro.util.Utf8;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.util.MinimalPrettyPrinter;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -267,7 +267,8 @@
         <module name="CommentsIndentation"/>
         <module name="IllegalImport">
             <property name="regexp" value="true"/>
-            <property name="illegalPkgs" value="org\.apache\.commons, com\.google\.common, org\.apache\.log4j"/>
+            <property name="illegalPkgs"
+                      value="org\.apache\.commons, com\.google\.common, org\.apache\.log4j, org\.codehaus\.jackson"/>
             <property name="illegalClasses"
               value="^java\.util\.Optional, ^org\.junit\.(?!jupiter|platform|contrib|Rule|runner)(.*)"/>
         </module>

--- a/style/scalastyle.xml
+++ b/style/scalastyle.xml
@@ -57,7 +57,7 @@
  <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
   <parameters>
-   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._,com.google.common,org.codehaus.jackson]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
@@ -130,10 +130,4 @@
    <parameter name="group.scala">scala\..*</parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-  <parameters>
-   <parameter name="illegalImports"><![CDATA[com.google.common]]></parameter>
-  </parameters>
- </check>
-
 </scalastyle>


### PR DESCRIPTION
### Change Logs

`org.codehaus.jackson` is a older version of Jackson Core (`com.fasterxml.jackson.core:jackson-core`).  `org.codehaus.jackson:jackson-mapper-asl` has critical vulnerabilities ([CWE-502](https://cwe.mitre.org/data/definitions/502.html) | [CVE-2019-10202](https://www.cve.org/CVERecord?id=CVE-2019-10202) | [CVSS 9.8](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) | [SNYK-JAVA-ORGCODEHAUSJACKSON-3326362](https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSJACKSON-3326362)), which should be avoided.  This PR changes `JsonEncoder` to use Jackson Core and adds rules to check illegal imports of `org.codehaus.jackson`.

### Impact

Unifies usage of JSON encoding.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
