### PR TITLE
[HUDI-7921] Making HoodieTable closeable

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -296,4 +296,12 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       }
     }
   }
+
+  protected void closeHoodieTable(HoodieTable table) {
+    try {
+      table.close();
+    } catch (Exception e) {
+      throw new HoodieException("Failed to close HoodieTable instance ", e);
+    }
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -123,7 +123,7 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartition
  * @param <K> Type of keys
  * @param <O> Type of outputs
  */
-public abstract class HoodieTable<T, I, K, O> implements Serializable {
+public abstract class HoodieTable<T, I, K, O> implements Serializable, AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieTable.class);
 
   protected final HoodieWriteConfig config;
@@ -1110,5 +1110,11 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     } else {
       HoodieMergeHelper.newInstance().runMerge(this, upsertHandle);
     }
+  }
+
+  @Override
+  public void close() throws Exception {
+    this.viewManager.close();
+    this.metadata.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -137,6 +137,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable, AutoClose
 
   private transient FileSystemViewManager viewManager;
   protected final transient HoodieEngineContext context;
+  private HoodieTableFileSystemView tableFileSystemView;
 
   protected HoodieTable(HoodieWriteConfig config, HoodieEngineContext context, HoodieTableMetaClient metaClient) {
     this.config = config;
@@ -326,7 +327,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable, AutoClose
    * Get the view of the file system for this table.
    */
   public TableFileSystemView getFileSystemView() {
-    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline());
+    if (tableFileSystemView == null) {
+      tableFileSystemView = new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline());
+    }
+    return tableFileSystemView;
   }
 
   /**
@@ -1114,7 +1118,12 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable, AutoClose
 
   @Override
   public void close() throws Exception {
+    if (tableFileSystemView != null) {
+      this.tableFileSystemView.close();
+      this.tableFileSystemView = null;
+    }
     this.viewManager.close();
+    this.viewManager = null;
     this.metadata.close();
   }
 }


### PR DESCRIPTION
### Change Logs

Making HoodieTable Closeable. We have few resources initialized in HoodieTable file FileSysteViewManager and metadata. So introducing close in HoodieTable and closing out all resources instantiated. 


### Impact

Avoids memory leaks with WriteClients.

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
