### PR TITLE
[HUDI-7779] Guard archival on savepoint removal until cleaner is able to clean it up

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.client.utils.MetadataTableUtils.shouldUseBatchLookup;
 import static org.apache.hudi.common.util.MapUtils.nonEmpty;
+import static org.apache.hudi.table.action.clean.CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
 import static org.apache.hudi.table.action.clean.CleanPlanner.SAVEPOINTED_TIMESTAMPS;
 
 public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K, O, Option<HoodieCleanerPlan>> {
@@ -149,17 +150,24 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
           .map(x -> new HoodieActionInstant(x.getTimestamp(), x.getAction(), x.getState().name())).orElse(null),
           planner.getLastCompletedCommitTimestamp(),
           config.getCleanerPolicy().name(), Collections.emptyMap(),
-          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete, prepareExtraMetadata(planner.getSavepointedTimestamps()));
+          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete, prepareExtraMetadata(planner.getSavepointedTimestamps(), planner.getEarliestCommitToNotArchive()));
     } catch (IOException e) {
       throw new HoodieIOException("Failed to schedule clean operation", e);
     }
   }
 
-  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps) {
-    if (savepointedTimestamps.isEmpty()) {
+  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps, Option<String> earliestCommitToNotArchive) {
+    if (savepointedTimestamps.isEmpty() && !earliestCommitToNotArchive.isPresent()) {
       return Collections.emptyMap();
     } else {
-      return Collections.singletonMap(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
+      Map<String, String> extraMetadata = new HashMap<>();
+      if (!savepointedTimestamps.isEmpty()) {
+        extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
+      }
+      if (earliestCommitToNotArchive.isPresent()) {
+        extraMetadata.put(EARLIEST_COMMIT_TO_NOT_ARCHIVE, earliestCommitToNotArchive.get());
+      }
+      return extraMetadata;
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.client.utils.MetadataTableUtils.shouldUseBatchLookup;
 import static org.apache.hudi.common.util.MapUtils.nonEmpty;
-import static org.apache.hudi.common.util.CleanerUtils.EARLIEST_SAVEPOINT;
 import static org.apache.hudi.common.util.CleanerUtils.SAVEPOINTED_TIMESTAMPS;
 
 public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K, O, Option<HoodieCleanerPlan>> {
@@ -150,23 +149,18 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
           .map(x -> new HoodieActionInstant(x.getTimestamp(), x.getAction(), x.getState().name())).orElse(null),
           planner.getLastCompletedCommitTimestamp(),
           config.getCleanerPolicy().name(), Collections.emptyMap(),
-          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete, prepareExtraMetadata(planner.getSavepointedTimestamps(), planner.getEarliestSavepoint()));
+          CleanPlanner.LATEST_CLEAN_PLAN_VERSION, cleanOps, partitionsToDelete, prepareExtraMetadata(planner.getSavepointedTimestamps()));
     } catch (IOException e) {
       throw new HoodieIOException("Failed to schedule clean operation", e);
     }
   }
 
-  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps, Option<String> earliestSavepoint) {
-    if (savepointedTimestamps.isEmpty() && !earliestSavepoint.isPresent()) {
+  private Map<String, String> prepareExtraMetadata(List<String> savepointedTimestamps) {
+    if (savepointedTimestamps.isEmpty()) {
       return Collections.emptyMap();
     } else {
       Map<String, String> extraMetadata = new HashMap<>();
-      if (!savepointedTimestamps.isEmpty()) {
-        extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
-      }
-      if (earliestSavepoint.isPresent()) {
-        extraMetadata.put(EARLIEST_SAVEPOINT, earliestSavepoint.get());
-      }
+      extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointedTimestamps.stream().collect(Collectors.joining(",")));
       return extraMetadata;
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -50,8 +50,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.client.utils.MetadataTableUtils.shouldUseBatchLookup;
 import static org.apache.hudi.common.util.MapUtils.nonEmpty;
-import static org.apache.hudi.table.action.clean.CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
-import static org.apache.hudi.table.action.clean.CleanPlanner.SAVEPOINTED_TIMESTAMPS;
+import static org.apache.hudi.common.util.CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
+import static org.apache.hudi.common.util.CleanerUtils.SAVEPOINTED_TIMESTAMPS;
 
 public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K, O, Option<HoodieCleanerPlan>> {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -78,8 +78,6 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   public static final Integer CLEAN_PLAN_VERSION_1 = CleanPlanV1MigrationHandler.VERSION;
   public static final Integer CLEAN_PLAN_VERSION_2 = CleanPlanV2MigrationHandler.VERSION;
   public static final Integer LATEST_CLEAN_PLAN_VERSION = CLEAN_PLAN_VERSION_2;
-  public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
-  public static final String EARLIEST_COMMIT_TO_NOT_ARCHIVE = "earliest_commit_to_not_archive";
 
   private final SyncableFileSystemView fileSystemView;
   private final HoodieTimeline commitTimeline;
@@ -221,7 +219,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
 
   private boolean isAnySavepointDeleted(HoodieCleanMetadata cleanMetadata) {
     List<String> savepointedTimestampsFromLastClean = cleanMetadata.getExtraMetadata() == null ? Collections.emptyList()
-        : Arrays.stream(cleanMetadata.getExtraMetadata().getOrDefault(SAVEPOINTED_TIMESTAMPS, StringUtils.EMPTY_STRING).split(","))
+        : Arrays.stream(cleanMetadata.getExtraMetadata().getOrDefault(CleanerUtils.SAVEPOINTED_TIMESTAMPS, StringUtils.EMPTY_STRING).split(","))
         .filter(partition -> !StringUtils.isNullOrEmpty(partition)).collect(Collectors.toList());
     if (savepointedTimestampsFromLastClean.isEmpty()) {
       return false;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -79,6 +79,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   public static final Integer CLEAN_PLAN_VERSION_2 = CleanPlanV2MigrationHandler.VERSION;
   public static final Integer LATEST_CLEAN_PLAN_VERSION = CLEAN_PLAN_VERSION_2;
   public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
+  public static final String EARLIEST_COMMIT_TO_NOT_ARCHIVE = "earliest_commit_to_not_archive";
 
   private final SyncableFileSystemView fileSystemView;
   private final HoodieTimeline commitTimeline;
@@ -88,6 +89,8 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   private final HoodieWriteConfig config;
   private transient HoodieEngineContext context;
   private List<String> savepointedTimestamps;
+  private Option<HoodieInstant> earliestCommitToRetain = Option.empty();
+  private Option<String> earliestCommitToNotArchive = Option.empty();
 
   public CleanPlanner(HoodieEngineContext context, HoodieTable<T, I, K, O> hoodieTable, HoodieWriteConfig config) {
     this.context = context;
@@ -124,11 +127,6 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   public Stream<String> getSavepointedDataFiles(String savepointTime) {
     HoodieSavepointMetadata metadata = getSavepointMetadata(savepointTime);
     return metadata.getPartitionMetadata().values().stream().flatMap(s -> s.getSavepointDataFile().stream());
-  }
-
-  private Stream<String> getPartitionsFromSavepoint(String savepointTime) {
-    HoodieSavepointMetadata metadata = getSavepointMetadata(savepointTime);
-    return metadata.getPartitionMetadata().keySet().stream();
   }
 
   private HoodieSavepointMetadata getSavepointMetadata(String savepointTimestamp) {
@@ -203,8 +201,9 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    */
   private List<String> getPartitionPathsForIncrementalCleaning(HoodieCleanMetadata cleanMetadata,
       Option<HoodieInstant> newInstantToRetain) {
-    boolean isSavepointDeleted = isAnySavepointDeleted(cleanMetadata);
-    if (isSavepointDeleted) {
+
+    boolean isAnySavepointDeleted = isAnySavepointDeleted(cleanMetadata);
+    if (isAnySavepointDeleted) {
       LOG.info("Since savepoints have been removed compared to previous clean, triggering clean planning for all partitions");
       return getPartitionPathsForFullCleaning();
     } else {
@@ -553,13 +552,59 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    * Returns the earliest commit to retain based on cleaning policy.
    */
   public Option<HoodieInstant> getEarliestCommitToRetain() {
-    return CleanerUtils.getEarliestCommitToRetain(
-        hoodieTable.getMetaClient().getActiveTimeline().getCommitsAndCompactionTimeline(),
-        config.getCleanerPolicy(),
-        config.getCleanerCommitsRetained(),
-        Instant.now(),
-        config.getCleanerHoursRetained(),
-        hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone());
+    if (!earliestCommitToRetain.isPresent()) {
+      earliestCommitToRetain = CleanerUtils.getEarliestCommitToRetain(
+          hoodieTable.getMetaClient().getActiveTimeline().getCommitsAndCompactionTimeline(),
+          config.getCleanerPolicy(),
+          config.getCleanerCommitsRetained(),
+          Instant.now(),
+          config.getCleanerHoursRetained(),
+          hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone());
+    }
+    return earliestCommitToRetain;
+  }
+
+  /**
+   * Returns earliest commit to not archive to assist with guarding archival.
+   * @return
+   */
+  public Option<String> getEarliestCommitToNotArchive() {
+    // compute only if not set
+    if (!earliestCommitToNotArchive.isPresent() && config.getCleanerPolicy() != HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS) { // earliest commit to retain and earliest commit to not archive
+      // makes sense only when clean policy is num commits based or hours based.
+      Option<HoodieInstant> earliestToRetain = getEarliestCommitToRetain();
+      if (!savepointedTimestamps.isEmpty()) { // if savepoints are found.
+        if (savepointedTimestamps.size() == 1) {
+          earliestCommitToNotArchive = Option.of(savepointedTimestamps.get(0));
+        } else {
+          // find the first savepoint timestamp
+          List<String> savepointsClone = new ArrayList<>(savepointedTimestamps);
+          Collections.sort(savepointsClone);
+          earliestCommitToNotArchive = Option.of(savepointsClone.get(0));
+        }
+
+        // earliest commit to not archive = min (earliest commit to retain, earliest commit to not archive)
+        if (earliestToRetain.isPresent() && HoodieTimeline.compareTimestamps(earliestCommitToNotArchive.get(), HoodieTimeline.GREATER_THAN, earliestToRetain.get().getTimestamp())) {
+          earliestCommitToNotArchive = Option.of(earliestToRetain.get().getTimestamp());
+          LOG.info(String.format("Setting Earliest Commit to Not Archive same as Earliest commit to retain to %s, total list of savepointed timestamps : %s", earliestCommitToNotArchive.get(),
+              Arrays.toString(savepointedTimestamps.toArray())));
+        } else {
+          LOG.info(String.format("Setting Earliest Commit to Not Archive to %s, total list of savepointed timestamps : %s", earliestCommitToNotArchive.get(),
+              Arrays.toString(savepointedTimestamps.toArray())));
+        }
+      } else {
+        // no savepoints found.
+        // lets set the value regardless. Would help us differentiate older versions of hudi where this will not be set vs latest version where this will be set to either earliest savepoint
+        // or the earliest commit to retain.
+        if (earliestToRetain.isPresent()) {
+          LOG.info(String.format("Setting Earliest Commit to Not Archive same as Earliest commit to retain to %s", earliestToRetain.get().getTimestamp()));
+          earliestCommitToNotArchive = Option.of(earliestToRetain.get().getTimestamp());
+        } else {
+          earliestCommitToNotArchive = Option.empty();
+        }
+      }
+    }
+    return earliestCommitToNotArchive;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -187,8 +187,7 @@ public class TestCleanPlanner {
     List<String> partitionsToClean = cleanPlanner.getPartitionPathsToClean(Option.of(earliestCommitToRetain));
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
-    assertEquals(expectedEarliestSavepointInLastClean, ClusteringUtils.getEarliestReplacedSavepointInClean(activeTimeline, config.getCleanerPolicy(),
-        cleanerPlan, false));
+    assertEquals(expectedEarliestSavepointInLastClean, ClusteringUtils.getEarliestReplacedSavepointInClean(activeTimeline, config.getCleanerPolicy(), cleanerPlan));
 
     Collections.sort(expectedPartitions);
     Collections.sort(partitionsToClean);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -56,9 +56,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -138,12 +140,18 @@ public class TestCleanPlanner {
     assertEquals(expected, actual);
   }
 
+  /**
+   * The test asserts clean planner results for APIs org.apache.hudi.table.action.clean.CleanPlanner#getEarliestCommitToNotArchive()
+   * and org.apache.hudi.table.action.clean.CleanPlanner#getPartitionPathsToClean(org.apache.hudi.common.util.Option)
+   * given the other input arguments for clean metadata. The idea is the two API results should match the expected results.
+   */
   @ParameterizedTest
   @MethodSource("incrCleaningPartitionsTestCases")
   void testPartitionsForIncrCleaning(boolean isPartitioned, HoodieWriteConfig config, String earliestInstant,
                                      String lastCompletedTimeInLastClean, String lastCleanInstant, String earliestInstantsInLastClean, List<String> partitionsInLastClean,
-                                     Map<String, List<String>> savepointsTrackedInLastClean, Option<String> earliestCommitToNotArchiveInLastClean, Map<String, List<String>> activeInstantsPartitions,
-                                     Map<String, List<String>> savepoints, List<String> expectedPartitions, boolean areCommitsForSavepointsRemoved) throws IOException {
+                                     Map<String, List<String>> savepointsTrackedInLastClean, Option<String> expectedEarliestCommitToNotArchiveInLastClean,
+                                     Map<String, List<String>> activeInstantsPartitions, Map<String, List<String>> savepoints, List<String> expectedPartitions,
+                                     boolean areCommitsForSavepointsRemoved) throws IOException, IllegalAccessException {
     HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
     when(mockHoodieTable.getActiveTimeline()).thenReturn(activeTimeline);
     // setup savepoint mocks
@@ -160,7 +168,7 @@ public class TestCleanPlanner {
     // prepare last Clean Metadata
     Pair<HoodieCleanMetadata, Option<byte[]>> cleanMetadataOptionPair =
         getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean,
-            savepointsTrackedInLastClean.keySet(), earliestCommitToNotArchiveInLastClean);
+            savepointsTrackedInLastClean.keySet(), expectedEarliestCommitToNotArchiveInLastClean);
     mockLastCleanCommit(mockHoodieTable, lastCleanInstant, earliestInstantsInLastClean, activeTimeline, cleanMetadataOptionPair);
     mockFewActiveInstants(mockHoodieTable, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved);
 
@@ -171,10 +179,21 @@ public class TestCleanPlanner {
     when(mockHoodieTable.getMetadataTable()).thenReturn(hoodieTableMetadata);
     when(hoodieTableMetadata.getAllPartitionPaths()).thenReturn(isPartitioned ? Arrays.asList(PARTITION1, PARTITION2, PARTITION3) : Collections.singletonList(StringUtils.EMPTY_STRING));
 
-    // Trigger clean and validate partitions to clean.
+    // setup clean planner so that it uses the input earliestCommitToRetain for API
+    // org.apache.hudi.table.action.clean.CleanPlanner.getEarliestCommitToRetain
     CleanPlanner<?, ?, ?, ?> cleanPlanner = new CleanPlanner<>(context, mockHoodieTable, config);
+    Field field = ReflectionUtils
+        .findFields(CleanPlanner.class, f -> f.getName().equals("earliestCommitToRetain"),
+            ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+        .get(0);
+    field.setAccessible(true);
     HoodieInstant earliestCommitToRetain = new HoodieInstant(HoodieInstant.State.COMPLETED, "COMMIT", earliestInstant);
+    field.set(cleanPlanner, Option.of(earliestCommitToRetain));
+
+    // Trigger clean and validate partitions to clean and earliest commit to not archive.
     List<String> partitionsToClean = cleanPlanner.getPartitionPathsToClean(Option.of(earliestCommitToRetain));
+    assertEquals(expectedEarliestCommitToNotArchiveInLastClean, cleanPlanner.getEarliestCommitToNotArchive());
+
     Collections.sort(expectedPartitions);
     Collections.sort(partitionsToClean);
     assertEquals(expectedPartitions, partitionsToClean);
@@ -372,35 +391,48 @@ public class TestCleanPlanner {
 
     List<Arguments> arguments = new ArrayList<>();
 
+    // Code snippet below generates different test cases which will assert the clean planner output
+    // for these cases. There is no sequential dependency between these cases and they can be considered
+    // independent.
+    // In the test cases below earliestInstant signifies the new value of earliest instant to retain as computed
+    // by CleanPlanner. The test case provides current state of the table and compare the expected values for
+    // earliestCommitToNotArchiveInLastClean and expectedPartitions against computed values for the same by clean planner
+
     // no savepoints tracked in last clean and no additional savepoints. all partitions in uncleaned instants should be expected
+    // earliest commit to not archive is same as earliestInstant here because there are no savepoints in the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
-        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.empty(),
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.of(earliestInstant),
         activeInstantsPartitionsMap3, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
 
     // a new savepoint is added after last clean. but rest of uncleaned touches all partitions, and so all partitions are expected
+    // earliest commit to not archive is same as savepoint2 since savepoint2 was added to the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
-        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.empty(),
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.of(savepoint2),
         activeInstantsPartitionsMap3, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), threePartitionsInActiveTimeline, false));
 
     // previous clean tracks a savepoint which exists in timeline still. only 2 partitions are touched by uncleaned instants. only 2 partitions are expected
+    // earliest commit to not archive is same as savepoint2 since savepoint2 is part of the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
         Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
 
     // savepoint tracked in previous clean was removed(touching partition1). latest uncleaned touched 2 other partitions. But when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(earliestInstant),
         activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
 
     // previous savepoint still exists and touches partition1. uncleaned touches only partition2 and partition3. expected partition2 and partition3.
+    // earliest commit to not archive is same as savepoint2 since savepoint2 is part of the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
         Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
 
     // a new savepoint was added compared to previous clean. all 2 partitions are expected since uncleaned commits touched just 2 partitions.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is the oldest savepoint timestamp in the timeline
     Map<String, List<String>> latestSavepoints = new HashMap<>();
     latestSavepoints.put(savepoint3, Collections.singletonList(PARTITION1));
     latestSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
@@ -410,35 +442,39 @@ public class TestCleanPlanner {
         activeInstantsPartitionsMap2, latestSavepoints, twoPartitionsInActiveTimeline, false));
 
     // 2 savepoints were tracked in previous clean. one of them is removed in latest. When savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is part of the timeline
     Map<String, List<String>> previousSavepoints = new HashMap<>();
     previousSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
     previousSavepoints.put(savepoint3, Collections.singletonList(PARTITION2));
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        previousSavepoints, Option.of(savepoint2), activeInstantsPartitionsMap2, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+        previousSavepoints, Option.of(savepoint3), activeInstantsPartitionsMap2, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
 
     // 2 savepoints were tracked in previous clean. one of them is removed in latest. But a partition part of removed savepoint is already touched by uncleaned commits.
     // Anyways, when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is part of the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        previousSavepoints, Option.of(savepoint2), activeInstantsPartitionsMap3, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+        previousSavepoints, Option.of(savepoint3), activeInstantsPartitionsMap3, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
 
     // unpartitioned test case. savepoint removed.
     List<String> unPartitionsInActiveTimeline = Arrays.asList(StringUtils.EMPTY_STRING);
     Map<String, List<String>> activeInstantsUnPartitionsMap = new HashMap<>();
     activeInstantsUnPartitionsMap.put(earliestInstantMinusThreeDays, unPartitionsInActiveTimeline);
 
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(false,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(StringUtils.EMPTY_STRING),
-        Collections.singletonMap(savepoint2, Collections.singletonList(StringUtils.EMPTY_STRING)), Option.of(savepoint2),
+        Collections.singletonMap(savepoint2, Collections.singletonList(StringUtils.EMPTY_STRING)), Option.of(earliestInstant),
         activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
 
     // savepoint tracked in previous clean was removed(touching partition1). active instants does not have the instant corresponding to the savepoint.
     // latest uncleaned touched 2 other partitions. But when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
     activeInstantsPartitionsMap2.remove(earliestInstantMinusOneWeek);
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(earliestInstant),
         activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, true));
 
     return arguments.stream();
@@ -469,23 +505,27 @@ public class TestCleanPlanner {
         Arguments.of(getCleanByCommitsConfig(), earliestInstant, allFileGroups, savepoints, replacedFileGroups, expected));
   }
 
-  // helper to build common cases for the two policies
+  /**
+   * The function generates test arguments for two cases. One where cleaning policy
+   * is set to KEEP_LATEST_BY_HOURS and the other where cleaning policy is set to
+   * KEEP_LATEST_COMMITS. Rest of the arguments are same.
+   */
   private static List<Arguments> buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(boolean isPartitioned, String earliestInstant,
                                                                                                  String latestCompletedInLastClean,
                                                                                                  String lastKnownCleanInstantTime,
                                                                                                  String earliestInstantInLastClean,
                                                                                                  List<String> partitionsInLastClean,
                                                                                                  Map<String, List<String>> savepointsTrackedInLastClean,
-                                                                                                 Option<String> earliestCommitToNotArchiveInLastClean,
+                                                                                                 Option<String> expectedEarliestCommitToNotArchiveInLastClean,
                                                                                                  Map<String, List<String>> activeInstantsToPartitionsMap,
                                                                                                  Map<String, List<String>> savepoints,
                                                                                                  List<String> expectedPartitions,
                                                                                                  boolean areCommitsForSavepointsRemoved) {
     return Arrays.asList(Arguments.of(isPartitioned, getCleanByHoursConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
-            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, earliestCommitToNotArchiveInLastClean,
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, expectedEarliestCommitToNotArchiveInLastClean,
             activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved),
         Arguments.of(isPartitioned, getCleanByCommitsConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
-            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, earliestCommitToNotArchiveInLastClean,
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, expectedEarliestCommitToNotArchiveInLastClean,
             activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved));
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -74,8 +74,8 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.apache.hudi.common.util.CleanerUtils.CLEAN_METADATA_VERSION_2;
-import static org.apache.hudi.table.action.clean.CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
-import static org.apache.hudi.table.action.clean.CleanPlanner.SAVEPOINTED_TIMESTAMPS;
+import static org.apache.hudi.common.util.CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
+import static org.apache.hudi.common.util.CleanerUtils.SAVEPOINTED_TIMESTAMPS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -72,6 +72,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.apache.hudi.common.util.CleanerUtils.CLEAN_METADATA_VERSION_2;
+import static org.apache.hudi.table.action.clean.CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
 import static org.apache.hudi.table.action.clean.CleanPlanner.SAVEPOINTED_TIMESTAMPS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -141,7 +142,7 @@ public class TestCleanPlanner {
   @MethodSource("incrCleaningPartitionsTestCases")
   void testPartitionsForIncrCleaning(boolean isPartitioned, HoodieWriteConfig config, String earliestInstant,
                                      String lastCompletedTimeInLastClean, String lastCleanInstant, String earliestInstantsInLastClean, List<String> partitionsInLastClean,
-                                     Map<String, List<String>> savepointsTrackedInLastClean, Map<String, List<String>> activeInstantsPartitions,
+                                     Map<String, List<String>> savepointsTrackedInLastClean, Option<String> earliestCommitToNotArchiveInLastClean, Map<String, List<String>> activeInstantsPartitions,
                                      Map<String, List<String>> savepoints, List<String> expectedPartitions, boolean areCommitsForSavepointsRemoved) throws IOException {
     HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
     when(mockHoodieTable.getActiveTimeline()).thenReturn(activeTimeline);
@@ -158,7 +159,8 @@ public class TestCleanPlanner {
 
     // prepare last Clean Metadata
     Pair<HoodieCleanMetadata, Option<byte[]>> cleanMetadataOptionPair =
-        getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean, savepointsTrackedInLastClean.keySet());
+        getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean,
+            savepointsTrackedInLastClean.keySet(), earliestCommitToNotArchiveInLastClean);
     mockLastCleanCommit(mockHoodieTable, lastCleanInstant, earliestInstantsInLastClean, activeTimeline, cleanMetadataOptionPair);
     mockFewActiveInstants(mockHoodieTable, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved);
 
@@ -372,39 +374,39 @@ public class TestCleanPlanner {
 
     // no savepoints tracked in last clean and no additional savepoints. all partitions in uncleaned instants should be expected
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
-        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(),
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.empty(),
         activeInstantsPartitionsMap3, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
 
     // a new savepoint is added after last clean. but rest of uncleaned touches all partitions, and so all partitions are expected
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
-        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(),
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.empty(),
         activeInstantsPartitionsMap3, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), threePartitionsInActiveTimeline, false));
 
     // previous clean tracks a savepoint which exists in timeline still. only 2 partitions are touched by uncleaned instants. only 2 partitions are expected
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
 
     // savepoint tracked in previous clean was removed(touching partition1). latest uncleaned touched 2 other partitions. But when savepoint is removed, entire list of partitions are expected.
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
 
     // previous savepoint still exists and touches partition1. uncleaned touches only partition2 and partition3. expected partition2 and partition3.
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
 
     // a new savepoint was added compared to previous clean. all 2 partitions are expected since uncleaned commits touched just 2 partitions.
     Map<String, List<String>> latestSavepoints = new HashMap<>();
-    latestSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
     latestSavepoints.put(savepoint3, Collections.singletonList(PARTITION1));
+    latestSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)),
+        Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION1)), Option.of(savepoint3),
         activeInstantsPartitionsMap2, latestSavepoints, twoPartitionsInActiveTimeline, false));
 
     // 2 savepoints were tracked in previous clean. one of them is removed in latest. When savepoint is removed, entire list of partitions are expected.
@@ -413,13 +415,13 @@ public class TestCleanPlanner {
     previousSavepoints.put(savepoint3, Collections.singletonList(PARTITION2));
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        previousSavepoints, activeInstantsPartitionsMap2, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+        previousSavepoints, Option.of(savepoint2), activeInstantsPartitionsMap2, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
 
     // 2 savepoints were tracked in previous clean. one of them is removed in latest. But a partition part of removed savepoint is already touched by uncleaned commits.
     // Anyways, when savepoint is removed, entire list of partitions are expected.
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        previousSavepoints, activeInstantsPartitionsMap3, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+        previousSavepoints, Option.of(savepoint2), activeInstantsPartitionsMap3, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
 
     // unpartitioned test case. savepoint removed.
     List<String> unPartitionsInActiveTimeline = Arrays.asList(StringUtils.EMPTY_STRING);
@@ -428,7 +430,7 @@ public class TestCleanPlanner {
 
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(false,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(StringUtils.EMPTY_STRING),
-        Collections.singletonMap(savepoint2, Collections.singletonList(StringUtils.EMPTY_STRING)),
+        Collections.singletonMap(savepoint2, Collections.singletonList(StringUtils.EMPTY_STRING)), Option.of(savepoint2),
         activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
 
     // savepoint tracked in previous clean was removed(touching partition1). active instants does not have the instant corresponding to the savepoint.
@@ -436,7 +438,7 @@ public class TestCleanPlanner {
     activeInstantsPartitionsMap2.remove(earliestInstantMinusOneWeek);
     arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCases(true,
         earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
-        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
         activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, true));
 
     return arguments.stream();
@@ -474,14 +476,17 @@ public class TestCleanPlanner {
                                                                                                  String earliestInstantInLastClean,
                                                                                                  List<String> partitionsInLastClean,
                                                                                                  Map<String, List<String>> savepointsTrackedInLastClean,
+                                                                                                 Option<String> earliestCommitToNotArchiveInLastClean,
                                                                                                  Map<String, List<String>> activeInstantsToPartitionsMap,
                                                                                                  Map<String, List<String>> savepoints,
                                                                                                  List<String> expectedPartitions,
                                                                                                  boolean areCommitsForSavepointsRemoved) {
     return Arrays.asList(Arguments.of(isPartitioned, getCleanByHoursConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
-            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved),
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, earliestCommitToNotArchiveInLastClean,
+            activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved),
         Arguments.of(isPartitioned, getCleanByCommitsConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
-            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved));
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, earliestCommitToNotArchiveInLastClean,
+            activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved));
   }
 
   private static HoodieFileGroup buildFileGroup(List<String> baseFileCommitTimes) {
@@ -516,7 +521,7 @@ public class TestCleanPlanner {
   }
 
   private static Pair<HoodieCleanMetadata, Option<byte[]>> getCleanCommitMetadata(List<String> partitions, String instantTime, String earliestCommitToRetain,
-                                                                                  String lastCompletedTime, Set<String> savepointsToTrack) {
+                                                                                  String lastCompletedTime, Set<String> savepointsToTrack, Option<String> earliestCommitToNotArchive) {
     try {
       Map<String, HoodieCleanPartitionMetadata> partitionMetadata = new HashMap<>();
       partitions.forEach(partition -> partitionMetadata.put(partition, new HoodieCleanPartitionMetadata(partition, HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name(),
@@ -524,6 +529,9 @@ public class TestCleanPlanner {
       Map<String, String> extraMetadata = new HashMap<>();
       if (!savepointsToTrack.isEmpty()) {
         extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointsToTrack.stream().collect(Collectors.joining(",")));
+        if (earliestCommitToNotArchive.isPresent()) {
+          extraMetadata.put(EARLIEST_COMMIT_TO_NOT_ARCHIVE, earliestCommitToNotArchive.get());
+        }
       }
       HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(instantTime, 100L, 10, earliestCommitToRetain, lastCompletedTime, partitionMetadata,
           CLEAN_METADATA_VERSION_2, Collections.EMPTY_MAP, extraMetadata.isEmpty() ? null : extraMetadata);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -545,7 +545,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     cleanStats.put("p1", 1);
     cleanStats.put("p2", 2);
     testTable.doClean(String.format("%08d", 8), cleanStats,
-        Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000003"));
+        Collections.singletonMap(CleanerUtils.EARLIEST_SAVEPOINT, "00000003"));
 
     // trigger archival
     commitsList = archiveAndGetCommitsList(writeConfig);
@@ -597,7 +597,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     }
 
     // add a clean commit with earliest commit to not archive set as c7
-    testTable.doClean(String.format("%08d", 9), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000007"));
+    testTable.doClean(String.format("%08d", 9), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_SAVEPOINT, "00000007"));
 
     // trigger archival
     commitsList = archiveAndGetCommitsList(writeConfig);
@@ -1205,7 +1205,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
           // 1 and 2 should be archived.
           commitToNotArchive = "00000010";
         }
-        testTable.doClean(String.format("%08d", i), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, commitToNotArchive));
+        testTable.doClean(String.format("%08d", i), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_SAVEPOINT, commitToNotArchive));
       }
       // trigger archival
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -288,7 +288,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         verifyArchival(
             getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
             getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000005", "00000006")),
-            commitsAfterArchival);
+            commitsAfterArchival, false);
       } else if (i < 8) {
         assertEquals(originalCommits, commitsAfterArchival);
       } else if (i == 8) {
@@ -296,7 +296,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         verifyArchival(
             getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004")),
             getActiveCommitInstants(Arrays.asList("00000005", "00000006", "00000007", "00000008")),
-            commitsAfterArchival);
+            commitsAfterArchival, false);
       } else {
         assertEquals(originalCommits, commitsAfterArchival);
       }
@@ -482,13 +482,13 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       // retains only 2 commits. C3 and C8. and savepointed commit for C3.
       verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000004", "00000005")),
           Stream.concat(getActiveCommitInstants(Arrays.asList("00000003", "00000006")).stream(), getActiveSavepointedCommitInstants(Arrays.asList("00000003")).stream())
-              .collect(Collectors.toList()), commitsAfterArchival);
+              .collect(Collectors.toList()), commitsAfterArchival, true);
     } else {
       // archives only C1 and C2. stops at first savepointed commit C3.
       verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
           Stream.concat(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000005", "00000006")).stream(),
                   getActiveSavepointedCommitInstants(Arrays.asList("00000003")).stream())
-              .collect(Collectors.toList()), commitsAfterArchival);
+              .collect(Collectors.toList()), commitsAfterArchival, false);
     }
 
     for (int i = 7; i < 10; i++) {
@@ -503,7 +503,122 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
     metaClient.reloadActiveTimeline();
     verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006", "00000007")),
-        getActiveCommitInstants(Arrays.asList("00000008", "00000009")), commitsAfterArchival);
+        getActiveCommitInstants(Arrays.asList("00000008", "00000009")), commitsAfterArchival, false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testClusteringCommitAndSavepointWithArchival(boolean archiveBeyondSavepoint) throws Exception {
+    boolean enableMetadata = false;
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 4, 5, 2, HoodieTableType.COPY_ON_WRITE,
+        10, HoodieFailedWritesCleaningPolicy.EAGER, WriteConcurrencyMode.SINGLE_WRITER, archiveBeyondSavepoint);
+
+    // min archival commits is 2 and max archival commits is 4. and so, after 5th commit, 3 commits will be archived.
+    for (int i = 1; i < 8; i++) {
+      if (i < 3 || i == 5) {
+        testTable.doWriteOperation(String.format("%08d", i), WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+      } else {
+        testTable.doCluster(String.format("%08d", i), Collections.singletonMap("p1", Collections.singletonList("f1")), Collections.singletonList("p2"), 2);
+      }
+    }
+
+    // savepoint 3rd commit
+    String commitToSavepoint = String.format("%08d", 3);
+    HoodieSavepointMetadata savepointMetadata = testTable.doSavepoint(commitToSavepoint);
+    testTable.addSavepoint(commitToSavepoint, savepointMetadata);
+
+    // trigger archival
+    Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
+    List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
+
+    // Only commits 1, 2 should be archived since savepoint exists at c3. In the case when
+    // archiveBeyondSavepoint is false, archival is blocked since replace commits have not yet been cleaned
+    List<HoodieInstant> expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000005"));
+    expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+    expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
+    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
+        expectedActiveInstants, commitsAfterArchival, false);
+
+    // add a clean commit with earliest instant to retain as c8 and earliest instant to not archive as c3.
+    // After this commit clean along with snapshot blocks archival even though earlies instant to retain is c8
+    Map<String, Integer> cleanStats = new HashMap<>();
+    cleanStats.put("p1", 1);
+    cleanStats.put("p2", 2);
+    testTable.doClean(String.format("%08d", 8), cleanStats,
+        Collections.singletonMap(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000003"));
+
+    // trigger archival
+    commitsList = archiveAndGetCommitsList(writeConfig);
+    commitsAfterArchival = commitsList.getValue();
+    if (archiveBeyondSavepoint) {
+      // retains only 2 commits. C7 and savepointed commit for C3 since archiveBeyondSavepoint is set to true
+      // clean commit advances earliest instant to retain so archival is unblocked in this case.
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000003", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), HoodieTimeline.CLEAN_ACTION));
+      expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
+      List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
+      archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000004", "00000006"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, true);
+    } else {
+      // archives only C1 and C2. stops at first savepointed commit C3.
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000005"));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), HoodieTimeline.CLEAN_ACTION));
+      verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
+          expectedActiveInstants, commitsAfterArchival, false);
+    }
+
+    // savepoint is removed
+    testTable.deleteSavepoint(commitToSavepoint);
+
+    // trigger archival
+    commitsList = archiveAndGetCommitsList(writeConfig);
+    commitsAfterArchival = commitsList.getValue();
+
+    if (archiveBeyondSavepoint) {
+      // change from last state - Removal of savepoint instant from the active timeline since it is deleted
+      // retains the 2 commits - C3 and C7. Since minInstantsToKeep is 2, c3 is retained. Once more commits
+      // are added, the next archival run would archive c3 as clean planner already shows earliestInstanToRetain as 8
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000003", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), HoodieTimeline.CLEAN_ACTION));
+      List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
+      archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000004", "00000006"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, true);
+    } else {
+      // change from last state - Removal of savepoint instant from the active timeline since it is deleted
+      // archives only C1 and C2. stops at c3 since clean earliest commit to not archive is c3.
+      // since savepoint is now deleted, it does not block archival.
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000005"));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), HoodieTimeline.CLEAN_ACTION));
+      verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
+          expectedActiveInstants, commitsAfterArchival, false);
+    }
+
+    // add a clean commit with earliest commit to not archive set as c7
+    testTable.doClean(String.format("%08d", 9), cleanStats, Collections.singletonMap(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000007"));
+
+    // trigger archival
+    commitsList = archiveAndGetCommitsList(writeConfig);
+    commitsAfterArchival = commitsList.getValue();
+
+    if (archiveBeyondSavepoint) {
+      // no change in state - only addition of c9 as clean commit
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000003", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
+      archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000004", "00000006"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, true);
+    } else {
+      // archival is triggered since clean does not block it
+      // c6 and c7 are retained since min instants to keep is 2
+      expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
+      archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000003", "00000004"), HoodieTimeline.REPLACE_COMMIT_ACTION));
+      verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, false);
+    }
   }
 
   @Test
