### PR TITLE
[HUDI-7844] Fix HoodieSparkSqlTestBase to throw error upon test failure

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.functional
+package org.apache.spark.sql.hudi.command.index
 
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.config.TypedProperties
@@ -35,9 +35,9 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.hudi.command.{CreateIndexCommand, ShowIndexesCommand}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Tag
+import org.scalatest.Ignore
 
-@Tag("functional")
+@Ignore
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {
 
   test("Test Functional Index With Hive Sync Non Partitioned Table") {
@@ -72,9 +72,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           spark.sql(s"insert into $tableName values(2, 'a2', 10, 100000)")
           // ts=10000000 and from_unixtime(ts, 'yyyy-MM-dd') = '1970-04-26'
           spark.sql(s"insert into $tableName values(3, 'a3', 10, 10000000)")
-
-          val createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
-          spark.sql(createIndexSql)
+          // create functional index
+          spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
           val metaClient = createMetaClient(spark, basePath)
           assertTrue(metaClient.getIndexMetadata.isPresent)
           val functionalIndexMetadata = metaClient.getIndexMetadata.get()
@@ -107,7 +106,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           )
 
           // teardown Hive
-          HiveTestUtil.clear()
+          hiveClient.close()
+          tool.close()
           HiveTestUtil.shutdown()
         }
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -87,8 +87,8 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
         testFun
       } finally {
         val catalog = spark.sessionState.catalog
-        catalog.listDatabases().foreach{db =>
-          catalog.listTables(db).foreach {table =>
+        catalog.listDatabases().foreach { db =>
+          catalog.listTables(db).foreach { table =>
             catalog.dropTable(table, true, true)
           }
         }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -81,24 +82,15 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
-    var ignoreTestErr = false
     super.test(testName, testTags: _*)(
       try {
         testFun
-      } catch {
-        case e: Throwable =>
-          ignoreTestErr = true
-          LOG.warn("Test error due to exception: " + e.getMessage, e)
-      }
-      finally {
+      } finally {
         val catalog = spark.sessionState.catalog
         catalog.listDatabases().foreach{db =>
           catalog.listTables(db).foreach {table =>
             catalog.dropTable(table, true, true)
           }
-        }
-        if (ignoreTestErr) {
-          spark.stop()
         }
       }
     )


### PR DESCRIPTION
### Change Logs

PR #11162 introduces the changes that make `HoodieSparkSqlTestBase` to swallow test failures.  This PR reverts the changes so that test failures are surfaced locally and in CI.

### Impact

Makes sure test failures are surfaced in CI.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
