### PR TITLE
[HUDI-7931] Initialize timeline for data table meta client while initializing HoodieBackedTableMetadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -134,6 +134,11 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       }
     } else if (this.metadataMetaClient == null) {
       try {
+        // Initialize data table meta client timeline. The data table timeline is not initialized by
+        // default whereas metadataMetaClient timeline is initialized while creating metadataFileSystemView.
+        // We initialize timeline for dataMetaClient to ensure that while creating log record scanner
+        // dataMetaClient timeline is in sync with metadataMetaClient timeline.
+        this.dataMetaClient.getActiveTimeline();
         this.metadataMetaClient = HoodieTableMetaClient.builder()
             .setStorage(storage)
             .setBasePath(metadataBasePath)


### PR DESCRIPTION
### Change Logs

Currently while initialising HoodieBackedTableMetadata, the data table timeline is not initialized by default whereas metadataMetaClient timeline is initialized while creating metadataFileSystemView. In this jira we aim to initialize timeline for dataMetaClient to ensure that while creating log record scanner dataMetaClient timeline is in sync with metadataMetaClient timeline.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
