### PR TITLE
[HUDI-7883] Make Hudi timeline backward compatible (#11443)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
@@ -104,7 +104,7 @@ public class PreferWriterConflictResolutionStrategy
 
     // Merge and sort the instants and return.
     List<HoodieInstant> instantsToConsider = Stream.concat(completedCommitsStream, inflightIngestionCommitsStream)
-        .sorted(Comparator.comparing(o -> o.getStateTransitionTime()))
+        .sorted(Comparator.comparing(o -> o.getCompletionTime()))
         .collect(Collectors.toList());
     LOG.info(String.format("Instants that may have conflict with %s are %s", currentInstant, instantsToConsider));
     return instantsToConsider.stream();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/MetadataConversionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/MetadataConversionUtils.java
@@ -56,7 +56,7 @@ public class MetadataConversionUtils {
     HoodieArchivedMetaEntry archivedMetaWrapper = new HoodieArchivedMetaEntry();
     archivedMetaWrapper.setCommitTime(hoodieInstant.getTimestamp());
     archivedMetaWrapper.setActionState(hoodieInstant.getState().name());
-    archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getStateTransitionTime());
+    archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getCompletionTime());
     switch (hoodieInstant.getAction()) {
       case HoodieTimeline.CLEAN_ACTION: {
         if (hoodieInstant.isCompleted()) {
@@ -141,7 +141,7 @@ public class MetadataConversionUtils {
     HoodieArchivedMetaEntry archivedMetaWrapper = new HoodieArchivedMetaEntry();
     archivedMetaWrapper.setCommitTime(hoodieInstant.getTimestamp());
     archivedMetaWrapper.setActionState(hoodieInstant.getState().name());
-    archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getStateTransitionTime());
+    archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getCompletionTime());
     switch (hoodieInstant.getAction()) {
       case HoodieTimeline.CLEAN_ACTION: {
         archivedMetaWrapper.setActionType(ActionType.clean.name());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -226,14 +226,14 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   @Override
   public HoodieDefaultTimeline findInstantsInRangeByStateTransitionTime(String startTs, String endTs) {
     return new HoodieDefaultTimeline(
-        getInstantsAsStream().filter(s -> HoodieTimeline.isInRange(s.getStateTransitionTime(), startTs, endTs)),
+        getInstantsAsStream().filter(s -> HoodieTimeline.isInRange(s.getCompletionTime(), startTs, endTs)),
         details);
   }
 
   @Override
   public HoodieDefaultTimeline findInstantsModifiedAfterByStateTransitionTime(String instantTime) {
     return new HoodieDefaultTimeline(instants.stream()
-        .filter(s -> HoodieTimeline.compareTimestamps(s.getStateTransitionTime(),
+        .filter(s -> HoodieTimeline.compareTimestamps(s.getCompletionTime(),
             GREATER_THAN, instantTime) && !s.getTimestamp().equals(instantTime)), details);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -19,11 +19,11 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.storage.StoragePathInfo;
 
 import java.io.Serializable;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,18 +38,20 @@ import java.util.regex.Pattern;
  */
 public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
 
-  // Instant like 20230104152218702.commit.request, 20230104152218702.inflight
+  // Instant like 20230104152218702.commit.request, 20230104152218702.inflight and 20230104152218702_20230104152630238.commit
   private static final Pattern NAME_FORMAT =
-      Pattern.compile("^(\\d+)(\\.\\w+)(\\.\\D+)?$");
+      Pattern.compile("^(\\d+(_\\d+)?)(\\.\\w+)(\\.\\D+)?$");
 
   private static final String DELIMITER = ".";
+
+  private static final String UNDERSCORE = "_";
 
   private static final String FILE_NAME_FORMAT_ERROR =
       "The provided file name %s does not conform to the required format";
 
   /**
    * A COMPACTION action eventually becomes COMMIT when completed. So, when grouping instants
-   * for state transitions, this needs to be taken into account
+   * for state transitions, this needs to be taken into account.
    */
   private static final Map<String, String> COMPARABLE_ACTIONS = createComparableActionsMap();
 
@@ -60,10 +62,10 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
       .thenComparing(ACTION_COMPARATOR).thenComparing(HoodieInstant::getState);
 
   public static final Comparator<HoodieInstant> STATE_TRANSITION_COMPARATOR =
-      Comparator.comparing(HoodieInstant::getStateTransitionTime)
+      Comparator.comparing(HoodieInstant::getCompletionTime)
           .thenComparing(COMPARATOR);
 
-  public static final String EMPTY_FILE_EXTENSION = "";
+  private static final String EMPTY_FILE_EXTENSION = "";
 
   public static String getComparableAction(String action) {
     return COMPARABLE_ACTIONS.getOrDefault(action, action);
@@ -72,7 +74,8 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
   public static String extractTimestamp(String fileName) throws IllegalArgumentException {
     Matcher matcher = NAME_FORMAT.matcher(fileName);
     if (matcher.find()) {
-      return matcher.group(1);
+      String timestamp = matcher.group(1);
+      return timestamp.contains(UNDERSCORE) ? timestamp.split(UNDERSCORE)[0] : timestamp;
     }
 
     throw new IllegalArgumentException("Failed to retrieve timestamp from name: "
@@ -107,7 +110,7 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
   private final State state;
   private final String action;
   private final String timestamp;
-  private final String stateTransitionTime;
+  private final String completionTime;
 
   /**
    * Load the instant from the meta FileStatus.
@@ -117,23 +120,26 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
     String fileName = pathInfo.getPath().getName();
     Matcher matcher = NAME_FORMAT.matcher(fileName);
     if (matcher.find()) {
-      timestamp = matcher.group(1);
-      if (matcher.group(2).equals(HoodieTimeline.INFLIGHT_EXTENSION)) {
+      String[] timestamps = matcher.group(1).split(UNDERSCORE);
+      timestamp = timestamps[0];
+      if (matcher.group(3).equals(HoodieTimeline.INFLIGHT_EXTENSION)) {
         // This is to support backwards compatibility on how in-flight commit files were written
         // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
         action = HoodieTimeline.COMMIT_ACTION;
         state = State.INFLIGHT;
       } else {
-        action = matcher.group(2).replaceFirst(DELIMITER, StringUtils.EMPTY_STRING);
-        if (matcher.groupCount() == 3 && matcher.group(3) != null) {
-          state = State.valueOf(matcher.group(3).replaceFirst(DELIMITER, StringUtils.EMPTY_STRING).toUpperCase());
+        action = matcher.group(3).replaceFirst(DELIMITER, StringUtils.EMPTY_STRING);
+        if (matcher.groupCount() == 4 && matcher.group(4) != null) {
+          state = State.valueOf(matcher.group(4).replaceFirst(DELIMITER, StringUtils.EMPTY_STRING).toUpperCase());
         } else {
           // Like 20230104152218702.commit
           state = State.COMPLETED;
         }
       }
-      stateTransitionTime =
-          HoodieInstantTimeGenerator.formatDate(new Date(pathInfo.getModificationTime()));
+      completionTime = timestamps.length > 1
+          ? timestamps[1]
+          // for backward compatibility with 0.x release.
+          : state == State.COMPLETED ? pathInfo.getModificationTime() + "" : null;
     } else {
       throw new IllegalArgumentException("Failed to construct HoodieInstant: " + String.format(FILE_NAME_FORMAT_ERROR, fileName));
     }
@@ -144,21 +150,21 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
     this.state = isInflight ? State.INFLIGHT : State.COMPLETED;
     this.action = action;
     this.timestamp = timestamp;
-    this.stateTransitionTime = null;
+    this.completionTime = null;
   }
 
   public HoodieInstant(State state, String action, String timestamp) {
     this.state = state;
     this.action = action;
     this.timestamp = timestamp;
-    this.stateTransitionTime = null;
+    this.completionTime = null;
   }
 
-  public HoodieInstant(State state, String action, String timestamp, String stateTransitionTime) {
+  public HoodieInstant(State state, String action, String timestamp, String completionTime) {
     this.state = state;
     this.action = action;
     this.timestamp = timestamp;
-    this.stateTransitionTime = stateTransitionTime;
+    this.completionTime = completionTime;
   }
 
   public boolean isCompleted() {
@@ -181,70 +187,127 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
     return timestamp;
   }
 
-  /**
-   * Get the filename for this instant.
-   */
-  public String getFileName() {
+  private static Map<String, String> createComparableActionsMap() {
+    Map<String, String> comparableMap = new HashMap<>();
+    comparableMap.put(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.COMMIT_ACTION);
+    comparableMap.put(HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION);
+    return comparableMap;
+  }
+
+  private String getPendingFileName() {
     if (HoodieTimeline.COMMIT_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightCommitFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedCommitFileName(timestamp)
-              : HoodieTimeline.makeCommitFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightCommitFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedCommitFileName(timestamp);
+      }
     } else if (HoodieTimeline.CLEAN_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightCleanerFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedCleanerFileName(timestamp)
-              : HoodieTimeline.makeCleanerFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightCleanerFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedCleanerFileName(timestamp);
+      }
     } else if (HoodieTimeline.ROLLBACK_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightRollbackFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedRollbackFileName(timestamp)
-              : HoodieTimeline.makeRollbackFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightRollbackFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedRollbackFileName(timestamp);
+      }
     } else if (HoodieTimeline.SAVEPOINT_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightSavePointFileName(timestamp)
-          : HoodieTimeline.makeSavePointFileName(timestamp);
+      return HoodieTimeline.makeInflightSavePointFileName(timestamp);
     } else if (HoodieTimeline.DELTA_COMMIT_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightDeltaFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedDeltaFileName(timestamp)
-              : HoodieTimeline.makeDeltaFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightDeltaFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedDeltaFileName(timestamp);
+      }
     } else if (HoodieTimeline.COMPACTION_ACTION.equals(action)) {
       if (isInflight()) {
         return HoodieTimeline.makeInflightCompactionFileName(timestamp);
       } else if (isRequested()) {
         return HoodieTimeline.makeRequestedCompactionFileName(timestamp);
-      } else {
-        return HoodieTimeline.makeCommitFileName(timestamp);
       }
     } else if (HoodieTimeline.LOG_COMPACTION_ACTION.equals(action)) {
       if (isInflight()) {
         return HoodieTimeline.makeInflightLogCompactionFileName(timestamp);
       } else if (isRequested()) {
         return HoodieTimeline.makeRequestedLogCompactionFileName(timestamp);
-      } else {
-        return HoodieTimeline.makeDeltaFileName(timestamp);
       }
     } else if (HoodieTimeline.RESTORE_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightRestoreFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedRestoreFileName(timestamp)
-          : HoodieTimeline.makeRestoreFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightRestoreFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedRestoreFileName(timestamp);
+      }
     } else if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightReplaceFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedReplaceFileName(timestamp)
-          : HoodieTimeline.makeReplaceFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightReplaceFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedReplaceFileName(timestamp);
+      }
     } else if (HoodieTimeline.INDEXING_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightIndexFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestedIndexFileName(timestamp)
-          : HoodieTimeline.makeIndexCommitFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightIndexFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedIndexFileName(timestamp);
+      }
     } else if (HoodieTimeline.SCHEMA_COMMIT_ACTION.equals(action)) {
-      return isInflight() ? HoodieTimeline.makeInflightSchemaFileName(timestamp)
-          : isRequested() ? HoodieTimeline.makeRequestSchemaFileName(timestamp)
-          : HoodieTimeline.makeSchemaFileName(timestamp);
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightSchemaFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestSchemaFileName(timestamp);
+      }
     }
     throw new IllegalArgumentException("Cannot get file name for unknown action " + action);
   }
 
-  private static final Map<String, String> createComparableActionsMap() {
-    Map<String, String> comparableMap = new HashMap<>();
-    comparableMap.put(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.COMMIT_ACTION);
-    comparableMap.put(HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION);
-    return comparableMap;
+  private String getCompleteFileName(String completionTime) {
+    ValidationUtils.checkArgument(!StringUtils.isNullOrEmpty(completionTime), "Completion time should not be empty");
+    String timestampWithCompletionTime = timestamp + "_" + completionTime;
+    switch (action) {
+      case HoodieTimeline.COMMIT_ACTION:
+      case HoodieTimeline.COMPACTION_ACTION:
+        return HoodieTimeline.makeCommitFileName(timestampWithCompletionTime);
+      case HoodieTimeline.CLEAN_ACTION:
+        return HoodieTimeline.makeCleanerFileName(timestampWithCompletionTime);
+      case HoodieTimeline.ROLLBACK_ACTION:
+        return HoodieTimeline.makeRollbackFileName(timestampWithCompletionTime);
+      case HoodieTimeline.SAVEPOINT_ACTION:
+        return HoodieTimeline.makeSavePointFileName(timestampWithCompletionTime);
+      case HoodieTimeline.DELTA_COMMIT_ACTION:
+      case HoodieTimeline.LOG_COMPACTION_ACTION:
+        return HoodieTimeline.makeDeltaFileName(timestampWithCompletionTime);
+      case HoodieTimeline.RESTORE_ACTION:
+        return HoodieTimeline.makeRestoreFileName(timestampWithCompletionTime);
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+        return HoodieTimeline.makeReplaceFileName(timestampWithCompletionTime);
+      case HoodieTimeline.INDEXING_ACTION:
+        return HoodieTimeline.makeIndexCommitFileName(timestampWithCompletionTime);
+      case HoodieTimeline.SCHEMA_COMMIT_ACTION:
+        return HoodieTimeline.makeSchemaFileName(timestampWithCompletionTime);
+      default:
+        throw new IllegalArgumentException("Cannot get complete instant's file name for unknown action "
+            + action);
+    }
+  }
+
+  /**
+   * Get the filename for this instant.
+   */
+  public String getFileName() {
+    if (isCompleted()) {
+      return getCompleteFileName(completionTime);
+    }
+
+    return getPendingFileName();
+  }
+
+  /**
+   * Get the filename for this instant.
+   */
+  public String getFileName(String completionTime) {
+    ValidationUtils.checkState(isCompleted());
+    return getCompleteFileName(completionTime);
   }
 
   @Override
@@ -263,8 +326,8 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
     return state;
   }
 
-  public String getStateTransitionTime() {
-    return stateTransitionTime;
+  public String getCompletionTime() {
+    return completionTime;
   }
 
   @Override
@@ -280,7 +343,8 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
   @Override
   public String toString() {
     return "[" + ((isInflight() || isRequested()) ? "==>" : "")
-        + timestamp + "__" + action + "__" + state
-        + (StringUtils.isNullOrEmpty(stateTransitionTime) ? "" : ("__" + stateTransitionTime)) + "]";
+        + timestamp
+        + (StringUtils.isNullOrEmpty(completionTime) ? "" : ("__" + completionTime))
+        + "__" + action + "__" + state + "]";
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -297,7 +297,7 @@ public class TimelineUtils {
       // Get 'hollow' instants that have less instant time than exclusiveStartInstantTime but with greater commit completion time
       HoodieDefaultTimeline hollowInstantsTimeline = (HoodieDefaultTimeline) timeline.getCommitsTimeline()
           .filter(s -> compareTimestamps(s.getTimestamp(), LESSER_THAN, exclusiveStartInstantTime))
-          .filter(s -> compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, lastMaxCompletionTime.get()));
+          .filter(s -> compareTimestamps(s.getCompletionTime(), GREATER_THAN, lastMaxCompletionTime.get()));
       if (!hollowInstantsTimeline.empty()) {
         return timelineSinceLastSync.mergeTimeline(hollowInstantsTimeline);
       }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -289,7 +289,7 @@ public class IncrementalInputSplits implements Serializable {
 
     // version number should be monotonically increasing
     // fetch the instant offset by completion time
-    String offsetToIssue = instants.stream().map(HoodieInstant::getStateTransitionTime).max(String::compareTo).orElse(endInstant);
+    String offsetToIssue = instants.stream().map(HoodieInstant::getCompletionTime).max(String::compareTo).orElse(endInstant);
 
     if (instantRange == null) {
       // reading from the earliest, scans the partitions and files directly.
@@ -384,12 +384,12 @@ public class IncrementalInputSplits implements Serializable {
     // while with smaller txn start time.
     List<HoodieInstant> instants = commitTimeline.getInstantsAsStream()
         .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, issuedInstant))
-        .filter(s -> HoodieTimeline.compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, issuedOffset))
+        .filter(s -> HoodieTimeline.compareTimestamps(s.getCompletionTime(), GREATER_THAN, issuedOffset))
         .filter(s -> StreamerUtil.isWriteCommit(metaClient.getTableType(), s, commitTimeline)).collect(Collectors.toList());
     if (instants.isEmpty()) {
       return Result.EMPTY;
     }
-    String offsetToIssue = instants.stream().map(HoodieInstant::getStateTransitionTime).max(String::compareTo).orElse(issuedOffset);
+    String offsetToIssue = instants.stream().map(HoodieInstant::getCompletionTime).max(String::compareTo).orElse(issuedOffset);
     List<MergeOnReadInputSplit> inputSplits = instants.stream().map(instant -> {
       String instantTs = instant.getTimestamp();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -610,7 +610,7 @@ public class TestInputFormat {
     TestData.assertRowDataEquals(result3, TestData.dataSetInsert(3, 4));
 
     // test c2 and c4, c2 completion time > c1, so it is not a hollow instant
-    IncrementalInputSplits.Result splits4 = incrementalInputSplits.inputSplits(metaClient, oriInstants.get(0).getTimestamp(), oriInstants.get(0).getStateTransitionTime(), false);
+    IncrementalInputSplits.Result splits4 = incrementalInputSplits.inputSplits(metaClient, oriInstants.get(0).getTimestamp(), oriInstants.get(0).getCompletionTime(), false);
     assertFalse(splits4.isEmpty());
     List<RowData> result4 = readData(inputFormat, splits4.getInputSplits().toArray(new MergeOnReadInputSplit[0]));
     TestData.assertRowDataEquals(result4, TestData.dataSetInsert(3, 4, 7, 8));
@@ -631,7 +631,7 @@ public class TestInputFormat {
 
     // test c2 and c4, c2 is recognized as a hollow instant
     // the (version_number, completion_time) pair is not consistent, just for test purpose
-    IncrementalInputSplits.Result splits7 = incrementalInputSplits.inputSplits(metaClient, oriInstants.get(2).getTimestamp(), oriInstants.get(3).getStateTransitionTime(), false);
+    IncrementalInputSplits.Result splits7 = incrementalInputSplits.inputSplits(metaClient, oriInstants.get(2).getTimestamp(), oriInstants.get(3).getCompletionTime(), false);
     assertFalse(splits7.isEmpty());
     List<RowData> result7 = readData(inputFormat, splits7.getInputSplits().toArray(new MergeOnReadInputSplit[0]));
     TestData.assertRowDataEquals(result7, TestData.dataSetInsert(3, 4, 7, 8));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -59,8 +59,12 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.VERSION_0;
 import static org.apache.hudi.common.testutils.Assertions.assertStreamEquals;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -676,6 +680,30 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     String testInstant = "20210101120101";
     assertEquals(HoodieActiveTimeline.parseDateFromInstantTime(testInstant).getTime(),
         HoodieActiveTimeline.parseDateFromInstantTimeSafely(testInstant).get().getTime());
+  }
+
+  @Test
+  public void testInstantCompletionTimeBackwardCompatibility() {
+    HoodieInstant requestedInstant = new HoodieInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
+    HoodieInstant inflightInstant = new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "2");
+    HoodieInstant completeInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "3");
+
+    timeline = new HoodieActiveTimeline(metaClient);
+    timeline.createNewInstant(requestedInstant);
+    timeline.createNewInstant(inflightInstant);
+
+    // Note:
+    // 0.x meta file name pattern: ${instant_time}.action[.state]
+    // 1.x meta file name pattern: ${instant_time}_${completion_time}.action[.state].
+    String legacyCompletedFileName = HoodieTimeline.makeCommitFileName(completeInstant.getTimestamp());
+    metaClient.getStorage().createImmutableFileInPath(new StoragePath(metaClient.getMetaPath().toString(), legacyCompletedFileName), Option.empty());
+
+    timeline = timeline.reload();
+    assertThat("Some instants might be missing", timeline.countInstants(), is(3));
+    List<HoodieInstant> instants = timeline.getInstants();
+    assertNull(instants.get(0).getCompletionTime(), "Requested instant does not have completion time");
+    assertNull(instants.get(1).getCompletionTime(), "Inflight instant does not have completion time");
+    assertNotNull(instants.get(2).getCompletionTime(), "Completed instant has modification time as completion time for 0.x release");
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstant.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstant.java
@@ -73,7 +73,7 @@ public class TestHoodieInstant extends HoodieCommonTestHarness {
 
       // Make sure StateTransitionTime is set in the timeline
       assertEquals(0,
-          timeline.getInstantsAsStream().filter(s -> s.getStateTransitionTime().isEmpty()).count());
+          timeline.getInstantsAsStream().filter(s -> s.getCompletionTime().isEmpty()).count());
     } finally {
       cleanMetaClient();
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -99,7 +99,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
     if (hollowCommitHandling == USE_TRANSITION_TIME) {
       commitTimeline.findInstantsInRangeByStateTransitionTime(
         optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key),
-        optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME.key(), lastInstant.getStateTransitionTime))
+        optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME.key(), lastInstant.getCompletionTime))
     } else {
       commitTimeline.findInstantsInRange(
         optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key),

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -145,7 +145,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
 
   protected def endTimestamp: String = optParams.getOrElse(
     DataSourceReadOptions.END_INSTANTTIME.key,
-    if (hollowCommitHandling == USE_TRANSITION_TIME) super.timeline.lastInstant().get.getStateTransitionTime
+    if (hollowCommitHandling == USE_TRANSITION_TIME) super.timeline.lastInstant().get.getCompletionTime
     else super.timeline.lastInstant().get.getTimestamp)
 
   protected def startInstantArchived: Boolean = super.timeline.isBeforeTimelineStarts(startTimestamp)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -124,7 +124,7 @@ class HoodieStreamSource(
             .skip(activeInstants.countInstants() - 1)
             .findFirst()
             .get()
-            .getStateTransitionTime
+            .getCompletionTime
         } else {
           activeInstants.lastInstant().get().getTimestamp
         }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
@@ -121,7 +121,7 @@ class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BasePr
       for (partitionWriteStat <- commitMetadata.getPartitionToWriteStats.entrySet.asScala) {
         for (hoodieWriteStat <- partitionWriteStat.getValue.asScala) {
           rows.add(Row(
-            commit.getTimestamp, commit.getStateTransitionTime, commit.getAction, hoodieWriteStat.getPartitionPath,
+            commit.getTimestamp, commit.getCompletionTime, commit.getAction, hoodieWriteStat.getPartitionPath,
             hoodieWriteStat.getFileId, hoodieWriteStat.getPrevCommit, hoodieWriteStat.getNumWrites,
             hoodieWriteStat.getNumInserts, hoodieWriteStat.getNumDeletes, hoodieWriteStat.getNumUpdateWrites,
             hoodieWriteStat.getTotalWriteErrors, hoodieWriteStat.getTotalLogBlocks, hoodieWriteStat.getTotalCorruptLogBlock,
@@ -151,7 +151,7 @@ class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BasePr
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
       val commitMetadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
-      rows.add(Row(commit.getTimestamp, commit.getStateTransitionTime, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
+      rows.add(Row(commit.getTimestamp, commit.getCompletionTime, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
         commitMetadata.fetchTotalFilesUpdated, commitMetadata.fetchTotalPartitionsWritten,
         commitMetadata.fetchTotalRecordsWritten, commitMetadata.fetchTotalUpdateRecordsWritten,
         commitMetadata.fetchTotalWriteErrors))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
@@ -106,7 +106,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
       for (partitionWriteStat <- commitMetadata.getPartitionToWriteStats.entrySet.asScala) {
         for (hoodieWriteStat <- partitionWriteStat.getValue.asScala) {
           rows.add(Row(
-            commit.getTimestamp, commit.getStateTransitionTime, commit.getAction, hoodieWriteStat.getPartitionPath,
+            commit.getTimestamp, commit.getCompletionTime, commit.getAction, hoodieWriteStat.getPartitionPath,
             hoodieWriteStat.getFileId, hoodieWriteStat.getPrevCommit, hoodieWriteStat.getNumWrites,
             hoodieWriteStat.getNumInserts, hoodieWriteStat.getNumDeletes, hoodieWriteStat.getNumUpdateWrites,
             hoodieWriteStat.getTotalWriteErrors, hoodieWriteStat.getTotalLogBlocks, hoodieWriteStat.getTotalCorruptLogBlock,
@@ -136,7 +136,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
       val commitMetadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
-      rows.add(Row(commit.getTimestamp, commit.getStateTransitionTime, commit.getAction, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
+      rows.add(Row(commit.getTimestamp, commit.getCompletionTime, commit.getAction, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
         commitMetadata.fetchTotalFilesUpdated, commitMetadata.fetchTotalPartitionsWritten,
         commitMetadata.fetchTotalRecordsWritten, commitMetadata.fetchTotalUpdateRecordsWritten,
         commitMetadata.fetchTotalWriteErrors))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
@@ -93,7 +93,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
       .option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "000")
       .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_TRANSITION_TIME.name())
-      .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getStateTransitionTime)
+      .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getCompletionTime)
       .load(basePath)
       .count()
     Assertions.assertEquals(result2, 100)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -203,7 +203,7 @@ class TestStreamingSource extends StreamTest {
 
       val timestamp = if (handlingMode == USE_TRANSITION_TIME) {
         metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
-          .firstInstant().get().getStateTransitionTime
+          .firstInstant().get().getCompletionTime
       } else {
         metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
           .firstInstant().get().getTimestamp

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -377,7 +377,7 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
         .getInstantsOrderedByStateTransitionTime()
         .skip(activeTimeline.countInstants() - 1)
         .findFirst()
-        .map(i -> Option.of(i.getStateTransitionTime()))
+        .map(i -> Option.of(i.getCompletionTime()))
         .orElse(Option.empty());
     if (lastCommitSynced.isPresent()) {
       try {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1642,7 +1642,7 @@ public class TestHiveSyncTool {
   private String getLastCommitCompletionTimeSynced() {
     return hiveClient.getActiveTimeline()
         .getInstantsOrderedByStateTransitionTime()
-        .skip(hiveClient.getActiveTimeline().countInstants() - 1).findFirst().get().getStateTransitionTime();
+        .skip(hiveClient.getActiveTimeline().countInstants() - 1).findFirst().get().getCompletionTime();
   }
 
   private void reInitHiveSyncClient() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -118,7 +118,7 @@ public class IncrSourceHelper {
     HoodieTimeline completedCommitTimeline = srcMetaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
     final HoodieTimeline activeCommitTimeline = handleHollowCommitIfNeeded(completedCommitTimeline, srcMetaClient, handlingMode);
     Function<HoodieInstant, String> timestampForLastInstant = instant -> handlingMode == HollowCommitHandling.USE_TRANSITION_TIME
-        ? instant.getStateTransitionTime() : instant.getTimestamp();
+        ? instant.getCompletionTime() : instant.getTimestamp();
     String beginInstantTime = beginInstant.orElseGet(() -> {
       if (missingCheckpointStrategy != null) {
         if (missingCheckpointStrategy == MissingCheckpointStrategy.READ_LATEST) {


### PR DESCRIPTION
### Change Logs

Cherry-pick 6aea47a13f5e0efc07a580ce7364f80497a0521a and corresponding `HoodieInstant` changes so that 0.16.0 can read instants written by 1.0.0.

### Impact

Timeline compatibility (both backward and forward)

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
