### PR TITLE
[HUDI-7892] Building workload support set parallelism

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -343,6 +343,12 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "of Spark tasks do not exceed the value. If rollback is slow due to the limited "
           + "parallelism, you can increase this to tune the performance.");
 
+  public static final ConfigProperty<String> BUILD_WORKLOAD_PARALLELISM_VALUE = ConfigProperty
+          .key("hoodie.build.workload.parallelism")
+          .defaultValue("0")
+          .markAdvanced()
+          .withDocumentation("Set number of parallelism during building workload profile.");
+
   public static final ConfigProperty<String> WRITE_BUFFER_LIMIT_BYTES_VALUE = ConfigProperty
       .key("hoodie.write.buffer.limit.bytes")
       .defaultValue(String.valueOf(4 * 1024 * 1024))
@@ -1420,6 +1426,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public int getFinalizeWriteParallelism() {
     return getInt(FINALIZE_WRITE_PARALLELISM_VALUE);
+  }
+
+  public int getBuildWorkloadParallelism() {
+    return getInt(BUILD_WORKLOAD_PARALLELISM_VALUE);
   }
 
   public boolean isTimelineServerBasedInstantStateEnabled() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1429,7 +1429,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public int getBuildWorkloadParallelism() {
-    return getInt(BUILD_WORKLOAD_PARALLELISM_VALUE);
+    return getIntOrDefault(BUILD_WORKLOAD_PARALLELISM_VALUE);
   }
 
   public boolean isTimelineServerBasedInstantStateEnabled() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -157,7 +157,10 @@ public abstract class BaseSparkCommitActionExecutor<T> extends
 
     // Handle records update with clustering
     HoodieData<HoodieRecord<T>> inputRecordsWithClusteringUpdate = clusteringHandleUpdate(inputRecords);
-
+    if (config.getBuildWorkloadParallelism() > 0) {
+      inputRecordsWithClusteringUpdate = inputRecordsWithClusteringUpdate.repartition(config.getBuildWorkloadParallelism());
+    }
+    
     context.setJobStatus(this.getClass().getSimpleName(), "Building workload profile:" + config.getTableName());
     HoodieTimer sourceReadAndIndexTimer = HoodieTimer.start(); // time taken from dedup -> tag location -> building workload profile
     WorkloadProfile workloadProfile =

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -160,7 +160,7 @@ public abstract class BaseSparkCommitActionExecutor<T> extends
     if (config.getBuildWorkloadParallelism() > 0) {
       inputRecordsWithClusteringUpdate = inputRecordsWithClusteringUpdate.repartition(config.getBuildWorkloadParallelism());
     }
-    
+
     context.setJobStatus(this.getClass().getSimpleName(), "Building workload profile:" + config.getTableName());
     HoodieTimer sourceReadAndIndexTimer = HoodieTimer.start(); // time taken from dedup -> tag location -> building workload profile
     WorkloadProfile workloadProfile =


### PR DESCRIPTION
### Change Logs

Building workload support set parallelism，currrenly user cannot special the parallelism during building workload which may due to memory error，the pr aim to support it.
![1718515593640.png](https://github.com/apache/hudi/assets/10645422/05923346-b8c3-4950-a15b-44113194ecd0)



### Impact

none

### Risk level (write none, low medium or high below)

low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
