### PR TITLE
[HUDI-7881] Verify table base path as well for syncing table in bigquery metastore

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -136,7 +136,7 @@ public class BigQuerySyncTool extends HoodieSyncTool {
       manifestFileWriter.writeManifestFile(true);
       // if table does not exist, create it using the manifest file
       // if table exists but is not yet using manifest file or needs to be recreated with the big-lake connection ID, update it to use manifest file
-      if (bqSyncClient.tableNotExistsOrDoesNotMatchSpecification(tableName)) {
+      if (bqSyncClient.tableNotExistsOrDoesNotMatchSpecification(tableName, bqSyncClient.getBasePath())) {
         bqSyncClient.createOrUpdateTableUsingBqManifestFile(
             tableName,
             manifestFileWriter.getManifestSourceUri(true),

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -136,7 +136,7 @@ public class BigQuerySyncTool extends HoodieSyncTool {
       manifestFileWriter.writeManifestFile(true);
       // if table does not exist, create it using the manifest file
       // if table exists but is not yet using manifest file or needs to be recreated with the big-lake connection ID, update it to use manifest file
-      if (bqSyncClient.tableNotExistsOrDoesNotMatchSpecification(tableName, bqSyncClient.getBasePath())) {
+      if (bqSyncClient.tableNotExistsOrDoesNotMatchSpecification(tableName)) {
         bqSyncClient.createOrUpdateTableUsingBqManifestFile(
             tableName,
             manifestFileWriter.getManifestSourceUri(true),

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -298,10 +298,9 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
   /**
    * Checks for the existence of a table that uses the manifest file approach and matches other requirements.
    * @param tableName name of the table
-   * @param basePath current base path of the table
    * @return Returns true if the table does not exist or if the table does exist but does not use the manifest file or table base path is outdated. False otherwise.
    */
-  public boolean tableNotExistsOrDoesNotMatchSpecification(String tableName, String basePath) {
+  public boolean tableNotExistsOrDoesNotMatchSpecification(String tableName) {
     TableId tableId = TableId.of(projectId, datasetName, tableName);
     Table table = bigquery.getTable(tableId);
     if (table == null || !table.exists()) {
@@ -314,8 +313,9 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions() == null ? "" :
         externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
     // remove trailing slash
-    basePathInTableDefinition = org.apache.commons.lang3.StringUtils.stripEnd(basePathInTableDefinition, "/");
-    basePath = org.apache.commons.lang3.StringUtils.stripEnd(basePath, "/");
+    basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
+    String basePath = getBasePath();
+    basePath = StringUtils.stripEnd(basePath, "/");
     if (!basePathInTableDefinition.equals(basePath)) {
       // if table base path is outdated, we need to replace the table.
       LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -318,6 +318,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     basePath = org.apache.commons.lang3.StringUtils.stripEnd(basePath, "/");
     if (!basePathInTableDefinition.equals(basePath)) {
       // if table base path is outdated, we need to replace the table.
+      LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);
       return true;
     }
     if (!StringUtils.isNullOrEmpty(config.getString(BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID))) {

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -316,12 +316,15 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     // remove trailing slash
     basePathInTableDefinition = org.apache.commons.lang3.StringUtils.stripEnd(basePathInTableDefinition, "/");
     basePath = org.apache.commons.lang3.StringUtils.stripEnd(basePath, "/");
-    boolean isTableBasePathOutdated = !basePathInTableDefinition.equals(basePath);
+    if (!basePathInTableDefinition.equals(basePath)) {
+      // if table base path is outdated
+      return true;
+    }
     if (!StringUtils.isNullOrEmpty(config.getString(BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID))) {
       // If bigLakeConnectionId is present and connectionId is not present in table definition, we need to replace the table.
-      return manifestDoesNotExist || isTableBasePathOutdated || externalTableDefinition.getConnectionId() == null;
+      return manifestDoesNotExist || externalTableDefinition.getConnectionId() == null;
     }
-    return manifestDoesNotExist || isTableBasePathOutdated;
+    return manifestDoesNotExist;
   }
 
   @Override

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -317,7 +317,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     basePathInTableDefinition = org.apache.commons.lang3.StringUtils.stripEnd(basePathInTableDefinition, "/");
     basePath = org.apache.commons.lang3.StringUtils.stripEnd(basePath, "/");
     if (!basePathInTableDefinition.equals(basePath)) {
-      // if table base path is outdated
+      // if table base path is outdated, we need to replace the table.
       return true;
     }
     if (!StringUtils.isNullOrEmpty(config.getString(BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID))) {

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 
 public class TestBigQuerySyncTool {
   private static final String TEST_TABLE = "test_table";
+  private static final String TEST_TABLE_BASE_PATH = "gs://test-bucket/test-lake/test-db/test_table";
   private final ManifestFileWriter mockManifestFileWriter = mock(ManifestFileWriter.class);
   private final HoodieBigQuerySyncClient mockBqSyncClient = mock(HoodieBigQuerySyncClient.class);
   private final BigQuerySchemaResolver mockBqSchemaResolver = mock(BigQuerySchemaResolver.class);
@@ -75,8 +76,9 @@ public class TestBigQuerySyncTool {
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_SOURCE_URI_PREFIX.key(), prefix);
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_PARTITION_FIELDS.key(), "datestr,type");
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(true);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(true);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Arrays.asList("datestr", "type")))).thenReturn(schema);
@@ -90,8 +92,9 @@ public class TestBigQuerySyncTool {
   void useBQManifestFile_newTableNonPartitioned() {
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_USE_BQ_MANIFEST_FILE.key(), "true");
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(true);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(true);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Collections.emptyList()))).thenReturn(schema);
@@ -108,8 +111,9 @@ public class TestBigQuerySyncTool {
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_SOURCE_URI_PREFIX.key(), prefix);
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_PARTITION_FIELDS.key(), "datestr,type");
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(false);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(false);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     List<String> partitionFields = Arrays.asList("datestr", "type");
@@ -124,8 +128,9 @@ public class TestBigQuerySyncTool {
   void useBQManifestFile_existingNonPartitionedTable() {
     properties.setProperty(BigQuerySyncConfig.BIGQUERY_SYNC_USE_BQ_MANIFEST_FILE.key(), "true");
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(false);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(false);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Collections.emptyList()))).thenReturn(schema);

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
@@ -78,7 +78,7 @@ public class TestBigQuerySyncTool {
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
     when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(true);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(true);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Arrays.asList("datestr", "type")))).thenReturn(schema);
@@ -94,7 +94,7 @@ public class TestBigQuerySyncTool {
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
     when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(true);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(true);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Collections.emptyList()))).thenReturn(schema);
@@ -113,7 +113,7 @@ public class TestBigQuerySyncTool {
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
     when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(false);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(false);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     List<String> partitionFields = Arrays.asList("datestr", "type");
@@ -130,7 +130,7 @@ public class TestBigQuerySyncTool {
     when(mockBqSyncClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
     when(mockBqSyncClient.getBasePath()).thenReturn(TEST_TABLE_BASE_PATH);
     when(mockBqSyncClient.datasetExists()).thenReturn(true);
-    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, TEST_TABLE_BASE_PATH)).thenReturn(false);
+    when(mockBqSyncClient.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE)).thenReturn(false);
     Path manifestPath = new Path("file:///local/path");
     when(mockManifestFileWriter.getManifestSourceUri(true)).thenReturn(manifestPath.toUri().getPath());
     when(mockBqSchemaResolver.getTableSchema(any(), eq(Collections.emptyList()))).thenReturn(schema);

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -173,7 +173,7 @@ public class TestHoodieBigQuerySyncClient {
     BigQuerySyncConfig config = new BigQuerySyncConfig(properties);
     client = new HoodieBigQuerySyncClient(config, mockBigQuery);
     // table does not exist
-    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
 
     TableId tableId = TableId.of(PROJECT_ID, TEST_DATASET, TEST_TABLE);
     Table table = mock(Table.class);
@@ -185,17 +185,17 @@ public class TestHoodieBigQuerySyncClient {
 
     // manifest does not exist
     when(externalTableDefinition.getSourceUris()).thenReturn(Collections.emptyList());
-    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
 
     // manifest exists but base path is outdated
     when(externalTableDefinition.getSourceUris()).thenReturn(Collections.singletonList(ManifestFileWriter.ABSOLUTE_PATH_MANIFEST_FOLDER_NAME));
     when(externalTableDefinition.getHivePartitioningOptions()).thenReturn(
         HivePartitioningOptions.newBuilder().setSourceUriPrefix(basePath + "1").build());
-    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
 
     // manifest exists, base path is up-to-date
     when(externalTableDefinition.getHivePartitioningOptions()).thenReturn(
         HivePartitioningOptions.newBuilder().setSourceUriPrefix(basePath + "/").build());
-    assertFalse(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+    assertFalse(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
   }
 }

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.sync.common.HoodieSyncConfig;
+import org.apache.hudi.sync.common.util.ManifestFileWriter;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.ExternalTableDefinition;
@@ -36,6 +37,7 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +52,10 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
@@ -160,5 +166,36 @@ public class TestHoodieBigQuerySyncClient {
     client.updateTableSchema(TEST_TABLE, schema, partitionFields);
     // Expect no update.
     verify(mockBigQuery, never()).update(mockTable);
+  }
+
+  @Test
+  void testTableNotExistsOrDoesNotMatchSpecification() {
+    BigQuerySyncConfig config = new BigQuerySyncConfig(properties);
+    client = new HoodieBigQuerySyncClient(config, mockBigQuery);
+    // table does not exist
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+
+    TableId tableId = TableId.of(PROJECT_ID, TEST_DATASET, TEST_TABLE);
+    Table table = mock(Table.class);
+    when(mockBigQuery.getTable(tableId)).thenReturn(table);
+
+    ExternalTableDefinition externalTableDefinition = mock(ExternalTableDefinition.class);
+    when(table.exists()).thenReturn(true);
+    when(table.getDefinition()).thenReturn(externalTableDefinition);
+
+    // manifest does not exist
+    when(externalTableDefinition.getSourceUris()).thenReturn(Collections.emptyList());
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+
+    // manifest exists but base path is outdated
+    when(externalTableDefinition.getSourceUris()).thenReturn(Collections.singletonList(ManifestFileWriter.ABSOLUTE_PATH_MANIFEST_FOLDER_NAME));
+    when(externalTableDefinition.getHivePartitioningOptions()).thenReturn(
+        HivePartitioningOptions.newBuilder().setSourceUriPrefix(basePath + "1").build());
+    assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
+
+    // manifest exists, base path is up-to-date
+    when(externalTableDefinition.getHivePartitioningOptions()).thenReturn(
+        HivePartitioningOptions.newBuilder().setSourceUriPrefix(basePath + "/").build());
+    assertFalse(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE, basePath));
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -302,4 +302,29 @@ public class StringUtils {
     buf.append(text.substring(start));
     return buf.toString();
   }
+
+  /**
+   * Strips given characters from end of the string and returns the result
+   * @param str - string to be stripped
+   * @param stripChars - characters to strip
+   */
+  public static String stripEnd(final String str, final String stripChars) {
+    int end;
+    if (str == null || (end = str.length()) == 0) {
+      return str;
+    }
+
+    if (stripChars == null) {
+      while (end != 0 && Character.isWhitespace(str.charAt(end - 1))) {
+        end--;
+      }
+    } else if (stripChars.isEmpty()) {
+      return str;
+    } else {
+      while (end != 0 && stripChars.indexOf(str.charAt(end - 1)) != INDEX_NOT_FOUND) {
+        end--;
+      }
+    }
+    return str.substring(0, end);
+  }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -131,4 +131,14 @@ public class TestStringUtils {
     assertTrue(StringUtils.compareVersions("1.10.1", "1.10") > 0);
     assertTrue(StringUtils.compareVersions("1.10", "1.10") == 0);
   }
+
+  @Test
+  public void testStripEnd() {
+    assertNull(StringUtils.stripEnd(null, "ab"));
+    assertEquals("", StringUtils.stripEnd("", "ab"));
+    assertEquals("abc", StringUtils.stripEnd("abc", null));
+    assertEquals("abc", StringUtils.stripEnd("abc  ", null));
+    assertEquals("abc", StringUtils.stripEnd("abc", ""));
+    assertEquals("abc", StringUtils.stripEnd("abcabab", "ab"));
+  }
 }


### PR DESCRIPTION
### Change Logs

Unless the tables in bigquery metastore are explicitly deleted & recreated, updates to basepath don't come into effect. Through these changes, any updates in table base path would be identified and the same will updated in bigquery metastore without having to delete & recreate it.

### Impact

Any updates in table base path would be identified and the same will updated in bigquery metastore without having to delete & recreate it.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
