### PR TITLE
[MINOR] `@TempDir` fails to cleanup temporary directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,9 @@
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>
-    <junit.jupiter.version>5.7.2</junit.jupiter.version>
-    <junit.vintage.version>5.7.2</junit.vintage.version>
-    <junit.platform.version>1.7.2</junit.platform.version>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
+    <junit.vintage.version>5.8.2</junit.vintage.version>
+    <junit.platform.version>1.8.2</junit.platform.version>
     <mockito.jupiter.version>3.12.4</mockito.jupiter.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### Change Logs

I got errors like
```
java.io.IOException: Failed to delete temp directory /tmp/junit*****
```
from time to time. The last time was on `ITTestConsistentBucketStreamWrite#testWriteMOR`. There `@TempDir` is used.

I suppose the problem could be fixed by this change: https://github.com/junit-team/junit5/pull/2624. There `@TempDir` cleanup resets readable and executable permissions of the root temporary directory and any contained directories instead of failing to delete them.

To integrate this change we could bump JUnit version to 5.8.2. For proper tests discovering, `junit.platform.version` also should be bumped to 1.8.2.

### Impact

Only on tests run, which would be checked.

### Risk level (write none, low medium or high below)

None

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
