### PR TITLE
[HUDI-7671] Make Hudi timeline backward compatible

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -136,7 +136,10 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
           state = State.COMPLETED;
         }
       }
-      completionTime = timestamps.length > 1 ? timestamps[1] : null;
+      completionTime = timestamps.length > 1
+          ? timestamps[1]
+          // for backward compatibility with 0.x release.
+          : state == State.COMPLETED ? pathInfo.getModificationTime() + "" : null;
     } else {
       throw new IllegalArgumentException("Failed to construct HoodieInstant: " + String.format(FILE_NAME_FORMAT_ERROR, fileName));
     }


### PR DESCRIPTION
### Change Logs

Keeping backward compatibility with 0.x branch for instant completion time.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
