### PR TITLE
[HUDI-7849] Reduce time spent on running testFiltersInFileFormat

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestFiltersInFileGroupReader.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestFiltersInFileGroupReader.java
@@ -47,8 +47,8 @@ public class TestFiltersInFileGroupReader extends TestBootstrapReadBase {
     this.dashPartitions = true;
     this.tableType = HoodieTableType.MERGE_ON_READ;
     this.nPartitions = 2;
-    this.nInserts = 100000;
-    this.nUpdates = 20000;
+    this.nInserts = 100;
+    this.nUpdates = 20;
     sparkSession.conf().set(SQLConf.PARQUET_RECORD_FILTER_ENABLED().key(), "true");
     setupDirs();
 


### PR DESCRIPTION
### Change Logs

reduced number of inserts/updates (from 100000/20000 to 100/20);  

### Impact

While running testFiltersInFileFormat locally:  
before: [true] - 1,26min, [false] - 1,01min;  
after: [true] - 37sec, [false] - 23 sec.  

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
