### PR TITLE
[HUDI-7945] Fix partition pruning using PARTITION_STATS index in Spark

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -303,10 +303,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     // Convert partition's path into partition descriptor
     return matchedPartitionPaths.stream()
-        .map(partitionPath -> {
-          Object[] partitionColumnValues = parsePartitionColumnValues(partitionColumns, partitionPath);
-          return new PartitionPath(partitionPath, partitionColumnValues);
-        })
+        .map(this::convertToPartitionPath)
         .collect(Collectors.toList());
   }
 
@@ -330,10 +327,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     // Convert partition's path into partition descriptor
     return matchedPartitionPaths.stream()
-        .map(partitionPath -> {
-          Object[] partitionColumnValues = parsePartitionColumnValues(partitionColumns, partitionPath);
-          return new PartitionPath(partitionPath, partitionColumnValues);
-        })
+        .map(this::convertToPartitionPath)
         .collect(Collectors.toList());
   }
 
@@ -492,6 +486,11 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
   protected boolean shouldReadAsPartitionedTable() {
     return (partitionColumns.length > 0 && canParsePartitionValues()) || HoodieTableMetadata.isMetadataTable(basePath);
+  }
+
+  protected PartitionPath convertToPartitionPath(String partitionPath) {
+    Object[] partitionColumnValues = parsePartitionColumnValues(partitionColumns, partitionPath);
+    return new PartitionPath(partitionPath, partitionColumnValues);
   }
 
   private static long fileSliceSize(FileSlice fileSlice) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.common.model;
 
+import org.apache.hudi.common.util.ValidationUtils;
+
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
@@ -153,13 +155,15 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
   /**
    * Merges the given two column range metadata.
    */
-  public static HoodieColumnRangeMetadata<Comparable> merge(
-      HoodieColumnRangeMetadata<Comparable> left,
-      HoodieColumnRangeMetadata<Comparable> right) {
+  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> merge(
+      HoodieColumnRangeMetadata<T> left,
+      HoodieColumnRangeMetadata<T> right) {
+    ValidationUtils.checkArgument(left.getColumnName().equals(right.getColumnName()),
+        "Column names should be the same for merging column ranges");
     String filePath = left.getFilePath();
     String columnName = left.getColumnName();
-    Comparable min = minVal(left.getMinValue(), right.getMinValue());
-    Comparable max = maxVal(left.getMaxValue(), right.getMaxValue());
+    T min = minVal(left.getMinValue(), right.getMinValue());
+    T max = maxVal(left.getMaxValue(), right.getMaxValue());
     long nullCount = left.getNullCount() + right.getNullCount();
     long valueCount = left.getValueCount() + right.getValueCount();
     long totalSize = left.getTotalSize() + right.getTotalSize();
@@ -167,7 +171,7 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
     return create(filePath, columnName, min, max, nullCount, valueCount, totalSize, totalUncompressedSize);
   }
 
-  private static Comparable minVal(Comparable val1, Comparable val2) {
+  private static <T extends Comparable<T>> T minVal(T val1, T val2) {
     if (val1 == null) {
       return val2;
     }
@@ -177,7 +181,7 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
     return val1.compareTo(val2) < 0 ? val1 : val2;
   }
 
-  private static Comparable maxVal(Comparable val1, Comparable val2) {
+  private static <T extends Comparable<T>> T maxVal(T val1, T val2) {
     if (val1 == null) {
       return val2;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -68,7 +68,6 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.unwrapAvroValueWrapper;
 import static org.apache.hudi.avro.HoodieAvroUtils.wrapValueIntoAvro;
-import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 import static org.apache.hudi.common.util.TypeUtils.unsafeCast;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
@@ -687,11 +686,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     return columnRangeMetadataList.stream().map(columnRangeMetadata -> {
       HoodieKey key = new HoodieKey(getPartitionStatsIndexKey(partitionPath, columnRangeMetadata.getColumnName()),
           MetadataPartitionType.PARTITION_STATS.getPartitionPath());
-      String fileName = nonEmpty(columnRangeMetadata.getFilePath()) ? new StoragePath(columnRangeMetadata.getFilePath()).getName() : null;
-
       HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(),
           HoodieMetadataColumnStats.newBuilder()
-              .setFileName(fileName)
+              .setFileName(columnRangeMetadata.getFilePath())
               .setColumnName(columnRangeMetadata.getColumnName())
               .setMinValue(wrapValueIntoAvro(columnRangeMetadata.getMinValue()))
               .setMaxValue(wrapValueIntoAvro(columnRangeMetadata.getMaxValue()))

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2043,7 +2043,7 @@ public class HoodieTableMetadataUtil {
           .collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, toList())); // Group by column name
       // Step 3: Aggregate Column Ranges
       Stream<HoodieColumnRangeMetadata<Comparable>> partitionStatsRangeMetadata = columnMetadataMap.entrySet().stream()
-          .map(entry -> FileFormatUtils.getColumnRangeInPartition(entry.getValue()));
+          .map(entry -> FileFormatUtils.getColumnRangeInPartition(partitionPath, entry.getValue()));
       return HoodieMetadataPayload.createPartitionStatsRecords(partitionPath, partitionStatsRangeMetadata.collect(toList()), false).iterator();
     });
   }
@@ -2107,7 +2107,7 @@ public class HoodieTableMetadataUtil {
             .collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, toList())); // Group by column name
         // Step 3: Aggregate Column Ranges
         Stream<HoodieColumnRangeMetadata<Comparable>> partitionStatsRangeMetadata = columnMetadataMap.entrySet().stream()
-            .map(entry -> FileFormatUtils.getColumnRangeInPartition(entry.getValue()));
+            .map(entry -> FileFormatUtils.getColumnRangeInPartition(partitionName, entry.getValue()));
         return HoodieMetadataPayload.createPartitionStatsRecords(partitionName, partitionStatsRangeMetadata.collect(toList()), false).iterator();
       });
     } catch (Exception e) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
