### PR TITLE
[HUDI-7880] Support extraMetadata in Spark SQL Insert Into

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.hudi.HoodieOptionConfig
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.isHoodieConfigKey
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.filterHoodieConfigs
 
 import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter, propertiesAsScalaMapConverter}
 
@@ -58,7 +58,7 @@ object HoodieCLIUtils {
     val finalParameters = HoodieWriterUtils.parametersWithWriteDefaults(
       (catalogProps ++
         metaClient.getTableConfig.getProps.asScala.toMap ++
-        sparkSession.sqlContext.getAllConfs.filterKeys(isHoodieConfigKey) ++
+        filterHoodieConfigs(sparkSession.sqlContext.getAllConfs) ++
         conf).toMap
     )
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi
 
+import org.apache.hudi.DataSourceWriteOptions.COMMIT_METADATA_KEYPREFIX
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
 import org.apache.hudi.common.fs.FSUtils
@@ -226,8 +227,13 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
    *
    * TODO: standardize the key prefix so that we don't need this helper (HUDI-4935)
    */
-  def isHoodieConfigKey(key: String): Boolean =
-    key.startsWith("hoodie.") || key == DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT.key
+  private def isHoodieConfigKey(key: String, commitMetadataKeyPrefix: String): Boolean =
+    key.startsWith("hoodie.") || key.startsWith(commitMetadataKeyPrefix) ||
+      key == DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT.key
+
+  def filterHoodieConfigs(opts: Map[String, String]): Map[String, String] =
+    opts.filterKeys(isHoodieConfigKey(_,
+      opts.getOrElse(COMMIT_METADATA_KEYPREFIX.key, COMMIT_METADATA_KEYPREFIX.defaultValue()))).toMap
 
   /**
    * Checks whether Spark is using Hive as Session's Catalog

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, L
 import org.apache.spark.sql.execution.datasources.FileStatusCache
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hudi.HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isHoodieConfigKey, isUsingHiveCatalog}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{filterHoodieConfigs, isUsingHiveCatalog}
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{combineOptions, getPartitionPathFieldWriteConfig}
 import org.apache.spark.sql.hudi.command.{SqlKeyGenerator, ValidateDuplicateKeyPayload}
 import org.apache.spark.sql.internal.SQLConf
@@ -574,8 +574,5 @@ object ProvidesHoodieConfig {
 
   private def filterNullValues(opts: Map[String, String]): Map[String, String] =
     opts.filter { case (_, v) => v != null }
-
-  private def filterHoodieConfigs(opts: Map[String, String]): Map[String, String] =
-    opts.filterKeys(isHoodieConfigKey).toMap
 
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
-import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
@@ -2583,6 +2582,58 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
         Seq(2, false)
       )
     })
+  }
+
+  test("Test Insert Into with extraMetadata") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  dt string,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | tblproperties (primaryKey = 'id')
+           | partitioned by (dt)
+           | location '$tablePath'
+       """.stripMargin)
+
+      spark.sql("set hoodie.datasource.write.commitmeta.key.prefix=commit_extra_meta_")
+
+      spark.sql("set commit_extra_meta_a=valA")
+      spark.sql("set commit_extra_meta_b=valB")
+      spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, '2024-06-14')")
+
+      assertResult("valA") {
+        getLastCommitMetadata(spark, tablePath).getExtraMetadata.get("commit_extra_meta_a")
+      }
+      assertResult("valB") {
+        getLastCommitMetadata(spark, tablePath).getExtraMetadata.get("commit_extra_meta_b")
+      }
+      checkAnswer(s"select id, name, price, dt from $tableName")(
+        Seq(1, "a1", 10.0, "2024-06-14")
+      )
+
+      spark.sql("set commit_extra_meta_a=new_valA")
+      spark.sql("set commit_extra_meta_b=new_valB")
+      spark.sql(s"insert into $tableName values (2, 'a2', 20, 2000, '2024-06-14')")
+
+      assertResult("new_valA") {
+        getLastCommitMetadata(spark, tablePath).getExtraMetadata.get("commit_extra_meta_a")
+      }
+      assertResult("new_valB") {
+        getLastCommitMetadata(spark, tablePath).getExtraMetadata.get("commit_extra_meta_b")
+      }
+      checkAnswer(s"select id, name, price, dt from $tableName")(
+        Seq(1, "a1", 10.0, "2024-06-14"),
+        Seq(2, "a2", 20.0, "2024-06-14")
+      )
+    }
   }
 
   def ingestAndValidateDataDupPolicy(tableType: String, tableName: String, tmp: File,


### PR DESCRIPTION
### Change Logs

[HUDI-7880] Support extraMetadata in Spark SQL Insert Into
### Impact

[HUDI-7880] Support extraMetadata in Spark SQL Insert Into

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
