### PR TITLE
[WIP] [HUDI-7905] New Action for Clustering

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ArchivedCommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ArchivedCommitsCommand.java
@@ -239,6 +239,7 @@ public class ArchivedCommitsCommand {
       case HoodieTimeline.COMPACTION_ACTION:
         return commitDetail(record, "hoodieCompactionMetadata", skipMetadata);
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
+      case HoodieTimeline.CLUSTER_ACTION:
         return commitDetail(record, "hoodieReplaceCommitMetadata", skipMetadata);
       default: {
         throw new HoodieException("Unexpected action type: " + actionType);

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -408,6 +408,7 @@ public class CommitsCommand {
     List<HoodieInstant> instants = Arrays.asList(
         new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime),
         new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime),
+        new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, instantTime),
         new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, instantTime));
 
     return Option.fromJavaOptional(instants.stream().filter(timeline::containsInstant).findAny());

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
@@ -98,7 +98,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
 
     // there is 1 requested clustering
     HoodieActiveTimeline timeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
-    assertEquals(1, timeline.filterPendingReplaceTimeline().countInstants());
+    assertEquals(1, timeline.filterPendingClusterTimeline().countInstants());
   }
 
   /**
@@ -115,7 +115,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
     // get clustering instance
     HoodieActiveTimeline timeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
     Option<String> instanceOpt =
-        timeline.filterPendingReplaceTimeline().firstInstant().map(HoodieInstant::getTimestamp);
+        timeline.filterPendingClusterTimeline().firstInstant().map(HoodieInstant::getTimestamp);
     assertTrue(instanceOpt.isPresent(), "Must have pending clustering.");
     final String instance = instanceOpt.get();
 
@@ -135,7 +135,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
         "Pending clustering must be completed");
 
     assertTrue(HoodieCLI.getTableMetaClient().getActiveTimeline().reload()
-            .getCompletedReplaceTimeline().getInstantsAsStream()
+            .getCompletedClusterTimeline().getInstantsAsStream()
             .map(HoodieInstant::getTimestamp).collect(Collectors.toList()).contains(instance),
         "Pending clustering must be completed");
   }
@@ -158,7 +158,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
 
     // assert clustering complete
     assertTrue(HoodieCLI.getTableMetaClient().getActiveTimeline().reload()
-            .getCompletedReplaceTimeline().getInstantsAsStream()
+            .getCompletedClusterTimeline().getInstantsAsStream()
             .map(HoodieInstant::getTimestamp).count() > 0,
         "Completed clustering couldn't be 0");
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -695,8 +695,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
   }
 
   private void inlineClustering(HoodieTable table, Option<Map<String, String>> extraMetadata) {
-    // TODO: #CLUSTER_REPLACE - Check if we need to replace here. This will lead to config value change for hoodie.table.service.manager.actions
-    if (shouldDelegateToTableServiceManager(config, ActionType.replacecommit)) {
+    if (shouldDelegateToTableServiceManager(config, ActionType.cluster)) {
       scheduleClustering(extraMetadata);
     } else {
       runAnyPendingClustering(table);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
@@ -122,6 +123,7 @@ public class ConcurrentOperation {
           this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata().getOperationType());
           break;
         case REPLACE_COMMIT_ACTION:
+        case CLUSTER_ACTION:
           if (instant.isCompleted()) {
             this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffixFromSpecificRecord(
                 this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getPartitionToWriteStats());
@@ -164,6 +166,7 @@ public class ConcurrentOperation {
         case COMMIT_ACTION:
         case DELTA_COMMIT_ACTION:
         case REPLACE_COMMIT_ACTION:
+        case CLUSTER_ACTION:
         case LOG_COMPACTION_ACTION:
           this.mutatedPartitionAndFileIds = CommitUtils.getPartitionAndFileIdWithoutSuffix(this.metadataWrapper.getCommitMetadata().getPartitionToWriteStats());
           this.operationType = this.metadataWrapper.getCommitMetadata().getOperationType();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/PreferWriterConflictResolutionStrategy.java
@@ -33,11 +33,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 
 /**
  * This class extends the base implementation of conflict resolution strategy.
@@ -71,7 +69,7 @@ public class PreferWriterConflictResolutionStrategy
     // We need to check for write conflicts since they may have mutated the same files
     // that are being newly created by the current write.
     List<HoodieInstant> completedCommitsInstants = activeTimeline
-        .getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION, COMPACTION_ACTION, DELTA_COMMIT_ACTION))
+        .getCommitsAndCompactionTimeline()
         .filterCompletedInstants()
         .findInstantsModifiedAfterByCompletionTime(currentInstant.getTimestamp())
         .getInstantsOrderedByCompletionTime()
@@ -90,7 +88,7 @@ public class PreferWriterConflictResolutionStrategy
     // Fetch list of completed commits.
     Stream<HoodieInstant> completedCommitsStream =
         activeTimeline
-            .getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION, COMPACTION_ACTION, DELTA_COMMIT_ACTION))
+            .getCommitsAndCompactionTimeline()
             .filterCompletedInstants()
             .findInstantsModifiedAfterByCompletionTime(currentInstant.getTimestamp())
             .getInstantsAsStream();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 
@@ -65,7 +66,8 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
         .getInstantsAsStream();
 
     Stream<HoodieInstant> compactionAndClusteringPendingTimeline = activeTimeline
-        .getTimelineOfActions(CollectionUtils.createSet(REPLACE_COMMIT_ACTION, COMPACTION_ACTION))
+        // TODO: #CLUSTER_REPLACE - Check if we need check only for cluster action. Ideally REPLACE_COMMIT_ACTION should also be checked
+        .getTimelineOfActions(CollectionUtils.createSet(REPLACE_COMMIT_ACTION, CLUSTER_ACTION, COMPACTION_ACTION))
         .findInstantsAfter(currentInstant.getTimestamp())
         .filterInflightsAndRequested()
         .getInstantsAsStream();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -122,6 +122,8 @@ public class LegacyArchivedMetaEntryReader {
         return Option.of("hoodieCompactionPlan");
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
         return Option.of("hoodieReplaceCommitMetadata");
+      case HoodieTimeline.CLUSTER_ACTION:
+        return Option.of("hoodieReplaceCommitMetadata");
       case HoodieTimeline.INDEXING_ACTION:
         return Option.of("hoodieIndexCommitMetadata");
       default:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -136,7 +136,7 @@ public class TransactionUtils {
   public static Set<String> getInflightAndRequestedInstants(HoodieTableMetaClient metaClient) {
     // collect InflightAndRequest instants for deltaCommit/commit/compaction/clustering
     Set<String> timelineActions = CollectionUtils
-        .createImmutableSet(HoodieTimeline.REPLACE_COMMIT_ACTION, HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION, HoodieTimeline.COMMIT_ACTION);
+        .createImmutableSet(HoodieTimeline.REPLACE_COMMIT_ACTION, HoodieTimeline.CLUSTER_ACTION, HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION, HoodieTimeline.COMMIT_ACTION);
     return metaClient
         .getActiveTimeline()
         .getTimelineOfActions(timelineActions)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -81,7 +81,7 @@ public class HoodieMetrics {
   public String commitTimerName = null;
   public String logCompactionTimerName = null;
   public String deltaCommitTimerName = null;
-  public String replaceCommitTimerName = null;
+  public String clusterCommitTimerName = null;
   public String finalizeTimerName = null;
   public String compactionTimerName = null;
   public String indexTimerName = null;
@@ -120,7 +120,7 @@ public class HoodieMetrics {
       this.archiveTimerName = getMetricsName(TIMER_ACTION, ARCHIVE_ACTION);
       this.commitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.COMMIT_ACTION);
       this.deltaCommitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION);
-      this.replaceCommitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION);
+      this.clusterCommitTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.CLUSTER_ACTION);
       this.finalizeTimerName = getMetricsName(TIMER_ACTION, FINALIZE_ACTION);
       this.compactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.COMPACTION_ACTION);
       this.logCompactionTimerName = getMetricsName(TIMER_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION);
@@ -165,7 +165,7 @@ public class HoodieMetrics {
 
   public Timer.Context getClusteringCtx() {
     if (config.isMetricsOn() && clusteringTimer == null) {
-      clusteringTimer = createTimer(replaceCommitTimerName);
+      clusteringTimer = createTimer(clusterCommitTimerName);
     }
     return clusteringTimer == null ? null : clusteringTimer.time();
   }
@@ -371,7 +371,7 @@ public class HoodieMetrics {
   }
 
   public void updateClusteringFileCreationMetrics(long durationInMs) {
-    reportMetrics(HoodieTimeline.REPLACE_COMMIT_ACTION, "fileCreationTime", durationInMs);
+    reportMetrics(HoodieTimeline.CLUSTER_ACTION, "fileCreationTime", durationInMs);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -652,7 +652,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    */
   public void rollbackInflightClustering(HoodieInstant inflightInstant,
                                          Function<String, Option<HoodiePendingRollbackInfo>> getPendingRollbackInstantFunc, boolean deleteInstants) {
-    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
+    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLUSTER_ACTION));
     rollbackInflightInstant(inflightInstant, getPendingRollbackInstantFunc);
     if (deleteInstants) {
       // above rollback would still keep requested in the timeline. so, lets delete it if if are looking to purge the pending clustering fully.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2Migrati
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.CleanerUtils;
+import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -243,8 +244,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    */
   private Stream<String> getPartitionsForInstants(HoodieInstant instant) {
     try {
-      if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())
-          || HoodieTimeline.CLUSTER_ACTION.equals(instant.getAction())) {
+      if (ClusteringUtils.isClusteringOrReplaceCommitAction(instant.getAction())) {
         HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(
             hoodieTable.getActiveTimeline().getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
         return Stream.concat(replaceCommitMetadata.getPartitionToReplaceFileIds().keySet().stream(), replaceCommitMetadata.getPartitionToWriteStats().keySet().stream());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -243,7 +243,8 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    */
   private Stream<String> getPartitionsForInstants(HoodieInstant instant) {
     try {
-      if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())) {
+      if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())
+          || HoodieTimeline.CLUSTER_ACTION.equals(instant.getAction())) {
         HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(
             hoodieTable.getActiveTimeline().getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
         return Stream.concat(replaceCommitMetadata.getPartitionToReplaceFileIds().keySet().stream(), replaceCommitMetadata.getPartitionToWriteStats().keySet().stream());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -91,14 +91,14 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseActionExecutor
     Option<HoodieClusteringPlan> planOption = createClusteringPlan();
     if (planOption.isPresent()) {
       HoodieInstant clusteringInstant =
-          new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime);
+          new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, instantTime);
       try {
         HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
             .setOperationType(WriteOperationType.CLUSTER.name())
             .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
             .setClusteringPlan(planOption.get())
             .build();
-        table.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant,
+        table.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant,
             TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
       } catch (IOException ioe) {
         throw new HoodieIOException("Exception scheduling clustering", ioe);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
@@ -58,7 +58,8 @@ public class ConsistentHashingUpdateStrategyUtils {
   public static Map<String, Pair<String, ConsistentBucketIdentifier>> constructPartitionToIdentifier(Set<String> partitions, HoodieTable table) {
     // Read all pending/ongoing clustering plans
     List<Pair<HoodieInstant, HoodieClusteringPlan>> instantPlanPairs =
-        table.getMetaClient().getActiveTimeline().filterInflightsAndRequested().filter(instant -> instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)).getInstantsAsStream()
+        table.getMetaClient().getActiveTimeline().filterInflightsAndRequested()
+            .filter(instant -> instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) || instant.getAction().equals(HoodieTimeline.CLUSTER_ACTION)).getInstantsAsStream()
             .map(instant -> ClusteringUtils.getClusteringPlan(table.getMetaClient(), instant))
             .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty())
             .collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
@@ -23,11 +23,10 @@ import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.common.model.ConsistentHashingNode;
 import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
 import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
@@ -58,8 +57,8 @@ public class ConsistentHashingUpdateStrategyUtils {
   public static Map<String, Pair<String, ConsistentBucketIdentifier>> constructPartitionToIdentifier(Set<String> partitions, HoodieTable table) {
     // Read all pending/ongoing clustering plans
     List<Pair<HoodieInstant, HoodieClusteringPlan>> instantPlanPairs =
-        table.getMetaClient().getActiveTimeline().filterInflightsAndRequested()
-            .filter(instant -> instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) || instant.getAction().equals(HoodieTimeline.CLUSTER_ACTION)).getInstantsAsStream()
+        table.getMetaClient().getActiveTimeline()
+            .filterPendingReplaceOrClusterTimeline().getInstantsAsStream()
             .map(instant -> ClusteringUtils.getClusteringPlan(table.getMetaClient(), instant))
             .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty())
             .collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -265,9 +265,9 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
 
   protected HoodieWriteMetadata<HoodieData<WriteStatus>> executeClustering(HoodieClusteringPlan clusteringPlan) {
     context.setJobStatus(this.getClass().getSimpleName(), "Clustering records for " + config.getTableName());
-    HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(instantTime);
+    HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(instantTime);
     // Mark instant as clustering inflight
-    table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+    table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
     table.getMetaClient().reloadActiveTimeline();
 
     // Disable auto commit. Strategy is only expected to write data in new files.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/AbstractIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/AbstractIndexingCatchupTask.java
@@ -106,6 +106,7 @@ public abstract class AbstractIndexingCatchupTask implements IndexingCatchupTask
             case HoodieTimeline.COMMIT_ACTION:
             case HoodieTimeline.DELTA_COMMIT_ACTION:
             case HoodieTimeline.REPLACE_COMMIT_ACTION:
+            case HoodieTimeline.CLUSTER_ACTION:
               updateIndexForWriteAction(instant);
               break;
             case CLEAN_ACTION:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
@@ -41,7 +41,8 @@ public class CopyOnWriteRestoreActionExecutor<T, I, K, O>
   @Override
   protected HoodieRollbackMetadata rollbackInstant(HoodieInstant instantToRollback) {
     if (!instantToRollback.getAction().equals(HoodieTimeline.COMMIT_ACTION)
-        && !instantToRollback.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
+        && !instantToRollback.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
+        && !instantToRollback.getAction().equals(HoodieTimeline.CLUSTER_ACTION)) {
       throw new HoodieRollbackException("Unsupported action in rollback instant:" + instantToRollback);
     }
     table.getMetaClient().reloadActiveTimeline();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.table.HoodieTable;
@@ -41,8 +42,7 @@ public class CopyOnWriteRestoreActionExecutor<T, I, K, O>
   @Override
   protected HoodieRollbackMetadata rollbackInstant(HoodieInstant instantToRollback) {
     if (!instantToRollback.getAction().equals(HoodieTimeline.COMMIT_ACTION)
-        && !instantToRollback.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-        && !instantToRollback.getAction().equals(HoodieTimeline.CLUSTER_ACTION)) {
+        && !ClusteringUtils.isClusteringOrReplaceCommitAction(instantToRollback.getAction())) {
       throw new HoodieRollbackException("Unsupported action in rollback instant:" + instantToRollback);
     }
     table.getMetaClient().reloadActiveTimeline();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
@@ -41,6 +41,7 @@ public class MergeOnReadRestoreActionExecutor<T, I, K, O>
       case HoodieTimeline.DELTA_COMMIT_ACTION:
       case HoodieTimeline.COMPACTION_ACTION:
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
+      case HoodieTimeline.CLUSTER_ACTION:
         // TODO : Get file status and create a rollback stat and file
         // TODO : Delete the .aux files along with the instant file, okay for now since the archival process will
         // delete these files when it does not see a corresponding instant file under .hoodie

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -128,6 +128,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
           switch (action) {
             case HoodieTimeline.COMMIT_ACTION:
             case HoodieTimeline.REPLACE_COMMIT_ACTION:
+            case HoodieTimeline.CLUSTER_ACTION:
               hoodieRollbackRequests.addAll(getHoodieRollbackRequests(partitionPath, filesToDelete.get()));
               break;
             case HoodieTimeline.COMPACTION_ACTION:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -69,7 +69,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
     try {
       // Get all the commits on the timeline after the provided commit time
       // rollback pending clustering instants first before other instants (See HUDI-3362)
-      List<HoodieInstant> pendingClusteringInstantsToRollback = table.getActiveTimeline().filterPendingReplaceTimeline()
+      List<HoodieInstant> pendingClusteringInstantsToRollback = table.getActiveTimeline().filterPendingClusterTimeline()
               // filter only clustering related replacecommits (Not insert_overwrite related commits)
               .filter(instant -> ClusteringUtils.isClusteringInstant(table.getActiveTimeline(), instant))
               .getReverseOrderedInstants()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
@@ -83,10 +83,10 @@ public abstract class WriteMarkers implements Serializable {
                                     String fileId, HoodieActiveTimeline activeTimeline) {
     if (writeConfig.getWriteConcurrencyMode().isOptimisticConcurrencyControl() && writeConfig.isEarlyConflictDetectionEnable()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
-      HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
+      HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceOrClusterTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.
       // Need to support early conflict detection between table service and common writers.
-      // ok to use filterPendingReplaceTimeline().containsInstant because early conflict detection is not relevant for insert overwrite as well
+      // ok to use filterPendingReplaceOrClusterTimeline().containsInstant because early conflict detection is not relevant for insert overwrite as well
       if (pendingCompactionTimeline.containsInstant(instantTime) || pendingReplaceTimeline.containsInstant(instantTime)) {
         return create(partitionPath, fileName, type, false);
       }
@@ -124,10 +124,10 @@ public abstract class WriteMarkers implements Serializable {
     if (writeConfig.isEarlyConflictDetectionEnable()
         && writeConfig.getWriteConcurrencyMode().isOptimisticConcurrencyControl()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
-      HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
+      HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceOrClusterTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.
       // Need to support early conflict detection between table service and common writers.
-      // ok to use filterPendingReplaceTimeline().containsInstant because early conflict detection is not relevant for insert overwrite as well
+      // ok to use filterPendingReplaceOrClusterTimeline().containsInstant because early conflict detection is not relevant for insert overwrite as well
       if (pendingCompactionTimeline.containsInstant(instantTime) || pendingReplaceTimeline.containsInstant(instantTime)) {
         return create(partitionPath, fileName, type, true);
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/repair/RepairUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/repair/RepairUtils.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -98,6 +99,7 @@ public final class RepairUtils {
         return Option.of(commitMetadata.getPartitionToWriteStats().values().stream().flatMap(List::stream)
             .map(HoodieWriteStat::getPath).collect(Collectors.toSet()));
       case REPLACE_COMMIT_ACTION:
+      case CLUSTER_ACTION:
         final HoodieReplaceCommitMetadata replaceCommitMetadata =
             HoodieReplaceCommitMetadata.fromBytes(
                 timeline.getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -542,10 +542,10 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
    */
   protected void verifyClusteredFilesWithReplaceCommitMetadata(String partitionPath) throws IOException {
     metaClient = HoodieTableMetaClient.reload(createMetaClient());
-    HoodieInstant replaceCommitInstant =
-            metaClient.getActiveTimeline().getCompletedReplaceTimeline().firstInstant().get();
+    HoodieInstant clusterCommitInstant =
+            metaClient.getActiveTimeline().getCompletedClusterTimeline().firstInstant().get();
     HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata
-            .fromBytes(metaClient.getActiveTimeline().getInstantDetails(replaceCommitInstant).get(),
+            .fromBytes(metaClient.getActiveTimeline().getInstantDetails(clusterCommitInstant).get(),
                     HoodieReplaceCommitMetadata.class);
 
     List<String> filesFromReplaceCommit = new ArrayList<>();
@@ -556,7 +556,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     List<StoragePathInfo> pathInfoList =
             storage.listDirectEntries(new StoragePath(basePath, partitionPath));
     List<String> clusteredFiles = pathInfoList.stream()
-            .filter(entry -> entry.getPath().getName().contains(replaceCommitInstant.getTimestamp()))
+            .filter(entry -> entry.getPath().getName().contains(clusterCommitInstant.getTimestamp()))
             .map(pathInfo -> partitionPath + StoragePath.SEPARATOR + pathInfo.getPath().getName())
             .collect(Collectors.toList());
     assertEquals(clusteredFiles, filesFromReplaceCommit);

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
@@ -51,7 +51,7 @@ public class HoodieJavaTableServiceClient<T> extends BaseHoodieTableServiceClien
   protected void validateClusteringCommit(HoodieWriteMetadata<List<WriteStatus>> clusteringMetadata, String clusteringCommitTime, HoodieTable table) {
     if (clusteringMetadata.getWriteStatuses().isEmpty()) {
       HoodieClusteringPlan clusteringPlan = ClusteringUtils.getClusteringPlan(
-              table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(clusteringCommitTime))
+              table.getMetaClient(), HoodieTimeline.getClusterCommitRequestedInstant(clusteringCommitTime))
           .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(
               "Unable to read clustering plan for instant: " + clusteringCommitTime));
       throw new HoodieClusteringException("Clustering plan produced 0 WriteStatus for " + clusteringCommitTime

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/cluster/JavaExecuteClusteringCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/cluster/JavaExecuteClusteringCommitActionExecutor.java
@@ -46,7 +46,7 @@ public class JavaExecuteClusteringCommitActionExecutor<T>
                                                    String instantTime) {
     super(context, config, table, instantTime, WriteOperationType.CLUSTER);
     this.clusteringPlan = ClusteringUtils.getClusteringPlan(
-        table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(instantTime))
+        table.getMetaClient(), HoodieTimeline.getClusterCommitRequestedInstant(instantTime))
         .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(
             "Unable to read clustering plan for instant: " + instantTime));
   }
@@ -60,6 +60,6 @@ public class JavaExecuteClusteringCommitActionExecutor<T>
 
   @Override
   protected String getCommitActionType() {
-    return HoodieTimeline.REPLACE_COMMIT_ACTION;
+    return HoodieTimeline.CLUSTER_ACTION;
   }
 }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -1848,7 +1848,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtils.deleteClusterCommit(basePath, clusteringCommitTime);
     HoodieWriteMetadata<List<WriteStatus>> updatedClusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     metaClient.reloadActiveTimeline();
@@ -1908,7 +1908,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieWriteMetadata<List<WriteStatus>> clusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtils.deleteClusterCommit(basePath, clusteringCommitTime);
 
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieWriteConfig updatedWriteConfig = HoodieWriteConfig.newBuilder().withProperties(initialConfig.getProps())

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -50,7 +50,7 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
   protected void validateClusteringCommit(HoodieWriteMetadata<JavaRDD<WriteStatus>> clusteringMetadata, String clusteringCommitTime, HoodieTable table) {
     if (clusteringMetadata.getWriteStatuses().isEmpty()) {
       HoodieClusteringPlan clusteringPlan = ClusteringUtils.getClusteringPlan(
-              table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(clusteringCommitTime))
+              table.getMetaClient(), HoodieTimeline.getClusterCommitRequestedInstant(clusteringCommitTime))
           .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(
               "Unable to read clustering plan for instant: " + clusteringCommitTime));
       throw new HoodieClusteringException("Clustering plan produced 0 WriteStatus for " + clusteringCommitTime

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
@@ -66,13 +66,13 @@ public class HoodieSparkConsistentBucketIndex extends HoodieConsistentBucketInde
       throws HoodieIndexException {
     HoodieInstant instant = hoodieTable.getMetaClient().getActiveTimeline().findInstantsAfterOrEquals(instantTime, 1).firstInstant().get();
     ValidationUtils.checkState(instant.getTimestamp().equals(instantTime), "Cannot get the same instant, instantTime: " + instantTime);
-    if (!instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
+    if (!instant.getAction().equals(HoodieTimeline.CLUSTER_ACTION)) {
       return writeStatuses;
     }
 
     // Double-check if it is a clustering operation by trying to obtain the clustering plan
     Option<Pair<HoodieInstant, HoodieClusteringPlan>> instantPlanPair =
-        ClusteringUtils.getClusteringPlan(hoodieTable.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(instantTime));
+        ClusteringUtils.getClusteringPlan(hoodieTable.getMetaClient(), HoodieTimeline.getClusterCommitRequestedInstant(instantTime));
     if (!instantPlanPair.isPresent()) {
       return writeStatuses;
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
@@ -42,7 +42,7 @@ public class SparkExecuteClusteringCommitActionExecutor<T>
                                                     String instantTime) {
     super(context, config, table, instantTime, WriteOperationType.CLUSTER);
     this.clusteringPlan = ClusteringUtils.getClusteringPlan(
-        table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(instantTime))
+        table.getMetaClient(), HoodieTimeline.getClusterCommitRequestedInstant(instantTime))
         .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(
             "Unable to read clustering plan for instant: " + instantTime));
   }
@@ -54,6 +54,6 @@ public class SparkExecuteClusteringCommitActionExecutor<T>
 
   @Override
   protected String getCommitActionType() {
-    return HoodieTimeline.REPLACE_COMMIT_ACTION;
+    return HoodieTimeline.CLUSTER_ACTION;
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -57,7 +58,9 @@ public class AverageRecordSizeUtils {
         try {
           HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
               .fromBytes(commitTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
-          if (instant.getAction().equals(COMMIT_ACTION) || instant.getAction().equals(REPLACE_COMMIT_ACTION)) {
+          if (instant.getAction().equals(COMMIT_ACTION) || instant.getAction().equals(REPLACE_COMMIT_ACTION)
+              || instant.getAction().equals(CLUSTER_ACTION)) {
+            // TODO: #CLUSTER_REPLACE - Check if we need check only for replace action here and do not need cluster
             long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
             long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
             if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -171,7 +172,8 @@ public class UpsertPartitioner<T> extends SparkHoodiePartitioner<T> {
      * may result in OOM by making spark underestimate the actual input record sizes.
      */
     long averageRecordSize = AverageRecordSizeUtils.averageBytesPerRecord(table.getMetaClient().getActiveTimeline()
-        .getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION))
+        .getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION))
+        // TODO: #CLUSTER_REPLACE - Check if we need check only for replace action here and do not need cluster
         .filterCompletedInstants(), config);
     LOG.info("AvgRecordSize => " + averageRecordSize);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -122,6 +122,7 @@ import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PA
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.VERSION_0;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
@@ -710,7 +711,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     List<List<FileSlice>> firstInsertFileSlicesList = table.getFileSystemView().getAllFileGroups(testPartitionPath)
         .map(fileGroup -> fileGroup.getAllFileSlices().collect(Collectors.toList())).collect(Collectors.toList());
     List<FileSlice>[] fileSlices = (List<FileSlice>[]) firstInsertFileSlicesList.toArray(new List[0]);
-    createRequestedReplaceInstant(this.metaClient, "002", fileSlices);
+    createRequestedClusterInstant(this.metaClient, "002", fileSlices);
 
     // 3. insert one record with no updating reject exception, and not merge the small file, just generate a new file group
     insertBatchRecords(client, "003", 1, 1, 1, SparkRDDWriteClient::upsert);
@@ -1628,14 +1629,14 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     assertThrows(HoodieWriteConflictException.class, () -> client.commit(inflightCommit, ingestionResult));
   }
 
-  protected HoodieInstant createRequestedReplaceInstant(HoodieTableMetaClient metaClient, String clusterTime, List<FileSlice>[] fileSlices) throws IOException {
+  protected HoodieInstant createRequestedClusterInstant(HoodieTableMetaClient metaClient, String clusterTime, List<FileSlice>[] fileSlices) throws IOException {
     HoodieClusteringPlan clusteringPlan =
         ClusteringUtils.createClusteringPlan(EXECUTION_STRATEGY_CLASS_NAME.defaultValue(), STRATEGY_PARAMS, fileSlices, Collections.emptyMap());
 
-    HoodieInstant clusteringInstant = new HoodieInstant(REQUESTED, REPLACE_COMMIT_ACTION, clusterTime);
+    HoodieInstant clusteringInstant = new HoodieInstant(REQUESTED, CLUSTER_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
     return clusteringInstant;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -474,7 +474,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     assertThrows(HoodieRollbackException.class, copyOnWriteRollbackActionExecutor::execute);
 
     // Schedule rollback for incomplete clustering instant.
-    needRollBackInstant = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringInstant1);
+    needRollBackInstant = new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, clusteringInstant1);
     rollbackInstant = writeClient.createNewInstantTime();
     copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, rollbackInstant, needRollBackInstant, false,

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
@@ -50,7 +50,7 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_ACTIONS = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".actions")
-      .noDefaultValue()
+      .defaultValue("")
       .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The actions deployed on table service manager, such as compaction or clean.");
@@ -171,7 +171,11 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
   }
 
   public boolean isEnabledAndActionSupported(ActionType actionType) {
-    return isTableServiceManagerEnabled() && getTableServiceManagerActions().contains(actionType.name());
+    boolean isActionSupported = getTableServiceManagerActions().contains(actionType.name());
+    if (actionType.equals(ActionType.cluster)) {
+      isActionSupported = isActionSupported || getTableServiceManagerActions().contains(ActionType.replacecommit.name());
+    }
+    return isTableServiceManagerEnabled() && isActionSupported;
   }
 
   public static class Builder {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/ActionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/ActionType.java
@@ -22,5 +22,5 @@ package org.apache.hudi.common.model;
  * The supported action types.
  */
 public enum ActionType {
-  commit, savepoint, compaction, clean, rollback, replacecommit, deltacommit, logcompaction
+  commit, savepoint, compaction, clean, rollback, replacecommit, deltacommit, logcompaction, cluster
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/TableServiceType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/TableServiceType.java
@@ -36,7 +36,7 @@ public enum TableServiceType {
       case CLEAN:
         return HoodieTimeline.CLEAN_ACTION;
       case CLUSTER:
-        return HoodieTimeline.REPLACE_COMMIT_ACTION;
+        return HoodieTimeline.CLUSTER_ACTION;
       case LOG_COMPACT:
         return HoodieTimeline.LOG_COMPACTION_ACTION;
       default:

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -60,6 +60,7 @@ import static org.apache.hudi.common.table.cdc.HoodieCDCInferenceCase.BASE_FILE_
 import static org.apache.hudi.common.table.cdc.HoodieCDCInferenceCase.BASE_FILE_INSERT;
 import static org.apache.hudi.common.table.cdc.HoodieCDCInferenceCase.LOG_FILE;
 import static org.apache.hudi.common.table.cdc.HoodieCDCInferenceCase.REPLACE_COMMIT;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -210,7 +211,7 @@ public class HoodieCDCExtractor {
    */
   private void initInstantAndCommitMetadata() {
     try {
-      Set<String> requiredActions = new HashSet<>(Arrays.asList(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION));
+      Set<String> requiredActions = new HashSet<>(Arrays.asList(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION));
       HoodieActiveTimeline activeTimeLine = metaClient.getActiveTimeline();
       this.commits = activeTimeLine.getInstantsAsStream()
           .filter(instant ->

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -74,7 +74,8 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
       ROLLBACK_EXTENSION, REQUESTED_ROLLBACK_EXTENSION, INFLIGHT_ROLLBACK_EXTENSION,
       REQUESTED_REPLACE_COMMIT_EXTENSION, INFLIGHT_REPLACE_COMMIT_EXTENSION, REPLACE_COMMIT_EXTENSION,
       REQUESTED_INDEX_COMMIT_EXTENSION, INFLIGHT_INDEX_COMMIT_EXTENSION, INDEX_COMMIT_EXTENSION,
-      REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION, INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION, SAVE_SCHEMA_ACTION_EXTENSION));
+      REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION, INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION, SAVE_SCHEMA_ACTION_EXTENSION,
+      REQUESTED_CLUSTER_COMMIT_EXTENSION, INFLIGHT_CLUSTER_COMMIT_EXTENSION, CLUSTER_COMMIT_EXTENSION));
 
   public static final Set<String> NOT_PARSABLE_TIMESTAMPS = new HashSet<String>(3) {{
       add(HoodieTimeline.INIT_INSTANT_TS);
@@ -224,7 +225,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     createFileInMetaPath(instant.getFileName(), Option.empty(), false);
   }
 
-  public void createRequestedReplaceCommit(String instantTime, String actionType) {
+  public void createRequestedCommitWithReplaceMetadata(String instantTime, String actionType) {
     try {
       HoodieInstant instant = new HoodieInstant(State.REQUESTED, actionType, instantTime);
       LOG.info("Creating a new instant " + instant);
@@ -630,7 +631,23 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   }
 
   /**
-   * Transition replace inflight to Committed.
+   * Transition cluster requested file to replace inflight.
+   *
+   * @param requestedInstant Requested instant
+   * @param data Extra Metadata
+   * @return inflight instant
+   */
+  public HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+    ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.CLUSTER_ACTION));
+    ValidationUtils.checkArgument(requestedInstant.isRequested());
+    HoodieInstant inflightInstant = new HoodieInstant(State.INFLIGHT, CLUSTER_ACTION, requestedInstant.getTimestamp());
+    // Then write to timeline
+    transitionPendingState(requestedInstant, inflightInstant, data);
+    return inflightInstant;
+  }
+
+  /**
+   * Transition cluster inflight to Committed.
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
@@ -642,6 +659,24 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = new HoodieInstant(State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.getTimestamp());
+    // Then write to timeline
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    return commitInstant;
+  }
+
+  /**
+   * Transition replace inflight to Committed.
+   *
+   * @param shouldLock Whether to hold the lock when performing transition
+   * @param inflightInstant Inflight instant
+   * @param data Extra Metadata
+   * @return commit instant
+   */
+  public HoodieInstant transitionClusterInflightToComplete(boolean shouldLock,
+                                                           HoodieInstant inflightInstant, Option<byte[]> data) {
+    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLUSTER_ACTION));
+    ValidationUtils.checkArgument(inflightInstant.isInflight());
+    HoodieInstant commitInstant = new HoodieInstant(State.COMPLETED, CLUSTER_ACTION, inflightInstant.getTimestamp());
     // Then write to timeline
     transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
     return commitInstant;
@@ -792,6 +827,14 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
    */
   public void saveToPendingReplaceCommit(HoodieInstant instant, Option<byte[]> content) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
+    createFileInMetaPath(instant.getFileName(), content, false);
+  }
+
+  /**
+   * Saves content for requested CLUSTER instant.
+   */
+  public void saveToPendingClusterCommit(HoodieInstant instant, Option<byte[]> content) {
+    ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLUSTER_ACTION));
     createFileInMetaPath(instant.getFileName(), content, false);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -293,7 +293,7 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
   @Override
   public HoodieDefaultTimeline getWriteTimeline() {
     // filter in-memory instants
-    Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
+    Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION);
     return new HoodieDefaultTimeline(getInstantsAsStream().filter(i ->
             readCommits.containsKey(i.getTimestamp()))
         .filter(s -> validActions.contains(s.getAction())), details);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -181,6 +181,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieTimeline getCompletedClusterTimeline() {
+    return new HoodieDefaultTimeline(
+        getInstantsAsStream().filter(s -> s.getAction().equals(CLUSTER_ACTION)).filter(HoodieInstant::isCompleted), details);
+  }
+
+  @Override
   public HoodieTimeline getCompletedReplaceOrClusterTimeline() {
     return new HoodieDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION) || s.getAction().equals(CLUSTER_ACTION))
@@ -557,12 +563,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   private Option<HoodieInstant> getLastOrFirstPendingClusterInstant(boolean isLast) {
-    HoodieTimeline replaceTimeline = filterPendingClusterTimeline();
+    HoodieTimeline pendingClusterTimeline = filterPendingClusterTimeline();
     Stream<HoodieInstant> replaceStream;
     if (isLast) {
-      replaceStream = replaceTimeline.getReverseOrderedInstants();
+      replaceStream = pendingClusterTimeline.getReverseOrderedInstants();
     } else {
-      replaceStream = replaceTimeline.getInstantsAsStream();
+      replaceStream = pendingClusterTimeline.getInstantsAsStream();
     }
     return  Option.fromJavaOptional(replaceStream
         .filter(i -> ClusteringUtils.isClusteringInstant(this, i)).findFirst());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -245,6 +245,12 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
       } else if (isRequested()) {
         return HoodieTimeline.makeRequestedReplaceFileName(timestamp);
       }
+    } else if (HoodieTimeline.CLUSTER_ACTION.equals(action)) {
+      if (isInflight()) {
+        return HoodieTimeline.makeInflightClusterFileName(timestamp);
+      } else if (isRequested()) {
+        return HoodieTimeline.makeRequestedClusterFileName(timestamp);
+      }
     } else if (HoodieTimeline.INDEXING_ACTION.equals(action)) {
       if (isInflight()) {
         return HoodieTimeline.makeInflightIndexFileName(timestamp);
@@ -281,6 +287,8 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
         return HoodieTimeline.makeRestoreFileName(timestampWithCompletionTime);
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
         return HoodieTimeline.makeReplaceFileName(timestampWithCompletionTime);
+      case HoodieTimeline.CLUSTER_ACTION:
+        return HoodieTimeline.makeClusterFileName(timestampWithCompletionTime);
       case HoodieTimeline.INDEXING_ACTION:
         return HoodieTimeline.makeIndexCommitFileName(timestampWithCompletionTime);
       case HoodieTimeline.SCHEMA_COMMIT_ACTION:

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -200,6 +200,13 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline getCompletedReplaceTimeline();
 
   /**
+   * Timeline to just include cluster instants.
+   *
+   * @return
+   */
+  HoodieTimeline getCompletedClusterTimeline();
+
+  /**
    * Timeline to just include replace or cluster instants
    *
    * @return

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -50,6 +50,7 @@ public interface HoodieTimeline extends Serializable {
   String ROLLBACK_ACTION = "rollback";
   String SAVEPOINT_ACTION = "savepoint";
   String REPLACE_COMMIT_ACTION = "replacecommit";
+  String CLUSTER_ACTION = "cluster";
   String INFLIGHT_EXTENSION = ".inflight";
   // With Async Compaction, compaction instant can be in 3 states :
   // (compaction-requested), (compaction-inflight), (completed)
@@ -63,7 +64,7 @@ public interface HoodieTimeline extends Serializable {
   String SCHEMA_COMMIT_ACTION = "schemacommit";
   String[] VALID_ACTIONS_IN_TIMELINE = {COMMIT_ACTION, DELTA_COMMIT_ACTION,
       CLEAN_ACTION, SAVEPOINT_ACTION, RESTORE_ACTION, ROLLBACK_ACTION,
-      COMPACTION_ACTION, REPLACE_COMMIT_ACTION, INDEXING_ACTION};
+      COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION, INDEXING_ACTION};
 
   String COMMIT_EXTENSION = "." + COMMIT_ACTION;
   String DELTA_COMMIT_EXTENSION = "." + DELTA_COMMIT_ACTION;
@@ -90,6 +91,9 @@ public interface HoodieTimeline extends Serializable {
   String INFLIGHT_REPLACE_COMMIT_EXTENSION = "." + REPLACE_COMMIT_ACTION + INFLIGHT_EXTENSION;
   String REQUESTED_REPLACE_COMMIT_EXTENSION = "." + REPLACE_COMMIT_ACTION + REQUESTED_EXTENSION;
   String REPLACE_COMMIT_EXTENSION = "." + REPLACE_COMMIT_ACTION;
+  String INFLIGHT_CLUSTER_COMMIT_EXTENSION = "." + CLUSTER_ACTION + INFLIGHT_EXTENSION;
+  String REQUESTED_CLUSTER_COMMIT_EXTENSION = "." + CLUSTER_ACTION + REQUESTED_EXTENSION;
+  String CLUSTER_COMMIT_EXTENSION = "." + CLUSTER_ACTION;
   String INFLIGHT_INDEX_COMMIT_EXTENSION = "." + INDEXING_ACTION + INFLIGHT_EXTENSION;
   String REQUESTED_INDEX_COMMIT_EXTENSION = "." + INDEXING_ACTION + REQUESTED_EXTENSION;
   String INDEX_COMMIT_EXTENSION = "." + INDEXING_ACTION;
@@ -196,6 +200,13 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline getCompletedReplaceTimeline();
 
   /**
+   * Timeline to just include replace or cluster instants
+   *
+   * @return
+   */
+  HoodieTimeline getCompletedReplaceOrClusterTimeline();
+
+  /**
    * Filter this timeline to just include requested and inflight compaction instants.
    * 
    * @return
@@ -220,6 +231,16 @@ public interface HoodieTimeline extends Serializable {
    * Filter this timeline to just include requested and inflight replacecommit instants.
    */
   HoodieTimeline filterPendingReplaceTimeline();
+
+  /**
+   * Filter this timeline to just include requested and inflight cluster commit instants.
+   */
+  HoodieTimeline filterPendingClusterTimeline();
+
+  /**
+   * Filter this timeline to just include requested and inflight cluster or replace commit instants.
+   */
+  HoodieTimeline filterPendingReplaceOrClusterTimeline();
 
   /**
    * Filter this timeline to include pending rollbacks.
@@ -513,6 +534,14 @@ public interface HoodieTimeline extends Serializable {
     return new HoodieInstant(State.INFLIGHT, REPLACE_COMMIT_ACTION, timestamp);
   }
 
+  static HoodieInstant getClusterCommitRequestedInstant(final String timestamp) {
+    return new HoodieInstant(State.REQUESTED, CLUSTER_ACTION, timestamp);
+  }
+
+  static HoodieInstant getClusterCommitInflightInstant(final String timestamp) {
+    return new HoodieInstant(State.INFLIGHT, CLUSTER_ACTION, timestamp);
+  }
+
   static HoodieInstant getRollbackRequestedInstant(HoodieInstant instant) {
     return instant.isRequested() ? instant : HoodieTimeline.getRequestedInstant(instant);
   }
@@ -646,6 +675,18 @@ public interface HoodieTimeline extends Serializable {
 
   static String makeRequestedReplaceFileName(String instant) {
     return StringUtils.join(instant, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
+  }
+
+  static String makeRequestedClusterFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_CLUSTER_COMMIT_EXTENSION);
+  }
+
+  static String makeInflightClusterFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_CLUSTER_COMMIT_EXTENSION);
+  }
+
+  static String makeClusterFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.CLUSTER_COMMIT_EXTENSION);
   }
 
   static String makeDeltaFileName(String instantTime) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -87,7 +87,8 @@ public class MetadataConversionUtils {
         archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
         break;
       }
-      case HoodieTimeline.REPLACE_COMMIT_ACTION: {
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+      case HoodieTimeline.CLUSTER_ACTION: {
         if (hoodieInstant.isCompleted()) {
           HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(instantDetails.get(), HoodieReplaceCommitMetadata.class);
           archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertReplaceCommitMetadata(replaceCommitMetadata));
@@ -107,7 +108,8 @@ public class MetadataConversionUtils {
             archivedMetaWrapper.setHoodieRequestedReplaceMetadata(requestedReplaceMetadata.get());
           }
         }
-        archivedMetaWrapper.setActionType(ActionType.replacecommit.name());
+        archivedMetaWrapper.setActionType(
+            hoodieInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) ? ActionType.replacecommit.name() : ActionType.cluster.name());
         break;
       }
       case HoodieTimeline.ROLLBACK_ACTION: {
@@ -157,7 +159,8 @@ public class MetadataConversionUtils {
         activeAction.getCleanPlan(metaClient).ifPresent(plan -> lsmTimelineInstant.setPlan(ByteBuffer.wrap(plan)));
         break;
       }
-      case HoodieTimeline.REPLACE_COMMIT_ACTION: {
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+      case HoodieTimeline.CLUSTER_ACTION: {
         // we may have cases with empty HoodieRequestedReplaceMetadata e.g. insert_overwrite_table or insert_overwrite
         // without clustering. However, we should revisit the requested commit file standardization
         activeAction.getRequestedCommitMetadata(metaClient).ifPresent(metadata -> lsmTimelineInstant.setPlan(ByteBuffer.wrap(metadata)));
@@ -201,6 +204,10 @@ public class MetadataConversionUtils {
       }
       case HoodieTimeline.REPLACE_COMMIT_ACTION: {
         archivedMetaWrapper.setActionType(ActionType.replacecommit.name());
+        break;
+      }
+      case HoodieTimeline.CLUSTER_ACTION: {
+        archivedMetaWrapper.setActionType(ActionType.cluster.name());
         break;
       }
       case HoodieTimeline.ROLLBACK_ACTION: {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -248,7 +248,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   private void resetFileGroupsReplaced(HoodieTimeline timeline) {
     HoodieTimer hoodieTimer = HoodieTimer.start();
     // for each REPLACE instant, get map of (partitionPath -> deleteFileGroup)
-    HoodieTimeline replacedTimeline = timeline.getCompletedReplaceTimeline();
+    HoodieTimeline replacedTimeline = timeline.getCompletedReplaceOrClusterTimeline();
     Stream<Map.Entry<HoodieFileGroupId, HoodieInstant>> resultStream = replacedTimeline.getInstantsAsStream().flatMap(instant -> {
       try {
         HoodieReplaceCommitMetadata replaceMetadata = HoodieReplaceCommitMetadata.fromBytes(metaClient.getActiveTimeline().getInstantDetails(instant).get(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.table.timeline.TimelineDiffHelper;
 import org.apache.hudi.common.table.timeline.TimelineDiffHelper.TimelineDiffResult;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.CleanerUtils;
+import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -309,8 +310,7 @@ public abstract class IncrementalTimelineSyncFileSystemView extends AbstractTabl
 
     if (metadata.getRestoreInstantInfo() != null) {
       Set<String> rolledbackInstants = metadata.getRestoreInstantInfo().stream()
-          .filter(instantInfo -> HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instantInfo.getAction())
-              || HoodieTimeline.CLUSTER_ACTION.equals(instantInfo.getAction()))
+          .filter(instantInfo -> ClusteringUtils.isClusteringOrReplaceCommitAction(instantInfo.getAction()))
           .map(HoodieInstantInfo::getCommitTime).collect(Collectors.toSet());
       removeReplacedFileIdsAtInstants(rolledbackInstants);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -79,6 +79,16 @@ public class ClusteringUtils {
    * is a clustering operation, by checking whether the requested instant contains
    * a clustering plan.
    *
+   * @param actionType      Action type
+   * @return whether the action type is a clustering or replace commit action type
+   */
+  public static boolean isClusteringOrReplaceCommitAction(String actionType) {
+    return actionType.equals(HoodieTimeline.CLUSTER_ACTION) || actionType.equals(HoodieTimeline.REPLACE_COMMIT_ACTION);
+  }
+
+  /**
+   * Checks if the action type is a clustering or replace commit action type.
+   *
    * @param timeline       Hudi timeline.
    * @param replaceInstant the instant of replacecommit action to check.
    * @return whether the instant is a clustering operation.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -68,9 +68,9 @@ public class ClusteringUtils {
    */
   public static Stream<Pair<HoodieInstant, HoodieClusteringPlan>> getAllPendingClusteringPlans(
       HoodieTableMetaClient metaClient) {
-    List<HoodieInstant> pendingReplaceInstants =
-        metaClient.getActiveTimeline().filterPendingReplaceTimeline().getInstants();
-    return pendingReplaceInstants.stream().map(instant -> getClusteringPlan(metaClient, instant))
+    List<HoodieInstant> pendingClusterInstants =
+        metaClient.getActiveTimeline().filterPendingClusterTimeline().getInstants();
+    return pendingClusterInstants.stream().map(instant -> getClusteringPlan(metaClient, instant))
         .filter(Option::isPresent).map(Option::get);
   }
 
@@ -84,26 +84,30 @@ public class ClusteringUtils {
    * @return whether the instant is a clustering operation.
    */
   public static boolean isClusteringInstant(HoodieTimeline timeline, HoodieInstant replaceInstant) {
-    return getClusteringPlan(timeline, replaceInstant).isPresent();
+    // TODO: #CLUSTER_REPLACE - Check if we need check only for cluster action
+    return replaceInstant.getAction().equals(HoodieTimeline.CLUSTER_ACTION)
+        || (replaceInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && getClusteringPlan(timeline, replaceInstant).isPresent());
   }
 
   /**
    * Get requested replace metadata from timeline.
    *
    * @param timeline              used to get the bytes stored in the requested replace instant in the timeline
-   * @param pendingReplaceInstant can be in any state, because it will always be converted to requested state
+   * @param pendingReplaceOrClusterInstant can be in any state, because it will always be converted to requested state
    * @return option of the replace metadata if present, else empty
    * @throws IOException
    */
-  private static Option<HoodieRequestedReplaceMetadata> getRequestedReplaceMetadata(HoodieTimeline timeline, HoodieInstant pendingReplaceInstant) throws IOException {
+  private static Option<HoodieRequestedReplaceMetadata> getRequestedReplaceMetadata(HoodieTimeline timeline, HoodieInstant pendingReplaceOrClusterInstant) throws IOException {
     final HoodieInstant requestedInstant;
-    if (!pendingReplaceInstant.isRequested()) {
+    if (!pendingReplaceOrClusterInstant.isRequested()) {
       // inflight replacecommit files don't have clustering plan.
       // This is because replacecommit inflight can have workload profile for 'insert_overwrite'.
       // Get the plan from corresponding requested instant.
-      requestedInstant = HoodieTimeline.getReplaceCommitRequestedInstant(pendingReplaceInstant.getTimestamp());
+      requestedInstant = pendingReplaceOrClusterInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
+          ? HoodieTimeline.getReplaceCommitRequestedInstant(pendingReplaceOrClusterInstant.getTimestamp())
+          : HoodieTimeline.getClusterCommitRequestedInstant(pendingReplaceOrClusterInstant.getTimestamp());
     } else {
-      requestedInstant = pendingReplaceInstant;
+      requestedInstant = pendingReplaceOrClusterInstant;
     }
     Option<byte[]> content = timeline.getInstantDetails(requestedInstant);
     if (!content.isPresent() || content.get().length == 0) {
@@ -244,8 +248,7 @@ public class ClusteringUtils {
   }
 
   public static List<HoodieInstant> getPendingClusteringInstantTimes(HoodieTableMetaClient metaClient) {
-    return metaClient.getActiveTimeline().filterPendingReplaceTimeline().getInstantsAsStream()
-        .filter(instant -> isClusteringInstant(metaClient.getActiveTimeline(), instant))
+    return metaClient.getActiveTimeline().filterPendingClusterTimeline().getInstantsAsStream()
         .collect(Collectors.toList());
   }
 
@@ -260,8 +263,8 @@ public class ClusteringUtils {
   public static Option<HoodieInstant> getEarliestInstantToRetainForClustering(
       HoodieActiveTimeline activeTimeline, HoodieTableMetaClient metaClient) throws IOException {
     Option<HoodieInstant> oldestInstantToRetain = Option.empty();
-    HoodieTimeline replaceTimeline = activeTimeline.getTimelineOfActions(CollectionUtils.createSet(HoodieTimeline.REPLACE_COMMIT_ACTION));
-    if (!replaceTimeline.empty()) {
+    HoodieTimeline replaceOrClusterTimeline = activeTimeline.getTimelineOfActions(CollectionUtils.createSet(HoodieTimeline.REPLACE_COMMIT_ACTION, HoodieTimeline.CLUSTER_ACTION));
+    if (!replaceOrClusterTimeline.empty()) {
       Option<HoodieInstant> cleanInstantOpt =
           activeTimeline.getCleanerTimeline().filterCompletedInstants().lastInstant();
       if (cleanInstantOpt.isPresent()) {
@@ -286,14 +289,14 @@ public class ClusteringUtils {
           retainLowerBound = cleanInstant.getTimestamp();
         }
 
-        oldestInstantToRetain = replaceTimeline.filter(instant ->
+        oldestInstantToRetain = replaceOrClusterTimeline.filter(instant ->
                 HoodieTimeline.compareTimestamps(
                     instant.getTimestamp(),
                     HoodieTimeline.GREATER_THAN_OR_EQUALS,
                     retainLowerBound))
             .firstInstant();
       } else {
-        oldestInstantToRetain = replaceTimeline.firstInstant();
+        oldestInstantToRetain = replaceOrClusterTimeline.firstInstant();
       }
     }
     return oldestInstantToRetain;
@@ -305,7 +308,7 @@ public class ClusteringUtils {
    * @return whether the given {@code instant} is a completed clustering operation.
    */
   public static boolean isCompletedClusteringInstant(HoodieInstant instant, HoodieTimeline timeline) {
-    if (!instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
+    if (!instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !instant.getAction().equals(HoodieTimeline.CLUSTER_ACTION)) {
       return false;
     }
     try {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -107,7 +107,7 @@ public class CommitUtils {
                                                              String commitActionType,
                                                              WriteOperationType operationType) {
     final HoodieCommitMetadata commitMetadata;
-    if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(commitActionType)) {
+    if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(commitActionType) || HoodieTimeline.CLUSTER_ACTION.equals(commitActionType)) {
       HoodieReplaceCommitMetadata replaceMetadata = new HoodieReplaceCommitMetadata();
       replaceMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
       commitMetadata = replaceMetadata;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -107,7 +107,7 @@ public class CommitUtils {
                                                              String commitActionType,
                                                              WriteOperationType operationType) {
     final HoodieCommitMetadata commitMetadata;
-    if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(commitActionType) || HoodieTimeline.CLUSTER_ACTION.equals(commitActionType)) {
+    if (ClusteringUtils.isClusteringOrReplaceCommitAction(commitActionType)) {
       HoodieReplaceCommitMetadata replaceMetadata = new HoodieReplaceCommitMetadata();
       replaceMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
       commitMetadata = replaceMetadata;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
@@ -307,7 +307,7 @@ public class MarkerUtils {
       String instantTime = markerDirToInstantTime(instantPath);
       return instantTime.compareToIgnoreCase(currentInstantTime) < 0
           && !activeTimeline.filterPendingCompactionTimeline().containsInstant(instantTime)
-          && !activeTimeline.filterPendingReplaceTimeline().containsInstant(instantTime);
+          && !activeTimeline.filterPendingReplaceOrClusterTimeline().containsInstant(instantTime);
     }).filter(instantPath -> {
       try {
         return !isHeartbeatExpired(markerDirToInstantTime(instantPath),

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -510,6 +510,10 @@ public class FileCreateUtils {
     removeMetaFile(basePath, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
   }
 
+  public static void deleteClusterCommit(String basePath, String instantTime) throws IOException {
+    removeMetaFile(basePath, instantTime, HoodieTimeline.CLUSTER_COMMIT_EXTENSION);
+  }
+
   public static void deleteRollbackCommit(String basePath, String instantTime) throws IOException {
     removeMetaFile(basePath, instantTime, HoodieTimeline.ROLLBACK_EXTENSION);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/ConsistentBucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/ConsistentBucketAssignFunction.java
@@ -135,7 +135,7 @@ public class ConsistentBucketAssignFunction extends ProcessFunction<HoodieRecord
 
   @Override
   public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
-    HoodieTimeline timeline = writeClient.getHoodieTable().getActiveTimeline().getCompletedReplaceTimeline().findInstantsAfter(lastRefreshInstant);
+    HoodieTimeline timeline = writeClient.getHoodieTable().getActiveTimeline().getCompletedReplaceOrClusterTimeline().findInstantsAfter(lastRefreshInstant);
     if (!timeline.empty()) {
       for (HoodieInstant instant : timeline.getInstants()) {
         HoodieReplaceCommitMetadata commitMetadata = HoodieReplaceCommitMetadata.fromBytes(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -128,7 +128,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
     HoodieClusteringPlan clusteringPlan = clusteringPlanCache.computeIfAbsent(instant, k -> {
       try {
         Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
-            this.writeClient.getHoodieTable().getMetaClient(), HoodieTimeline.getReplaceCommitInflightInstant(instant));
+            this.writeClient.getHoodieTable().getMetaClient(), HoodieTimeline.getClusterCommitInflightInstant(instant));
         return clusteringPlanOption.get().getRight();
       } catch (Exception e) {
         throw new HoodieException(e);
@@ -191,7 +191,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
           Option.empty(),
           WriteOperationType.CLUSTER,
           this.writeClient.getConfig().getSchema(),
-          HoodieTimeline.REPLACE_COMMIT_ACTION);
+          HoodieTimeline.CLUSTER_ACTION);
       writeMetadata.setCommitMetadata(Option.of(commitMetadata));
     }
     // commit the clustering

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanOperator.java
@@ -119,7 +119,7 @@ public class ClusteringPlanOperator extends AbstractStreamOperator<ClusteringPla
 
     // generate clustering plan
     // should support configurable commit metadata
-    HoodieInstant clusteringInstant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstantTime);
+    HoodieInstant clusteringInstant = HoodieTimeline.getClusterCommitRequestedInstant(clusteringInstantTime);
     Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
         table.getMetaClient(), clusteringInstant);
 
@@ -137,7 +137,7 @@ public class ClusteringPlanOperator extends AbstractStreamOperator<ClusteringPla
       LOG.info("Empty clustering plan for instant " + clusteringInstantTime);
     } else {
       // Mark instant as clustering inflight
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(clusteringInstant, Option.empty());
+      table.getActiveTimeline().transitionClusterRequestedToInflight(clusteringInstant, Option.empty());
       table.getMetaClient().reloadActiveTimeline();
 
       for (HoodieClusteringGroup clusteringGroup : clusteringPlan.getInputGroups()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
@@ -279,7 +279,7 @@ public class HoodieFlinkClusteringJob {
             CompactionUtil.isLIFO(cfg.clusteringSeq) ? instants.get(instants.size() - 1) : instants.get(0);
       }
 
-      HoodieInstant inflightInstant = HoodieTimeline.getReplaceCommitInflightInstant(
+      HoodieInstant inflightInstant = HoodieTimeline.getClusterCommitInflightInstant(
           clusteringInstant.getTimestamp());
       if (table.getMetaClient().getActiveTimeline().containsInstant(inflightInstant)) {
         LOG.info("Rollback inflight clustering instant: [" + clusteringInstant + "]");
@@ -308,7 +308,7 @@ public class HoodieFlinkClusteringJob {
         return;
       }
 
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstant.getTimestamp());
+      HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(clusteringInstant.getTimestamp());
 
       int inputGroupSize = clusteringPlan.getInputGroups().size();
 
@@ -318,7 +318,7 @@ public class HoodieFlinkClusteringJob {
           : Math.min(conf.getInteger(FlinkOptions.CLUSTERING_TASKS), inputGroupSize);
 
       // Mark instant as clustering inflight
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+      table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
 
       final Schema tableAvroSchema = StreamerUtil.getTableAvroSchema(table.getMetaClient(), false);
       final DataType rowDataType = AvroSchemaConverter.convertToDataType(tableAvroSchema);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClusteringUtil.java
@@ -104,7 +104,7 @@ public class ClusteringUtil {
    * @param instantTime The instant time
    */
   public static void rollbackClustering(HoodieFlinkTable<?> table, HoodieFlinkWriteClient<?> writeClient, String instantTime) {
-    HoodieInstant inflightInstant = HoodieTimeline.getReplaceCommitInflightInstant(instantTime);
+    HoodieInstant inflightInstant = HoodieTimeline.getClusterCommitInflightInstant(instantTime);
     if (table.getMetaClient().reloadActiveTimeline().isPendingClusterInstant(instantTime)) {
       LOG.warn("Rollback failed clustering instant: [" + instantTime + "]");
       table.rollbackInflightClustering(inflightInstant,

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestFlinkConsistentHashingClustering.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestFlinkConsistentHashingClustering.java
@@ -114,7 +114,7 @@ public class ITTestFlinkConsistentHashingClustering {
     HoodieFlinkTable<?> table = writeClient.getHoodieTable();
     table.getMetaClient().reloadActiveTimeline();
     Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
-        table.getMetaClient(), table.getMetaClient().getActiveTimeline().filterPendingReplaceTimeline().lastInstant().get());
+        table.getMetaClient(), table.getMetaClient().getActiveTimeline().filterPendingClusterTimeline().lastInstant().get());
     return clusteringPlanOption.get().getRight();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
@@ -164,7 +164,7 @@ public class ITTestHoodieFlinkClustering {
 
       // fetch the instant based on the configured execution sequence
       table.getMetaClient().reloadActiveTimeline();
-      HoodieTimeline timeline = table.getActiveTimeline().filterPendingReplaceTimeline()
+      HoodieTimeline timeline = table.getActiveTimeline().filterPendingClusterTimeline()
           .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
 
       // generate clustering plan
@@ -175,8 +175,8 @@ public class ITTestHoodieFlinkClustering {
       HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
 
       // Mark instant as clustering inflight
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstantTime);
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+      HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(clusteringInstantTime);
+      table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
 
       final Schema tableAvroSchema = StreamerUtil.getTableAvroSchema(table.getMetaClient(), false);
       final DataType rowDataType = AvroSchemaConverter.convertToDataType(tableAvroSchema);
@@ -373,7 +373,7 @@ public class ITTestHoodieFlinkClustering {
 
       // fetch the instant based on the configured execution sequence
       table.getMetaClient().reloadActiveTimeline();
-      HoodieTimeline timeline = table.getActiveTimeline().filterPendingReplaceTimeline()
+      HoodieTimeline timeline = table.getActiveTimeline().filterPendingClusterTimeline()
           .filter(i -> i.getState() == HoodieInstant.State.REQUESTED);
 
       // generate clustering plan
@@ -384,8 +384,8 @@ public class ITTestHoodieFlinkClustering {
       HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
 
       // Mark instant as clustering inflight
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(firstClusteringInstant);
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+      HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(firstClusteringInstant);
+      table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
 
       final Schema tableAvroSchema = StreamerUtil.getTableAvroSchema(table.getMetaClient(), false);
       final DataType rowDataType = AvroSchemaConverter.convertToDataType(tableAvroSchema);
@@ -419,14 +419,14 @@ public class ITTestHoodieFlinkClustering {
       // wait for the asynchronous commit to finish
       TimeUnit.SECONDS.sleep(3);
 
-      // archive the first commit, retain the second commit before the inflight replacecommit
+      // archive the first commit, retain the second commit before the inflight cluster commit
       writeClient.archive();
 
       scheduled = writeClient.scheduleClusteringAtInstant(writeClient.createNewInstantTime(), Option.empty());
 
       assertTrue(scheduled, "The clustering plan should be scheduled");
       table.getMetaClient().reloadActiveTimeline();
-      timeline = table.getActiveTimeline().filterPendingReplaceTimeline()
+      timeline = table.getActiveTimeline().filterPendingClusterTimeline()
           .filter(i -> i.getState() == HoodieInstant.State.REQUESTED);
 
       HoodieInstant secondClusteringInstant = timeline.lastInstant().get();
@@ -570,7 +570,7 @@ public class ITTestHoodieFlinkClustering {
 
       // fetch the instant based on the configured execution sequence
       table.getMetaClient().reloadActiveTimeline();
-      HoodieTimeline timeline = table.getActiveTimeline().filterPendingReplaceTimeline()
+      HoodieTimeline timeline = table.getActiveTimeline().filterPendingClusterTimeline()
           .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
 
       // generate clustering plan
@@ -581,8 +581,8 @@ public class ITTestHoodieFlinkClustering {
       HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
 
       // Mark instant as clustering inflight
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstantTime);
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+      HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(clusteringInstantTime);
+      table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
 
       DataStream<ClusteringCommitEvent> dataStream = env.addSource(new ClusteringPlanSourceFunction(clusteringInstantTime, clusteringPlan, conf))
           .name("clustering_source")
@@ -691,7 +691,7 @@ public class ITTestHoodieFlinkClustering {
 
       // fetch the instant based on the configured execution sequence
       table.getMetaClient().reloadActiveTimeline();
-      HoodieTimeline timeline = table.getActiveTimeline().filterPendingReplaceTimeline()
+      HoodieTimeline timeline = table.getActiveTimeline().filterPendingClusterTimeline()
           .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
 
       // generate clustering plan
@@ -702,8 +702,8 @@ public class ITTestHoodieFlinkClustering {
       HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
 
       // Mark instant as clustering inflight
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstantTime);
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
+      HoodieInstant instant = HoodieTimeline.getClusterCommitRequestedInstant(clusteringInstantTime);
+      table.getActiveTimeline().transitionClusterRequestedToInflight(instant, Option.empty());
 
       final Schema tableAvroSchema = StreamerUtil.getTableAvroSchema(table.getMetaClient(), false);
       final DataType rowDataType = AvroSchemaConverter.convertToDataType(tableAvroSchema);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -154,18 +154,18 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     HoodieInstant commit2 = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "2");
     // commit3: clustering
     timelineMOR.createCompleteInstant(commit2);
-    HoodieInstant commit3 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "3");
+    HoodieInstant commit3 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, "3");
     timelineMOR.createNewInstant(commit3);
-    commit3 = timelineMOR.transitionReplaceRequestedToInflight(commit3, Option.empty());
+    commit3 = timelineMOR.transitionClusterRequestedToInflight(commit3, Option.empty());
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(
             new ArrayList<>(),
             new HashMap<>(),
             Option.empty(),
             WriteOperationType.CLUSTER,
             "",
-            HoodieTimeline.REPLACE_COMMIT_ACTION);
-    timelineMOR.transitionReplaceInflightToComplete(true,
-        HoodieTimeline.getReplaceCommitInflightInstant(commit3.getTimestamp()),
+            HoodieTimeline.CLUSTER_ACTION);
+    timelineMOR.transitionClusterInflightToComplete(true,
+        HoodieTimeline.getClusterCommitInflightInstant(commit3.getTimestamp()),
         serializeCommitMetadata(commitMetadata));
     // commit4: insert overwrite
     HoodieInstant commit4 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");
@@ -235,18 +235,18 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     HoodieInstant commit2 = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "2");
     // commit3: clustering
     timelineCOW.createCompleteInstant(commit2);
-    HoodieInstant commit3 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "3");
+    HoodieInstant commit3 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, "3");
     timelineCOW.createNewInstant(commit3);
-    commit3 = timelineCOW.transitionReplaceRequestedToInflight(commit3, Option.empty());
+    commit3 = timelineCOW.transitionClusterRequestedToInflight(commit3, Option.empty());
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(
             new ArrayList<>(),
             new HashMap<>(),
             Option.empty(),
             WriteOperationType.CLUSTER,
             "",
-            HoodieTimeline.REPLACE_COMMIT_ACTION);
-    timelineCOW.transitionReplaceInflightToComplete(true,
-            HoodieTimeline.getReplaceCommitInflightInstant(commit3.getTimestamp()),
+            HoodieTimeline.CLUSTER_ACTION);
+    timelineCOW.transitionClusterInflightToComplete(true,
+            HoodieTimeline.getClusterCommitInflightInstant(commit3.getTimestamp()),
             serializeCommitMetadata(commitMetadata));
     // commit4: insert overwrite
     HoodieInstant commit4 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -519,7 +519,7 @@ public class TestInputFormat {
     TestData.writeData(TestData.DATA_SET_UPDATE_INSERT, conf);
 
     // read from the clustering commit
-    String secondCommit = TestUtils.getNthCompleteInstant(metaClient.getBasePath(), 0, HoodieTimeline.REPLACE_COMMIT_ACTION);
+    String secondCommit = TestUtils.getNthCompleteInstant(metaClient.getBasePath(), 0, HoodieTimeline.CLUSTER_ACTION);
     conf.setString(FlinkOptions.READ_START_COMMIT, secondCommit);
 
     IncrementalInputSplits.Result splits2 = incrementalInputSplits.inputSplits(metaClient, null, false);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -136,11 +136,11 @@ public class TestClusteringUtil {
         plan, Collections.emptyMap(), 1);
     String instantTime = table.getMetaClient().createNewInstantTime();
     HoodieInstant clusteringInstant =
-        new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime);
+        new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, instantTime);
     try {
-      metaClient.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant,
+      metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant,
           TimelineMetadataUtils.serializeRequestedReplaceMetadata(metadata));
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(clusteringInstant, Option.empty());
+      table.getActiveTimeline().transitionClusterRequestedToInflight(clusteringInstant, Option.empty());
     } catch (IOException ioe) {
       throw new HoodieIOException("Exception scheduling clustering", ioe);
     }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -66,6 +67,7 @@ import static org.apache.hudi.common.table.timeline.HoodieInstant.State.COMPLETE
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
@@ -104,8 +106,9 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     cleanMetaClient();
   }
 
-  @Test
-  public void testGetPartitionsWithReplaceCommits() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testGetPartitionsWithReplaceOrClusterCommits(boolean withReplace) throws IOException {
     HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
     HoodieTimeline activeCommitTimeline = activeTimeline.getCommitAndReplaceTimeline();
     assertTrue(activeCommitTimeline.empty());
@@ -113,7 +116,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     String ts1 = "1";
     String replacePartition = "2021/01/01";
     String newFilePartition = "2021/01/02";
-    HoodieInstant instant1 = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, ts1);
+    HoodieInstant instant1 = new HoodieInstant(true, withReplace ? HoodieTimeline.REPLACE_COMMIT_ACTION : HoodieTimeline.CLUSTER_ACTION, ts1);
     activeTimeline.createNewInstant(instant1);
     // create replace metadata only with replaced file Ids (no new files created)
     activeTimeline.saveAsComplete(instant1,
@@ -126,7 +129,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     assertEquals(replacePartition, partitions.get(0));
 
     String ts2 = "2";
-    HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, ts2);
+    HoodieInstant instant2 = new HoodieInstant(true, withReplace ? HoodieTimeline.REPLACE_COMMIT_ACTION : HoodieTimeline.CLUSTER_ACTION, ts2);
     activeTimeline.createNewInstant(instant2);
     // create replace metadata only with replaced file Ids (no new files created)
     activeTimeline.saveAsComplete(instant2,
@@ -262,7 +265,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
 
     // verify adding clustering commit doesn't change behavior of getExtraMetadataFromLatest
     String ts2 = "2";
-    HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, ts2);
+    HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, ts2);
     activeTimeline.createNewInstant(instant2);
     String newValueForMetadata = "newValue2";
     extraMetadata.put(extraMetadataKey, newValueForMetadata);
@@ -417,7 +420,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
                     new HoodieInstant(COMPLETED, CLEAN_ACTION, "002"),
                     new HoodieInstant(REQUESTED, CLEAN_ACTION, "003"),
                     new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
-                    new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011"))), false));
+                    new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011"),
+                    new HoodieInstant(COMPLETED, CLUSTER_ACTION, "012"))), false));
 
     // No inflight instants
     assertEquals(
@@ -429,7 +433,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
                     new HoodieInstant(COMPLETED, CLEAN_ACTION, "002"),
                     new HoodieInstant(COMPLETED, CLEAN_ACTION, "003"),
                     new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
-                    new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011"))), false));
+                    new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011"),
+                    new HoodieInstant(COMPLETED, CLUSTER_ACTION, "012"))), false));
 
     // Rollbacks only
     assertEquals(

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
@@ -142,10 +142,10 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
     replacedFileIdsP2.add(fileId4);
     partitionToReplaceFileIds.put(partitionPath2, replacedFileIdsP2);
     HoodieCommitMetadata commitMetadata =
-        CommitUtils.buildMetadata(Collections.emptyList(), partitionToReplaceFileIds, Option.empty(), WriteOperationType.INSERT_OVERWRITE, "", HoodieTimeline.REPLACE_COMMIT_ACTION);
+        CommitUtils.buildMetadata(Collections.emptyList(), partitionToReplaceFileIds, Option.empty(), WriteOperationType.CLUSTER, "", HoodieTimeline.REPLACE_COMMIT_ACTION);
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
-    HoodieInstant instant1 = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, commitTime1);
+    HoodieInstant instant1 = new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, commitTime1);
     saveAsComplete(
         commitTimeline,
         instant1,

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -182,9 +182,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant instant1 = new HoodieInstant(true, HoodieTimeline.COMMIT_ACTION, instantTime1);
     HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.COMMIT_ACTION, instantTime2);
     HoodieInstant clusteringInstant3 =
-        new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringInstantTime3);
+        new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, clusteringInstantTime3);
     HoodieInstant clusteringInstant4 =
-        new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringInstantTime4);
+        new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, clusteringInstantTime4);
     HoodieCommitMetadata commitMetadata =
         CommitUtils.buildMetadata(Collections.emptyList(), partitionToReplaceFileIds,
             Option.empty(), WriteOperationType.CLUSTER, "", HoodieTimeline.REPLACE_COMMIT_ACTION);
@@ -204,16 +204,16 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     StoragePath completeInstantPath = HoodieTestUtils.getCompleteInstantPath(
         metaClient.getStorage(), metaClient.getMetaPath(),
         clusteringInstantTime3,
-        HoodieTimeline.REPLACE_COMMIT_ACTION);
+        HoodieTimeline.CLUSTER_ACTION);
 
-    boolean deleteReplaceCommit = metaClient.getStorage().deleteDirectory(completeInstantPath);
-    boolean deleteReplaceCommitRequested = new File(
-        this.basePath + "/.hoodie/" + clusteringInstantTime3 + ".replacecommit.requested").delete();
-    boolean deleteReplaceCommitInflight = new File(
-        this.basePath + "/.hoodie/" + clusteringInstantTime3 + ".replacecommit.inflight").delete();
+    boolean deleteClusterCommit = metaClient.getStorage().deleteDirectory(completeInstantPath);
+    boolean deleteClusterCommitRequested = new File(
+        this.basePath + "/.hoodie/" + clusteringInstantTime3 + ".cluster.requested").delete();
+    boolean deleteClusterCommitInflight = new File(
+        this.basePath + "/.hoodie/" + clusteringInstantTime3 + ".cluster.inflight").delete();
 
     // confirm deleted
-    assertTrue(deleteReplaceCommit && deleteReplaceCommitInflight && deleteReplaceCommitRequested);
+    assertTrue(deleteClusterCommit && deleteClusterCommitInflight && deleteClusterCommitRequested);
     assertDoesNotThrow(() -> fsView.close());
 
   }
@@ -1861,7 +1861,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
   }
 
   private void saveAsCompleteCluster(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<byte[]> data) {
-    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, inflight.getAction());
+    assertEquals(HoodieTimeline.CLUSTER_ACTION, inflight.getAction());
     HoodieInstant clusteringInstant = new HoodieInstant(State.REQUESTED, inflight.getAction(), inflight.getTimestamp());
     HoodieClusteringPlan plan = new HoodieClusteringPlan();
     plan.setExtraMetadata(new HashMap<>());
@@ -1875,7 +1875,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
           .setExtraMetadata(Collections.emptyMap())
           .setClusteringPlan(plan)
           .build();
-      timeline.saveToPendingReplaceCommit(clusteringInstant,
+      timeline.saveToPendingClusterCommit(clusteringInstant,
           TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
     } catch (IOException ioe) {
       throw new HoodieIOException("Exception scheduling clustering", ioe);
@@ -2091,10 +2091,10 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         fileSliceGroups, Collections.emptyMap());
 
     String clusterTime = "2";
-    HoodieInstant instant2 = new HoodieInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, clusterTime);
+    HoodieInstant instant2 = new HoodieInstant(State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(plan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(instant2, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(instant2, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
 
     //make sure view doesn't include fileId1
     refreshFsView();
@@ -2205,7 +2205,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     String fileName3 = FSUtils.makeBaseFileName(commitTime2, TEST_WRITE_TOKEN, fileId3, BASE_FILE_EXTENSION);
     new File(basePath + "/" + partitionPath + "/" + fileName3).createNewFile();
 
-    HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.REPLACE_COMMIT_ACTION, commitTime2);
+    HoodieInstant instant2 = new HoodieInstant(true, HoodieTimeline.CLUSTER_ACTION, commitTime2);
     Map<String, List<String>> partitionToReplaceFileIds = new HashMap<>();
     List<String> replacedFileIds = new ArrayList<>();
     replacedFileIds.add(fileId1);
@@ -2219,7 +2219,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     List<HoodieWriteStat> writeStats2 = buildWriteStats(partitionToFile2, commitTime2);
 
     HoodieCommitMetadata commitMetadata2 =
-        CommitUtils.buildMetadata(writeStats2, partitionToReplaceFileIds, Option.empty(), WriteOperationType.CLUSTER, "", HoodieTimeline.REPLACE_COMMIT_ACTION);
+        CommitUtils.buildMetadata(writeStats2, partitionToReplaceFileIds, Option.empty(), WriteOperationType.CLUSTER, "", HoodieTimeline.CLUSTER_ACTION);
     saveAsCompleteCluster(
         commitTimeline,
         instant2,
@@ -2298,7 +2298,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     storage.deleteFile(new StoragePath(basePath + "/.hoodie", "1.commit.requested"));
     StoragePath instantPath2 = HoodieTestUtils
         .getCompleteInstantPath(storage, metaClient.getMetaPath(), "2",
-            HoodieTimeline.REPLACE_COMMIT_ACTION);
+            HoodieTimeline.CLUSTER_ACTION);
     storage.deleteFile(instantPath2);
 
     metaClient.reloadActiveTimeline();

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -105,7 +105,7 @@ import static org.apache.hudi.common.model.WriteOperationType.CLUSTER;
 import static org.apache.hudi.common.model.WriteOperationType.COMPACT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createCleanFile;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createCommit;
@@ -1011,7 +1011,7 @@ public class HoodieTestTable {
     }
     HoodieReplaceCommitMetadata replaceMetadata =
         (HoodieReplaceCommitMetadata) buildMetadata(writeStats, partitionToReplaceFileIds, Option.empty(), CLUSTER, PHONY_TABLE_SCHEMA,
-            REPLACE_COMMIT_ACTION);
+            CLUSTER_ACTION);
     addReplaceCommit(commitTime, Option.empty(), Option.empty(), replaceMetadata);
     return replaceMetadata;
   }
@@ -1197,6 +1197,7 @@ public class HoodieTestTable {
   private Option<HoodieCommitMetadata> getCommitMeta(HoodieInstant hoodieInstant) throws IOException {
     switch (hoodieInstant.getAction()) {
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
+      case CLUSTER_ACTION:
         HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata
             .fromBytes(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieReplaceCommitMetadata.class);
         return Option.of(replaceCommitMetadata);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -76,7 +76,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     fileIds1.add(UUID.randomUUID().toString());
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
-    createRequestedReplaceInstant(partitionPath1, clusterTime1, fileIds1);
+    createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
 
     List<String> fileIds2 = new ArrayList<>();
     fileIds2.add(UUID.randomUUID().toString());
@@ -87,7 +87,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     fileIds3.add(UUID.randomUUID().toString());
 
     String clusterTime = "2";
-    createRequestedReplaceInstant(partitionPath1, clusterTime, fileIds2, fileIds3);
+    createRequestedClusterInstant(partitionPath1, clusterTime, fileIds2, fileIds3);
 
     // create replace.requested without clustering plan. this instant should be ignored by ClusteringUtils
     createRequestedReplaceInstantNotClustering("3");
@@ -96,7 +96,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     metaClient.getActiveTimeline().createNewInstant(new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4"));
 
     metaClient.reloadActiveTimeline();
-    assertEquals(4, metaClient.getActiveTimeline().filterPendingReplaceTimeline().countInstants());
+    assertEquals(2, metaClient.getActiveTimeline().filterPendingClusterTimeline().countInstants());
 
     Map<HoodieFileGroupId, HoodieInstant> fileGroupToInstantMap =
         ClusteringUtils.getAllFileGroupsInPendingClusteringPlans(metaClient);
@@ -109,13 +109,13 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     assertEquals("2", lastPendingClustering.get().getTimestamp());
 
     //check that it still gets picked if it is inflight
-    HoodieInstant inflight = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(lastPendingClustering.get(), Option.empty());
+    HoodieInstant inflight = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(lastPendingClustering.get(), Option.empty());
     assertEquals(HoodieInstant.State.INFLIGHT, inflight.getState());
     lastPendingClustering = metaClient.reloadActiveTimeline().getLastPendingClusterInstant();
     assertEquals("2", lastPendingClustering.get().getTimestamp());
 
     //now that it is complete, the first instant should be picked
-    HoodieInstant complete = metaClient.getActiveTimeline().transitionReplaceInflightToComplete(false, inflight, Option.empty());
+    HoodieInstant complete = metaClient.getActiveTimeline().transitionClusterInflightToComplete(false, inflight, Option.empty());
     assertEquals(HoodieInstant.State.COMPLETED, complete.getState());
     lastPendingClustering = metaClient.reloadActiveTimeline().getLastPendingClusterInstant();
     assertEquals("1", lastPendingClustering.get().getTimestamp());
@@ -131,7 +131,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     fileIds1.add(UUID.randomUUID().toString());
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
-    HoodieInstant requestedInstant = createRequestedReplaceInstant(partitionPath1, clusterTime1, fileIds1);
+    HoodieInstant requestedInstant = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
     HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant, Option.empty());
     assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), requestedInstant));
     HoodieClusteringPlan requestedClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, requestedInstant).get().getRight();
@@ -146,24 +146,24 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     List<String> fileIds1 = new ArrayList<>();
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
-    HoodieInstant requestedInstant1 = createRequestedReplaceInstant(partitionPath1, clusterTime1, fileIds1);
-    HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant1, Option.empty());
-    metaClient.getActiveTimeline().transitionReplaceInflightToComplete(true, inflightInstant1, Option.empty());
+    HoodieInstant requestedInstant1 = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
+    HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant1, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, Option.empty());
     List<String> fileIds2 = new ArrayList<>();
     fileIds2.add(UUID.randomUUID().toString());
     fileIds2.add(UUID.randomUUID().toString());
     String clusterTime2 = "2";
-    HoodieInstant requestedInstant2 = createRequestedReplaceInstant(partitionPath1, clusterTime2, fileIds2);
-    HoodieInstant inflightInstant2 = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant2, Option.empty());
-    metaClient.getActiveTimeline().transitionReplaceInflightToComplete(true, inflightInstant2, Option.empty());
+    HoodieInstant requestedInstant2 = createRequestedClusterInstant(partitionPath1, clusterTime2, fileIds2);
+    HoodieInstant inflightInstant2 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant2, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant2, Option.empty());
     List<String> fileIds3 = new ArrayList<>();
     fileIds3.add(UUID.randomUUID().toString());
     fileIds3.add(UUID.randomUUID().toString());
     fileIds3.add(UUID.randomUUID().toString());
     String clusterTime3 = "3";
-    HoodieInstant requestedInstant3 = createRequestedReplaceInstant(partitionPath1, clusterTime3, fileIds3);
-    HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant3, Option.empty());
-    HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionReplaceInflightToComplete(true, inflightInstant3, Option.empty());
+    HoodieInstant requestedInstant3 = createRequestedClusterInstant(partitionPath1, clusterTime3, fileIds3);
+    HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
+    HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
     Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient);
     assertTrue(actual.isPresent());
@@ -199,9 +199,9 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     List<String> fileIds1 = new ArrayList<>();
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
-    HoodieInstant requestedInstant1 = createRequestedReplaceInstant(partitionPath1, clusterTime1, fileIds1);
-    HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant1, Option.empty());
-    metaClient.getActiveTimeline().transitionReplaceInflightToComplete(true, inflightInstant1, Option.empty());
+    HoodieInstant requestedInstant1 = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
+    HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant1, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, Option.empty());
 
     String cleanTime1 = "2";
     HoodieInstant requestedInstant2 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, cleanTime1);
@@ -220,9 +220,9 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     fileIds2.add(UUID.randomUUID().toString());
     fileIds2.add(UUID.randomUUID().toString());
     String clusterTime2 = "3";
-    HoodieInstant requestedInstant3 = createRequestedReplaceInstant(partitionPath1, clusterTime2, fileIds2);
-    HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant3, Option.empty());
-    metaClient.getActiveTimeline().transitionReplaceInflightToComplete(true, inflightInstant3, Option.empty());
+    HoodieInstant requestedInstant3 = createRequestedClusterInstant(partitionPath1, clusterTime2, fileIds2);
+    HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
     metaClient.reloadActiveTimeline();
 
     Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient);
@@ -245,7 +245,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     return newRequestedInstant;
   }
 
-  private HoodieInstant createRequestedReplaceInstant(String partitionPath1, String clusterTime, List<String>... fileIds) throws IOException {
+  private HoodieInstant createRequestedClusterInstant(String partitionPath1, String clusterTime, List<String>... fileIds) throws IOException {
     List<FileSlice>[] fileSliceGroups = new List[fileIds.length];
     for (int i = 0; i < fileIds.length; i++) {
       fileSliceGroups[i] = fileIds[i].stream().map(fileId -> generateFileSlice(partitionPath1, fileId, "0")).collect(Collectors.toList());
@@ -254,10 +254,10 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieClusteringPlan clusteringPlan =
         ClusteringUtils.createClusteringPlan(CLUSTERING_STRATEGY_CLASS, STRATEGY_PARAMS, fileSliceGroups, Collections.emptyMap());
 
-    HoodieInstant clusteringInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, clusterTime);
+    HoodieInstant clusteringInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
     return clusteringInstant;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA;
@@ -210,8 +211,8 @@ public class TestCommitUtils {
             .setExtraMetadata(Collections.emptyMap())
             .setClusteringPlan(new HoodieClusteringPlan())
             .build();
-    timeline.saveToPendingReplaceCommit(
-        new HoodieInstant(HoodieInstant.State.REQUESTED, REPLACE_COMMIT_ACTION, ts),
+    timeline.saveToPendingClusterCommit(
+        new HoodieInstant(HoodieInstant.State.REQUESTED, CLUSTER_ACTION, ts),
         TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata)
     );
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
@@ -325,7 +325,8 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
             new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, "06"),
             new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "07"),
             new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "08"),
-            new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, "09")).collect(Collectors.toList()));
+            new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, "09"),
+            new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, "10")).collect(Collectors.toList()));
 
     actual =
         CompactionUtils.getDeltaCommitsSinceLatestCompaction(timeline).get();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -163,7 +163,7 @@ class HoodieStreamingSink(sqlContext: SQLContext,
           }
           if (clusteringInstant.isPresent) {
             asyncClusteringService.enqueuePendingAsyncServiceInstant(new HoodieInstant(
-              State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringInstant.get()
+              State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, clusteringInstant.get()
             ))
           }
           Success((true, commitOps, compactionInstantOps))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -155,8 +155,8 @@ class IncrementalRelation(val sqlContext: SQLContext,
       var metaBootstrapFileIdToFullPath = mutable.HashMap[String, String]()
 
       // create Replaced file group
-      val replacedTimeline = commitsTimelineToReturn.getCompletedReplaceTimeline
-      val replacedFile = replacedTimeline.getInstants.asScala.flatMap { instant =>
+      val replacedOrClusterTimeline = commitsTimelineToReturn.getCompletedReplaceOrClusterTimeline
+      val replacedFile = replacedOrClusterTimeline.getInstants.asScala.flatMap { instant =>
         val replaceMetadata = HoodieReplaceCommitMetadata.
           fromBytes(metaClient.getActiveTimeline.getInstantDetails(instant).get, classOf[HoodieReplaceCommitMetadata])
         replaceMetadata.getPartitionToReplaceFileIds.entrySet().asScala.flatMap { entry =>

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -175,7 +175,7 @@ class RunClusteringProcedure extends BaseProcedure
       }
 
       val clusteringInstants = metaClient.reloadActiveTimeline().getInstants.iterator().asScala
-        .filter(p => p.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION && filteredPendingClusteringInstants.contains(p.getTimestamp))
+        .filter(p => p.getAction == HoodieTimeline.CLUSTER_ACTION && filteredPendingClusteringInstants.contains(p.getTimestamp))
         .toSeq
         .sortBy(f => f.getTimestamp)
         .reverse

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
@@ -58,7 +58,7 @@ class ShowClusteringProcedure extends BaseProcedure with ProcedureBuilder with S
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = createMetaClient(jsc, basePath)
     val clusteringInstants = metaClient.getActiveTimeline.getInstants.iterator().asScala
-      .filter(p => p.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || p.getAction == HoodieTimeline.CLUSTER_ACTION)
+      .filter(p => ClusteringUtils.isClusteringOrReplaceCommitAction(p.getAction))
       .toSeq
       .sortBy(f => f.getTimestamp)
       .reverse

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
@@ -58,7 +58,7 @@ class ShowClusteringProcedure extends BaseProcedure with ProcedureBuilder with S
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = createMetaClient(jsc, basePath)
     val clusteringInstants = metaClient.getActiveTimeline.getInstants.iterator().asScala
-      .filter(p => p.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION)
+      .filter(p => p.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || p.getAction == HoodieTimeline.CLUSTER_ACTION)
       .toSeq
       .sortBy(f => f.getTimestamp)
       .reverse

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
@@ -109,6 +109,7 @@ class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBui
     val instants: util.List[HoodieInstant] = util.Arrays.asList(
       new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime),
+      new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, instantTime))
 
     val hoodieInstant: Option[HoodieInstant] = instants.asScala.find((i: HoodieInstant) => timeline.containsInstant(i))
@@ -117,7 +118,7 @@ class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBui
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION) {
+      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
@@ -20,14 +20,13 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieReplaceCommitMetadata}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.ClusteringUtils
 import org.apache.hudi.exception.HoodieException
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util
 import java.util.function.Supplier
-
 import scala.collection.JavaConverters._
 
 class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBuilder {
@@ -118,7 +117,7 @@ class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBui
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
+      if (ClusteringUtils.isClusteringOrReplaceCommitAction(hoodieInstant.get.getAction)) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieReplaceCommitMetadata, HoodieWriteStat}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.ClusteringUtils
 import org.apache.hudi.exception.HoodieException
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
@@ -101,7 +101,7 @@ class ShowCommitFilesProcedure() extends BaseProcedure with ProcedureBuilder {
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
+      if (ClusteringUtils.isClusteringOrReplaceCommitAction(hoodieInstant.get.getAction)) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
@@ -92,6 +92,7 @@ class ShowCommitFilesProcedure() extends BaseProcedure with ProcedureBuilder {
     val instants: util.List[HoodieInstant] = util.Arrays.asList(
       new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime),
+      new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, instantTime))
 
     val hoodieInstant: Option[HoodieInstant] = instants.asScala.find((i: HoodieInstant) => timeline.containsInstant(i))
@@ -100,7 +101,7 @@ class ShowCommitFilesProcedure() extends BaseProcedure with ProcedureBuilder {
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION) {
+      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
@@ -107,6 +107,7 @@ class ShowCommitPartitionsProcedure() extends BaseProcedure with ProcedureBuilde
     val instants: util.List[HoodieInstant] = util.Arrays.asList(
       new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime),
+      new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, instantTime))
 
     val hoodieInstant: Option[HoodieInstant] = instants.asScala.find((i: HoodieInstant) => timeline.containsInstant(i))
@@ -115,7 +116,7 @@ class ShowCommitPartitionsProcedure() extends BaseProcedure with ProcedureBuilde
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION) {
+      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieReplaceCommitMetadata, HoodieWriteStat}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.ClusteringUtils
 import org.apache.hudi.exception.HoodieException
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
@@ -116,7 +116,7 @@ class ShowCommitPartitionsProcedure() extends BaseProcedure with ProcedureBuilde
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
+      if (ClusteringUtils.isClusteringOrReplaceCommitAction(hoodieInstant.get.getAction)) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieReplaceCommitMetadata}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.ClusteringUtils
 import org.apache.hudi.exception.HoodieException
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
@@ -93,8 +93,7 @@ class ShowCommitWriteStatsProcedure() extends BaseProcedure with ProcedureBuilde
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      // TODO: #CLUSTER_REPLACE - move this check to a separate function
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
+      if (ClusteringUtils.isClusteringOrReplaceCommitAction(hoodieInstant.get.getAction)) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
@@ -84,6 +84,7 @@ class ShowCommitWriteStatsProcedure() extends BaseProcedure with ProcedureBuilde
     val instants: util.List[HoodieInstant] = util.Arrays.asList(
       new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime),
+      new HoodieInstant(false, HoodieTimeline.CLUSTER_ACTION, instantTime),
       new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, instantTime))
 
     val hoodieInstant: Option[HoodieInstant] = instants.asScala.find((i: HoodieInstant) => timeline.containsInstant(i))
