### PR TITLE
[HUDI-7390] fix: HoodieStreamer no longer works without --props being supplied

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -446,7 +446,7 @@ public class HoodieStreamer implements Serializable {
     }
 
     public static TypedProperties getProps(Configuration conf, Config cfg) {
-      return cfg.propsFilePath.isEmpty()
+      return cfg.propsFilePath.isEmpty() || cfg.propsFilePath.equals(DEFAULT_DFS_SOURCE_PROPERTIES)
           ? buildProperties(cfg.configs)
           : readConfig(conf, new Path(cfg.propsFilePath), cfg.configs).getProps();
     }


### PR DESCRIPTION
When attempting to run HoodieStreamer without a props file, specifying all required extra configuration via --hoodie-conf parameters, the execution fails and an exception is thrown:  
`HoodieIOException: Cannot read properties from dfs from file file:/private/tmp/hudi-props-repro/src/test/resources/streamer-config/dfs-source.properties`  

### Change Logs

When --props is not provided in command, then `propsFilePath` is set to default DEFAULT_DFS_SOURCE_PROPERTIES. So, if propsFilePath == DEFAULT_DFS_SOURCE_PROPERTIES, we should not try to read props file.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
