### PR TITLE
[MINOR] doap: don't nest multiple versions in a release

### DIFF
--- a/doap_HUDI.rdf
+++ b/doap_HUDI.rdf
@@ -41,106 +41,148 @@
         <created>2019-10-24</created>
         <revision>0.5.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi-incubating 0.5.1</name>
         <created>2020-01-31</created>
         <revision>0.5.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi-incubating 0.5.2</name>
         <created>2020-03-26</created>
         <revision>0.5.2</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.5.3</name>
         <created>2020-06-16</created>
         <revision>0.5.3</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.6.0</name>
         <created>2020-08-22</created>
         <revision>0.6.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.7.0</name>
         <created>2021-01-25</created>
         <revision>0.7.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.8.0</name>
         <created>2021-04-06</created>
         <revision>0.8.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.9.0</name>
         <created>2021-08-26</created>
         <revision>0.9.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.10.0</name>
         <created>2021-12-08</created>
         <revision>0.10.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.10.1</name>
         <created>2022-01-26</created>
         <revision>0.10.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.11.0</name>
         <created>2022-04-30</created>
         <revision>0.11.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.11.1</name>
         <created>2022-06-18</created>
         <revision>0.11.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.12.0</name>
         <created>2022-08-16</created>
         <revision>0.12.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.12.1</name>
         <created>2022-10-18</created>
         <revision>0.12.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.12.2</name>
         <created>2022-12-28</created>
         <revision>0.12.2</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.13.0</name>
         <created>2023-02-25</created>
         <revision>0.13.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.12.3</name>
         <created>2023-04-23</created>
         <revision>0.12.3</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.13.1</name>
         <created>2023-05-25</created>
         <revision>0.13.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.14.0</name>
         <created>2023-09-28</created>
         <revision>0.14.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 1.0.0-beta1</name>
         <created>2023-11-14</created>
         <revision>1.0.0-beta1</revision>
       </Version>
+    </release>
+    <release>
       <Version> 
         <name>Apache Hudi 0.14.1</name> 
         <created>2024-01-04</created>
         <revision>0.14.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Hudi 0.15.0</name>
         <created>2024-06-04</created>


### PR DESCRIPTION
### Change Logs

Fix the syntax of the project's DOAP description

### Impact

whatever generates https://projects.apache.org/json/projects/hudi.json and https://projects.apache.org/project.html?hudi should start working again

### Risk level (write none, low medium or high below)

none

### Documentation Update

n/a

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed