### PR TITLE
[HUDI-7934] Fix RocksDBDAO prefixDelete to delete last entry properly

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -414,7 +414,7 @@ public class RocksDBDAO {
         // This will not delete the last entry
         getRocksDB().deleteRange(managedHandlesMap.get(columnFamilyName), getUTF8Bytes(firstEntry), getUTF8Bytes(lastEntry));
         // Delete the last entry
-        getRocksDB().delete(getUTF8Bytes(lastEntry));
+        getRocksDB().delete(managedHandlesMap.get(columnFamilyName), getUTF8Bytes(lastEntry));
       } catch (RocksDBException e) {
         LOG.error("Got exception performing range delete");
         throw new HoodieException(e);

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAO.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAO.java
@@ -77,14 +77,12 @@ public class TestRocksDBDAO {
     final List<Payload<String>> payloads = new ArrayList<>();
     IntStream.range(0, 100).forEach(index -> {
       String prefix = prefixes.get(index % 4);
-      String key = prefix + UUID.randomUUID().toString();
+      String key = prefix + UUID.randomUUID();
       String family = colFamilies.get(index % 2);
-      String val = "VALUE_" + UUID.randomUUID().toString();
+      String val = "VALUE_" + UUID.randomUUID();
       payloads.add(new Payload(prefix, key, val, family));
     });
 
-    colFamilies.forEach(family -> dbManager.dropColumnFamily(family));
-    colFamilies.forEach(family -> dbManager.addColumnFamily(family));
     colFamilies.forEach(family -> dbManager.dropColumnFamily(family));
     colFamilies.forEach(family -> dbManager.addColumnFamily(family));
 
@@ -128,11 +126,13 @@ public class TestRocksDBDAO {
     });
 
     colFamilies.forEach(family -> {
+      long countBeforeDeletion = dbManager.prefixSearch(family, prefix1).count();
       dbManager.prefixDelete(family, prefix1);
-
-      int got = dbManager.prefixSearch(family, prefix1).collect(Collectors.toList()).size();
-      assertEquals(countsMap.get(family).get(prefix1) == null ? 0 : 1, got,
-          "Expected prefix delete to leave at least one item for family: " + family);
+      if (countBeforeDeletion > 0) {
+        long countAfterDeletion = dbManager.prefixSearch(family, prefix1).count();
+        assertEquals(0, countAfterDeletion,
+                "Expected prefixDelete to remove all items for family: " + family);
+      }
     });
 
     payloads.stream().filter(p -> !p.getPrefix().equalsIgnoreCase(prefix1)).forEach(payload -> {


### PR DESCRIPTION
### Change Logs

Done this https://github.com/apache/hudi/issues/11075  
+  
Fix UT:  
Accordinly to commented code, all items must be deleted:  
```
// Delete the last entry
getRocksDB().delete(getUTF8Bytes(lastEntry));
```
I fixed deletion of last entry and fix assertion in UT.

### Impact

RocksDBDAO prefixDelete deletes all items

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
