### PR TITLE
[HUDI-7854] Bump AWS SDK v2 version to 2.25.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <zk-curator.version>2.7.1</zk-curator.version>
     <disruptor.version>3.4.2</disruptor.version>
     <antlr.version>4.8</antlr.version>
-    <aws.sdk.version>2.18.40</aws.sdk.version>
+    <aws.sdk.version>2.25.69</aws.sdk.version>
     <proto.version>3.21.7</proto.version>
     <protoc.version>3.21.5</protoc.version>
     <dynamodb.lockclient.version>1.2.0</dynamodb.lockclient.version>


### PR DESCRIPTION
### Change Logs

PR targeting master: https://github.com/apache/hudi/pull/11426

This PR bumps the dependency AWS SDK v2 version to 2.25.69 on `branch-0.x`.

### Impact

Dependency upgrade

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
