### PR TITLE
[HUDI-7954] Fix data skipping with secondary index when there are no log files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -952,7 +952,6 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     Map<String, List<HoodieRecord<HoodieMetadataPayload>>> resultMap = new HashMap<>();
     if (reader == null) {
       // No base file at all
-      timings.add(timer.endTimer());
       logRecordsMap.forEach((secondaryKey, logRecords) -> {
         List<HoodieRecord<HoodieMetadataPayload>> recordList = new ArrayList<>();
         logRecords.values().forEach(record -> {
@@ -960,13 +959,19 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         });
         resultMap.put(secondaryKey, recordList);
       });
+      timings.add(timer.endTimer());
       return resultMap;
     }
 
     HoodieTimer readTimer = HoodieTimer.start();
-
     Map<String, List<HoodieRecord<HoodieMetadataPayload>>> baseFileRecordsMap =
         fetchBaseFileAllRecordsByKeys(reader, sortedKeys, true, partitionName);
+    if (logRecordsMap.isEmpty() && !baseFileRecordsMap.isEmpty()) {
+      // file slice has only base file
+      timings.add(timer.endTimer());
+      return baseFileRecordsMap;
+    }
+
     logRecordsMap.forEach((secondaryKey, logRecords) -> {
       if (!baseFileRecordsMap.containsKey(secondaryKey)) {
         List<HoodieRecord<HoodieMetadataPayload>> recordList = logRecords

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -71,14 +71,20 @@ class TestSecondaryIndexPruning extends SecondaryIndexTestBase {
         .setConf(HoodieTestUtils.getDefaultStorageConf)
         .build()
       assert(metaClient.getTableConfig.getMetadataPartitions.contains("secondary_index_idx_not_record_key_col"))
-      // validate data skipping
-      verifyQueryPredicate(hudiOpts, "not_record_key_col")
       // validate the secondary index records themselves
       checkAnswer(s"select key, SecondaryIndexMetadata.recordKey from hudi_metadata('$basePath') where type=7")(
         Seq("abc", "row1"),
         Seq("cde", "row2"),
         Seq("def", "row3")
       )
+      // validate data skipping with filters on secondary key column
+      spark.sql("set hoodie.metadata.enable=true")
+      spark.sql("set hoodie.enable.data.skipping=true")
+      spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
+      checkAnswer(s"select ts, record_key_col, not_record_key_col, partition_key_col from $tableName where not_record_key_col = 'abc'")(
+        Seq(1, "row1", "abc", "p1")
+      )
+      verifyQueryPredicate(hudiOpts, "not_record_key_col")
 
       // create another secondary index on non-string column
       spark.sql(s"create index idx_ts on $tableName using secondary_index(ts)")


### PR DESCRIPTION
### Change Logs

When there are no log files in index, then the lookup returns no secondary keys or candidate files, because of a bug - `logRecordsMap` is empty in this code and base file records are ignored - https://github.com/apache/hudi/blob/70f44efe298771fcef9d029820a9b431e1ff165c/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java#L970

Even though current tests for pruning asserts the filtered files count < total data files count. It is weak in the sense that it does not filtered files count > 0, and hence the assertion passed even when filtered files count = 0. This PR fixes the code and the test. The test without the change in `HoodieBackedTableMetadata` will fail. With the change, we also see number of files getting scanned is lesser (without the change, number of files read is more than 1):
<img width="467" alt="Screenshot 2024-07-05 at 3 39 52 PM" src="https://github.com/apache/hudi/assets/16440354/47898914-daaf-4f3f-9da6-05dadbbda31b">

### Impact

Data skipping with secondary index

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
