### PR TITLE
[HUDI-7830] Add predicate filter pruning for snapshot queries in hudi related sources

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
@@ -130,7 +130,7 @@ public class CustomKeyGenerator extends BuiltinKeyGenerator {
     return UTF8String.fromString(getPartitionPath(Option.empty(), Option.empty(), Option.of(Pair.of(row, schema))));
   }
 
-  private String getPartitionPath(Option<GenericRecord> record, Option<Row> row, Option<Pair<InternalRow, StructType>> internalRowStructTypePair) {
+  public String getPartitionPath(Option<GenericRecord> record, Option<Row> row, Option<Pair<InternalRow, StructType>> internalRowStructTypePair) {
     if (getPartitionPathFields() == null) {
       throw new HoodieKeyException("Unable to find field names for partition path in cfg");
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -229,6 +229,7 @@ public class HoodieIncrSource extends RowSource {
               queryInfo.getStartInstant()))
           .filter(String.format("%s <= '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
               queryInfo.getEndInstant()));
+      source = queryInfo.getPredicateFilter().map(source::filter).orElse(source);
     }
 
     HoodieRecord.HoodieRecordType recordType = createRecordMerger(props).getRecordType();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
@@ -18,6 +18,10 @@
 
 package org.apache.hudi.utilities.sources.helpers;
 
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,12 +31,24 @@ import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL;
 /**
  * This class is used to prepare query information for s3 and gcs incr source.
  * Some of the information in this class is used for batching based on sourceLimit.
+ * <p>
+ * queryType: Incremental or Snapshot query on the hudi table
+ * previousInstant: instant before startInstant.
+ * startInstant: start instant for range query
+ * endInstant: end instant for range query
+ * predicateFilter: predicate filters on columns to prune partitions and files.
+ * orderColumn: colum used for ordering results eg: _hoodie_record_key can be used.
+ * keyColumn: column used for performing range query eg: _hoodie_commit_time > startInstant and _hoodie_commit_time <= endInstant
+ * limitColumn: limits the numbers of rows returned by query
+ * orderByColumns: (orderColumn, keyColumn)
+ * </p>
  */
 public class QueryInfo {
   private final String queryType;
   private final String previousInstant;
   private final String startInstant;
   private final String endInstant;
+  private final String predicateFilter;
   private final String orderColumn;
   private final String keyColumn;
   private final String limitColumn;
@@ -43,10 +59,32 @@ public class QueryInfo {
       String startInstant, String endInstant,
       String orderColumn, String keyColumn,
       String limitColumn) {
+    this(
+        queryType,
+        previousInstant,
+        startInstant,
+        endInstant,
+        StringUtils.EMPTY_STRING,
+        orderColumn,
+        keyColumn,
+        limitColumn
+    );
+  }
+
+  public QueryInfo(
+      String queryType,
+      String previousInstant,
+      String startInstant,
+      String endInstant,
+      String predicateFilter,
+      String orderColumn,
+      String keyColumn,
+      String limitColumn) {
     this.queryType = queryType;
     this.previousInstant = previousInstant;
     this.startInstant = startInstant;
     this.endInstant = endInstant;
+    this.predicateFilter = predicateFilter;
     this.orderColumn = orderColumn;
     this.keyColumn = keyColumn;
     this.limitColumn = limitColumn;
@@ -97,12 +135,32 @@ public class QueryInfo {
     return orderByColumns;
   }
 
+  public Option<String> getPredicateFilter() {
+    if (!StringUtils.isNullOrEmpty(predicateFilter)) {
+      return Option.of(predicateFilter);
+    }
+    return Option.empty();
+  }
+
   public QueryInfo withUpdatedEndInstant(String newEndInstant) {
     return new QueryInfo(
         this.queryType,
         this.previousInstant,
         this.startInstant,
         newEndInstant,
+        this.orderColumn,
+        this.keyColumn,
+        this.limitColumn
+    );
+  }
+
+  public QueryInfo withUpdatedCheckpoint(SnapshotLoadQuerySplitter.CheckpointWithPredicates checkpointWithPredicates) {
+    return new QueryInfo(
+        this.queryType,
+        this.previousInstant,
+        this.startInstant,
+        checkpointWithPredicates.getEndInstant(),
+        checkpointWithPredicates.getPredicateFilter(),
         this.orderColumn,
         this.keyColumn,
         this.limitColumn

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -106,11 +106,12 @@ public class QueryRunner {
   }
 
   public Dataset<Row> applySnapshotQueryFilters(Dataset<Row> snapshot, QueryInfo snapshotQueryInfo) {
-    return snapshot
+    Dataset<Row> df = snapshot
         // add filtering so that only interested records are returned.
         .filter(String.format("%s >= '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
             snapshotQueryInfo.getStartInstant()))
         .filter(String.format("%s <= '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
             snapshotQueryInfo.getEndInstant()));
+    return snapshotQueryInfo.getPredicateFilter().map(df::filter).orElse(df);
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
@@ -29,12 +28,16 @@ import org.apache.spark.sql.Row;
 
 import java.util.List;
 
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.PARTITION_PATH_METADATA_FIELD;
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.lit;
+import static org.apache.spark.sql.functions.max;
+import static org.apache.spark.sql.functions.min;
 
 public class TestSnapshotQuerySplitterImpl extends SnapshotLoadQuerySplitter {
 
-  private static final String COMMIT_TIME_METADATA_FIELD = HoodieRecord.COMMIT_TIME_METADATA_FIELD;
+  public static final String MAX_ROWS_PER_BATCH = "test.snapshot.load.max.row.count";
 
   /**
    * Constructor initializing the properties.
@@ -50,5 +53,24 @@ public class TestSnapshotQuerySplitterImpl extends SnapshotLoadQuerySplitter {
     List<Row> row = df.filter(col(COMMIT_TIME_METADATA_FIELD).gt(lit(beginCheckpointStr)))
         .orderBy(col(COMMIT_TIME_METADATA_FIELD)).limit(1).collectAsList();
     return Option.ofNullable(row.size() > 0 ? row.get(0).getAs(COMMIT_TIME_METADATA_FIELD) : null);
+  }
+
+  @Override
+  public Option<CheckpointWithPredicates> getNextCheckpointWithPredicates(Dataset<Row> df, String beginCheckpointStr) {
+    int maxRowsPerBatch = properties.getInteger(MAX_ROWS_PER_BATCH, 1);
+    List<Row> row = df.select(col(COMMIT_TIME_METADATA_FIELD)).filter(col(COMMIT_TIME_METADATA_FIELD).gt(lit(beginCheckpointStr)))
+        .orderBy(col(COMMIT_TIME_METADATA_FIELD)).limit(maxRowsPerBatch).collectAsList();
+    if (!row.isEmpty()) {
+      String endInstant = row.get(row.size() - 1).getAs(COMMIT_TIME_METADATA_FIELD);
+      List<Row> minMax =
+          df.filter(col(COMMIT_TIME_METADATA_FIELD).gt(lit(beginCheckpointStr)))
+              .filter(col(COMMIT_TIME_METADATA_FIELD).leq(endInstant))
+              .select(PARTITION_PATH_METADATA_FIELD).agg(min(PARTITION_PATH_METADATA_FIELD).alias("min_partition_path"), max(PARTITION_PATH_METADATA_FIELD).alias("max_partition_path"))
+              .collectAsList();
+      String partitionFilter = String.format("partition_path >= '%s' and partition_path <= '%s'", minMax.get(0).getAs("min_partition_path"), minMax.get(0).getAs("max_partition_path"));
+      return Option.of(new CheckpointWithPredicates(endInstant, partitionFilter));
+    } else {
+      return Option.empty();
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

Add new method getNextCheckpointWithPredicates in abstract class SnapshotLoadQuerySplitter for retrieving the next checkpoint along with file pruning predicates (partition filters etc.) for optimising snapshot query. These predicates help us in identifying the parquet files as part of the buildScan stage in spark data source.

### Impact

No impact to existing API, new functionality being added for retrieving the next checkpoint with predicate filters. Null or Empty predicates are handled to ensure backwards compatibility.

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
