### PR TITLE
[HUDI-7957] fix data skew when writing with bulk_insert + bucket_inde…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/BucketIndexUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/BucketIndexUtil.java
@@ -1,27 +1,24 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-package org.apache.hudi.sink.utils;
+package org.apache.hudi.common.util.hash;
 
 import org.apache.hudi.common.util.Functions;
-import org.apache.hudi.index.bucket.BucketIdentifier;
 
 /**
  * Utility class for bucket index.
@@ -43,20 +40,20 @@ public class BucketIndexUtil {
       return (partition, curBucket) -> {
         int partitionIndex = (partition.hashCode() & Integer.MAX_VALUE) / parallelism * bucketNum;
         int globalIndex = partitionIndex + curBucket;
-        return BucketIdentifier.mod(globalIndex, parallelism);
+        return globalIndex % parallelism;
       };
     } else {
       if (parallelism % bucketNum == 0) {
         return (partition, curBucket) -> {
           int partitionIndex = (partition.hashCode() & Integer.MAX_VALUE) / (parallelism / bucketNum) * bucketNum;
           int globalIndex = partitionIndex + curBucket;
-          return BucketIdentifier.mod(globalIndex, parallelism);
+          return globalIndex % parallelism;
         };
       } else {
         return (partition, curBucket) -> {
           int partitionIndex = (partition.hashCode() & Integer.MAX_VALUE) / (parallelism / bucketNum + 1) * bucketNum;
           int globalIndex = partitionIndex + curBucket;
-          return BucketIdentifier.mod(globalIndex, parallelism);
+          return globalIndex % parallelism;
         };
       }
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -22,11 +22,11 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.sink.StreamWriteFunction;
-import org.apache.hudi.sink.utils.BucketIndexUtil;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
@@ -20,8 +20,8 @@ package org.apache.hudi.sink.partitioner;
 
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.index.bucket.BucketIdentifier;
-import org.apache.hudi.sink.utils.BucketIndexUtil;
 
 import org.apache.flink.api.common.functions.Partitioner;
 


### PR DESCRIPTION
…x enabled

### Change Logs

- imporve `BucketIndexUtil` partitionIndex algorithm make the data be evenly distributed.
- `BucketPartitionUtils` in spark use `BucketIndexUtil` method, same logic as flink.

### Impact

- flink partitionIndex will use new algorithm

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
