### PR TITLE
[HUDI-7926] dataskipping failure mode should be strict in query test

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
@@ -137,6 +137,7 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
   protected SparkRDDWriteClient writeClient;
   protected SparkRDDReadClient readClient;
   protected HoodieTableFileSystemView tableView;
+  protected Map<String, String> extraConf = new HashMap<>();
 
   protected TimelineService timelineService;
   protected final SparkTaskContextSupplier supplier = new SparkTaskContextSupplier();
@@ -200,6 +201,7 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
 
     // Initialize a local spark env
     SparkConf sc = HoodieClientTestUtils.getSparkConfForTest(appName + "#" + testMethodName);
+    extraConf.forEach(sc::set);
     SparkContext sparkContext = new SparkContext(sc);
     HoodieClientTestUtils.overrideSparkHadoopConfiguration(sparkContext);
     jsc = new JavaSparkContext(sparkContext);
@@ -227,6 +229,10 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
    */
   protected void initSparkContexts() {
     initSparkContexts(this.getClass().getSimpleName());
+  }
+
+  protected void initQueryIndexConf() {
+    extraConf.put("hoodie.fileIndex.dataSkippingFailureMode", "strict");
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -211,7 +211,7 @@ class HoodieMergeOnReadSnapshotHadoopFsRelationFactory(override val sqlContext: 
     includeLogFiles = true,
     shouldEmbedFileSlices = true)
 
-  val configProperties: TypedProperties = getConfigProperties(sparkSession, options)
+  val configProperties: TypedProperties = getConfigProperties(sparkSession, options, metaClient.getTableConfig)
   val metadataConfig: HoodieMetadataConfig = HoodieMetadataConfig.newBuilder
     .fromProperties(configProperties)
     .enable(configProperties.getBoolean(ENABLE.key, DEFAULT_METADATA_ENABLE_FOR_READERS)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -89,7 +89,7 @@ class HoodieCDCRDD(
 
   private val cdcSupplementalLoggingMode = metaClient.getTableConfig.cdcSupplementalLoggingMode
 
-  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty)
+  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty, metaClient.getTableConfig)
 
   protected val payloadProps: Properties = Option(metaClient.getTableConfig.getPreCombineField)
     .map { preCombineField =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -134,7 +134,7 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tableState: HoodieTableState,
     val broadcastedStorageConf = spark.sparkContext.broadcast(augmentedStorageConf)
     val broadcastedDataSchema =  spark.sparkContext.broadcast(dataAvroSchema)
     val broadcastedRequestedSchema =  spark.sparkContext.broadcast(requestedAvroSchema)
-    val fileIndexProps: TypedProperties = HoodieFileIndex.getConfigProperties(spark, options)
+    val fileIndexProps: TypedProperties = HoodieFileIndex.getConfigProperties(spark, options, null)
 
     (file: PartitionedFile) => {
       file.partitionValues match {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
@@ -60,6 +60,7 @@ class ColumnStatIndexTestBase extends HoodieSparkClientTestBase {
   @BeforeEach
   override def setUp() {
     initPath()
+    initQueryIndexConf()
     initSparkContexts()
     initHoodieStorage()
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -74,6 +74,7 @@ class PartitionStatsIndexTestBase extends HoodieSparkClientTestBase {
   @BeforeEach
   override def setUp(): Unit = {
     initPath()
+    initQueryIndexConf()
     initSparkContexts()
     initHoodieStorage()
     initTestDataGenerator()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -84,6 +84,7 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   @BeforeEach
   override def setUp() {
     initPath()
+    initQueryIndexConf()
     initSparkContexts()
     initHoodieStorage()
     initTestDataGenerator()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/SecondaryIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/SecondaryIndexTestBase.scala
@@ -58,6 +58,7 @@ class SecondaryIndexTestBase extends HoodieSparkClientTestBase {
   @BeforeEach
   override def setUp(): Unit = {
     initPath()
+    initQueryIndexConf()
     initSparkContexts()
     initHoodieStorage()
     initTestDataGenerator()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
@@ -69,6 +69,7 @@ class TestBloomFiltersIndexSupport extends HoodieSparkClientTestBase {
   @BeforeEach
   override def setUp(): Unit = {
     initPath()
+    initQueryIndexConf()
     initSparkContexts()
     initHoodieStorage()
     initTestDataGenerator()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.{BeforeAll, Tag}
 
 import scala.collection.JavaConverters._
 
@@ -41,6 +41,11 @@ import scala.collection.JavaConverters._
 class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
 
   val sqlTempTable = "hudi_tbl"
+
+  @BeforeAll
+  def init(): Unit = {
+    initQueryIndexConf()
+  }
 
   test("Test partition stats index following insert, merge into, update and delete") {
     Seq("cow", "mor").foreach { tableType =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -41,6 +41,10 @@ import org.scalatest.Ignore
 @Ignore
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {
 
+  override protected def beforeAll(): Unit = {
+    initQueryIndexConf()
+  }
+
   test("Test Functional Index With Hive Sync Non Partitioned Table") {
     // There is a big difference between Java class loader architecture of versions 1.8 and 17.
     // Hive 2.3.7 is compiled with Java 1.8, and the class loader used there throws error when Hive APIs are run on Java 17.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -29,6 +29,7 @@ import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
 
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageContains
@@ -70,8 +71,18 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 
   private var tableId = 0
 
+  private var extraConf = Map[String, String]()
+
   def sparkConf(): SparkConf = {
-    getSparkConfForTest("Hoodie SQL Test")
+    val conf = getSparkConfForTest("Hoodie SQL Test")
+    conf.setAll(extraConf)
+    conf
+  }
+
+  protected def initQueryIndexConf(): Unit = {
+    extraConf = extraConf ++ Map(
+      DataSkippingFailureMode.configName -> DataSkippingFailureMode.Strict.value
+    )
   }
 
   protected def withTempDir(f: File => Unit): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDataSkippingQuery.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDataSkippingQuery.scala
@@ -23,6 +23,10 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
 class TestDataSkippingQuery extends HoodieSparkSqlTestBase {
 
+  override protected def beforeAll(): Unit = {
+    initQueryIndexConf()
+  }
+
   test("Test the data skipping query involves conditions " +
     "that cover both columns supported by column stats and those that are not supported.") {
     withTempDir { tmp =>
@@ -98,6 +102,8 @@ class TestDataSkippingQuery extends HoodieSparkSqlTestBase {
       checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red'")(
         Seq(1, "a1", 10.0, 1000, "2021-01-05")
       )
+      // TODO add this fallback param, cause by PartitionStatsIndexSupport, cause by HUDI-7144,may be fix by HUDI-7903
+      spark.sql("set hoodie.fileIndex.dataSkippingFailureMode = fallback")
       // Check the case where the WHERE condition only includes columns supported by column stats
       checkAnswer(s"select id, name, price, ts, dt from $tableName where name='a1'")(
         Seq(1, "a1", 10.0, 1000, "2021-01-05")


### PR DESCRIPTION
### Change Logs

dataskipping failure mode should be strict in test. if use fallback mode default, the query ut is meaningless.

There may be other codes that have been introduced into bugs but cannot be measured.

change:
- query index use dataskipping strick mode 
- bucket query index add required parameters

### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
