### PR TITLE
[HUDI-7950] Shade roaring bitmap dependency in root POM

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -92,7 +92,6 @@
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
-                  <include>org.roaringbitmap:RoaringBitmap</include>
                   <!-- Bundle Jackson JSR310 library since it is not present in spark 2.x. For spark 3.x this will
                        bundle the same JSR310 version that is included in spark runtime -->
                   <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
@@ -199,10 +198,6 @@
                 <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.roaringbitmap.</pattern>
-                  <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.uber.m3.</pattern>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -116,7 +116,6 @@
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
                   <include>org.apache.parquet:parquet-avro</include>
-                  <include>org.roaringbitmap:RoaringBitmap</include>
                   <!-- Bundle Jackson JSR310 library since it is not present in spark 2.x. For spark 3.x this will
                        bundle the same JSR310 version that is included in spark runtime -->
                   <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
@@ -235,10 +234,6 @@
                 <relocation>
                   <pattern>com.google.protobuf.</pattern>
                   <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.roaringbitmap.</pattern>
-                  <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.uber.m3.</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -483,6 +483,8 @@
               <include>org.apache.hbase.thirdparty:hbase-shaded-protobuf</include>
               <include>org.apache.hbase.thirdparty:hbase-unsafe</include>
               <include>org.apache.htrace:htrace-core4</include>
+              <!-- roaring bitmap -->
+              <include>org.roaringbitmap:RoaringBitmap</include>
               <!-- afterburner module for jackson performance -->
               <include>com.fasterxml.jackson.module:jackson-module-afterburner</include>
               <include>com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}</include>
@@ -582,6 +584,10 @@
               <pattern>org.apache.hadoop.metrics2.util.MetricSampleQuantiles</pattern>
               <shadedPattern>org.apache.hudi.org.apache.hadoop.metrics2.util.MetricSampleQuantiles
               </shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.roaringbitmap.</pattern>
+              <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
             </relocation>
             <relocation>
               <pattern>com.fasterxml.jackson.module</pattern>


### PR DESCRIPTION
### Change Logs

This PR unifies the shading rule of roaring bitmap dependency in the root POM for consistency among bundles.

### Impact

Makes sure there is no conflict due to roaring bitmap dependency.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
