### PR TITLE
[HUDI-7955] Account for WritableTimestampObjectInspector#getPrimitive…

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HiveAvroSerializer.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HiveAvroSerializer.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.UnionObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableDateObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableTimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
@@ -305,7 +304,7 @@ public class HiveAvroSerializer {
       case DATE:
         return HoodieHiveUtils.getDays(structFieldData);
       case TIMESTAMP:
-        Object timestamp = ((WritableTimestampObjectInspector) fieldOI).getPrimitiveJavaObject(structFieldData);
+        Object timestamp = HoodieHiveUtils.getTimestamp(structFieldData);
         return HoodieHiveUtils.getMills(timestamp);
       case INT:
         if (schema.getLogicalType() != null && schema.getLogicalType().getName().equals("date")) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
@@ -182,6 +182,10 @@ public class HoodieHiveUtils {
     return HIVE_SHIM.getDateWriteable(value);
   }
 
+  public static Object getTimestamp(Object fieldData) {
+    return HIVE_SHIM.getPrimitiveJavaObject(fieldData);
+  }
+
   public static int getDays(Object dateWritable) {
     return HIVE_SHIM.getDays(dateWritable);
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive2Shim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive2Shim.java
@@ -42,6 +42,11 @@ public class Hive2Shim implements HiveShim {
     return new TimestampWritable(timestamp);
   }
 
+  @Override
+  public Object getPrimitiveJavaObject(Object o) {
+    return o == null ? null : ((TimestampWritable) o).getTimestamp();
+  }
+
   public Writable getDateWriteable(int value) {
     return new DateWritable(value);
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
@@ -43,6 +43,7 @@ public class Hive3Shim implements HiveShim {
   private static Class<?> TIMESTAMP_CLASS = null;
   private static Method SET_TIME_IN_MILLIS = null;
   private static Method TO_SQL_TIMESTAMP = null;
+  private static Method GET_TIMESTAMP = null;
   private static Constructor<?> TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR = null;
 
   private static Class<?> DATE_WRITEABLE_CLASS = null;
@@ -54,6 +55,7 @@ public class Hive3Shim implements HiveShim {
     try {
       TIMESTAMP_CLASS = Class.forName(HIVE_TIMESTAMP_TYPE_CLASS);
       SET_TIME_IN_MILLIS = TIMESTAMP_CLASS.getDeclaredMethod("setTimeInMillis", long.class);
+      GET_TIMESTAMP = TIMESTAMP_CLASS.getDeclaredMethod("getTimestamp");
       TO_SQL_TIMESTAMP = TIMESTAMP_CLASS.getDeclaredMethod("toSqlTimestamp");
       TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR = Class.forName(TIMESTAMP_WRITEABLE_V2_CLASS).getConstructor(TIMESTAMP_CLASS);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
@@ -91,6 +93,19 @@ public class Hive3Shim implements HiveShim {
       return (Writable) TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR.newInstance(timestamp);
     } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
       throw new HoodieException("can not create writable v2 class!", e);
+    }
+  }
+
+  @Override
+  public Object getPrimitiveJavaObject(Object o) {
+    if (o == null) {
+      return null;
+    }
+
+    try {
+      return GET_TIMESTAMP.invoke(o);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new HoodieException("unable to get timestamp from writable using v2 class!", e);
     }
   }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/HiveShim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/HiveShim.java
@@ -27,6 +27,8 @@ public interface HiveShim {
 
   Writable getTimestampWriteable(long value, boolean timestampMillis);
 
+  Object getPrimitiveJavaObject(Object o);
+
   Writable getDateWriteable(int value);
 
   int getDays(Object dateWritable);


### PR DESCRIPTION
…JavaObject discrepancies in Hive3 and Hive2

The invocation of `getPrimitiveJavaObject` returns a different implementation of timestamp in Hive3 and Hive2. 

Hive2: `java.sql.Timestamp`
Hive3: `org.apache.hadoop.hive.common.type.Timestamp`

Hudi common is compiled with Hive2, but Trino is using Hive3, causing the discrepancy between compile and runtime. When execution flow falls into this section of the code where the trigger conditions are listed below:

1. MOR table is used
2. User is querying the _rt table
3. User's table has a TIMESTAMP type and query requires it
4. Merge is required as record is present in both Parquet and Log file

Error below will be thrown:

```
Query 20240704_075218_05052_yfmfc failed: 'java.sql.Timestamp org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableTimestampObjectInspector.getPrimitiveJavaObject(java.lang.Object)'
java.lang.NoSuchMethodError: 'java.sql.Timestamp org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableTimestampObjectInspector.getPrimitiveJavaObject(java.lang.Object)'
        at org.apache.hudi.hadoop.utils.HiveAvroSerializer.serializePrimitive(HiveAvroSerializer.java:304)
        at org.apache.hudi.hadoop.utils.HiveAvroSerializer.serialize(HiveAvroSerializer.java:212)
        at org.apache.hudi.hadoop.utils.HiveAvroSerializer.setUpRecordFieldFromWritable(HiveAvroSerializer.java:121)
        at org.apache.hudi.hadoop.utils.HiveAvroSerializer.serialize(HiveAvroSerializer.java:108)
        at org.apache.hudi.hadoop.realtime.RealtimeCompactedRecordReader.convertArrayWritableToHoodieRecord(RealtimeCompactedRecordReader.java:185)
        at org.apache.hudi.hadoop.realtime.RealtimeCompactedRecordReader.mergeRecord(RealtimeCompactedRecordReader.java:172)
        at org.apache.hudi.hadoop.realtime.RealtimeCompactedRecordReader.next(RealtimeCompactedRecordReader.java:114)
        at org.apache.hudi.hadoop.realtime.RealtimeCompactedRecordReader.next(RealtimeCompactedRecordReader.java:49)
        at org.apache.hudi.hadoop.realtime.HoodieRealtimeRecordReader.next(HoodieRealtimeRecordReader.java:88)
        at org.apache.hudi.hadoop.realtime.HoodieRealtimeRecordReader.next(HoodieRealtimeRecordReader.java:36)
        at io.trino.plugin.hive.GenericHiveRecordCursor.advanceNextPosition(GenericHiveRecordCursor.java:215)
        at io.trino.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:88)
        at io.trino.plugin.hudi.HudiPageSource.getNextPage(HudiPageSource.java:120)
```

For more details on screenshots + SQL to reproduce, please refer to the JIRA ticket [HUDI-7955](https://issues.apache.org/jira/browse/HUDI-7955).

### Change Logs

Added Hive Shimming for `WritableTimestampObjectInspector#getPrimitiveJavaObject`.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
