### PR TITLE
[HUDI-7859] Rename instant files to be consistent with 0.x naming format when downgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToSevenDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToSevenDowngradeHandler.java
@@ -20,18 +20,59 @@ package org.apache.hudi.table.upgrade;
 
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
+import static org.apache.hudi.common.table.timeline.HoodieInstant.UNDERSCORE;
+
 
 /**
  * Version 7 is going to be placeholder version for bridge release 0.16.0.
  * Version 8 is the placeholder version to track 1.x.
  */
 public class EightToSevenDowngradeHandler implements DowngradeHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EightToSevenDowngradeHandler.class);
+
   @Override
   public Map<ConfigProperty, String> downgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
+    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+    UpgradeDowngradeUtils.runCompaction(table, context, config, upgradeDowngradeHelper);
+    UpgradeDowngradeUtils.syncCompactionRequestedFileToAuxiliaryFolder(table);
+
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf().newInstance()).setBasePath(config.getBasePath()).build();
+    List<HoodieInstant> instants = metaClient.getActiveTimeline().getInstants();
+    if (!instants.isEmpty()) {
+      context.map(instants, instant -> {
+        if (instant.getFileName().contains(UNDERSCORE)) {
+          try {
+            // Rename the metadata file name from the ${instant_time}_${completion_time}.action[.state] format in version 1.x to the ${instant_time}.action[.state] format in version 0.x.
+            StoragePath fromPath = new StoragePath(metaClient.getMetaPath(), instant.getFileName());
+            StoragePath toPath = new StoragePath(metaClient.getMetaPath(), instant.getFileName().replaceAll(UNDERSCORE + "\\d+", ""));
+            boolean success = metaClient.getStorage().rename(fromPath, toPath);
+            // TODO: We need to rename the action-related part of the metadata file name here when we bring separate action name for clustering/compaction in 1.x as well.
+            if (!success) {
+              throw new HoodieIOException("an error that occurred while renaming " + fromPath + " to: " + toPath);
+            }
+            return true;
+          } catch (IOException e) {
+            LOG.warn("Can not to complete the downgrade from version eight to version seven. The reason for failure is {}", e.getMessage());
+          }
+        }
+        return false;
+      }, instants.size());
+    }
     return Collections.emptyMap();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.upgrade;
+
+import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
+import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
+
+import java.io.IOException;
+
+public class UpgradeDowngradeUtils {
+
+  /**
+   * Utility method to run compaction for MOR table as part of downgrade step.
+   */
+  public static void runCompaction(HoodieTable table, HoodieEngineContext context, HoodieWriteConfig config,
+                                   SupportsUpgradeDowngrade upgradeDowngradeHelper) {
+    try {
+      if (table.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ) {
+        // set required configs for scheduling compaction.
+        HoodieInstantTimeGenerator.setCommitTimeZone(table.getMetaClient().getTableConfig().getTimelineTimezone());
+        HoodieWriteConfig compactionConfig = HoodieWriteConfig.newBuilder().withProps(config.getProps()).build();
+        compactionConfig.setValue(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+        compactionConfig.setValue(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1");
+        compactionConfig.setValue(HoodieCompactionConfig.INLINE_COMPACT_TRIGGER_STRATEGY.key(), CompactionTriggerStrategy.NUM_COMMITS.name());
+        compactionConfig.setValue(HoodieCompactionConfig.COMPACTION_STRATEGY.key(), UnBoundedCompactionStrategy.class.getName());
+        compactionConfig.setValue(HoodieMetadataConfig.ENABLE.key(), "false");
+        try (BaseHoodieWriteClient writeClient = upgradeDowngradeHelper.getWriteClient(compactionConfig, context)) {
+          Option<String> compactionInstantOpt = writeClient.scheduleCompaction(Option.empty());
+          if (compactionInstantOpt.isPresent()) {
+            writeClient.compact(compactionInstantOpt.get());
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new HoodieException(e);
+    }
+  }
+
+  /**
+   * See HUDI-6040.
+   */
+  public static void syncCompactionRequestedFileToAuxiliaryFolder(HoodieTable table) {
+    HoodieTableMetaClient metaClient = table.getMetaClient();
+    HoodieTimeline compactionTimeline = new HoodieActiveTimeline(metaClient, false).filterPendingCompactionTimeline()
+        .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
+    compactionTimeline.getInstantsAsStream().forEach(instant -> {
+      String fileName = instant.getFileName();
+      try {
+        if (!metaClient.getStorage().exists(new StoragePath(metaClient.getMetaAuxiliaryPath(), fileName))) {
+          FileIOUtils.copy(metaClient.getStorage(),
+              new StoragePath(metaClient.getMetaPath(), fileName),
+              new StoragePath(metaClient.getMetaAuxiliaryPath(), fileName));
+        }
+      } catch (IOException e) {
+        throw new HoodieIOException(e.getMessage(), e);
+      }
+    });
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -44,7 +44,7 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
 
   private static final String DELIMITER = ".";
 
-  private static final String UNDERSCORE = "_";
+  public static final String UNDERSCORE = "_";
 
   private static final String FILE_NAME_FORMAT_ERROR =
       "The provided file name %s does not conform to the required format";

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory
 
 import java.io.File
 import java.util.TimeZone
+import java.util.regex.Pattern
 
 class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
@@ -248,6 +249,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 }
 
 object HoodieSparkSqlTestBase {
+
+  // the naming format of 0.x version
+  final val NAME_FORMAT_0_X: Pattern = Pattern.compile("^(\\d+)(\\.\\w+)(\\.\\D+)?$")
 
   def getLastCommitMetadata(spark: SparkSession, tablePath: String) = {
     val metaClient = createMetaClient(spark, tablePath)


### PR DESCRIPTION
### Change Logs

When downgrading the hudi table version from 8 to 7, rename the instant file to match the 0.x naming format.

### Impact

EightToSevenDowngradeHandler

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
