### PR TITLE
Deltastreamer changes to add support for reading kafka commit offsets from Kafka instead of Hoodie Commit Timeline.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -698,10 +698,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (checkpointStr != null) {
+      if (cfg.checkpointWriteToHoodie && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (cfg.checkpoint != null) {
+      if (cfg.checkpointWriteToHoodie && cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -698,10 +698,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (cfg.checkpointWriteToHoodie && checkpointStr != null) {
+      if (!cfg.disableCheckpointWriteToHoodie && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (cfg.checkpointWriteToHoodie && cfg.checkpoint != null) {
+      if (!cfg.disableCheckpointWriteToHoodie && cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -424,7 +424,9 @@ public class DeltaSync implements Serializable, Closeable {
     // Retrieve the previous round checkpoints, if any
     Option<String> resumeCheckpointStr = Option.empty();
     if (commitTimelineOpt.isPresent()) {
-      resumeCheckpointStr = getCheckpointToResume(commitTimelineOpt);
+      if (!cfg.disableHoodieTimelineCheckpoint) {
+        resumeCheckpointStr = getCheckpointToResume(commitTimelineOpt);
+      }
     } else {
       // initialize the table for the first time.
       String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props);
@@ -698,10 +700,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (!cfg.disableCheckpointWriteToHoodie && checkpointStr != null) {
+      if (!cfg.disableHoodieTimelineCheckpoint && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (!cfg.disableCheckpointWriteToHoodie && cfg.checkpoint != null) {
+      if (cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,8 +373,9 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
-    @Parameter(names = {"--disable-checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
-    public Boolean disableCheckpointWriteToHoodie = false;
+    @Parameter(names = {"--disable-hoodie-commit-checkpoint"}, description = "Disable reading checkpoint from " +
+            ".hoodie commit timeline and do not write checkpoint to .hoodie commit timeline")
+    public Boolean disableHoodieTimelineCheckpoint = false;
 
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,6 +373,9 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
+    @Parameter(names = {"--checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
+    public boolean checkpointWriteToHoodie = true;
+
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "
         + "for the first run. This field will override the checkpoint of last commit using the checkpoint field. "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,8 +373,8 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
-    @Parameter(names = {"--checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
-    public boolean checkpointWriteToHoodie = true;
+    @Parameter(names = {"--disable-checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
+    public Boolean disableCheckpointWriteToHoodie = false;
 
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -476,7 +476,7 @@ public class KafkaOffsetGen {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
         LOG.warn("There are no commits associated with this consumer group, starting to consume from latest offset");
-        fromOffsets = consumer.endOffsets(topicPartitions);
+        fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -476,6 +476,8 @@ public class KafkaOffsetGen {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
         LOG.warn("There are no commits associated with this consumer group, starting to consume from earliest offset");
+        // Fetching the offset from the beginning will be done only for the first time.
+        // When the offsets are not yet committed to Kafka.
         fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -475,7 +475,7 @@ public class KafkaOffsetGen {
       if (committedOffsetAndMetadata != null) {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
-        LOG.warn("There are no commits associated with this consumer group, starting to consume from latest offset");
+        LOG.warn("There are no commits associated with this consumer group, starting to consume from earliest offset");
         fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }


### PR DESCRIPTION
### Change Logs

Deltastreamer changes to add support for reading kafka commit offsets from Kafka instead of Hoodie Commit Timeline.

### Impact

The change will not have any impact unless the config flag `--disable-hoodie-commit-checkpoint` is added.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

New config added : `--disable-hoodie-commit-checkpoint`.
If this flag is provided, then the Deltastreamer will not read the start offset from the hoodie commit timeline and get it from the source (Kafka commit offset for example). This may not be used for DFS or sources where the source can not keep track of the consumer offset. With kafka source, this might need additional configuration `hoodie.deltastreamer.source.kafka.enable.commit.offset=true` and `auto.offset.reset=group` so that kafka is committed appropriately and offset is fetched from the kafka group.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