@@ -92,7 +93,8 @@ class ShowCommitWriteStatsProcedure() extends BaseProcedure with ProcedureBuilde
 
   private def getHoodieCommitMetadata(timeline: HoodieTimeline, hoodieInstant: Option[HoodieInstant]): Option[HoodieCommitMetadata] = {
     if (hoodieInstant.isDefined) {
-      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION) {
+      // TODO: #CLUSTER_REPLACE - move this check to a separate function
+      if (hoodieInstant.get.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || hoodieInstant.get.getAction == HoodieTimeline.CLUSTER_ACTION) {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -256,7 +256,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
     assertEquals(1, timeline.findInstantsAfter("003", Integer.MAX_VALUE).countInstants(),
         "Expecting a single commit.");
     assertEquals(clusteringCommitTime, timeline.lastInstant().get().getTimestamp());
-    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, timeline.lastInstant().get().getAction());
+    assertEquals(HoodieTimeline.CLUSTER_ACTION, timeline.lastInstant().get().getAction());
     if (cfg.populateMetaFields()) {
       assertEquals(400, HoodieClientTestUtils.countRecordsOptionallySince(jsc(), basePath(), sqlContext(), timeline, Option.of("000")),
           "Must contain 200 records");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
@@ -112,7 +112,7 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
 
     String clusteringTime = (String) writeClient.scheduleClustering(Option.empty()).get();
     HoodieClusteringPlan plan = ClusteringUtils.getClusteringPlan(
-        metaClient, HoodieTimeline.getReplaceCommitRequestedInstant(clusteringTime)).map(Pair::getRight).get();
+        metaClient, HoodieTimeline.getClusterCommitRequestedInstant(clusteringTime)).map(Pair::getRight).get();
 
     List<HoodieClusteringGroup> inputGroups = plan.getInputGroups();
     Assertions.assertEquals(1, inputGroups.size(), "Clustering plan will contain 1 input group");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -117,7 +117,7 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
       .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
       .lastInstant().get()
     if (getLatestCompactionInstant() != getLatestMetaClient(false).getActiveTimeline.lastInstant()
-      && lastInstant.getAction != ActionType.replacecommit.name()
+      && lastInstant.getAction != ActionType.cluster.name()
       && lastInstant.getAction != ActionType.clean.name()) {
       mergedDfList = mergedDfList.take(mergedDfList.size - 1)
     }
@@ -175,7 +175,7 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   }
 
   protected def getLatestClusteringInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
-    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
+    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceOrClusterTimeline.lastInstant()
   }
 
   protected def doWriteAndValidateDataAndRecordIndex(hudiOpts: Map[String, String],

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1913,10 +1913,8 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
     val instants = timeline.getCommitsTimeline.getInstants
     assertEquals(6, instants.size)
     val replaceInstants = instants.asScala.filter(i => i.getAction.equals(HoodieTimeline.REPLACE_COMMIT_ACTION)).toList
-    assertEquals(5, replaceInstants.size)
-    val clusterInstants = replaceInstants.filter(i => {
-      TimelineUtils.getCommitMetadata(i, metaClient.getActiveTimeline).getOperationType.equals(WriteOperationType.CLUSTER)
-    })
+    assertEquals(3, replaceInstants.size)
+    val clusterInstants = instants.asScala.filter(i => i.getAction.equals(HoodieTimeline.CLUSTER_ACTION)).toList
     assertEquals(2, clusterInstants.size)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -447,9 +447,9 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
     var success = false
     while ({!success && (currTime - beginTime) < timeoutMsecs}) try {
       this.metaClient.reloadActiveTimeline()
-      val completeReplaceSize = this.metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.toArray.length
-      println("completeReplaceSize:" + completeReplaceSize)
-      if (completeReplaceSize > 0) {
+      val completeClusterSize = this.metaClient.getActiveTimeline.getCompletedReplaceOrClusterTimeline.getInstants.toArray.length
+      println("completeClusterSize:" + completeClusterSize)
+      if (completeClusterSize > 0) {
         success = true
       }
     } catch {
@@ -459,7 +459,7 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
       Thread.sleep(sleepSecsAfterEachRun * 1000)
       currTime = System.currentTimeMillis
     }
-    if (!success) throw new IllegalStateException("Timed-out waiting for completing replace instant appear in " + tablePath)
+    if (!success) throw new IllegalStateException("Timed-out waiting for completing cluster instant appear in " + tablePath)
   }
 
   private def latestInstant(storage: HoodieStorage, basePath: String, instantAction: String): String = {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTER_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -209,7 +210,8 @@ public class MarkerHandler extends Handler {
           // instead of starting the conflict detector for every request
           if (!markerDir.equalsIgnoreCase(currentMarkerDir)) {
             this.currentMarkerDir = markerDir;
-            Set<String> actions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION);
+            // TODO: #CLUSTER_REPLACE - Check if we need check only for replace action here and do not need cluster
+            Set<String> actions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTER_ACTION);
             Set<HoodieInstant> completedCommits = new HashSet<>(
                 viewManager.getFileSystemView(basePath)
                     .getTimeline()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -801,7 +801,7 @@ public class HoodieStreamer implements Serializable {
                 Option<String> clusteringInstant = streamSync.getClusteringInstantOpt();
                 if (clusteringInstant.isPresent()) {
                   LOG.info("Scheduled async clustering for instant: " + clusteringInstant.get());
-                  asyncClusteringService.get().enqueuePendingAsyncServiceInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringInstant.get()));
+                  asyncClusteringService.get().enqueuePendingAsyncServiceInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.CLUSTER_ACTION, clusteringInstant.get()));
                   asyncClusteringService.get().waitTillPendingAsyncServiceInstantsReducesTo(cfg.maxPendingClustering);
                   if (asyncClusteringService.get().hasError()) {
                     error = true;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -477,8 +477,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     addCommitToTimeline(metaClient, WriteOperationType.UPSERT, HoodieTimeline.COMMIT_ACTION, extraMetadata);
   }
 
-  static void addReplaceCommitToTimeline(HoodieTableMetaClient metaClient, Map<String, String> extraMetadata) throws IOException {
-    addCommitToTimeline(metaClient, WriteOperationType.CLUSTER, HoodieTimeline.REPLACE_COMMIT_ACTION, extraMetadata);
+  static void addClusterCommitToTimeline(HoodieTableMetaClient metaClient, Map<String, String> extraMetadata) throws IOException {
+    addCommitToTimeline(metaClient, WriteOperationType.CLUSTER, HoodieTimeline.CLUSTER_ACTION, extraMetadata);
   }
 
   static void addCommitToTimeline(HoodieTableMetaClient metaClient, WriteOperationType writeOperationType, String commitActiontype,

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -2642,7 +2642,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         .getCommitsTimeline()).get().getMetadata(HoodieDeltaStreamer.CHECKPOINT_KEY), "def");
 
     // add a replace commit which does not have CHECKPOINT_KEY. Deltastreamer should be able to go back and pick the right checkpoint.
-    addReplaceCommitToTimeline(metaClient, Collections.emptyMap());
+    addClusterCommitToTimeline(metaClient, Collections.emptyMap());
     metaClient.reloadActiveTimeline();
     assertEquals(testDeltaSync.getLatestCommitMetadataWithValidCheckpointInfo(metaClient.getActiveTimeline()
         .getCommitsTimeline()).get().getMetadata(HoodieDeltaStreamer.CHECKPOINT_KEY), "def");


### PR DESCRIPTION
### Change Logs

Currently, we use replacecommit for clustering, insert overwrite and delete partition. Clustering should be a separate action. This simplifies a few things such as we do not need to scan the replacecommit.requested to determine whether we are looking at clustering plan or not. This also standardizes the usage of replacecommit to some extent (related to [HUDI-1739](https://issues.apache.org/jira/browse/HUDI-1739)).

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
