### PR TITLE
[HUDI-7891] Fix HoodieActiveTimeline#deleteCompletedRollback missing check for Action type

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -269,6 +269,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
 
   public void deleteCompletedRollback(HoodieInstant instant) {
     ValidationUtils.checkArgument(instant.isCompleted());
+    ValidationUtils.checkArgument(Objects.equals(instant.getAction(), HoodieTimeline.ROLLBACK_ACTION));
     deleteInstantFile(instant);
   }
 


### PR DESCRIPTION
### Change Logs

HoodieActiveTimeline#deleteCompletedRollback missing check for Action type, If called incorrectly, the meta files that are not Rollback Actions will be deleted by mistake.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [1] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [1] Change Logs and Impact were stated clearly
- [1] Adequate tests were added if applicable
- [1] CI passed
