### PR TITLE
[HUDI-7782] Task not serializable due to DynamoDBBasedLockProvider and HiveMetastoreBasedLockProvider in clean action

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
@@ -47,6 +47,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,13 +59,13 @@ import java.util.concurrent.TimeUnit;
  * using DynamoDB. Users need to have access to AWS DynamoDB to be able to use this lock.
  */
 @NotThreadSafe
-public class DynamoDBBasedLockProvider implements LockProvider<LockItem> {
+public class DynamoDBBasedLockProvider implements LockProvider<LockItem>, Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamoDBBasedLockProvider.class);
 
   private static final String DYNAMODB_ATTRIBUTE_NAME = "key";
 
-  private final AmazonDynamoDBLockClient client;
+  private final transient AmazonDynamoDBLockClient client;
   private final String tableName;
   private final String dynamoDBPartitionKey;
   protected final DynamoDbBasedLockConfig dynamoDBLockConfiguration;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -44,6 +44,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -75,18 +76,18 @@ import static org.apache.hudi.common.lock.LockState.RELEASING;
  * using hive metastore APIs. Users need to have a HiveMetastore & Zookeeper cluster deployed to be able to use this lock.
  *
  */
-public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse> {
+public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse>, Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveMetastoreBasedLockProvider.class);
 
   private final String databaseName;
   private final String tableName;
   private final String hiveMetastoreUris;
-  private IMetaStoreClient hiveClient;
+  private transient IMetaStoreClient hiveClient;
   private volatile LockResponse lock = null;
   protected LockConfiguration lockConfiguration;
-  private ScheduledFuture<?> future = null;
-  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+  private transient ScheduledFuture<?> future = null;
+  private final transient ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
 
   public HiveMetastoreBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
     this(lockConfiguration);


### PR DESCRIPTION
### Change Logs

Fixed task not serializable due to DynamoDBBasedLockProvider and HiveMetastoreBasedLockProvider in clean action  
with the same solution as ZookeeperBasedLockProvider (HUDI-3638, https://github.com/apache/hudi/pull/5112/files)

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
