### PR TITLE
[HUDI-7921] Closing fsview in HoodieTableFileIndex

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/SyncableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/SyncableFileSystemView.java
@@ -26,7 +26,7 @@ import org.apache.hudi.common.table.view.TableFileSystemView.SliceView;
  * update operations.
  */
 public interface SyncableFileSystemView
-    extends TableFileSystemView, BaseFileOnlyView, SliceView {
+    extends TableFileSystemView, BaseFileOnlyView, SliceView, AutoCloseable {
 
 
 


### PR DESCRIPTION
### Change Logs

Closing fsview in HoodieTableFileIndex

### Impact

Avoid memory leaks w/ FileIndex

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
