### PR TITLE
[HUDI-7906] improve the parallelism deduce in rdd write

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -168,7 +168,7 @@ public class HoodieIndexConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> GLOBAL_SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.global.simple.index.parallelism")
-      .defaultValue("100")
+      .defaultValue("0")
       .markAdvanced()
       .withDocumentation("Only applies if index type is GLOBAL_SIMPLE. "
           + "This limits the parallelism of fetching records from the base files of all table "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
@@ -69,8 +69,11 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
       HoodieData<HoodieRecord<R>> inputRecords, HoodieEngineContext context,
       HoodieTable hoodieTable) {
     List<Pair<String, HoodieBaseFile>> latestBaseFiles = getAllBaseFilesInTable(context, hoodieTable);
+    int configuredSimpleIndexParallelism = config.getGlobalSimpleIndexParallelism();
+    int fetchParallelism =
+        configuredSimpleIndexParallelism > 0 ? configuredSimpleIndexParallelism : inputRecords.deduceNumPartitions();
     HoodiePairData<String, HoodieRecordGlobalLocation> allKeysAndLocations =
-        fetchRecordGlobalLocations(context, hoodieTable, config.getGlobalSimpleIndexParallelism(), latestBaseFiles);
+        fetchRecordGlobalLocations(context, hoodieTable, fetchParallelism, latestBaseFiles);
     boolean mayContainDuplicateLookup = hoodieTable.getMetaClient().getTableType() == MERGE_ON_READ;
     boolean shouldUpdatePartitionPath = config.getGlobalSimpleIndexUpdatePartitionPath() && hoodieTable.isPartitioned();
     return tagGlobalLocationBackToRecords(inputRecords, allKeysAndLocations,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieDeleteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieDeleteHelper.java
@@ -50,7 +50,7 @@ public class HoodieDeleteHelper<T, R> extends
     BaseDeleteHelper<T, HoodieData<HoodieRecord<T>>, HoodieData<HoodieKey>, HoodieData<WriteStatus>, R> {
 
   private HoodieDeleteHelper() {
-    super(HoodieData::getNumPartitions);
+    super(HoodieData::deduceNumPartitions);
   }
 
   private static class DeleteHelperHolder {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieWriteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieWriteHelper.java
@@ -38,7 +38,7 @@ public class HoodieWriteHelper<T, R> extends BaseWriteHelper<T, HoodieData<Hoodi
     HoodieData<HoodieKey>, HoodieData<WriteStatus>, R> {
 
   private HoodieWriteHelper() {
-    super(HoodieData::getNumPartitions);
+    super(HoodieData::deduceNumPartitions);
   }
 
   private static class WriteHelperHolder {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/commit/TestWriterHelperBase.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/commit/TestWriterHelperBase.java
@@ -19,7 +19,6 @@
 
 package org.apache.hudi.table.action.commit;
 
-import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -27,13 +26,10 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for write helpers
@@ -59,21 +55,6 @@ public abstract class TestWriterHelperBase<I> extends HoodieCommonTestHarness {
   @AfterEach
   public void tearDown() throws Exception {
     cleanupResources();
-  }
-
-  @ParameterizedTest
-  @CsvSource({"true,0", "true,50", "false,0", "false,50"})
-  public void testCombineParallelism(boolean shouldCombine, int configuredShuffleParallelism) {
-    int inputParallelism = 5;
-    inputRecords = getInputRecords(
-        dataGen.generateInserts("20230915000000000", 10), inputParallelism);
-    HoodieData<HoodieRecord> outputRecords = (HoodieData<HoodieRecord>) writeHelper.combineOnCondition(
-        shouldCombine, inputRecords, configuredShuffleParallelism, table);
-    if (!shouldCombine || configuredShuffleParallelism == 0) {
-      assertEquals(inputParallelism, outputRecords.getNumPartitions());
-    } else {
-      assertEquals(configuredShuffleParallelism, outputRecords.getNumPartitions());
-    }
   }
 
   private void initResources() throws IOException {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -88,7 +88,7 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       Map<String, List<BloomIndexFileInfo>> partitionToFileInfo,
       Map<String, Long> recordsPerPartition) {
 
-    int inputParallelism = HoodieJavaPairRDD.getJavaPairRDD(partitionRecordKeyPairs).getNumPartitions();
+    int inputParallelism = partitionRecordKeyPairs.deduceNumPartitions();
     int configuredBloomIndexParallelism = config.getBloomIndexParallelism();
 
     // NOTE: Target parallelism could be overridden by the config

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -108,7 +108,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
     //       Additionally, we have to explicitly wrap around resulting [[RDD]] into the one
     //       injecting [[SQLConf]], which by default isn't propagated by Spark to the executor(s).
     //       [[SQLConf]] is required by [[AvroSerializer]]
-    injectSQLConf(df.queryExecution.toRdd.mapPartitions { rows =>
+    injectSQLConf(df.queryExecution.toRdd.mapPartitions (rows => {
       if (rows.isEmpty) {
         Iterator.empty
       } else {
@@ -126,7 +126,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
 
         rows.map { ir => transform(convert(ir)) }
       }
-    }, SQLConf.get)
+    }, preservesPartitioning = true), SQLConf.get)
   }
 
   def injectSQLConf[T: ClassTag](rdd: RDD[T], conf: SQLConf): RDD[T] =

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieData.java
@@ -94,6 +94,11 @@ public interface HoodieData<T> extends Serializable {
   int getNumPartitions();
 
   /**
+   * @return the deduce number of shuffle partitions
+   */
+  int deduceNumPartitions();
+
+  /**
    * Maps every element in the collection using provided mapping {@code func}.
    * <p>
    * This is an intermediate operation

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListData.java
@@ -202,6 +202,11 @@ public class HoodieListData<T> extends HoodieBaseListData<T> implements HoodieDa
   }
 
   @Override
+  public int deduceNumPartitions() {
+    return 1;
+  }
+
+  @Override
   public List<T> collectAsList() {
     return super.collectAsList();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListPairData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListPairData.java
@@ -201,6 +201,11 @@ public class HoodieListPairData<K, V> extends HoodieBaseListData<Pair<K, V>> imp
     return super.collectAsList();
   }
 
+  @Override
+  public int deduceNumPartitions() {
+    return 1;
+  }
+
   public static <K, V> HoodieListPairData<K, V> lazy(List<Pair<K, V>> data) {
     return new HoodieListPairData<>(data, true);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
@@ -129,4 +129,9 @@ public interface HoodiePairData<K, V> extends Serializable {
    * This is a terminal operation
    */
   List<Pair<K, V>> collectAsList();
+
+  /**
+   * @return the deduce number of shuffle partitions
+   */
+  int deduceNumPartitions();
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -69,6 +69,8 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
              location '${tablePath}'
              """.stripMargin)
 
+      spark.sql("set spark.sql.shuffle.partitions = 11")
+
       spark.sql(
         s"""
            |insert into ${targetTable}


### PR DESCRIPTION
### Change Logs

as https://github.com/apache/hudi/issues/11274 and https://github.com/apache/hudi/pull/11463 describe, there has two case question.

- if the rdd is input rdd without shuffle, the partitiion number is too bigger or too small
- user need can not control it easy
  - in some case user can set `spark.default.parallelism` change it.
  - in some case user can not change because hard-code
  - and in spark, the better way is use `spark.default.parallelism` or `spark.sql.shuffle.partitions` can control it, other is advanced in hudi.

### Impact

like dedup where use new deduce logical, user can use `spark.sql.shuffle.partitions` or `spark.default.parallelism` control the parallelism.
For special scenes, also can use advanced params.

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
