### PR TITLE
[HUDI-7942] Fix SmallFileAssignState#totalUnassigned naming error

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssigner.java
@@ -291,17 +291,17 @@ public class BucketAssigner implements AutoCloseable {
    */
   private static class SmallFileAssignState {
     long assigned;
-    long totalUnassigned;
+    long total;
     final String fileId;
 
     SmallFileAssignState(long parquetMaxFileSize, SmallFile smallFile, long averageRecordSize) {
       this.assigned = 0;
-      this.totalUnassigned = (parquetMaxFileSize - smallFile.sizeBytes) / averageRecordSize;
+      this.total = (parquetMaxFileSize - smallFile.sizeBytes) / averageRecordSize;
       this.fileId = smallFile.location.getFileId();
     }
 
     public boolean canAssign() {
-      return this.totalUnassigned > 0 && this.totalUnassigned > this.assigned;
+      return this.total > 0 && this.total > this.assigned;
     }
 
     /**


### PR DESCRIPTION
### Change Logs

SmallFileAssignState#totalUnassigned means the total number of records, but the variable name 'totalUnassigned' has a significant meaning. It should be changed to 'total'.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [1] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [1] Change Logs and Impact were stated clearly
- [1] Adequate tests were added if applicable
- [1] CI passed
