### PR TITLE
[HUDI-7943] Resolve version conflict of fasterxml on spark3.2

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
@@ -44,6 +44,8 @@ public class JsonUtils {
     MAPPER.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
     MAPPER.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
     MAPPER.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
+
+    registerModules();
   }
 
   public static ObjectMapper getObjectMapper() {
@@ -60,7 +62,7 @@ public class JsonUtils {
   }
 
   public static void registerModules() {
-    // NOTE: Registering [[JavaTimeModule]] is required for Jackson >= 2.11 (Spark >= 3.3)
+    // NOTE: Registering [[JavaTimeModule]] is required for Jackson >= 2.11 (Spark >= 3.2)
     MAPPER.registerModules(new JavaTimeModule());
   }
 }

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -48,8 +48,8 @@ import scala.collection.JavaConverters._
  */
 abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
 
-  // JsonUtils for Support Spark Version >= 3.3
-  if (HoodieSparkUtils.gteqSpark3_3) JsonUtils.registerModules()
+  // JsonUtils for Support Spark Version >= 3.2
+  if (HoodieSparkUtils.gteqSpark3_2) JsonUtils.registerModules()
 
   private val cache = new ConcurrentHashMap[ZoneId, DateFormatter](1)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2523,6 +2523,7 @@
         <orc.spark.version>1.6.12</orc.spark.version>
         <avro.version>1.10.2</avro.version>
         <antlr.version>4.8</antlr.version>
+        <fasterxml.spark3.version>2.12.3</fasterxml.spark3.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>


### PR DESCRIPTION
### Change Logs
- set fasterxml version for spark3.2

### Impact
- dependencies

### Risk level (write none, low medium or high below)
- low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
