### PR TITLE
[HUDI-7852] Constrain the comparison of different types of ordering values to limited cases

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.HoodieUnsafeRowUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -135,6 +136,15 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
         HoodieInternalRowUtils.getCachedUnsafeRowWriter(getCachedSchema(from), getCachedSchema(to), renamedColumns);
     return row -> (InternalRow) unsafeRowWriter.apply(row);
 
+  }
+
+  @Override
+  public int compareTo(Comparable o1, Comparable o2) {
+    if ((o1 instanceof String && o2 instanceof UTF8String)
+        || (o1 instanceof UTF8String && o2 instanceof String)) {
+      return o1.toString().compareTo(o2.toString());
+    }
+    return super.compareTo(o1, o2);
   }
 
   protected UnaryOperator<InternalRow> getIdentityProjection() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -251,6 +251,18 @@ public abstract class HoodieReaderContext<T> {
   public abstract T seal(T record);
 
   /**
+   * Compares values in different types which can contain engine-specific types.
+   *
+   * @param o1 {@link Comparable} object.
+   * @param o2 other {@link Comparable} object to compare to.
+   * @return comparison result.
+   */
+  public int compareTo(Comparable o1, Comparable o2) {
+    throw new IllegalArgumentException("Cannot compare values in different types: "
+        + o1 + "(" + o1.getClass() + "), " + o2 + "(" + o2.getClass() + ")");
+  }
+
+  /**
    * Generates metadata map based on the information.
    *
    * @param recordKey     Record key in String.


### PR DESCRIPTION
### Change Logs

`HoodieBaseFileGroupRecordBuffer#compareTo` compares the numbers by casting them to the long value, which may not be safe for Float and Double.  This PR limits the allowed cases of ordering value comparison to avoid wrong results.

### Impact

Makes ordering value comparison safe.

### Risk level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
