### PR TITLE
[HUDI-3304][branch-0.x] Add support for selective partial update

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/SortedPrecombineComparator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/SortedPrecombineComparator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.avro.Schema;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+class SortedPrecombineComparator<T> implements Comparator<HoodieRecord<T>>, Serializable {
+
+  Schema schema;
+  TypedProperties props;
+
+  public SortedPrecombineComparator(Schema schema, TypedProperties props) {
+    this.schema = schema;
+    this.props = props;
+  }
+
+  @Override
+  public int compare(HoodieRecord<T> o1, HoodieRecord<T> o2) {
+    return ((Comparable) o1.getOrderingValue(schema, props)).compareTo(o2.getOrderingValue(schema, props));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/data/HoodieJavaPairRDD.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/data/HoodieJavaPairRDD.java
@@ -111,6 +111,11 @@ public class HoodieJavaPairRDD<K, V> implements HoodiePairData<K, V> {
   }
 
   @Override
+  public HoodiePairData<K, V> groupByKeyAndReduce(SerializableFunction<Iterable<V>,V> function) {
+    return new HoodieJavaPairRDD<>(pairRDDData.groupByKey().mapValues(function::apply));
+  }
+
+  @Override
   public HoodiePairData<K, V> reduceByKey(SerializableBiFunction<V, V, V> combiner, int parallelism) {
     return HoodieJavaPairRDD.of(pairRDDData.reduceByKey(combiner::apply, parallelism));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
@@ -80,6 +80,11 @@ public interface HoodiePairData<K, V> extends Serializable {
   HoodiePairData<K, Iterable<V>> groupByKey();
 
   /**
+   * Groups the values for each key in the dataset into a single sequence and applies a reduce function
+   */
+  HoodiePairData<K, V> groupByKeyAndReduce(SerializableFunction<Iterable<V>,V> function);
+
+  /**
    * Reduces original sequence by de-duplicating the pairs w/ the same key, using provided
    * binary operator {@code combiner}. Returns an instance of {@link HoodiePairData} holding
    * the "de-duplicated" pairs, ie only pairs with unique keys.

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestPartialUpdatesAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestPartialUpdatesAvroPayload.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.hudi.common.model.PartialUpdateAvroPayload.isRecordNewer;
+
+/**
+ * Payload clazz that is used for partial updates to Hudi Table based on fields contained in new column.
+ *
+ * <p>Controlled partial update Logic:
+ * <pre>
+ *  1. #preCombine
+ *  For records with the same record key in one batch,
+ *  sort them based on ordering value so they are merged in-order
+ *  by overwriting the previous record for fields specified in _hoodie_change_cols.
+ *  During precombine phase, we merge the fields specified in _hoodie_change_cols
+ *
+ *  2. #combineAndGetUpdateValue
+ *  For every incoming record with existing record in storage (same record key)
+ *  Checks whether incoming record's ordering value is larger than the existing record.
+ *  If yes, overwrites the existing one for fields specified in _hoodie_change_cols
+ *  and returns a merged record.
+ *  We null out _hoodie_change_cols when saving to storage to save space.
+ *
+ *
+ *  Illustration with simple data.
+ *  let's say the order field is 'ts' and schema is :
+ *  {
+ *    [
+ *      {"name":"id","type":"string"},
+ *      {"name":"ts","type":"long"},
+ *      {"name":"name","type":"string"},
+ *      {"name":"price","type":"string"},
+ *      {"name":"_hoodie_change_cols", "type":"string"}
+ *    ]
+ *  }
+ *
+ *  case 1 - precombine
+ *  Upsert data one:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       4       name_1  price_1   name
+ *  Upsert data two:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       3       name_2  price_2   price
+ *  Upsert data three:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       5       name_3  price_3   price
+ *
+ *  Final record to be merged after sorted #precombine phase:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       5       name_1  price_3   price,name
+ *
+ *  case 2 - combineAndGetUpdateValue
+ *  Current data:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       2       name_1  null      null
+ *  Insert data:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       5       name_2  price_3   price,name
+ *
+ *  Result data after #combineAndGetUpdateValue:
+ *      id      ts      name    price     _hoodie_change_cols
+ *      1       5       name_2  price_3   null
+ *</pre>
+ */
+public class OverwriteWithLatestPartialUpdatesAvroPayload extends OverwriteWithLatestAvroPayload {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OverwriteWithLatestPartialUpdatesAvroPayload.class);
+
+  private static final String HOODIE_CHANGE_COLS = "_hoodie_change_columns";
+
+  public OverwriteWithLatestPartialUpdatesAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public OverwriteWithLatestPartialUpdatesAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  @Override
+  public OverwriteWithLatestPartialUpdatesAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue, Schema schema, Properties properties) {
+    if (oldValue.recordBytes.length == 0) {
+      // use natural order for delete record
+      return this;
+    }
+
+    if (oldValue.orderingVal.compareTo(orderingVal) > 0) {
+      throw new HoodieException("Records need to be sorted before precombine for OverwriteWithLatestPartialUpdatesAvroPayload");
+    }
+
+    try {
+      GenericRecord oldRecord = HoodieAvroUtils.bytesToAvro(oldValue.recordBytes, schema);
+      Option<IndexedRecord> mergedRecord = mergeOldRecord(oldRecord, schema, false, false);
+      if (mergedRecord.isPresent()) {
+        return new OverwriteWithLatestPartialUpdatesAvroPayload((GenericRecord) mergedRecord.get(), this.orderingVal);
+      }
+    } catch (Exception ex) {
+      return this;
+    }
+    return this;
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    return mergeOldRecord(currentValue, schema, false, true);
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties prop) throws IOException {
+    return mergeOldRecord(currentValue, schema, isRecordNewer(orderingVal, currentValue, prop), true);
+  }
+
+  protected Option<IndexedRecord> mergeOldRecord(IndexedRecord oldRecord,
+                                                 Schema schema,
+                                                 boolean isOldRecordNewer,
+                                                 boolean nullChangeCols) throws IOException {
+    Option<IndexedRecord> recordOption = getInsertValue(schema);
+
+    if (!recordOption.isPresent()) {
+      // use natural order for delete record
+      return Option.empty();
+    }
+
+    if (isOldRecordNewer) {
+      // Records out of order can result in a dropped partial update
+      LOG.error("Out of order record. Partial update could be missed for " + recordOption.get());
+      return Option.of(oldRecord);
+    } else {
+      return mergeRecords(schema, (GenericRecord) recordOption.get(), (GenericRecord) oldRecord, nullChangeCols);
+    }
+  }
+
+  protected Option<IndexedRecord> mergeRecords(Schema schema, GenericRecord newRecord, GenericRecord previousRecord, boolean nullChangeCols) {
+    if (isDeleteRecord(newRecord)) {
+      return Option.empty();
+    } else {
+      final GenericRecordBuilder builder = new GenericRecordBuilder(schema);
+      Set<String> oldChangeColSet = getChangeColSetFromRecord(schema, previousRecord);
+      Set<String> changeColSet = getChangeColSetFromRecord(schema, newRecord);
+      schema.getFields().forEach(field -> setFieldFromChangeCols(newRecord, previousRecord, builder, field, changeColSet));
+
+      // Null change cols for combineAndGetUpdateValue, merge change cols for precombine
+      if (nullChangeCols) {
+        nullChangeColField(builder);
+      } else {
+        changeColSet.addAll(oldChangeColSet);
+        builder.set(HOODIE_CHANGE_COLS, String.join(",", changeColSet));
+      }
+      return Option.of(builder.build());
+    }
+  }
+
+  private Set<String> getChangeColSetFromRecord(Schema schema, GenericRecord record) {
+    Set<String> changeColSet = new HashSet<>();
+
+    Schema.Field changeCols = schema.getField(HOODIE_CHANGE_COLS);
+    Object changeColValue = record.get(HOODIE_CHANGE_COLS);
+    if (changeCols == null) {
+      throw new HoodieException("When using OverwriteWithLatestPartialUpdatesAvroPayload the column \""
+          + HOODIE_CHANGE_COLS + " \" must be included in schema.");
+    } else if (changeColValue instanceof Utf8) {
+      List<String> strChangeColumns = Arrays.asList(changeColValue.toString().split(","));
+      changeColSet.addAll(strChangeColumns);
+    }
+
+    return changeColSet;
+  }
+
+  private void setFieldFromChangeCols(
+      GenericRecord baseRecord,
+      GenericRecord mergedRecord,
+      GenericRecordBuilder builder,
+      Schema.Field field,
+      Set<String> changeColSet) {
+    Object value = baseRecord.get(field.name());
+    value = field.schema().getType().equals(Schema.Type.STRING) && value != null ? value.toString() : value;
+    if (changeColSet.contains(field.name())) {
+      builder.set(field, value);
+    } else {
+      builder.set(field, mergedRecord.get(field.name()));
+    }
+  }
+
+  // null out change column field to reduce record space
+  private void nullChangeColField(GenericRecordBuilder builder) {
+    builder.set(HOODIE_CHANGE_COLS, null);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
@@ -261,7 +261,7 @@ public class PartialUpdateAvroPayload extends OverwriteNonDefaultsWithLatestAvro
    * @param prop        The payload properties
    * @return true if the given record is newer
    */
-  private static boolean isRecordNewer(Comparable orderingVal, IndexedRecord record, Properties prop) {
+  protected static boolean isRecordNewer(Comparable orderingVal, IndexedRecord record, Properties prop) {
     String orderingField = ConfigUtils.getOrderingField(prop);
     if (!StringUtils.isNullOrEmpty(orderingField)) {
       boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(prop.getProperty(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOverwriteWithLatestPartialUpdatesAvroPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOverwriteWithLatestPartialUpdatesAvroPayload.scala
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import java.util.function.Consumer
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hudi.HoodieConversionUtils.toJavaOption
+import org.apache.hudi.{DataSourceReadOptions, DataSourceUtils, DataSourceWriteOptions, QuickstartUtils}
+import org.apache.hudi.QuickstartUtils.{convertToStringList, getQuickstartWriteConfigs}
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.common.model.{HoodieRecordPayload, HoodieTableType, OverwriteWithLatestAvroPayload}
+import org.apache.hudi.common.util
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.table.action.compact.CompactionTriggerStrategy
+import org.apache.hudi.testutils.HoodieClientTestBase
+import org.apache.hudi.util.JFunction
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{lit, typedLit}
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.apache.spark.sql.types.StringType
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+import scala.collection.JavaConversions._
+
+class TestOverwriteWithLatestPartialUpdatesAvroPayload extends HoodieClientTestBase {
+  var spark: SparkSession = null
+
+  override def getSparkSessionExtensionsInjector: util.Option[Consumer[SparkSessionExtensions]] =
+    toJavaOption(
+      Some(
+        JFunction.toJavaConsumer((receiver: SparkSessionExtensions) => new HoodieSparkSessionExtension().apply(receiver)))
+    )
+
+  @BeforeEach override def setUp() {
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+    initTestDataGenerator()
+    initHoodieStorage()
+  }
+
+  @AfterEach override def tearDown() = {
+    cleanupSparkContexts()
+    cleanupTestDataGenerator()
+    cleanupFileSystem()
+    FileSystem.closeAll()
+    System.gc()
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testOverwriteWithLatestPartialUpdatesAvroPayload(): Unit = {
+    val hoodieTableType = HoodieTableType.COPY_ON_WRITE
+    val dataGenerator = new QuickstartUtils.DataGenerator()
+    val records = convertToStringList(dataGenerator.generateInserts(5))
+    val recordsRDD = spark.sparkContext.parallelize(records, 2)
+    val inputDF = spark.read.json(sparkSession.createDataset(recordsRDD)(Encoders.STRING)).withColumn("_hoodie_change_columns", lit(null).cast(StringType)).withColumn("ts", lit(1L))
+    inputDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val records2 = convertToStringList(dataGenerator.generateUniqueUpdates(5))
+    val inputDF2 = spark.read.json(sparkSession.createDataset(records2)(Encoders.STRING)).withColumn("_hoodie_change_columns", lit("rider")).withColumn("ts", lit(2L))
+    inputDF2.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val finalDF = spark.read.format("hudi").load(basePath)
+
+    // Validate only "rider" is updated to inputDF2 value
+    assertEquals(finalDF.select("rider").collectAsList().get(0).getString(0), inputDF2.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("rider").collectAsList().get(1).getString(0), inputDF2.select("rider").collectAsList().get(1).getString(0))
+    assertEquals(finalDF.select("rider").collectAsList().get(2).getString(0), inputDF2.select("rider").collectAsList().get(2).getString(0))
+    assertEquals(finalDF.select("rider").collectAsList().get(3).getString(0), inputDF2.select("rider").collectAsList().get(3).getString(0))
+    assertEquals(finalDF.select("rider").collectAsList().get(4).getString(0), inputDF2.select("rider").collectAsList().get(4).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(0).getString(0), inputDF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(1).getString(0), inputDF.select("driver").collectAsList().get(1).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(2).getString(0), inputDF.select("driver").collectAsList().get(2).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(3).getString(0), inputDF.select("driver").collectAsList().get(3).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(4).getString(0), inputDF.select("driver").collectAsList().get(4).getString(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(1).getString(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(2).getString(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(3).getString(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(4).getString(0))
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testOverwriteWithLatestPartialUpdatesAvroPayloadOutOfOrder(hoodieTableType: HoodieTableType): Unit = {
+    val dataGenerator = new QuickstartUtils.DataGenerator()
+    val records = convertToStringList(dataGenerator.generateInserts(1))
+    val recordsRDD = spark.sparkContext.parallelize(records, 2)
+    val inputDF = spark.read.json(sparkSession.createDataset(recordsRDD)(Encoders.STRING)).withColumn("_hoodie_change_columns", lit(null).cast(StringType)).withColumn("ts", lit(2L))
+    inputDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val records2 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val inputDF2 = spark.read.json(sparkSession.createDataset(records2)(Encoders.STRING)).withColumn("_hoodie_change_columns", lit("rider")).withColumn("ts", lit(1L))
+    inputDF2.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val finalDF = spark.read.format("hudi").load(basePath)
+
+    // Validate rider is not updated
+    assertEquals(finalDF.select("rider").collectAsList().get(0).getString(0), inputDF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("driver").collectAsList().get(0).getString(0), inputDF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testOverwriteWithLatestPartialUpdatesAvroPayloadPrecombine(hoodieTableType: HoodieTableType): Unit = {
+    val dataGenerator = new QuickstartUtils.DataGenerator()
+    val records = convertToStringList(dataGenerator.generateInserts(1))
+    val recordsRDD = spark.sparkContext.parallelize(records, 2)
+    val inputDF = spark.read.json(sparkSession.createDataset(recordsRDD)(Encoders.STRING)).withColumn("ts", lit(1L)).withColumn("_hoodie_change_columns", typedLit(null).cast(StringType))
+    inputDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val upsert1 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert1DF = spark.read.json(sparkSession.createDataset(upsert1)(Encoders.STRING)).withColumn("ts", lit(4L)).withColumn("_hoodie_change_columns", lit("rider,driver,ts"))
+
+    val upsert2 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert2DF = spark.read.json(sparkSession.createDataset(upsert2)(Encoders.STRING)).withColumn("ts", lit(6L)).withColumn("_hoodie_change_columns", lit("rider,ts"))
+
+    val upsert3 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert3DF = spark.read.json(sparkSession.createDataset(upsert3)(Encoders.STRING)).withColumn("ts", lit(3L)).withColumn("_hoodie_change_columns", lit("driver,ts"))
+
+    val mergedDF = upsert1DF.union(upsert2DF).union(upsert3DF)
+
+    mergedDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val finalDF = spark.read.format("hudi").load(basePath)
+
+    assertEquals(finalDF.select("driver").collectAsList().get(0).getString(0), upsert1DF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("rider").collectAsList().get(0).getString(0), upsert2DF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(finalDF.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(finalDF.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testOverwriteWithLatestPartialUpdatesAvroPayloadDelete(hoodieTableType: HoodieTableType): Unit = {
+    val dataGenerator = new QuickstartUtils.DataGenerator()
+    val records = convertToStringList(dataGenerator.generateInserts(1))
+    val recordsRDD = spark.sparkContext.parallelize(records, 2)
+    val inputDF = spark.read.json(sparkSession.createDataset(recordsRDD)(Encoders.STRING)).withColumn("ts", lit(1L))
+        .withColumn("_hoodie_is_deleted", lit(false))
+        .withColumn("_hoodie_change_columns", typedLit(null).cast(StringType))
+    inputDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val upsert1 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert1DF = spark.read.json(sparkSession.createDataset(upsert1)(Encoders.STRING)).withColumn("ts", lit(4L))
+      .withColumn("_hoodie_change_columns", typedLit(null).cast(StringType)).withColumn("_hoodie_is_deleted", lit(true))
+
+    val upsert2 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert2DF = spark.read.json(sparkSession.createDataset(upsert2)(Encoders.STRING)).withColumn("ts", lit(6L))
+      .withColumn("_hoodie_change_columns", lit("rider")).withColumn("_hoodie_is_deleted", lit(false))
+
+    val upsert3 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert3DF = spark.read.json(sparkSession.createDataset(upsert3)(Encoders.STRING)).withColumn("ts", lit(3L))
+      .withColumn("_hoodie_change_columns", lit("driver")).withColumn("_hoodie_is_deleted", lit(false))
+
+    val mergedDF = upsert1DF.union(upsert2DF).union(upsert3DF)
+
+    mergedDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val finalDF = spark.read.format("hudi").load(basePath)
+    assertEquals(finalDF.collect().length, 0)
+  }
+
+  @Test
+  def testOverwriteWithLatestPartialUpdatesAvroPayloadCompactionMOR(): Unit = {
+    val (tableName, tablePath) = ("hoodie_mor_test_table", s"${basePath}_mor_test_table")
+
+    val dataGenerator = new QuickstartUtils.DataGenerator()
+    val records = convertToStringList(dataGenerator.generateInserts(1))
+    val recordsRDD = spark.sparkContext.parallelize(records, 2)
+    val inputDF = spark.read.json(sparkSession.createDataset(recordsRDD)(Encoders.STRING)).withColumn("ts", lit(1L)).withColumn("_hoodie_change_columns", typedLit(null).cast(StringType))
+    inputDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .mode(SaveMode.Overwrite)
+      .save(tablePath)
+
+    val upsert1 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert1DF = spark.read.json(sparkSession.createDataset(upsert1)(Encoders.STRING)).withColumn("ts", lit(4L)).withColumn("_hoodie_change_columns", lit("rider,driver,ts"))
+
+    val upsert2 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert2DF = spark.read.json(sparkSession.createDataset(upsert2)(Encoders.STRING)).withColumn("ts", lit(6L)).withColumn("_hoodie_change_columns", lit("rider,ts"))
+
+    val upsert3 = convertToStringList(dataGenerator.generateUniqueUpdates(1))
+    val upsert3DF = spark.read.json(sparkSession.createDataset(upsert3)(Encoders.STRING)).withColumn("ts", lit(3L)).withColumn("_hoodie_change_columns", lit("driver,ts"))
+
+    val mergedDF = upsert1DF.union(upsert2DF).union(upsert3DF)
+
+    mergedDF.write.format("hudi")
+      .options(getQuickstartWriteConfigs)
+      .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name())
+      .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload")
+      .mode(SaveMode.Append)
+      .save(tablePath)
+
+    val snapshotDF = spark.read.format("hudi").load(tablePath)
+    val readOptimizedDF = spark.read.format("hudi").option(DataSourceReadOptions.QUERY_TYPE.key,
+       DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL).load(tablePath)
+
+    assertEquals(snapshotDF.select("driver").collectAsList().get(0).getString(0), upsert1DF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(snapshotDF.select("rider").collectAsList().get(0).getString(0), upsert2DF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(snapshotDF.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(snapshotDF.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+
+    assertEquals(readOptimizedDF.select("driver").collectAsList().get(0).getString(0), inputDF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(readOptimizedDF.select("rider").collectAsList().get(0).getString(0), inputDF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(readOptimizedDF.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(readOptimizedDF.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+
+    val compactionOptions = getQuickstartWriteConfigs ++ Map(
+      DataSourceWriteOptions.TABLE_TYPE.key() -> HoodieTableType.MERGE_ON_READ.name(),
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "uuid",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key ->"partitionpath",
+      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
+      DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      HoodieWriteConfig.TBL_NAME.key -> tableName,
+      HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key -> "org.apache.hudi.common.model.OverwriteWithLatestPartialUpdatesAvroPayload",
+      HoodieCompactionConfig.INLINE_COMPACT_TRIGGER_STRATEGY.key -> CompactionTriggerStrategy.NUM_COMMITS.name,
+      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "1",
+      DataSourceWriteOptions.ASYNC_COMPACT_ENABLE.key -> "false",
+      HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key -> classOf[OverwriteWithLatestAvroPayload].getName
+    )
+    val client = DataSourceUtils.createHoodieClient(
+      spark.sparkContext, "", tablePath, tableName,
+      mapAsJavaMap(compactionOptions)).asInstanceOf[SparkRDDWriteClient[HoodieRecordPayload[Nothing]]]
+    val compactionInstant = client.scheduleCompaction(org.apache.hudi.common.util.Option.empty()).get()
+
+    // NOTE: this executes the compaction to write the compacted base files, and leaves the
+    // compaction instant still inflight, emulating a compaction action that is in progress
+    client.commitCompaction(compactionInstant, client.compact(compactionInstant).getCommitMetadata.get(), org.apache.hudi.common.util.Option.empty())
+
+    val snapshotDF2 = spark.read.format("hudi").load(tablePath)
+    val readOptimizedDF2 = spark.read.format("hudi").option(DataSourceReadOptions.QUERY_TYPE.key,
+      DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL).load(tablePath)
+
+    assertEquals(snapshotDF2.select("driver").collectAsList().get(0).getString(0), upsert1DF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(snapshotDF2.select("rider").collectAsList().get(0).getString(0), upsert2DF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(snapshotDF2.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(snapshotDF2.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+
+    assertEquals(readOptimizedDF2.select("driver").collectAsList().get(0).getString(0), upsert1DF.select("driver").collectAsList().get(0).getString(0))
+    assertEquals(readOptimizedDF2.select("rider").collectAsList().get(0).getString(0), upsert2DF.select("rider").collectAsList().get(0).getString(0))
+    assertEquals(readOptimizedDF2.select("fare").collectAsList().get(0).getDouble(0), inputDF.select("fare").collectAsList().get(0).getDouble(0))
+    assertNull(readOptimizedDF2.select("_hoodie_change_columns").collectAsList().get(0).getString(0))
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2358,7 +2358,7 @@
       </activation>
     </profile>
 
-    <!-- "spark3" is an alias for "spark3.4" -->
+    <!-- "spark3" is an alias for "spark3.5" -->
     <!-- NOTE: This profile is deprecated and soon will be removed -->
     <profile>
       <id>spark3</id>
@@ -2367,8 +2367,7 @@
         <spark.version>${spark3.version}</spark.version>
         <sparkbundle.version>3</sparkbundle.version>
         <scala12.version>2.12.18</scala12.version>
-        <scala.version>${scala12.version}</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
+        <scala13.version>2.13.8</scala13.version>
         <hudi.spark.module>hudi-spark3.5.x</hudi.spark.module>
         <!-- This glob has to include hudi-spark3-common, hudi-spark3.2plus-common -->
         <hudi.spark.common.modules.1>hudi-spark3-common</hudi.spark.common.modules.1>
@@ -2388,9 +2387,7 @@
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
-        </fasterxml.jackson.dataformat.yaml.version>
-        <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
         <log4j2.version>2.20.0</log4j2.version>
         <slf4j.version>2.0.7</slf4j.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>


### PR DESCRIPTION
### Change Logs
Expand on the Hudi partial update payload to create one that will allow "null" to be updated also. This payload will use "_hoodie_change_columns" to select which specific columns will be updated. It also will sort during precombine phase to ensure merges are not lost if precombined out-of-order.

See #9979 for PR tageting the master branch

### Impact

None

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
