### PR TITLE
[MINOR] Disable new HFile reader by default

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 public class HoodieReaderConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> USE_NATIVE_HFILE_READER = ConfigProperty
       .key("_hoodie.hfile.use.native.reader")
-      .defaultValue(true)
+      .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("When enabled, the native HFile reader is used to read HFiles.  This is an internal config.");


### PR DESCRIPTION
### Change Logs

This PR disables new HFile reader by default as Spark tests encounter OOM in Github CI due to not releasing resources with the new HFile reader properly.  To unblock CI, we temporarily turn it off while working on a fix.

### Impact

Unblocks CI.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