@@ -870,7 +985,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
             .map(p -> new HoodieInstant(State.COMPLETED, p.getValue(), p.getKey())).collect(Collectors.toList());
         List<HoodieInstant> expectedActiveInstants = instants.subList(numArchivedInstants, instants.size()).stream()
             .map(p -> new HoodieInstant(State.COMPLETED, p.getValue(), p.getKey())).collect(Collectors.toList());
-        verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival);
+        verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival, false);
       }
     }
     assertTrue(hasArchivedInstants, "Some instants should be archived");
@@ -940,7 +1055,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     archivedInstants.add(new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000002"));
     verifyArchival(archivedInstants,
         getActiveCommitInstants(Arrays.asList("00000005", "00000006", "00000007", "00000008"), HoodieTimeline.DELTA_COMMIT_ACTION),
-        commitsAfterArchival);
+        commitsAfterArchival, false);
   }
 
   @ParameterizedTest
@@ -1063,7 +1178,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
           expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000004", "00000005")));
           expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003"), HoodieTimeline.CLEAN_ACTION));
 
-          verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival);
+          verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival, false);
         } else {
           // with metadata enabled, archival in data table is fenced based on compaction in metadata table.
           assertEquals(originalCommits, commitsAfterArchival);
@@ -1081,7 +1196,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
           expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000004", "00000005", "00000006")));
           expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003"), HoodieTimeline.CLEAN_ACTION));
 
-          verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival);
+          verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival, false);
         }
       }
     }
