### PR TITLE
[HUDI-7877] Add record position to record index metadata payload

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -430,7 +430,10 @@
                         },
                         {
                             "name": "position",
-                            "type": "long",
+                            "type": [
+                                "null",
+                                "long"
+                            ],
                             "default": null,
                             "doc": "Represents position of record within a file group for easier access. It will be used for index lookup."
                         }

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -427,6 +427,12 @@
                             "type": "int",
                             "default": 0,
                             "doc": "Represents fileId encoding. Possible values are 0 and 1. O represents UUID based fileID, and 1 represents raw string format of the fileId. \nWhen the encoding is 0, reader can deduce fileID from fileIdLowBits, fileIdHighBits and fileIndex."
+                        },
+                        {
+                            "name": "position",
+                            "type": "long",
+                            "default": null,
+                            "doc": "Represents position of record within a file group for easier access"
                         }
                     ]
                 }

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -432,7 +432,7 @@
                             "name": "position",
                             "type": "long",
                             "default": null,
-                            "doc": "Represents position of record within a file group for easier access"
+                            "doc": "Represents position of record within a file group for easier access. It will be used for index lookup."
                         }
                     ]
                 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -156,6 +156,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   public static final String RECORD_INDEX_FIELD_FILEID_ENCODING = "fileIdEncoding";
   public static final int RECORD_INDEX_FIELD_FILEID_ENCODING_UUID = 0;
   public static final int RECORD_INDEX_FIELD_FILEID_ENCODING_RAW_STRING = 1;
+  public static final String RECORD_INDEX_POSITION = "position";
 
   /**
    * FileIndex value saved in record index record when the fileId has no index (old format of base filename)
@@ -267,7 +268,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
             Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILE_INDEX).toString()),
             recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID).toString(),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_INSTANT_TIME).toString()),
-            Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_ENCODING).toString()));
+            Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_ENCODING).toString()),
+            Long.parseLong(recordIndexRecord.get(RECORD_INDEX_POSITION).toString()));
       } else if (type == METADATA_TYPE_SECONDARY_INDEX) {
         GenericRecord secondaryIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_SECONDARY_INDEX);
         checkState(secondaryIndexRecord != null, "Valid SecondaryIndexMetadata record expected for type: " + METADATA_TYPE_SECONDARY_INDEX);
@@ -797,7 +799,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               fileIndex,
               "",
               instantTimeMillis,
-              0));
+              0,
+              null));
       return new HoodieAvroRecord<>(key, payload);
     } else {
       HoodieMetadataPayload payload = new HoodieMetadataPayload(recordKey,
@@ -808,7 +811,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               -1,
               fileId,
               instantTimeMillis,
-              1));
+              1,
+              null));
       return new HoodieAvroRecord<>(key, payload);
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -156,7 +156,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   public static final String RECORD_INDEX_FIELD_FILEID_ENCODING = "fileIdEncoding";
   public static final int RECORD_INDEX_FIELD_FILEID_ENCODING_UUID = 0;
   public static final int RECORD_INDEX_FIELD_FILEID_ENCODING_RAW_STRING = 1;
-  public static final String RECORD_INDEX_POSITION = "position";
+  public static final String RECORD_INDEX_FIELD_POSITION = "position";
 
   /**
    * FileIndex value saved in record index record when the fileId has no index (old format of base filename)
@@ -262,7 +262,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
         }
       } else if (type == METADATA_TYPE_RECORD_INDEX) {
         GenericRecord recordIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_RECORD_INDEX);
-        Object recordIndexPosition = recordIndexRecord.get(RECORD_INDEX_POSITION);
+        Object recordIndexPosition = recordIndexRecord.get(RECORD_INDEX_FIELD_POSITION);
         recordIndexMetadata = new HoodieRecordIndexInfo(recordIndexRecord.get(RECORD_INDEX_FIELD_PARTITION).toString(),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_HIGH_BITS).toString()),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_LOW_BITS).toString()),

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -262,6 +262,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
         }
       } else if (type == METADATA_TYPE_RECORD_INDEX) {
         GenericRecord recordIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_RECORD_INDEX);
+        Object recordIndexPosition = recordIndexRecord.get(RECORD_INDEX_POSITION);
         recordIndexMetadata = new HoodieRecordIndexInfo(recordIndexRecord.get(RECORD_INDEX_FIELD_PARTITION).toString(),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_HIGH_BITS).toString()),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_LOW_BITS).toString()),
@@ -269,7 +270,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
             recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID).toString(),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_INSTANT_TIME).toString()),
             Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_ENCODING).toString()),
-            Long.parseLong(recordIndexRecord.get(RECORD_INDEX_POSITION).toString()));
+            recordIndexPosition != null ? Long.parseLong(recordIndexPosition.toString()) : null);
       } else if (type == METADATA_TYPE_SECONDARY_INDEX) {
         GenericRecord secondaryIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_SECONDARY_INDEX);
         checkState(secondaryIndexRecord != null, "Valid SecondaryIndexMetadata record expected for type: " + METADATA_TYPE_SECONDARY_INDEX);


### PR DESCRIPTION
### Change Logs

RLI should save the record position so that can be used in the index lookup. This PR adds a position field in the RLI metadata to track the same.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
