### PR TITLE
[HUDI-7924] Capture Latency and Failure Metrics For Hive Table recreation

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -328,11 +328,11 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       syncAllPartitions(tableName);
       syncClient.updateLastCommitTimeSynced(tableName);
       if (Objects.nonNull(timerContext)) {
-        long durationInMs = metrics.getDurationInMs(timerContext.stop());
-        metrics.updateRecreateAndSyncMetrics(durationInMs);
+        long durationInNs = timerContext.stop();
+        metrics.updateRecreateAndSyncDurationInMs(durationInNs);
       }
     } catch (HoodieHiveSyncException ex) {
-      metrics.emitRecreateAndSyncFailureMetric();
+      metrics.incrementRecreateAndSyncFailureCounter();
       throw new HoodieHiveSyncException("failed to recreate the table for " + tableName, ex);
     }
   }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
@@ -44,6 +45,7 @@ import org.apache.hudi.hive.ddl.HiveSyncMode;
 import org.apache.hudi.hive.testutils.HiveTestUtil;
 import org.apache.hudi.hive.util.IMetaStoreClientUtil;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.sync.common.HoodieSyncConfig;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
@@ -100,6 +102,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_SERDE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
+import static org.apache.hudi.hive.testutils.HiveTestUtil.BASE_PATH;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.basePath;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.ddlExecutor;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.getHiveConf;
@@ -829,6 +832,9 @@ public class TestHiveSyncTool {
     hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), syncMode);
     hiveSyncProps.setProperty(HIVE_SYNC_FILTER_PUSHDOWN_ENABLED.key(), enablePushDown);
     hiveSyncProps.setProperty(RECREATE_HIVE_TABLE_ON_ERROR.key(), "true");
+    hiveSyncProps.setProperty(HoodieMetricsConfig.TURN_METRICS_ON.key(), "true");
+    hiveSyncProps.setProperty(BASE_PATH, basePath);
+    hiveSyncProps.setProperty(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key(), MetricsReporterType.INMEMORY.name());
 
     String commitTime1 = "100";
     HiveTestUtil.createCOWTable(commitTime1, 5, true);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -102,7 +103,6 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_SERDE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
