### PR TITLE
[HUDI-7953] Improved the variable naming and formatting of HoodieActiveTimeline and HoodieIndex

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
@@ -193,6 +193,7 @@ public abstract class HoodieIndex<I, O> implements Serializable {
         + "hashing, particularly beneficial in large scale. Use `hoodie.index.bucket.engine` to "
         + "choose bucket engine type, i.e., how buckets are generated.")
     BUCKET,
+
     @EnumFieldDescription("Internal Config for indexing based on Flink state.")
     FLINK_STATE,
 


### PR DESCRIPTION
### Change Logs

1) HoodieActiveTimeline#createNewInstant 
Delete the incorrect comment "Create the in-flight file". The parameter HoodieInstant of createNewInstant can be request or infight, not just inflight.

2) HoodieActiveTimeline#deleteInstantFile
deleteInstantFile parameter HoodieInstant not only infight commit.

3) HoodieActiveTimeline#revertCompleteToInflight
Same reason as above.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [1] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [1] Change Logs and Impact were stated clearly
- [1] Adequate tests were added if applicable
- [1] CI passed