@@ -1135,7 +1250,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
             Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005"), HoodieTimeline.COMMIT_ACTION));
         expectedArchivedInstants.addAll(getAllArchivedCommitInstants(
             Arrays.asList("00000006", "00000011"), HoodieTimeline.CLEAN_ACTION));
-        verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival);
+        verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival, false);
       }
     }
   }
@@ -1191,7 +1306,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     List<HoodieInstant> expectedActiveInstants = instants.subList(archived, instants.size()).stream()
         .map(p -> new HoodieInstant(State.COMPLETED, p.getValue(), p.getKey())).collect(Collectors.toList());
 
-    verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival);
+    verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival, false);
   }
 
   @ParameterizedTest
@@ -1285,7 +1400,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     // after archival 4,5,6,7
     assertEquals(originalCommits.size() - commitsAfterArchival.size(), 3);
     verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 3)),
-        getActiveCommitInstants(instants.subList(3, 7)), commitsAfterArchival);
+        getActiveCommitInstants(instants.subList(3, 7)), commitsAfterArchival, false);
 
     // 3 more commits, 4 to 6 will be archived. but will not move after 6 since compaction has to kick in metadata table.
     for (int i = 0; i < 3; i++) {
@@ -1298,7 +1413,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     originalCommits = commitsList.getKey();
     commitsAfterArchival = commitsList.getValue();
     assertEquals(originalCommits.size() - commitsAfterArchival.size(), 3);
-    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 6)), getActiveCommitInstants(instants.subList(6, 10)), commitsAfterArchival);
+    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 6)), getActiveCommitInstants(instants.subList(6, 10)), commitsAfterArchival, false);
 
     // No archival should kick in since compaction has not kicked in metadata table
     for (int i = 0; i < 2; i++) {
@@ -1310,7 +1425,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     originalCommits = commitsList.getKey();
     commitsAfterArchival = commitsList.getValue();
     assertEquals(originalCommits, commitsAfterArchival);
-    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 6)), getActiveCommitInstants(instants.subList(6, 12)), commitsAfterArchival);
+    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 6)), getActiveCommitInstants(instants.subList(6, 12)), commitsAfterArchival, false);
 
     String instant13 = metaClient.createNewInstantTime();
     instants.add(instant13);