-import static org.apache.hudi.hive.testutils.HiveTestUtil.BASE_PATH;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.basePath;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.ddlExecutor;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.getHiveConf;
@@ -833,7 +833,7 @@ public class TestHiveSyncTool {
     hiveSyncProps.setProperty(HIVE_SYNC_FILTER_PUSHDOWN_ENABLED.key(), enablePushDown);
     hiveSyncProps.setProperty(RECREATE_HIVE_TABLE_ON_ERROR.key(), "true");
     hiveSyncProps.setProperty(HoodieMetricsConfig.TURN_METRICS_ON.key(), "true");
-    hiveSyncProps.setProperty(BASE_PATH, basePath);
+    hiveSyncProps.setProperty(HoodieCommonConfig.BASE_PATH.key(), basePath);
     hiveSyncProps.setProperty(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key(), MetricsReporterType.INMEMORY.name());
 
     String commitTime1 = "100";

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -123,6 +123,7 @@ public class HiveTestUtil {
 
   public static final String DB_NAME = "testdb";
   public static final String TABLE_NAME = "test1";
+  public static final String BASE_PATH = "hoodie.base.path";
   public static String basePath;
   public static TypedProperties hiveSyncProps;
   public static HiveTestService hiveTestService;
@@ -167,6 +168,7 @@ public class HiveTestUtil {
       hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
       hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
       hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
+      hiveSyncProps.setProperty(BASE_PATH, basePath);
     }
     hiveSyncConfig = new HiveSyncConfig(hiveSyncProps, hiveTestService.getHiveConf());
     fileSystem = hiveSyncConfig.getHadoopFileSystem();

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -123,7 +123,6 @@ public class HiveTestUtil {
 
   public static final String DB_NAME = "testdb";
   public static final String TABLE_NAME = "test1";
-  public static final String BASE_PATH = "hoodie.base.path";
   public static String basePath;
   public static TypedProperties hiveSyncProps;
   public static HiveTestService hiveTestService;
@@ -168,7 +167,6 @@ public class HiveTestUtil {
       hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
       hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
       hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
-      hiveSyncProps.setProperty(BASE_PATH, basePath);
     }
     hiveSyncConfig = new HiveSyncConfig(hiveSyncProps, hiveTestService.getHiveConf());
     fileSystem = hiveSyncConfig.getHadoopFileSystem();

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.HadoopConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS;
 import static org.apache.hudi.common.table.HoodieTableConfig.BASE_FILE_FORMAT;
 import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
@@ -199,6 +201,7 @@ public class HoodieSyncConfig extends HoodieConfig {
           + "obtained from Hudi's internal metadata table. Note, " + HoodieMetadataConfig.ENABLE + " must be set to true.");
 
   private Configuration hadoopConf;
+  private HoodieMetricsConfig metricsConfig;
 
   public HoodieSyncConfig(Properties props) {
     this(props, HadoopConfigUtils.createHadoopConf(props));
@@ -213,6 +216,11 @@ public class HoodieSyncConfig extends HoodieConfig {
         .collect(Collectors.joining("\n")));
     setDefaults(HoodieSyncConfig.class.getName());
     this.hadoopConf = hadoopConf;
+    this.metricsConfig = HoodieMetricsConfig.newBuilder().fromProperties(props).build();
+  }
+
+  public String getBasePath() {
+    return getString(BASE_PATH);
   }
 
   public void setHadoopConf(Configuration hadoopConf) {
@@ -221,6 +229,10 @@ public class HoodieSyncConfig extends HoodieConfig {
 
   public Configuration getHadoopConf() {
     return hadoopConf;
+  }
+
+  public HoodieMetricsConfig getMetricsConfig() {
+    return metricsConfig;
   }
 
   public FileSystem getHadoopFileSystem() {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncTool.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncTool.java
@@ -19,6 +19,7 @@ package org.apache.hudi.sync.common;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.HadoopConfigUtils;
+import org.apache.hudi.sync.common.metrics.HoodieMetaSyncMetrics;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -33,6 +34,7 @@ public abstract class HoodieSyncTool implements AutoCloseable {
 
   protected Properties props;
   protected Configuration hadoopConf;
+  protected HoodieMetaSyncMetrics metrics;
 
   public HoodieSyncTool(Properties props) {
     this(props, HadoopConfigUtils.createHadoopConf(props));
@@ -41,6 +43,7 @@ public abstract class HoodieSyncTool implements AutoCloseable {
   public HoodieSyncTool(Properties props, Configuration hadoopConf) {
     this.props = props;
     this.hadoopConf = hadoopConf;
+    this.metrics = new HoodieMetaSyncMetrics(new HoodieSyncConfig(props, hadoopConf), getClass().getSimpleName());
   }
 
   @Deprecated

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -83,7 +83,7 @@ public class HoodieMetaSyncMetrics {
     if (metricsConfig.isMetricsOn()) {
       long durationInMs = getDurationInMs(durationInNs);
       LOG.info("Sending recreate and sync metrics {}", durationInMs);
-      metrics.registerGauge(getMetricsName("meta_sync", "recreate_table.duration"), durationInMs);
+      metrics.registerGauge(getMetricsName("meta_sync", "recreate_table_duration_ms"), durationInMs);
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class HoodieMetaSyncMetrics {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMetaSyncMetrics.class);
+  // Metrics are shut down by the shutdown hook added in the Metrics class
   private Metrics metrics;
   private HoodieMetricsConfig metricsConfig;
   private transient HoodieStorage storage;

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -35,6 +35,12 @@ import org.slf4j.LoggerFactory;
 public class HoodieMetaSyncMetrics {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMetaSyncMetrics.class);
+  private static final String TIMER_ACTION = "timer";
+  private static final String COUNTER_ACTION = "counter";
+  private static final String META_SYNC_RECREATE_TABLE_METRIC = "meta_sync.recreate_table";
+  private static final String META_SYNC_RECREATE_TABLE_FAILURE_METRIC = "meta_sync.recreate_table.failure";
+  private static final String META_SYNC_ACTION = "meta_sync";
+  private static final String RECREATE_TABLE_DURATION_MS_METRIC = "recreate_table_duration_ms";
   // Metrics are shut down by the shutdown hook added in the Metrics class
   private Metrics metrics;
   private HoodieMetricsConfig metricsConfig;
@@ -54,8 +60,8 @@ public class HoodieMetaSyncMetrics {
     if (metricsConfig.isMetricsOn()) {
       this.storage = HoodieStorageUtils.getStorage(config.getBasePath(), HadoopFSUtils.getStorageConf(config.getHadoopConf()));
       metrics = Metrics.getInstance(metricsConfig, storage);
-      recreateAndSyncTimerName = getMetricsName("timer", "meta_sync.recreate_table");
-      recreateAndSyncFailureCounterName = getMetricsName("counter", "meta_sync.recreate_table.failure");
+      recreateAndSyncTimerName = getMetricsName(TIMER_ACTION, META_SYNC_RECREATE_TABLE_METRIC);
+      recreateAndSyncFailureCounterName = getMetricsName(COUNTER_ACTION, META_SYNC_RECREATE_TABLE_FAILURE_METRIC);
     }
   }
 
@@ -83,7 +89,7 @@ public class HoodieMetaSyncMetrics {
     if (metricsConfig.isMetricsOn()) {
       long durationInMs = getDurationInMs(durationInNs);
       LOG.info("Sending recreate and sync metrics {}", durationInMs);
-      metrics.registerGauge(getMetricsName("meta_sync", "recreate_table_duration_ms"), durationInMs);
+      metrics.registerGauge(getMetricsName(META_SYNC_ACTION, RECREATE_TABLE_DURATION_MS_METRIC), durationInMs);
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -75,13 +75,14 @@ public class HoodieMetaSyncMetrics {
     return metricsConfig.isMetricsOn() ? metrics.getRegistry().timer(name) : null;
   }
 
-  public void emitRecreateAndSyncFailureMetric() {
+  public void incrementRecreateAndSyncFailureCounter() {
     recreateAndSyncFailureCounter = getCounter(recreateAndSyncFailureCounter, recreateAndSyncFailureCounterName);
     recreateAndSyncFailureCounter.inc();
   }
 
-  public void updateRecreateAndSyncMetrics(long durationInMs) {
+  public void updateRecreateAndSyncDurationInMs(long durationInNs) {
     if (metricsConfig.isMetricsOn()) {
+      long durationInMs = getDurationInMs(durationInNs);
       LOG.info("Sending recreate and sync metrics {}", durationInMs);
       metrics.registerGauge(getMetricsName("meta_sync", "recreate_table.duration"), durationInMs);
     }
@@ -90,7 +91,7 @@ public class HoodieMetaSyncMetrics {
   /**
    * By default, the timer context returns duration with nano seconds. Convert it to millisecond.
    */
-  public long getDurationInMs(long ctxDuration) {
+  private long getDurationInMs(long ctxDuration) {
     return ctxDuration / 1000000;
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -36,7 +36,6 @@ public class HoodieMetaSyncMetrics {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMetaSyncMetrics.class);
   private Metrics metrics;
-  private HoodieSyncConfig config;
   private HoodieMetricsConfig metricsConfig;
   private transient HoodieStorage storage;
 
@@ -49,7 +48,6 @@ public class HoodieMetaSyncMetrics {
   private Counter recreateAndSyncFailureCounter;
 
   public HoodieMetaSyncMetrics(HoodieSyncConfig config, String syncToolName) {
-    this.config = config;
     this.metricsConfig = config.getMetricsConfig();
     this.syncToolName = syncToolName;
     if (metricsConfig.isMetricsOn()) {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -42,8 +42,8 @@ public class HoodieMetaSyncMetrics {
 
   private final String syncToolName;
 
-  private String recreateAndSyncFailureCounterName;
-  private String recreateAndSyncTimerName;
+  private static String recreateAndSyncFailureCounterName;
+  private static String recreateAndSyncTimerName;
 
   private Timer recreateAndSyncTimer;
   private Counter recreateAndSyncFailureCounter;
@@ -54,8 +54,8 @@ public class HoodieMetaSyncMetrics {
     if (metricsConfig.isMetricsOn()) {
       this.storage = HoodieStorageUtils.getStorage(config.getBasePath(), HadoopFSUtils.getStorageConf(config.getHadoopConf()));
       metrics = Metrics.getInstance(metricsConfig, storage);
-      this.recreateAndSyncTimerName = getMetricsName("timer", "meta_sync.recreate_table");
-      this.recreateAndSyncFailureCounterName = getMetricsName("counter", "meta_sync.recreate_table.failure");
+      recreateAndSyncTimerName = getMetricsName("timer", "meta_sync.recreate_table");
+      recreateAndSyncFailureCounterName = getMetricsName("counter", "meta_sync.recreate_table.failure");
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/metrics/HoodieMetaSyncMetrics.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sync.common.metrics;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.metrics.Metrics;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.sync.common.HoodieSyncConfig;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HoodieMetaSyncMetrics {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieMetaSyncMetrics.class);
+  private Metrics metrics;
+  private HoodieSyncConfig config;
+  private HoodieMetricsConfig metricsConfig;
+  private transient HoodieStorage storage;
+
+  private final String syncToolName;
+
+  private String recreateAndSyncFailureCounterName;
+  private String recreateAndSyncTimerName;
+
+  private Timer recreateAndSyncTimer;
+  private Counter recreateAndSyncFailureCounter;
+
+  public HoodieMetaSyncMetrics(HoodieSyncConfig config, String syncToolName) {
+    this.config = config;
+    this.metricsConfig = config.getMetricsConfig();
+    this.syncToolName = syncToolName;
+    if (metricsConfig.isMetricsOn()) {
+      this.storage = HoodieStorageUtils.getStorage(config.getBasePath(), HadoopFSUtils.getStorageConf(config.getHadoopConf()));
+      metrics = Metrics.getInstance(metricsConfig, storage);
+      this.recreateAndSyncTimerName = getMetricsName("timer", "meta_sync.recreate_table");
+      this.recreateAndSyncFailureCounterName = getMetricsName("counter", "meta_sync.recreate_table.failure");
+    }
+  }
+
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  public Timer.Context getRecreateAndSyncTimer() {
+    if (metricsConfig.isMetricsOn() && recreateAndSyncTimer == null) {
+      recreateAndSyncTimer = createTimer(recreateAndSyncTimerName);
+    }
+    return recreateAndSyncTimer == null ? null : recreateAndSyncTimer.time();
+  }
+
+  private Timer createTimer(String name) {
+    return metricsConfig.isMetricsOn() ? metrics.getRegistry().timer(name) : null;
+  }
+
+  public void emitRecreateAndSyncFailureMetric() {
+    recreateAndSyncFailureCounter = getCounter(recreateAndSyncFailureCounter, recreateAndSyncFailureCounterName);
+    recreateAndSyncFailureCounter.inc();
+  }
+
+  public void updateRecreateAndSyncMetrics(long durationInMs) {
+    if (metricsConfig.isMetricsOn()) {
+      LOG.info("Sending recreate and sync metrics {}", durationInMs);
+      metrics.registerGauge(getMetricsName("meta_sync", "recreate_table.duration"), durationInMs);
+    }
+  }
+
+  /**
+   * By default, the timer context returns duration with nano seconds. Convert it to millisecond.
+   */
+  public long getDurationInMs(long ctxDuration) {
+    return ctxDuration / 1000000;
+  }
+
+  @VisibleForTesting
+  public String getMetricsName(String action, String metric) {
+    if (StringUtils.isNullOrEmpty(metricsConfig.getMetricReporterMetricsNamePrefix())) {
+      return String.format("%s.%s.%s", action, metric, syncToolName);
+    } else {
+      return String.format("%s.%s.%s.%s", metricsConfig.getMetricReporterMetricsNamePrefix(), action, metric, syncToolName);
+    }
+  }
+
+  public Counter getCounter(Counter counter, String name) {
+    if (counter == null) {
+      return metrics.getRegistry().counter(name);
+    }
+    return counter;
+  }
+}

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sync.common.metrics;
+
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
+import org.apache.hudi.metrics.Metrics;
+import org.apache.hudi.metrics.MetricsReporterType;
+import org.apache.hudi.sync.common.HoodieSyncConfig;
+
+import com.codahale.metrics.Timer;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestHoodieMetaSyncMetrics {
+
+
+  @Mock
+  HoodieSyncConfig syncConfig;
+  @Mock
+  HoodieMetricsConfig metricsConfig;
+  HoodieMetaSyncMetrics hoodieSyncMetrics;
+  Metrics metrics;
+  private static Configuration hadoopConf;
+  private static Path basepath;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    hadoopConf = new Configuration();
+    basepath = Files.createTempDirectory("hivesyncmetricstest" + Instant.now().toEpochMilli());
+    when(metricsConfig.isMetricsOn()).thenReturn(true);
+    when(syncConfig.getMetricsConfig()).thenReturn(metricsConfig);
+    when(syncConfig.getHadoopConf()).thenReturn(hadoopConf);
+    when(syncConfig.getBasePath()).thenReturn(basepath.toUri().toString());
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.INMEMORY);
+    when(metricsConfig.getBasePath()).thenReturn(basepath.toUri().toString());
+    when(metricsConfig.getMetricReporterMetricsNamePrefix()).thenReturn("test_prefix");
+    hoodieSyncMetrics = new HoodieMetaSyncMetrics(syncConfig, "TestHiveSyncTool");
+    metrics = hoodieSyncMetrics.getMetrics();
+  }
+
+  @AfterEach
+  void shutdownMetrics() throws IOException {
+    Files.delete(basepath);
+    metrics.shutdown();
+  }
+
+  @Test
+  void testUpdateRecreateAndSyncMetrics() throws InterruptedException {
+    Timer.Context timerCtx = hoodieSyncMetrics.getRecreateAndSyncTimer();
+    Thread.sleep(5);
+    long durationInMs = hoodieSyncMetrics.getDurationInMs(timerCtx.stop());
+    hoodieSyncMetrics.updateRecreateAndSyncMetrics(durationInMs);
+    String metricName = hoodieSyncMetrics.getMetricsName("meta_sync.recreate_table", "duration");
+    long timeIsMs = (Long) metrics.getRegistry().getGauges().get(metricName).getValue();
+    assertTrue(timeIsMs > 0, "recreate_table duration metric value should be > 0");
+  }
+
+  @Test
+  void testEmitRecreateAndSyncFailureMetric() {
+    hoodieSyncMetrics.emitRecreateAndSyncFailureMetric();
+    String metricsName = hoodieSyncMetrics.getMetricsName("counter", "meta_sync.recreate_table.failure");
+    long count = metrics.getRegistry().getCounters().get(metricsName).getCount();
+    assertEquals(1, count, "recreate_table failure counter value should be 1");
+  }
+
+  @Test
+  void testEmitRecreateAndSyncFailureMetric_WithoutMetricsNamePrefix() {
+    when(metricsConfig.getMetricReporterMetricsNamePrefix()).thenReturn("");
+    hoodieSyncMetrics = new HoodieMetaSyncMetrics(syncConfig, "TestHiveSyncTool");
+    metrics = hoodieSyncMetrics.getMetrics();
+    hoodieSyncMetrics.emitRecreateAndSyncFailureMetric();
+    String metricsName = hoodieSyncMetrics.getMetricsName("counter", "meta_sync.recreate_table.failure");
+    long count = metrics.getRegistry().getCounters().get(metricsName).getCount();
+    assertEquals(1, count, "recreate_table failure counter value should be 1");
+  }
+}

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
@@ -80,7 +80,7 @@ public class TestHoodieMetaSyncMetrics {
     Thread.sleep(5);
     long durationInNs = timerCtx.stop();
     hoodieSyncMetrics.updateRecreateAndSyncDurationInMs(durationInNs);
-    String metricName = hoodieSyncMetrics.getMetricsName("meta_sync.recreate_table", "duration");
+    String metricName = hoodieSyncMetrics.getMetricsName("meta_sync", "recreate_table_duration_ms");
     long timeIsMs = (Long) metrics.getRegistry().getGauges().get(metricName).getValue();
     assertTrue(timeIsMs > 0, "recreate_table duration metric value should be > 0");
   }

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/metrics/TestHoodieMetaSyncMetrics.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class TestHoodieMetaSyncMetrics {
 
-
   @Mock
   HoodieSyncConfig syncConfig;
   @Mock
@@ -76,30 +75,30 @@ public class TestHoodieMetaSyncMetrics {
   }
 
   @Test
-  void testUpdateRecreateAndSyncMetrics() throws InterruptedException {
+  void testUpdateRecreateAndSyncDurationInMs() throws InterruptedException {
     Timer.Context timerCtx = hoodieSyncMetrics.getRecreateAndSyncTimer();
     Thread.sleep(5);
-    long durationInMs = hoodieSyncMetrics.getDurationInMs(timerCtx.stop());
-    hoodieSyncMetrics.updateRecreateAndSyncMetrics(durationInMs);
+    long durationInNs = timerCtx.stop();
+    hoodieSyncMetrics.updateRecreateAndSyncDurationInMs(durationInNs);
     String metricName = hoodieSyncMetrics.getMetricsName("meta_sync.recreate_table", "duration");
     long timeIsMs = (Long) metrics.getRegistry().getGauges().get(metricName).getValue();
     assertTrue(timeIsMs > 0, "recreate_table duration metric value should be > 0");
   }
 
   @Test
-  void testEmitRecreateAndSyncFailureMetric() {
-    hoodieSyncMetrics.emitRecreateAndSyncFailureMetric();
+  void testIncrementRecreateAndSyncFailureCounter() {
+    hoodieSyncMetrics.incrementRecreateAndSyncFailureCounter();
     String metricsName = hoodieSyncMetrics.getMetricsName("counter", "meta_sync.recreate_table.failure");
     long count = metrics.getRegistry().getCounters().get(metricsName).getCount();
     assertEquals(1, count, "recreate_table failure counter value should be 1");
   }
 
   @Test
-  void testEmitRecreateAndSyncFailureMetric_WithoutMetricsNamePrefix() {
+  void testIncrementRecreateAndSyncFailureCounter_WithoutMetricsNamePrefix() {
     when(metricsConfig.getMetricReporterMetricsNamePrefix()).thenReturn("");
     hoodieSyncMetrics = new HoodieMetaSyncMetrics(syncConfig, "TestHiveSyncTool");
     metrics = hoodieSyncMetrics.getMetrics();
-    hoodieSyncMetrics.emitRecreateAndSyncFailureMetric();
+    hoodieSyncMetrics.incrementRecreateAndSyncFailureCounter();
     String metricsName = hoodieSyncMetrics.getMetricsName("counter", "meta_sync.recreate_table.failure");
     long count = metrics.getRegistry().getCounters().get(metricsName).getCount();
     assertEquals(1, count, "recreate_table failure counter value should be 1");


### PR DESCRIPTION
### Change Logs

Added latency and failure metrics for recreate table on meta sync failure.

### Impact

- Results in pushing new metrics to prometheus which helps in monitoring the performance of recreating table.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
