### PR TITLE
[MINOR] fix the error message for glue sync tool

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -101,6 +101,9 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
           case JDBC:
             ddlExecutor = new JDBCExecutor(config);
             break;
+          case GLUE:
+            throw new HoodieHiveSyncException("GLUE mode is supported in AwsGlueCatalogSyncTool class only. "
+                    + "Please specify a correct sync-tool class.");
           default:
             throw new HoodieHiveSyncException("Invalid sync mode given " + config.getString(HIVE_SYNC_MODE));
         }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1969,6 +1969,15 @@ public class TestHiveSyncTool {
     assertEquals(3, hiveClient.getAllPartitions(tableName).size());
   }
 
+  @Test
+  public void testGlueSyncNotAllowed() {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), "GLUE");
+    assertThrows(HoodieHiveSyncException.class, this::reInitHiveSyncClient);
+
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), "HMS");
+    assertDoesNotThrow(this::reInitHiveSyncClient);
+  }
+
   private void reSyncHiveTable() {
     hiveSyncTool.syncHoodieTable();
     // we need renew the hive client after tool.syncHoodieTable(), because it will close hive


### PR DESCRIPTION
### Change Logs

When I tried using `GLUE` mode for syncing meta, I kept getting an error about entering an incorrect mode. I realised a but later that my `--sync-tool-classes` setting was not pointing to `org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool`. A better error message will go a long way in improve developer experience in this regard.

### Impact

Better error message. No public impact.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

"none"

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