@@ -1332,7 +1447,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     // before archival 7,8,9,10,11,12,13,14
     // after archival 11,12,13,14
     assertEquals(originalCommits.size() - commitsAfterArchival.size(), 4);
-    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 10)), getActiveCommitInstants(instants.subList(10, 14)), commitsAfterArchival);
+    verifyArchival(getAllArchivedCommitInstants(instants.subList(0, 10)), getActiveCommitInstants(instants.subList(10, 14)), commitsAfterArchival, false);
   }
 
   @ParameterizedTest
@@ -1729,7 +1844,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     return Pair.of(originalCommits, commitsAfterArchival);
   }
 
-  private void verifyArchival(List<HoodieInstant> expectedArchivedInstants, List<HoodieInstant> expectedActiveInstants, List<HoodieInstant> commitsAfterArchival) {
+  private void verifyArchival(List<HoodieInstant> expectedArchivedInstants, List<HoodieInstant> expectedActiveInstants, List<HoodieInstant> commitsAfterArchival, boolean isArchivalBeyondSavepoint) {
     expectedActiveInstants.sort(Comparator.comparing(HoodieInstant::getTimestamp));
     commitsAfterArchival.sort(Comparator.comparing(HoodieInstant::getTimestamp));
     assertEquals(expectedActiveInstants, commitsAfterArchival);
@@ -1743,7 +1858,13 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     HoodieTimeline timeline = metaClient.getActiveTimeline();
     expectedArchivedInstants.forEach(entry -> {
           // check safety
-          if (!entry.getAction().equals(HoodieTimeline.ROLLBACK_ACTION)) {
+          // when isArchivalBeyondSavepoint is set to true, there is a case possible where archival instant
+          // is after the first completed instant in the timeline. Lets say savepoint was taken at commit c1
+          // and commit c1 is a deltacommit which is not archived but c2 got archived. If savepoint is deleted
+          // then containsOrBeforeTimelineStarts check would fail for c2 archived commit as the function compares
+          // against first non savepoint commit in the timeline which is now deleted. With c1 it would succeed but
+          // once c1 is removed, it would start failing.
+          if (!entry.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !isArchivalBeyondSavepoint) {
             assertTrue(timeline.containsOrBeforeTimelineStarts(entry.getTimestamp()), "Archived commits should always be safe");
           }
         }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
@@ -67,7 +68,6 @@ import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.table.action.clean.CleanPlanner;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
 import org.junit.jupiter.api.AfterEach;
@@ -545,7 +545,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     cleanStats.put("p1", 1);
     cleanStats.put("p2", 2);
     testTable.doClean(String.format("%08d", 8), cleanStats,
-        Collections.singletonMap(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000003"));
+        Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000003"));
 
     // trigger archival
     commitsList = archiveAndGetCommitsList(writeConfig);
@@ -597,7 +597,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     }
 
     // add a clean commit with earliest commit to not archive set as c7
-    testTable.doClean(String.format("%08d", 9), cleanStats, Collections.singletonMap(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000007"));
+    testTable.doClean(String.format("%08d", 9), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, "00000007"));
 
     // trigger archival
     commitsList = archiveAndGetCommitsList(writeConfig);
@@ -1205,7 +1205,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
           // 1 and 2 should be archived.
           commitToNotArchive = "00000010";
         }
-        testTable.doClean(String.format("%08d", i), cleanStats, Collections.singletonMap(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE, commitToNotArchive));
+        testTable.doClean(String.format("%08d", i), cleanStats, Collections.singletonMap(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, commitToNotArchive));
       }
       // trigger archival
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -291,6 +291,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
+    return new HoodieDefaultTimeline(getInstantsAsStream()
+        .filter(s -> compareTimestamps(s.getTimestamp(), GREATER_THAN_OR_EQUALS, commitTime)), details);
+  }
+
+  @Override
   public HoodieDefaultTimeline findInstantsBefore(String instantTime) {
     return new HoodieDefaultTimeline(getInstantsAsStream()
             .filter(s -> compareTimestamps(s.getTimestamp(), LESSER_THAN, instantTime)),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -455,6 +455,15 @@ public interface HoodieTimeline extends Serializable {
     return predicateToApply.test(commit1, commit2);
   }
 
+  static String minTimestamp(String commit1, String commit2) {
+    if (commit1 == null) {
+      return commit2;
+    } else if (commit2 == null) {
+      return commit1;
+    }
+    return GREATER_THAN.test(commit1, commit2) ? commit2 : commit1;
+  }
+
   /**
    * Returns the smaller of the given two instants.
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.StringUtils;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -250,9 +251,14 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline filterRequestedRollbackTimeline();
 
   /**
-   * Create a new Timeline with all the instants after startTs.
+   * Create a new Timeline with numCommits after startTs.
    */
   HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits);
+
+  /**
+   * Create a new Timeline with all the instants after startTs.
+   */
+  HoodieTimeline findInstantsAfterOrEquals(String commitTime);
 
   /**
    * Create a new Timeline with instants after startTs and before or on endTs.
@@ -455,6 +461,9 @@ public interface HoodieTimeline extends Serializable {
     return predicateToApply.test(commit1, commit2);
   }
 
+  /**
+   * Returns smaller of the two given timestamps. Returns the non null argument if one of the argument is null.
+   */
   static String minTimestamp(String commit1, String commit2) {
     if (StringUtils.isNullOrEmpty(commit1)) {
       return commit2;
@@ -462,6 +471,17 @@ public interface HoodieTimeline extends Serializable {
       return commit1;
     }
     return GREATER_THAN.test(commit1, commit2) ? commit2 : commit1;
+  }
+
+  /**
+   * Returns smaller of the two given instants compared by their respective timestamps.
+   * Returns the non null argument if one of the argument is null.
+   */
+  static HoodieInstant minTimestampInstant(HoodieInstant instant1, HoodieInstant instant2) {
+    String commit1 = instant1 != null ? instant1.getTimestamp() : null;
+    String commit2 = instant2 != null ? instant2.getTimestamp() : null;
+    String minTimestamp = minTimestamp(commit1, commit2);
+    return Objects.equals(minTimestamp, commit1) ? instant1 : instant2;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -470,7 +470,7 @@ public interface HoodieTimeline extends Serializable {
     } else if (StringUtils.isNullOrEmpty(commit2)) {
       return commit1;
     }
-    return GREATER_THAN.test(commit1, commit2) ? commit2 : commit1;
+    return minInstant(commit1, commit2);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -456,9 +456,9 @@ public interface HoodieTimeline extends Serializable {
   }
 
   static String minTimestamp(String commit1, String commit2) {
-    if (commit1 == null) {
+    if (StringUtils.isNullOrEmpty(commit1)) {
       return commit2;
-    } else if (commit2 == null) {
+    } else if (StringUtils.isNullOrEmpty(commit2)) {
       return commit1;
     }
     return GREATER_THAN.test(commit1, commit2) ? commit2 : commit1;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -56,6 +56,8 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
  */
 public class CleanerUtils {
 
+  public static final String EARLIEST_COMMIT_TO_NOT_ARCHIVE = "earliest_commit_to_not_archive";
+  public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
   private static final Logger LOG = LoggerFactory.getLogger(CleanerUtils.class);
 
   public static final Integer CLEAN_METADATA_VERSION_1 = CleanMetadataV1MigrationHandler.VERSION;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -56,7 +56,9 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
  */
 public class CleanerUtils {
 
-  public static final String EARLIEST_COMMIT_TO_NOT_ARCHIVE = "earliest_commit_to_not_archive";
+  // With incremental cleaning, it tracks the earliest savepoint which has a following replace commit and the
+  // replace commit has been cleaned.
+  public static final String EARLIEST_SAVEPOINT = "earliest_savepoint";
   public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
   private static final Logger LOG = LoggerFactory.getLogger(CleanerUtils.class);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -56,12 +56,8 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
  */
 public class CleanerUtils {
 
-  // With incremental cleaning, it tracks the earliest savepoint which has a following replace commit and the
-  // replace commit has been cleaned.
-  public static final String EARLIEST_SAVEPOINT = "earliest_savepoint";
-  public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
   private static final Logger LOG = LoggerFactory.getLogger(CleanerUtils.class);
-
+  public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
   public static final Integer CLEAN_METADATA_VERSION_1 = CleanMetadataV1MigrationHandler.VERSION;
   public static final Integer CLEAN_METADATA_VERSION_2 = CleanMetadataV2MigrationHandler.VERSION;
   public static final Integer LATEST_CLEAN_METADATA_VERSION = CLEAN_METADATA_VERSION_2;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -347,19 +347,19 @@ public class ClusteringUtils {
     HoodieTimeline replaceOrClusterTimeline = activeTimeline.getTimelineOfActions(CollectionUtils.createSet(HoodieTimeline.REPLACE_COMMIT_ACTION, HoodieTimeline.CLUSTERING_ACTION));
     Option<HoodieInstant> cleanInstantOpt =
         activeTimeline.getCleanerTimeline().filterCompletedInstants().lastInstant();
-    Option<HoodieInstant> earliestSavepointInClean = getEarliestSavepointInClean(activeTimeline, metaClient, cleanerPolicy, cleanInstantOpt, shouldArchiveBeyondSavepoint);
     if (!replaceOrClusterTimeline.empty()) {
       if (cleanInstantOpt.isPresent()) {
         // The first clustering instant of which timestamp is greater than or equal to the earliest commit to retain of
         // the clean metadata.
         HoodieInstant cleanInstant = cleanInstantOpt.get();
-        HoodieActionInstant earliestInstantToRetain = CleanerUtils.getCleanerPlan(metaClient, cleanInstant.isRequested()
-                ? cleanInstant
-                : HoodieTimeline.getCleanRequestedInstant(cleanInstant.getTimestamp()))
-            .getEarliestInstantToRetain();
+        HoodieCleanerPlan cleanerPlan = CleanerUtils.getCleanerPlan(metaClient, cleanInstant.isRequested() ? cleanInstant : HoodieTimeline.getCleanRequestedInstant(cleanInstant.getTimestamp()));
+        Option<String> earliestInstantToRetain = Option.ofNullable(cleanerPlan.getEarliestInstantToRetain()).map(HoodieActionInstant::getTimestamp);
         String retainLowerBound;
-        if (earliestInstantToRetain != null && !StringUtils.isNullOrEmpty(earliestInstantToRetain.getTimestamp())) {
-          retainLowerBound = earliestInstantToRetain.getTimestamp();
+        Option<String> earliestReplacedSavepointInClean = getEarliestReplacedSavepointInClean(activeTimeline, cleanerPolicy, cleanerPlan, shouldArchiveBeyondSavepoint);
+        if (earliestReplacedSavepointInClean.isPresent()) {
+          retainLowerBound = earliestReplacedSavepointInClean.get();
+        } else if (earliestInstantToRetain.isPresent() && !StringUtils.isNullOrEmpty(earliestInstantToRetain.get())) {
+          retainLowerBound = earliestInstantToRetain.get();
         } else {
           // no earliestInstantToRetain, indicate KEEP_LATEST_FILE_VERSIONS clean policy,
           // retain first instant after clean instant.
@@ -370,27 +370,24 @@ public class ClusteringUtils {
           // TODO: This case has to be handled. HUDI-6352
           retainLowerBound = cleanInstant.getTimestamp();
         }
-
-        oldestInstantToRetain = replaceOrClusterTimeline.filter(instant ->
-                HoodieTimeline.compareTimestamps(
-                    instant.getTimestamp(),
-                    HoodieTimeline.GREATER_THAN_OR_EQUALS,
-                    retainLowerBound))
-            .firstInstant();
+        oldestInstantToRetain = replaceOrClusterTimeline.findInstantsAfterOrEquals(retainLowerBound).firstInstant();
       } else {
         oldestInstantToRetain = replaceOrClusterTimeline.firstInstant();
       }
     }
-    oldestInstantToRetain = Option.ofNullable(
-        HoodieTimeline.minTimestampInstant(oldestInstantToRetain.orElse(null), earliestSavepointInClean.orElse(null)));
+    if (!shouldArchiveBeyondSavepoint) {
+      // explicitly check the savepoint timeline and guard against the first one
+      Option<HoodieInstant> firstSavepointOpt = activeTimeline.getSavePointTimeline().filterCompletedInstants().firstInstant();
+      oldestInstantToRetain = Option.ofNullable(HoodieTimeline.minTimestampInstant(oldestInstantToRetain.orElse(null), firstSavepointOpt.orElse(null)));
+    }
     return oldestInstantToRetain;
   }
 
-  public static Option<HoodieInstant> getEarliestSavepointInClean(HoodieActiveTimeline activeTimeline, HoodieTableMetaClient metaClient, HoodieCleaningPolicy cleanerPolicy,
-                                                                   Option<HoodieInstant> cleanInstantOpt, boolean shouldArchiveBeyondSavepoint) throws IOException {
+  public static Option<String> getEarliestReplacedSavepointInClean(HoodieActiveTimeline activeTimeline, HoodieCleaningPolicy cleanerPolicy,
+                                                                   HoodieCleanerPlan cleanerPlan, boolean shouldArchiveBeyondSavepoint) {
     // EarliestSavepoint in clean is required to block archival when savepoint is deleted.
     // This ensures that archival is blocked until clean has cleaned up files retained due to savepoint.
-    // If this guard is not present, the archival of commits can lead to duplicates. Here is a scenario
+    // If this guard is not present, the archiving of commits can lead to duplicates. Here is a scenario
     // illustrating the same. This scenario considers a case where EarliestSavepoint guard is not present
     // c1.dc - f1 (c1 deltacommit creates file with id f1)
     // c2.dc - f2 (c2 deltacommit creates file with id f2)
@@ -400,54 +397,27 @@ public class ClusteringUtils {
     //
     // Lets say Incremental cleaner moved past the c3.rc without cleaning f2 since savepoint is created at c2.
     // Archival is blocked at c2 since there is a savepoint at c2.
-    // Lets say the savepoint at c2 is now deleted, Archival would archive c3.rc since it is unblocked now.
+    // Let's say the savepoint at c2 is now deleted, Archival would archive c3.rc since it is unblocked now.
     // Since c3 is archived and f2 has not been cleaned, the table view would be considering f2 as a valid
     // file id. This causes duplicates.
-    if (shouldArchiveBeyondSavepoint) {
-      // When archive beyond savepoint is enabled, we do not block the archival based on cleaner earliestSavepoint
-      return Option.empty();
-    }
-    // explicitly check the savepoint timeline and guard against the first one
-    Option<String> firstSavepointOpt = activeTimeline.getSavePointTimeline().filterCompletedInstants().firstInstant().map(HoodieInstant::getTimestamp);
-    String earliestSavepointTs = firstSavepointOpt.orElse(null);
-    Option<String> cleanerEarliestSavepoint = Option.empty();
-    Option<HoodieActionInstant> cleanerEarliestToRetain = Option.empty();
 
-    if (cleanerPolicy != HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS && cleanInstantOpt.isPresent()) {
-      HoodieInstant cleanInstant = cleanInstantOpt.get();
-      Option<HoodieCleanerPlan> cleanerPlan = Option.ofNullable(CleanerUtils.getCleanerPlan(metaClient, cleanInstant.isRequested()
-                  ? cleanInstant
-                  : HoodieTimeline.getCleanRequestedInstant(cleanInstant.getTimestamp())));
-      cleanerEarliestToRetain = cleanerPlan.map(HoodieCleanerPlan::getEarliestInstantToRetain);
-      cleanerEarliestSavepoint = cleanerPlan.map(HoodieCleanerPlan::getExtraMetadata)
-          .flatMap(metadata -> Option.fromJavaOptional(
-              Arrays.stream(metadata.getOrDefault(CleanerUtils.SAVEPOINTED_TIMESTAMPS, StringUtils.EMPTY_STRING).split(","))
-                  .sorted()
-                  .findFirst()));
-      if (cleanerEarliestToRetain.isPresent() && cleanerEarliestSavepoint.isPresent()) {
-        String earliestToRetainTs = cleanerEarliestToRetain.get().getTimestamp();
+    Option<String> earliestInstantToRetain = Option.ofNullable(cleanerPlan.getEarliestInstantToRetain()).map(HoodieActionInstant::getTimestamp);
+    Option<String[]> savepoints = Option.ofNullable(cleanerPlan.getExtraMetadata()).map(metadata -> metadata.getOrDefault(CleanerUtils.SAVEPOINTED_TIMESTAMPS, StringUtils.EMPTY_STRING).split(","));
+    Option<String> earliestSavepoint = savepoints.flatMap(arr -> Option.fromJavaOptional(Arrays.stream(arr).sorted().findFirst()));
+    if (cleanerPolicy != HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS) {
+      if (earliestInstantToRetain.isPresent() && !StringUtils.isNullOrEmpty(earliestInstantToRetain.get()) && earliestSavepoint.isPresent()) {
         // When earliestToRetainTs is greater than first savepoint timestamp and there are no
         // replace commits between the first savepoint and the earliestToRetainTs, we can set the
         // earliestSavepointOpt to empty as there was no cleaning blocked due to savepoint
-        if (HoodieTimeline.compareTimestamps(earliestToRetainTs, HoodieTimeline.GREATER_THAN, cleanerEarliestSavepoint.get())) {
-          HoodieTimeline replaceTimeline = activeTimeline.getCompletedReplaceTimeline().findInstantsInClosedRange(cleanerEarliestSavepoint.get(), earliestToRetainTs);
-          if (replaceTimeline.empty()) {
-            cleanerEarliestSavepoint = Option.empty();
+        if (HoodieTimeline.compareTimestamps(earliestInstantToRetain.get(), HoodieTimeline.GREATER_THAN, earliestSavepoint.get())) {
+          HoodieTimeline replaceTimeline = activeTimeline.getCompletedReplaceTimeline().findInstantsInClosedRange(earliestSavepoint.get(), earliestInstantToRetain.get());
+          if (!replaceTimeline.empty()) {
+            return earliestSavepoint;
           }
         }
-        earliestSavepointTs = cleanerEarliestSavepoint.orElse(null);
       }
-
-      // We do not want last clean instant to be archived since that is referred for fetching earliestSavepointTs
-      // earliestSavepointTs should always be greater than last clean instant since
-      // earliestSavepointTs tracks oldest savepoint or commit not yet cleaned by cleaner(which should be less than the clean instant itself)
-      earliestSavepointTs = HoodieTimeline.minTimestamp(earliestSavepointTs, cleanInstant.getTimestamp());
     }
-
-    Option<HoodieInstant> earliestSavepoint = Option.ofNullable(earliestSavepointTs).flatMap(ts -> activeTimeline.findInstantsAfterOrEquals(ts).firstInstant());
-    LOG.info("Using earliestSavepoint as {}, given first savepoint {}, clean instant {}, cleanerEarliestSavepoint {} cleanerEarliestToRetain {}",
-        earliestSavepoint, firstSavepointOpt, cleanInstantOpt, cleanerEarliestSavepoint, cleanerEarliestToRetain);
-    return earliestSavepoint;
+    return Option.empty();
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -625,6 +625,17 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
   }
 
   @Test
+  public void testMinTimestamp() {
+    String timestamp1 = "20240601040632402";
+    String timestamp2 = "20250601040632402";
+    assertEquals(timestamp1, HoodieTimeline.minTimestamp(null, timestamp1));
+    assertEquals(timestamp1, HoodieTimeline.minTimestamp("", timestamp1));
+    assertEquals(timestamp1, HoodieTimeline.minTimestamp(timestamp1, null));
+    assertEquals(timestamp1, HoodieTimeline.minTimestamp(timestamp1, ""));
+    assertEquals(timestamp1, HoodieTimeline.minTimestamp(timestamp1, timestamp2));
+  }
+
+  @Test
   public void testParseDateFromInstantTime() throws ParseException {
     // default second granularity instant ID
     String secondGranularityInstant = "20210101120101123";

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -1056,6 +1056,10 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieCleanMetadata doClean(String commitTime, Map<String, Integer> partitionFileCountsToDelete) throws IOException {
+    return doClean(commitTime, partitionFileCountsToDelete, Collections.emptyMap());
+  }
+
+  public HoodieCleanMetadata doClean(String commitTime, Map<String, Integer> partitionFileCountsToDelete, Map<String, String> extraMetadata) throws IOException {
     Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
     for (Map.Entry<String, Integer> entry : partitionFileCountsToDelete.entrySet()) {
       partitionFilesToDelete.put(entry.getKey(), getEarliestFilesInPartition(entry.getKey(), entry.getValue()));
@@ -1066,8 +1070,11 @@ public class HoodieTestTable implements AutoCloseable {
       deleteFilesInPartition(entry.getKey(), entry.getValue());
     }
     Pair<HoodieCleanerPlan, HoodieCleanMetadata> cleanerMeta = getHoodieCleanMetadata(commitTime, testTableState);
-    addClean(commitTime, cleanerMeta.getKey(), cleanerMeta.getValue());
-    return cleanerMeta.getValue();
+    HoodieCleanMetadata cleanMetadata = cleanerMeta.getValue();
+    cleanerMeta.getKey().setExtraMetadata(extraMetadata);
+    cleanMetadata.setExtraMetadata(extraMetadata);
+    addClean(commitTime, cleanerMeta.getKey(), cleanMetadata);
+    return cleanMetadata;
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -165,7 +165,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
     HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
-    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
+    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null);
     assertTrue(actual.isPresent());
     assertEquals(clusterTime1, actual.get().getTimestamp(), "no clean in timeline, retain first replace commit");
 
@@ -187,7 +187,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant4,
         TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
     metaClient.reloadActiveTimeline();
-    actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
+    actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null);
     assertEquals(clusterTime3, actual.get().getTimestamp(),
         "retain the first replace commit after the earliestInstantToRetain ");
   }
@@ -225,7 +225,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
 
-    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS, false);
+    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS);
     assertEquals(clusterTime2, actual.get().getTimestamp(),
         "retain the first replace commit after the last complete clean ");
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -225,7 +225,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
 
-    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
+    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS, false);
     assertEquals(clusterTime2, actual.get().getTimestamp(),
         "retain the first replace commit after the last complete clean ");
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -165,7 +165,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
     HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
-    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient);
+    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
     assertTrue(actual.isPresent());
     assertEquals(clusterTime1, actual.get().getTimestamp(), "no clean in timeline, retain first replace commit");
 
@@ -187,7 +187,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant4,
         TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
     metaClient.reloadActiveTimeline();
-    actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient);
+    actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
     assertEquals(clusterTime3, actual.get().getTimestamp(),
         "retain the first replace commit after the earliestInstantToRetain ");
   }
@@ -225,7 +225,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
 
-    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient);
+    Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null, false);
     assertEquals(clusterTime2, actual.get().getTimestamp(),
         "retain the first replace commit after the last complete clean ");
   }


### PR DESCRIPTION
### Change Logs

The PR adds changes such that:
If cleaner last clean commit tracks savepointed instants and there is a replace commit following the savepoint and before earliest instant to retain for cleaner, then the archival will block on the replace commit instead of the earliest instant to retain. 
This is required to handle the issue of duplicates. If replace commit is replacing file groups retained by the savepoint, the cleaner must be able to clean these file groups before the replace commit is archived.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
