### PR TITLE
[HUDI-7940] Pass HoodieIngestionMetrics to Error Table Writer to be able to emit metrics for Error Table Writer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -50,7 +50,7 @@ public abstract class HoodieIngestionMetrics implements Serializable {
 
   public abstract Timer.Context getMetaSyncTimerContext();
 
-  public abstract Timer.Context getErrorTableTimerContext();
+  public abstract Timer.Context getErrorTableWriteTimerContext();
 
   public abstract void updateStreamerMetrics(long durationNanos);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -50,11 +50,15 @@ public abstract class HoodieIngestionMetrics implements Serializable {
 
   public abstract Timer.Context getMetaSyncTimerContext();
 
+  public abstract Timer.Context getErrorTableTimerContext();
+
   public abstract void updateStreamerMetrics(long durationNanos);
 
   public abstract void updateStreamerMetaSyncMetrics(String syncClassShortName, long syncTimeNanos);
 
   public abstract void updateStreamerSyncMetrics(long syncEpochTimeMs);
+
+  public abstract void updateErrorTableCommitDuration(long durationInNs);
 
   public abstract void updateStreamerHeartbeatTimestamp(long heartbeatTimestampMs);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.spark.api.java.JavaRDD;
@@ -52,6 +53,14 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> implements Seri
 
   public BaseErrorTableWriter(HoodieStreamer.Config cfg, SparkSession sparkSession,
                               TypedProperties props, HoodieSparkEngineContext hoodieSparkContext, FileSystem fileSystem) {
+  }
+
+  public BaseErrorTableWriter(HoodieStreamer.Config cfg,
+                              SparkSession sparkSession,
+                              TypedProperties props,
+                              HoodieSparkEngineContext hoodieSparkContext,
+                              FileSystem fs,
+                              Option<HoodieIngestionMetrics> metrics) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_WRITE_CLASS;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
@@ -55,12 +55,12 @@ public final class ErrorTableUtils {
 
     Class<?>[] legacyArgClass = new Class[]{HoodieStreamer.Config.class,
         SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class, FileSystem.class};
-    Class<?>[] argClassV1 = new Class[]{HoodieStreamer.Config.class,
+    Class<?>[] argClass = new Class[] {HoodieStreamer.Config.class,
         SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class, FileSystem.class, Option.class};
 
     try {
-      if (ReflectionUtils.hasConstructor(errorTableWriterClass, argClassV1)) {
-        return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(argClassV1)
+      if (ReflectionUtils.hasConstructor(errorTableWriterClass, argClass)) {
+        return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(argClass)
             .newInstance(cfg, sparkSession, props, hoodieSparkContext, fs, metrics));
       } else if (ReflectionUtils.hasConstructor(errorTableWriterClass, legacyArgClass)) {
         return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(legacyArgClass)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorTableUtils.java
@@ -52,24 +52,25 @@ public final class ErrorTableUtils {
                                                                  Option<HoodieIngestionMetrics> metrics) {
     String errorTableWriterClass = props.getString(ERROR_TABLE_WRITE_CLASS.key());
     ValidationUtils.checkState(!StringUtils.isNullOrEmpty(errorTableWriterClass),
-        "Missing error table config " + ERROR_TABLE_WRITE_CLASS);
+                               "Missing error table config " + ERROR_TABLE_WRITE_CLASS);
 
-    Class<?>[] argClassArr = new Class[] {HoodieStreamer.Config.class,
-        SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class,
-        FileSystem.class, Option.class};
-    String errMsg = "Unable to instantiate ErrorTableWriter with arguments type "
-        + Arrays.toString(argClassArr);
-    ValidationUtils.checkArgument(
-        ReflectionUtils.hasConstructor(BaseErrorTableWriter.class.getName(), argClassArr, false),
-        errMsg);
+    Class<?>[] legacyArgClass = new Class[]{HoodieStreamer.Config.class,
+        SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class, FileSystem.class};
+    Class<?>[] argClassV1 = new Class[]{HoodieStreamer.Config.class,
+        SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class, FileSystem.class, Option.class};
 
     try {
-      return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass)
-          .getConstructor(argClassArr)
-          .newInstance(cfg, sparkSession, props, hoodieSparkContext, fs, metrics));
-    } catch (NoSuchMethodException | InvocationTargetException | InstantiationException
-             | IllegalAccessException e) {
-      throw new HoodieException(errMsg, e);
+      if (ReflectionUtils.hasConstructor(errorTableWriterClass, argClassV1)) {
+        return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(argClassV1)
+            .newInstance(cfg, sparkSession, props, hoodieSparkContext, fs, metrics));
+      } else if (ReflectionUtils.hasConstructor(errorTableWriterClass, legacyArgClass)) {
+        return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(legacyArgClass)
+            .newInstance(cfg, sparkSession, props, hoodieSparkContext, fs));
+      } else {
+        throw new HoodieException(String.format("The configured Error table class %s does not have the appropriate constructor", errorTableWriterClass));
+      }
+    } catch (Exception exception) {
+      throw new HoodieException("Could not load Error Table class " + BaseErrorTableWriter.class.getName(), exception);
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.streamer;
 
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.metrics.Metrics;
@@ -53,6 +54,11 @@ public class HoodieStreamerMetrics extends HoodieIngestionMetrics {
       this.metaSyncTimerName = getMetricsName("timer", "deltastreamerMetaSync");
       this.errorTableWriteTimerName = getMetricsName("timer", "errorTableWrite");
     }
+  }
+
+  @VisibleForTesting
+  Metrics getMetrics() {
+    return metrics;
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
@@ -80,7 +80,7 @@ public class HoodieStreamerMetrics extends HoodieIngestionMetrics {
   }
 
   @Override
-  public Timer.Context getErrorTableTimerContext() {
+  public Timer.Context getErrorTableWriteTimerContext() {
     if (writeConfig.isMetricsOn() && errorTableWriteTimer == null) {
       errorTableWriteTimer = createTimer(errorTableWriteTimerName);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -316,7 +316,7 @@ public class StreamSync implements Serializable, Closeable {
     this.hoodieMetrics = new HoodieMetrics(hoodieWriteConfig, storage);
     if (props.getBoolean(ERROR_TABLE_ENABLED.key(), ERROR_TABLE_ENABLED.defaultValue())) {
       this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(
-          cfg, sparkSession, props, hoodieSparkContext, fs, Option.ofthis.metrics));
+          cfg, sparkSession, props, hoodieSparkContext, fs, Option.of(metrics));
       this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
     }
     refreshTimeline();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -316,7 +316,7 @@ public class StreamSync implements Serializable, Closeable {
     this.hoodieMetrics = new HoodieMetrics(hoodieWriteConfig, storage);
     if (props.getBoolean(ERROR_TABLE_ENABLED.key(), ERROR_TABLE_ENABLED.defaultValue())) {
       this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(
-          cfg, sparkSession, props, hoodieSparkContext, fs);
+          cfg, sparkSession, props, hoodieSparkContext, fs, Option.ofthis.metrics));
       this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
     }
     refreshTimeline();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieErrorTableConfig;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.AvroKafkaSource;
@@ -321,6 +322,17 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
 
     public static void resetTargetSchema() {
       TestSchemaProvider.targetSchema = null;
+    }
+  }
+
+  public static class TestErrorTableV1 extends TestErrorTable {
+    public TestErrorTableV1(HoodieStreamer.Config cfg,
+                            SparkSession sparkSession,
+                            TypedProperties props,
+                            HoodieSparkEngineContext hoodieSparkContext,
+                            FileSystem fs,
+                            Option<HoodieIngestionMetrics> metrics) {
+      super(cfg, sparkSession, props, hoodieSparkContext, fs);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestErrorTableUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestErrorTableUtils.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamerSchemaEvolutionBase.TestErrorTable;
+import org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamerSchemaEvolutionBase.TestErrorTableV1;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.spark.sql.SparkSession;
@@ -57,10 +58,15 @@ public class TestErrorTableUtils {
         () -> ErrorTableUtils.getErrorTableWriter(
             new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()));
 
-    // Proper error table writer config
+    // Proper error table writer config: legacy constructor
     props.put("hoodie.errortable.write.class", TestErrorTable.class.getName());
     assertTrue(ErrorTableUtils.getErrorTableWriter(
         new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()).get() instanceof TestErrorTable);
+
+    // Proper error table writer config: latest constructor
+    props.put("hoodie.errortable.write.class", TestErrorTableV1.class.getName());
+    assertTrue(ErrorTableUtils.getErrorTableWriter(
+        new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()).get() instanceof TestErrorTableV1);
 
     // Wrong error table writer config
     props.put("hoodie.errortable.write.class", HoodieConfig.class.getName());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestErrorTableUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestErrorTableUtils.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.streamer;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamerSchemaEvolutionBase.TestErrorTable;
@@ -48,23 +49,23 @@ public class TestErrorTableUtils {
     // No error table writer config
     assertThrows(IllegalArgumentException.class,
         () -> ErrorTableUtils.getErrorTableWriter(
-            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem));
+            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()));
 
     // Empty error table writer config
     props.put("hoodie.errortable.write.class", StringUtils.EMPTY_STRING);
     assertThrows(IllegalStateException.class,
         () -> ErrorTableUtils.getErrorTableWriter(
-            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem));
+            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()));
 
     // Proper error table writer config
     props.put("hoodie.errortable.write.class", TestErrorTable.class.getName());
     assertTrue(ErrorTableUtils.getErrorTableWriter(
-        new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem).get() instanceof TestErrorTable);
+        new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()).get() instanceof TestErrorTable);
 
     // Wrong error table writer config
     props.put("hoodie.errortable.write.class", HoodieConfig.class.getName());
     assertThrows(HoodieException.class,
         () -> ErrorTableUtils.getErrorTableWriter(
-            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem));
+            new HoodieStreamer.Config(), sparkSession, props, sparkContext, fileSystem, Option.empty()));
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieStreamerMetrics.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieStreamerMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
+import org.apache.hudi.storage.HoodieStorageUtils;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests {@link HoodieStreamerMetrics}.
+ */
+public class TestHoodieStreamerMetrics {
+  @Test
+  public void testHoodieStreamerMetricsForErrorTableIfEnabled() throws InterruptedException {
+    HoodieMetricsConfig metricsConfig = HoodieMetricsConfig.newBuilder()
+        .on(true)
+        .withPath("/tmp/path1")
+        .withReporterType("INMEMORY")
+        .build();
+    HoodieStreamerMetrics metrics = new HoodieStreamerMetrics(
+        metricsConfig, HoodieStorageUtils.getStorage(getDefaultStorageConf()));
+    Timer.Context timerContext = metrics.getErrorTableWriteTimerContext();
+    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+    long duration = timerContext.stop();
+    metrics.updateErrorTableCommitDuration(duration);
+    MetricRegistry registry = metrics.getMetrics().getRegistry();
+    assertEquals(1, registry.getGauges().size());
+    assertEquals(".deltastreamer.errorTableCommitDuration", registry.getGauges().firstKey());
+  }
+
+  @Test
+  public void testHoodieStreamerMetricsForErrorTableIfDisabled() {
+    HoodieMetricsConfig metricsConfig = HoodieMetricsConfig.newBuilder()
+        .on(false)
+        .withPath("/tmp/path2")
+        .withReporterType("INMEMORY")
+        .build();
+    HoodieStreamerMetrics metrics = new HoodieStreamerMetrics(
+        metricsConfig, HoodieStorageUtils.getStorage(getDefaultStorageConf()));
+    Timer.Context timerContext = metrics.getErrorTableWriteTimerContext();
+    assertNull(timerContext);
+    metrics.updateErrorTableCommitDuration(0L);
+    assertNull(metrics.getMetrics());
+  }
+}


### PR DESCRIPTION
### Change Logs

Pass HoodieIngestionMetrics to Error Table Writer, keep support for old interface for ErrorTableWriter.

### Impact

Pass HoodieIngestionMetrics to Error Table Writer to be able to emit metrics for Error Table Wrier.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
