### PR TITLE
[HUDI-7825]Support Report pending clustering and compaction plan metric

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -440,5 +440,4 @@ public class HoodieMetrics {
     }
     return counter;
   }
-
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -440,4 +440,5 @@ public class HoodieMetrics {
     }
     return counter;
   }
+
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -191,7 +191,6 @@ public class StreamWriteOperatorCoordinator
     this.context = context;
     this.parallelism = context.currentParallelism();
     this.storageConf = HadoopFSUtils.getStorageConfWithCopy(HadoopConfigurations.getHiveConf(conf));
-    this.registerMetrics();
   }
 
   @Override
@@ -221,6 +220,7 @@ public class StreamWriteOperatorCoordinator
     if (OptionsResolver.isMultiWriter(conf)) {
       initClientIds(conf);
     }
+    this.registerMetrics();
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

1、when just async clustering or async compaction schedule enable, and 

clustering.async.enabled or compaction.async.enabled  set false, then the flink job will not add clusterPlanOperator or  CompactionPlanOperator

2、 but the pending plan metric emit in clusterPlanOperator or CompactionPlanOperator

3、so maybe support emit pending plan metric in StreamWriteOperatorCoordinator

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