@@ -30,18 +30,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestBaseFileUtils {
+  private static final String PARTITION_PATH = "partition";
+  private static final String COLUMN_NAME = "columnName";
 
   @Test
   public void testGetColumnRangeInPartition() {
     // Step 1: Set Up Test Data
     HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
-        "path/to/file1", "columnName", 1, 5, 0, 10, 100, 200);
+        "path/to/file1", COLUMN_NAME, 1, 5, 0, 10, 100, 200);
     HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
-        "path/to/file2", "columnName", 3, 8, 1, 15, 120, 250);
+        "path/to/file2", COLUMN_NAME, 3, 8, 1, 15, 120, 250);
     List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
     // Step 2: Call the Method
-    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(fileColumnRanges);
+    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(PARTITION_PATH, fileColumnRanges);
     // Step 3: Assertions
+    assertEquals(PARTITION_PATH, result.getFilePath());
+    assertEquals(COLUMN_NAME, result.getColumnName());
     assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
     assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
     assertEquals(1, result.getNullCount());
@@ -54,14 +58,16 @@ public class TestBaseFileUtils {
   public void testGetColumnRangeInPartitionWithNullMinMax() {
     // Step 1: Set Up Test Data
     HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
-        "path/to/file1", "columnName", 1, null, 0, 10, 100, 200);
+        "path/to/file1", COLUMN_NAME, 1, null, 0, 10, 100, 200);
     HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
-        "path/to/file2", "columnName", null, 8, 1, 15, 120, 250);
+        "path/to/file2", COLUMN_NAME, null, 8, 1, 15, 120, 250);
 
     List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
     // Step 2: Call the Method
-    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(fileColumnRanges);
+    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(PARTITION_PATH, fileColumnRanges);
     // Step 3: Assertions
+    assertEquals(PARTITION_PATH, result.getFilePath());
+    assertEquals(COLUMN_NAME, result.getColumnName());
     assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
     assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
     assertEquals(1, result.getNullCount());
@@ -79,6 +85,6 @@ public class TestBaseFileUtils {
         "path/to/file2", "columnName2", null, 8, 1, 15, 120, 250);
     List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
     // Step 2: Call the Method
