### PR TITLE
[HUDI-7386] Add Builder to FileGroup Reader

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -292,7 +292,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
         .withTableConfig(metaClient.getTableConfig())
         .withStart(0)
         .withLength(fileSlice.getTotalFileSize())
-        .withMaxMemorySizeInBytes(1024 * 1024 * 1000)
+        .withMaxMemorySizeInBytes(HoodieCommonConfig.DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES)
         .withSpillableMapBasePath(metaClient.getTempFolderPath())
         .withDiskMapType(ExternalSpillableMap.DiskMapType.ROCKS_DB)
         .withBitCaskDiskMapCompressionEnabled(false)

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -113,25 +113,26 @@ public class HoodieFileGroupReaderTestUtils {
         boolean shouldUseRecordPosition,
         HoodieTableMetaClient metaClient
     ) {
-      return new HoodieFileGroupReader<>(
-          readerContext,
-          storage,
-          basePath,
-          latestCommitTime,
-          fileSlice,
-          schema,
-          schema,
-          Option.empty(),
-          metaClient,
-          props,
-          tableConfig,
-          start,
-          length,
-          shouldUseRecordPosition,
-          1024 * 1024 * 1000,
-          basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME,
-          ExternalSpillableMap.DiskMapType.ROCKS_DB,
-          false);
+
+      return ((HoodieFileGroupReader.Builder<IndexedRecord>) HoodieFileGroupReader.builder())
+          .withReaderContext(readerContext)
+          .withHoodieStorage(storage)
+          .withTablePath(basePath)
+          .withLatestCommitTime(latestCommitTime)
+          .withFileSlice(fileSlice)
+          .withDataSchema(schema)
+          .withRequestedSchema(schema)
+          .withMetaClient(metaClient)
+          .withTypedProperties(props)
+          .withTableConfig(tableConfig)
+          .withStart(start)
+          .withLength(length)
+          .withUseRecordPosition(shouldUseRecordPosition)
+          .withMaxMemorySizeInBytes(1024 * 1024 * 1000)
+          .withSpillableMapBasePath(basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME)
+          .withDiskMapType(ExternalSpillableMap.DiskMapType.ROCKS_DB)
+          .withBitCaskDiskMapCompressionEnabled(false)
+          .build();
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -32,6 +32,8 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES;
+
 public class HoodieFileGroupReaderTestUtils {
   public static HoodieFileGroupReader<IndexedRecord> createFileGroupReader(
       Option<FileSlice> fileSliceOpt,
@@ -128,7 +130,7 @@ public class HoodieFileGroupReaderTestUtils {
           .withStart(start)
           .withLength(length)
           .withUseRecordPosition(shouldUseRecordPosition)
-          .withMaxMemorySizeInBytes(1024 * 1024 * 1000)
+          .withMaxMemorySizeInBytes(DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES)
           .withSpillableMapBasePath(basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME)
           .withDiskMapType(ExternalSpillableMap.DiskMapType.ROCKS_DB)
           .withBitCaskDiskMapCompressionEnabled(false)


### PR DESCRIPTION
### Change Logs

Number of constructor params is getting too long for the fg reader. Use builder style instead.

### Impact

Easier to keep track of params for fg reader 

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
