### PR TITLE
[HUDI-7867] Ensuring delete invalid all files during finalizing the writer

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -59,6 +59,7 @@ import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.table.view.TableFileSystemView.SliceView;
 import org.apache.hudi.common.util.Functions;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.RetryHelper;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -713,11 +714,24 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
           final HoodieStorage storage = metaClient.getStorage();
           LOG.info("Deleting invalid data file=" + partitionFilePair);
           // Delete
-          try {
-            storage.deleteFile(new StoragePath(partitionFilePair.getValue()));
-          } catch (IOException e) {
-            throw new HoodieIOException(e.getMessage(), e);
-          }
+          RetryHelper<Void, HoodieIOException> retryHelper = new RetryHelper(5000, 3, 5000, HoodieIOException.class.getName())
+              .tryWith(() -> {
+                try {
+                  StoragePath deletePath = new StoragePath(partitionFilePair.getValue());
+                  boolean success = storage.deleteFile(deletePath);
+                  if (!success) {
+                    if (storage.exists(deletePath)) {
+                      throw new HoodieIOException("Failed to delete invalid data file: " + deletePath);
+                    } else {
+                      LOG.debug("Already delete invalid data file: " + deletePath);
+                    }
+                  }
+                } catch (IOException e) {
+                  throw new HoodieIOException(e.getMessage(), e);
+                }
+                return null;
+              });
+          retryHelper.start();
           return true;
         }, config.getFinalizeWriteParallelism());
   }


### PR DESCRIPTION
### Change Logs

We should not skip failure which means fail to delete invalid files because users might get wrong result.
The pr aims to fix the [issue#11419](https://github.com/apache/hudi/issues/11419).

### Impact

Fix the bug when delete invalid files.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