-    assertThrows(IllegalArgumentException.class, () -> FileFormatUtils.getColumnRangeInPartition(fileColumnRanges));
+    assertThrows(IllegalArgumentException.class, () -> FileFormatUtils.getColumnRangeInPartition(PARTITION_PATH, fileColumnRanges));
   }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -430,23 +430,7 @@ public class ParquetUtils extends FileFormatUtils {
     // there are multiple blocks. Compute min(block_mins) and max(block_maxs)
     return blockRanges.stream()
         .sequential()
-        .reduce(this::combineRanges).get();
-  }
-
-  private <T extends Comparable<T>> HoodieColumnRangeMetadata<T> combineRanges(
-      HoodieColumnRangeMetadata<T> one,
-      HoodieColumnRangeMetadata<T> another
-  ) {
-    final T minValue = getMinValueForColumnRanges(one, another);
-    final T maxValue = getMaxValueForColumnRanges(one, another);
-
-    return HoodieColumnRangeMetadata.create(
-        one.getFilePath(),
-        one.getColumnName(), minValue, maxValue,
-        one.getNullCount() + another.getNullCount(),
-        one.getValueCount() + another.getValueCount(),
-        one.getTotalSize() + another.getTotalSize(),
-        one.getTotalUncompressedSize() + another.getTotalUncompressedSize());
+        .reduce(HoodieColumnRangeMetadata::merge).get();
   }
 
   private static Comparable<?> convertToNativeJavaType(PrimitiveType primitiveType, Comparable<?> val) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -63,7 +63,7 @@ class ColumnStatsIndexSupport(spark: SparkSession,
 
   // NOTE: Since [[metadataConfig]] is transient this has to be eagerly persisted, before this will be passed
   //       on to the executor
-  private val inMemoryProjectionThreshold = metadataConfig.getColumnStatsIndexInMemoryProjectionThreshold
+  protected val inMemoryProjectionThreshold = metadataConfig.getColumnStatsIndexInMemoryProjectionThreshold
 
   private lazy val indexedColumns: Set[String] = {
     val customIndexedColumns = metadataConfig.getColumnsEnabledForColumnStatsIndex
@@ -86,12 +86,6 @@ class ColumnStatsIndexSupport(spark: SparkSession,
                                          shouldPushDownFilesFilter: Boolean
                                         ): Option[Set[String]] = {
     if (isIndexAvailable && queryFilters.nonEmpty && queryReferencedColumns.nonEmpty) {
-      // NOTE: Since executing on-cluster via Spark API has its own non-trivial amount of overhead,
-      //       it's most often preferential to fetch Column Stats Index w/in the same process (usually driver),
-      //       w/o resorting to on-cluster execution.
-      //       For that we use a simple-heuristic to determine whether we should read and process CSI in-memory or
-      //       on-cluster: total number of rows of the expected projected portion of the index has to be below the
-      //       threshold (of 100k records)
       val readInMemory = shouldReadInMemory(fileIndex, queryReferencedColumns, inMemoryProjectionThreshold)
       val prunedFileNames = getPrunedFileNames(prunedPartitionsAndFileSlices)
       // NOTE: If partition pruning doesn't prune any files, then there's no need to apply file filters

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -23,15 +23,18 @@ import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.avro.model.{HoodieMetadataColumnStats, HoodieMetadataRecord}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieData
-import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.hash.ColumnIndexID
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
 import org.apache.hudi.util.JFunction
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{And, Expression}
+import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, SparkSession}
 
 import scala.collection.JavaConverters._
 
@@ -47,6 +50,15 @@ class PartitionStatsIndexSupport(spark: SparkSession,
   override def isIndexAvailable: Boolean = {
     metadataConfig.isEnabled &&
       metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS)
+  }
+
+  override def computeCandidateFileNames(fileIndex: HoodieFileIndex,
+                                         queryFilters: Seq[Expression],
+                                         queryReferencedColumns: Seq[String],
+                                         prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
+                                         shouldPushDownFilesFilter: Boolean
+                                        ): Option[Set[String]] = {
+    throw new UnsupportedOperationException("This method is not supported by PartitionStatsIndexSupport")
   }
 
   override def loadColumnStatsIndexRecords(targetColumns: Seq[String], shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
@@ -65,6 +77,40 @@ class PartitionStatsIndexSupport(spark: SparkSession,
         .filter(JFunction.toJavaSerializableFunction(columnStatsRecord => columnStatsRecord != null))
 
     columnStatsRecords
+  }
+
+  def prunePartitions(fileIndex: HoodieFileIndex,
+                      queryFilters: Seq[Expression],
+                      queryReferencedColumns: Seq[String]): Option[Set[String]] = {
+    if (isIndexAvailable && queryFilters.nonEmpty && queryReferencedColumns.nonEmpty) {
+      val readInMemory = shouldReadInMemory(fileIndex, queryReferencedColumns, inMemoryProjectionThreshold)
+      loadTransposed(queryReferencedColumns, readInMemory, Option.empty) {
+        transposedPartitionStatsDF => {
+          val allPartitions = transposedPartitionStatsDF.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+            .collect()
+            .map(_.getString(0))
+            .toSet
+          if (allPartitions.nonEmpty) {
+            // PARTITION_STATS index exist for all or some columns in the filters
+            // NOTE: [[translateIntoColumnStatsIndexFilterExpr]] has covered the case where the
+            //       column in a filter does not have the stats available, by making sure such a
+            //       filter does not prune any partition.
+            val indexSchema = transposedPartitionStatsDF.schema
+            val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema)).reduce(And)
+            Some(transposedPartitionStatsDF.where(new Column(indexFilter))
+              .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+              .collect()
+              .map(_.getString(0))
+              .toSet)
+          } else {
+            // PARTITION_STATS index does not exist for any column in the filters, skip the pruning
+            Option.empty
+          }
+        }
+      }
+    } else {
+      Option.empty
+    }
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -216,11 +216,12 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     val fileIndex = new HoodieFileIndex(sparkSession, metaClient, Option.empty, Map("glob.paths" -> globbedPaths), includeLogFiles = includeLogFiles)
     val selectedPartition = "2016/03/15"
     val partitionFilter: Expression = EqualTo(AttributeReference("partition", StringType)(), Literal(selectedPartition))
-    val prunedPaths = fileIndex.getFileSlicesForPrunedPartitions(Seq(partitionFilter))
+    val (isPruned, prunedPaths) = fileIndex.prunePartitionsAndGetFileSlices(Seq.empty, Seq(partitionFilter))
     val storagePaths = RecordLevelIndexSupport.getPrunedStoragePaths(prunedPaths, fileIndex)
     // verify pruned paths contain the selected partition and the size of the pruned file paths
     // when includeLogFiles is set to true, there are two storages paths - base file and log file
     // every partition contains only one file slice
+    assertTrue(isPruned)
     assertEquals(if (includeLogFiles) 2 else 1, storagePaths.size)
     assertTrue(storagePaths.forall(path => path.toString.contains(selectedPartition)))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDataSkippingQuery.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDataSkippingQuery.scala
@@ -102,8 +102,6 @@ class TestDataSkippingQuery extends HoodieSparkSqlTestBase {
       checkAnswer(s"select id, name, price, ts, dt from $tableName where attributes.color = 'red'")(
         Seq(1, "a1", 10.0, 1000, "2021-01-05")
       )
-      // TODO add this fallback param, cause by PartitionStatsIndexSupport, cause by HUDI-7144,may be fix by HUDI-7903
-      spark.sql("set hoodie.fileIndex.dataSkippingFailureMode = fallback")
       // Check the case where the WHERE condition only includes columns supported by column stats
       checkAnswer(s"select id, name, price, ts, dt from $tableName where name='a1'")(
         Seq(1, "a1", 10.0, 1000, "2021-01-05")


### PR DESCRIPTION
### Change Logs

This PR fixes the partition and file pruning using `PARTITION_STATS` index in Spark.

Before this fix, when there were more than one base file in a table partition, the corresponding `PARTITION_STATS` index record in the metadata table contained `null` as the `file_path` field in `HoodieColumnRangeMetadata`.  The `null` causes `NPE` when loading the column stats per partition from `PARTITION_STATS` index (see the stacktrace at the end).  Also, the current implementation of `PartitionStatsIndexSupport` assumes that the `file_path` field contains the exact file name and it does not work if the the file path is filled as `null`.

To fix the problem, the following changes are made:
- The relative partition path is filled into the `file_path` field of the `PARTITION_STATS` index record using `HoodieColumnRangeMetadata`. When fetching the `PARTITION_STATS` index records, through the `file_path` field we know which partition the stats are for.
- The partition pruning based on `PARTITION_STATS` index now happens at the beginning of the file listing in `HoodieFileIndex` in Spark, instead of being one index support among `indicesSupport` which only happened conditionally before.
- The partition pruning logic is adjusted based on the conditions (`HoodieFileIndex::prunePartitionsAndGetFileSlices`):
  - For partitioned table and partition filters that are present, prune the partitions by the partition filters;
  - For partitioned table and no partition filters, if data skipping is enabled, try using the `PARTITION_STATS` index to prune the partitions; if the pruning based on `PARTITION_STATS` index does not work, fall back to listing all partitions
  - For non-partitioned table, or partitioned table without partition filter or data skipping or `PARTITION_STATS` index, list all partitions.
- `PartitionStatsIndexSupport::prunePartitions` is added to prune partitions based on the data filters and `PARTITION_STATS` index, if the partition filter is absent.
- The redundant methods around merging `HoodieColumnRangeMetadata` are removed.  `HoodieColumnRangeMetadata::merge` is adjusted and reused.

Tests are adjusted to cover the new logic.  Existing tests around `PARTITION_STATS` and `COLUMN_STATS` index also cover the new partition pruning logic to guarantee the results are correct.

`NPE` when loading the column stats per partition from `PARTITION_STATS` index before this fix:
```
Caused by: java.lang.NullPointerException: element cannot be mapped to a null key
    at java.util.Objects.requireNonNull(Objects.java:228)
    at java.util.stream.Collectors.lambda$groupingBy$45(Collectors.java:907)
    at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
    at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    at java.util.Iterator.forEachRemaining(Iterator.java:116)
    at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
    at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
    at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
    at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:747)
    at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:721)
    at java.util.stream.AbstractTask.compute(AbstractTask.java:327)
    at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:401)
    at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
    at java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:714)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
    at org.apache.hudi.common.data.HoodieListPairData.groupByKey(HoodieListPairData.java:115)
    at org.apache.hudi.ColumnStatsIndexSupport.transpose(ColumnStatsIndexSupport.scala:253)
    at org.apache.hudi.ColumnStatsIndexSupport.$anonfun$loadTransposed$1(ColumnStatsIndexSupport.scala:149)
    at org.apache.hudi.HoodieCatalystUtils$.withPersistedData(HoodieCatalystUtils.scala:61)
    at org.apache.hudi.ColumnStatsIndexSupport.loadTransposed(ColumnStatsIndexSupport.scala:148)
    at org.apache.hudi.ColumnStatsIndexSupport.computeCandidateFileNames(ColumnStatsIndexSupport.scala:101)
    at org.apache.hudi.HoodieFileIndex.$anonfun$lookupCandidateFilesInMetadataTable$3(HoodieFileIndex.scala:354)
    at org.apache.hudi.HoodieFileIndex.$anonfun$lookupCandidateFilesInMetadataTable$3$adapted(HoodieFileIndex.scala:351)
    at scala.collection.TraversableLike$WithFilter.$anonfun$foreach$1(TraversableLike.scala:985)
    at scala.collection.immutable.List.foreach(List.scala:431)
    at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:984)
    at org.apache.hudi.HoodieFileIndex.$anonfun$lookupCandidateFilesInMetadataTable$1(HoodieFileIndex.scala:351)
    at scala.util.Try$.apply(Try.scala:213)
    at org.apache.hudi.HoodieFileIndex.lookupCandidateFilesInMetadataTable(HoodieFileIndex.scala:338)
    at org.apache.hudi.HoodieFileIndex.filterFileSlices(HoodieFileIndex.scala:241)
    ... 106 more 
```
### Impact

Fixes the bug in partition and file pruning using `PARTITION_STATS` index in Spark.

### Risk level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
