### PR TITLE
[HUDI-7847] Infer record merge mode during table upgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -22,12 +22,13 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.table.HoodieTable;
 
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -40,30 +41,34 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
   @Override
   public Map<ConfigProperty, String> upgrade(HoodieWriteConfig config, HoodieEngineContext context,
                                              String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
-    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+    final HoodieTableConfig tableConfig = upgradeDowngradeHelper.getTable(config, context).getMetaClient().getTableConfig();
 
-    // Record merge mode is required to dictate the merging behavior in version 8,
-    // playing the same role as the payload class config in version 7.
-    // Inferring of record merge mode from payload class here.
-    String payloadClassName = table.getMetaClient().getTableConfig().getPayloadClass();
-    String propToAdd;
-    if (null != payloadClassName) {
-      if (payloadClassName.equals(OverwriteWithLatestAvroPayload.class.getName())) {
-        propToAdd = RecordMergeMode.OVERWRITE_WITH_LATEST.toString();
-      } else if (payloadClassName.equals(DefaultHoodieRecordPayload.class.getName())) {
-        propToAdd = RecordMergeMode.EVENT_TIME_ORDERING.toString();
+    if (tableConfig.getTableType().equals(HoodieTableType.MERGE_ON_READ)) {
+      // Record merge mode is required to dictate the merging behavior in version 8,
+      // playing the same role as the payload class config in version 7.
+      // Inferring of record merge mode from payload class here.
+      String payloadClassName = tableConfig.getPayloadClass();
+      String propToAdd;
+      if (null != payloadClassName) {
+        if (payloadClassName.equals(OverwriteWithLatestAvroPayload.class.getName())) {
+          propToAdd = RecordMergeMode.OVERWRITE_WITH_LATEST.toString();
+        } else if (payloadClassName.equals(DefaultHoodieRecordPayload.class.getName())) {
+          propToAdd = RecordMergeMode.EVENT_TIME_ORDERING.toString();
+        } else {
+          propToAdd = RecordMergeMode.CUSTOM.toString();
+        }
       } else {
-        propToAdd = RecordMergeMode.CUSTOM.toString();
+        propToAdd =  RecordMergeMode.CUSTOM.toString();
       }
+      ValidationUtils.checkState(null != propToAdd, String.format("Couldn't infer (%s) from (%s) class name",
+          HoodieTableConfig.RECORD_MERGE_MODE.key(), payloadClassName));
+
+      Map<ConfigProperty, String> tablePropsToAdd = new Hashtable<>();
+      tablePropsToAdd.put(HoodieTableConfig.RECORD_MERGE_MODE, propToAdd);
+
+      return tablePropsToAdd;
     } else {
-      propToAdd =  RecordMergeMode.CUSTOM.toString();
+      return Collections.emptyMap();
     }
-    ValidationUtils.checkState(null != propToAdd, String.format("Couldn't infer (%s) from (%s) class name",
-        HoodieTableConfig.RECORD_MERGE_MODE.key(), payloadClassName));
-
-    Map<ConfigProperty, String> tablePropsToAdd = new Hashtable<>();
-    tablePropsToAdd.put(HoodieTableConfig.RECORD_MERGE_MODE, propToAdd);
-
-    return tablePropsToAdd;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -19,10 +19,16 @@
 package org.apache.hudi.table.upgrade;
 
 import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
 
-import java.util.Collections;
+import java.util.Hashtable;
 import java.util.Map;
 
 /**
@@ -30,9 +36,34 @@ import java.util.Map;
  * Version 8 is the placeholder version to track 1.x.
  */
 public class SevenToEightUpgradeHandler implements UpgradeHandler {
+
   @Override
   public Map<ConfigProperty, String> upgrade(HoodieWriteConfig config, HoodieEngineContext context,
                                              String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
-    return Collections.emptyMap();
+    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+
+    // Record merge mode is required to dictate the merging behavior in version 8,
+    // playing the same role as the payload class config in version 7.
+    // Inferring of record merge mode from payload class here.
+    String payloadClassName = table.getMetaClient().getTableConfig().getPayloadClass();
+    String propToAdd;
+    if (null != payloadClassName) {
+      if (payloadClassName.equals(OverwriteWithLatestAvroPayload.class.getName())) {
+        propToAdd = RecordMergeMode.OVERWRITE_WITH_LATEST.toString();
+      } else if (payloadClassName.equals(DefaultHoodieRecordPayload.class.getName())) {
+        propToAdd = RecordMergeMode.EVENT_TIME_ORDERING.toString();
+      } else {
+        propToAdd = RecordMergeMode.CUSTOM.toString();
+      }
+    } else {
+      propToAdd =  RecordMergeMode.CUSTOM.toString();
+    }
+    ValidationUtils.checkState(null != propToAdd, String.format("Couldn't infer (%s) from (%s) class name",
+        HoodieTableConfig.RECORD_MERGE_MODE.key(), payloadClassName));
+
+    Map<ConfigProperty, String> tablePropsToAdd = new Hashtable<>();
+    tablePropsToAdd.put(HoodieTableConfig.RECORD_MERGE_MODE, propToAdd);
+
+    return tablePropsToAdd;
   }
 }


### PR DESCRIPTION
### Change Logs

Added infer logic to `SevenToEightUpgradeHandler` similar to `HoodieTableMetaClient.inferRecordMergeMode()`. Record merge mode is required to dictate the merging behavior in release 1.x after merging https://github.com/apache/hudi/pull/9894. It plays the same role as the payload class config in the release 0.x.

As mentioned in [`HoodieTableVersion`](https://github.com/apache/hudi/blob/3415a4a1a2cdf415bd5fd9893196ef9e619e6728/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java#L45):
- version 7 is Hudi 0.16, which has not been released yet,
- version 8 is Hudi 1.0 beta.

So I couldn't make end-to-end tests with upgrade from 7 to 8.
And due to added completion time in the timeline after https://github.com/apache/hudi/pull/9617, I couldn't update and read some table by Hudi 1.0 beta (version 8), after it has been written by Hudi 0.14 (version 6).

I could only [write some table by version 6](https://github.com/geserdugarov/test-hudi-issues/blob/main/HUDI-7847/create-table-version-6.py), and try to [call upgrade with checking `hoodie.properties`](https://github.com/geserdugarov/test-hudi-issues/blob/main/HUDI-7847/upgrade-from-6-to-8.py). I did this check locally by using linked scripts with corresponding Hudi versions.

### Impact

Low

### Risk level (write none, low medium or high below)

Low

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
