### PR TITLE
[HUDI-7816] Provide SourceProfileSupplier option into the SnapshotLoadQuerySplitter (branch-0.x)

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -203,7 +203,7 @@ public class HoodieIncrSource extends RowSource {
           .option(DataSourceReadOptions.QUERY_TYPE().key(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
           .load(srcPath);
       if (snapshotLoadQuerySplitter.isPresent()) {
-        queryInfo = snapshotLoadQuerySplitter.get().getNextCheckpoint(snapshot, queryInfo);
+        queryInfo = snapshotLoadQuerySplitter.get().getNextCheckpoint(snapshot, queryInfo, sourceProfileSupplier);
       }
       source = snapshot
           // add filtering so that only interested records are returned.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
@@ -18,6 +18,9 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.ApiMaturityLevel;
+import org.apache.hudi.PublicAPIClass;
+import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
@@ -31,6 +34,7 @@ import static org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter.Config
 /**
  * Abstract splitter responsible for managing the snapshot load query operations.
  */
+@PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
 public abstract class SnapshotLoadQuerySplitter {
 
   /**
@@ -65,6 +69,7 @@ public abstract class SnapshotLoadQuerySplitter {
    * @param sourceProfileSupplier An Option of a SourceProfileSupplier to use in load splitting implementation
    * @return The next checkpoint as an Option.
    */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr, Option<SourceProfileSupplier> sourceProfileSupplier);
 
   /**
@@ -72,6 +77,7 @@ public abstract class SnapshotLoadQuerySplitter {
    *
    * @param df The dataset to process.
    * @param queryInfo The query information object.
+   * @param sourceProfileSupplier An Option of a SourceProfileSupplier to use in load splitting implementation
    * @return Updated query information with the next checkpoint, in case of empty checkpoint,
    * returning endPoint same as queryInfo.getEndInstant().
    */

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.utilities.sources.helpers.QueryInfo;
+import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
@@ -61,20 +62,21 @@ public abstract class SnapshotLoadQuerySplitter {
    *
    * @param df The dataset to process.
    * @param beginCheckpointStr The starting checkpoint string.
+   * @param sourceProfileSupplier An Option of a SourceProfileSupplier to use in load splitting implementation
    * @return The next checkpoint as an Option.
    */
-  public abstract Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr);
+  public abstract Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr, Option<SourceProfileSupplier> sourceProfileSupplier);
 
   /**
-   * Retrieves the next checkpoint based on query information.
+   * Retrieves the next checkpoint based on query information and a SourceProfileSupplier.
    *
    * @param df The dataset to process.
    * @param queryInfo The query information object.
    * @return Updated query information with the next checkpoint, in case of empty checkpoint,
    * returning endPoint same as queryInfo.getEndInstant().
    */
-  public QueryInfo getNextCheckpoint(Dataset<Row> df, QueryInfo queryInfo) {
-    return getNextCheckpoint(df, queryInfo.getStartInstant())
+  public QueryInfo getNextCheckpoint(Dataset<Row> df, QueryInfo queryInfo, Option<SourceProfileSupplier> sourceProfileSupplier) {
+    return getNextCheckpoint(df, queryInfo.getStartInstant(), sourceProfileSupplier)
         .map(checkpoint -> queryInfo.withUpdatedEndInstant(checkpoint))
         .orElse(queryInfo);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -100,7 +100,7 @@ public class QueryRunner {
     Dataset<Row> snapshot = sparkSession.read().format("org.apache.hudi")
         .option(DataSourceReadOptions.QUERY_TYPE().key(), queryInfo.getQueryType()).load(sourcePath);
     QueryInfo snapshotQueryInfo = snapshotLoadQuerySplitterOption
-        .map(snapshotLoadQuerySplitter -> snapshotLoadQuerySplitter.getNextCheckpoint(snapshot, queryInfo))
+        .map(snapshotLoadQuerySplitter -> snapshotLoadQuerySplitter.getNextCheckpoint(snapshot, queryInfo, Option.empty()))
         .orElse(queryInfo);
     return Pair.of(snapshotQueryInfo, applySnapshotQueryFilters(snapshot, snapshotQueryInfo));
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter;
+import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import java.util.List;
@@ -43,7 +44,7 @@ public class TestSnapshotQuerySplitterImpl extends SnapshotLoadQuerySplitter {
   }
 
   @Override
-  public Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr) {
+  public Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr, Option<SourceProfileSupplier> sourceProfileSupplierOption) {
     List<Row> row = df.filter(col(COMMIT_TIME_METADATA_FIELD).gt(lit(beginCheckpointStr)))
         .orderBy(col(COMMIT_TIME_METADATA_FIELD)).limit(1).collectAsList();
     return Option.ofNullable(row.size() > 0 ? row.get(0).getAs(COMMIT_TIME_METADATA_FIELD) : null);


### PR DESCRIPTION
cherry-picking changes from https://github.com/apache/hudi/pull/11368 to `branch-0.x`

### Change Logs

Expanding the interface of the SnapshotLoadQuerySplitter to accept SourceProfileSupplier option.

### Impact

Some SnapshotLoadQuerySplitter implementations may want to consider a SourceProfileSupplier in their logic, allowing source estimations to be used when splitting queries.

### Risk level (write none, low medium or high below)

Low, small change to the API but no logic change within hudi itself.

### Documentation Update

Updated javadocs for the modified interface

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
