### PR TITLE
[HUDI-7507] Adding timestamp ordering validation before creating requested instant

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -30,6 +30,7 @@ import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.callback.util.HoodieCommitCallbackFactory;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.HeartbeatUtils;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.client.utils.TransactionUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieCommonConfig;
@@ -931,6 +932,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         "Found pending restore in active timeline. Please complete the restore fully before proceeding. As of now, "
             + "table could be in an inconsistent state. Pending restores: " + Arrays.toString(inflightRestoreTimeline.getInstantsAsStream()
             .map(instant -> instant.getTimestamp()).collect(Collectors.toList()).toArray()));
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
 
     // if there are pending compactions, their instantTime must not be greater than that of this instant time
     metaClient.getActiveTimeline().filterPendingCompactionTimeline().lastInstant().ifPresent(latestPending ->
@@ -941,7 +943,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     if (config.getFailedWritesCleanPolicy().isLazy()) {
       this.heartbeatClient.start(instantTime);
     }
-
     if (actionType.equals(HoodieTimeline.REPLACE_COMMIT_ACTION)) {
       metaClient.getActiveTimeline().createRequestedReplaceCommit(instantTime, actionType);
     } else {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.timeline;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ValidationUtils;
+
+public class TimestampUtils {
+
+  public static void validateForLatestTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
+    // validate that the instant for which requested is about to be created is the latest in the timeline.
+    HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
+    reloadedMetaClient.getActiveTimeline().getWriteTimeline().lastInstant().ifPresent(entry -> {
+      ValidationUtils.checkArgument(HoodieTimeline.compareTimestamps(entry.getTimestamp(), HoodieTimeline.LESSER_THAN, instantTime),
+          "Found later commit time " + entry + ", compared to the current instant " + instantTime + ", hence failing to create requested commit meta file");
+    });
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
@@ -29,7 +29,7 @@ public class TimestampUtils {
     if (!metaClient.isMetadataTable()) { // lets validate data table that timestamps are generated in monotically increasing order. 
       HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
       reloadedMetaClient.getActiveTimeline().getWriteTimeline().lastInstant().ifPresent(entry -> {
-        ValidationUtils.checkArgument(HoodieTimeline.compareTimestamps(entry.getTimestamp(), HoodieTimeline.LESSER_THAN, instantTime),
+        ValidationUtils.checkArgument(HoodieTimeline.compareTimestamps(entry.getTimestamp(), HoodieTimeline.LESSER_THAN_OR_EQUALS, instantTime),
             "Found later commit time " + entry + ", compared to the current instant " + instantTime + ", hence failing to create requested commit meta file");
       });
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/TimestampUtils.java
@@ -26,10 +26,12 @@ public class TimestampUtils {
 
   public static void validateForLatestTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
     // validate that the instant for which requested is about to be created is the latest in the timeline.
-    HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
-    reloadedMetaClient.getActiveTimeline().getWriteTimeline().lastInstant().ifPresent(entry -> {
-      ValidationUtils.checkArgument(HoodieTimeline.compareTimestamps(entry.getTimestamp(), HoodieTimeline.LESSER_THAN, instantTime),
-          "Found later commit time " + entry + ", compared to the current instant " + instantTime + ", hence failing to create requested commit meta file");
-    });
+    if (!metaClient.isMetadataTable()) { // lets validate data table that timestamps are generated in monotically increasing order. 
+      HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
+      reloadedMetaClient.getActiveTimeline().getWriteTimeline().lastInstant().ifPresent(entry -> {
+        ValidationUtils.checkArgument(HoodieTimeline.compareTimestamps(entry.getTimestamp(), HoodieTimeline.LESSER_THAN, instantTime),
+            "Found later commit time " + entry + ", compared to the current instant " + instantTime + ", hence failing to create requested commit meta file");
+      });
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -741,6 +741,14 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "The class must be a subclass of `org.apache.hudi.callback.HoodieClientInitCallback`."
           + "By default, no Hudi client init callback is executed.");
 
+  public static final ConfigProperty<Boolean> ENABLE_TIMESTAMP_ORDERING_VALIDATION = ConfigProperty
+      .key("hoodie.timestamp.ordering.validate.enable")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("0.15.1")
+      .withDocumentation("Enable validation for commit time generation to ensure new commit time generated is always the latest among other entries. "
+          + "This is for additional safety to always generate a monotonically increasing commit times (for ingestion writer, table services etc).");
+
   /**
    * Config key with boolean value that indicates whether record being written during MERGE INTO Spark SQL
    * operation are already prepped.
@@ -2621,6 +2629,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return props.getInteger(WRITES_FILEID_ENCODING, HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_UUID);
   }
 
+  public Boolean shouldEnableTimestampOrderinValidation() {
+    return getBoolean(ENABLE_TIMESTAMP_ORDERING_VALIDATION);
+  }
+
   public static class Builder {
 
     protected final HoodieWriteConfig writeConfig = new HoodieWriteConfig();
@@ -3132,6 +3144,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withWritesFileIdEncoding(Integer fileIdEncoding) {
       writeConfig.setValue(WRITES_FILEID_ENCODING, Integer.toString(fileIdEncoding));
+      return this;
+    }
+
+    public Builder withEnableTimestampOrderingValidation(boolean enableTimestampOrderingValidation) {
+      writeConfig.setValue(ENABLE_TIMESTAMP_ORDERING_VALIDATION, Boolean.toString(enableTimestampOrderingValidation));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -904,7 +904,9 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   public abstract void validateForLatestTimestamp(String instantTime);
 
   protected void validateForLatestTimestampInternal(String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    if (this.config.shouldEnableTimestampOrderinValidation() && config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+      TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    }
   }
 
   public HoodieFileFormat getBaseFileFormat() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -901,6 +902,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * @param instantTime instant time of interest.
    */
   public abstract void validateForLatestTimestamp(String instantTime);
+
+  protected void validateForLatestTimestampInternal(String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+  }
 
   public HoodieFileFormat getBaseFileFormat() {
     return metaClient.getTableConfig().getBaseFileFormat();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -894,6 +895,14 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     } catch (HoodieException e) {
       throw new HoodieInsertException("Failed insert schema compatibility check", e);
     }
+  }
+
+  /**
+   * Validates that the instantTime is latest in the write timeline.
+   * @param instantTime instant time of interest.
+   */
+  public void validateForLatestTimestamp(String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
   }
 
   public HoodieFileFormat getBaseFileFormat() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -31,7 +31,6 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
-import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -901,9 +900,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * Validates that the instantTime is latest in the write timeline.
    * @param instantTime instant time of interest.
    */
-  public void validateForLatestTimestamp(String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
-  }
+  public abstract void validateForLatestTimestamp(String instantTime);
 
   public HoodieFileFormat getBaseFileFormat() {
     return metaClient.getTableConfig().getBaseFileFormat();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -179,6 +179,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
       final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
       // Save to both aux and timeline folder
       try {
+        table.validateForLatestTimestamp(cleanInstant.getTimestamp());
         table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
         LOG.info("Requesting Cleaning with instant time " + cleanInstant);
       } catch (IOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -98,6 +98,7 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseActionExecutor
             .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
             .setClusteringPlan(planOption.get())
             .build();
+        table.validateForLatestTimestamp(clusteringInstant.getTimestamp());
         table.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant,
             TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
       } catch (IOException ioe) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -114,6 +114,7 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseActionExec
     Option<HoodieCompactionPlan> option = Option.empty();
     if (plan != null && nonEmpty(plan.getOperations())) {
       extraMetadata.ifPresent(plan::setExtraMetadata);
+      table.validateForLatestTimestamp(instantTime);
       try {
         if (operationType.equals(WriteOperationType.COMPACT)) {
           HoodieInstant compactionInstant = new HoodieInstant(HoodieInstant.State.REQUESTED,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
@@ -113,6 +113,7 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
       HoodieRollbackPlan rollbackPlan = new HoodieRollbackPlan(new HoodieInstantInfo(instantToRollback.getTimestamp(),
           instantToRollback.getAction()), rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION);
       if (!skipTimelinePublish) {
+        table.validateForLatestTimestamp(rollbackInstant.getTimestamp());
         if (table.getRollbackTimeline().filterInflightsAndRequested().containsInstant(rollbackInstant.getTimestamp())) {
           LOG.warn("Request Rollback found with instant time " + rollbackInstant + ", hence skipping scheduling rollback");
         } else {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -124,6 +124,11 @@ public class HoodieFlinkWriteClient<T> extends
   }
 
   @Override
+  protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
+    // no op
+  }
+
+  @Override
   public List<HoodieRecord<T>> filterExists(List<HoodieRecord<T>> hoodieRecords) {
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieFlinkTable<T> table = getHoodieTable();

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
@@ -92,6 +92,11 @@ public class HoodieFlinkCopyOnWriteTable<T>
     super(config, context, metaClient);
   }
 
+  @Override
+  public void validateForLatestTimestamp(String instantTime) {
+    // no-op
+  }
+
   /**
    * Upsert a batch of new records into Hoodie table at the supplied instantTime.
    *

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -20,7 +20,6 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
-import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -106,7 +105,7 @@ public class HoodieJavaWriteClient<T> extends
 
   @Override
   protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    validateTimestampInternal(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -20,6 +20,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -101,6 +102,11 @@ public class HoodieJavaWriteClient<T> extends
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config, Configuration hadoopConf, HoodieTableMetaClient metaClient) {
     return HoodieJavaTable.create(config, context, metaClient);
+  }
+
+  @Override
+  protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -90,6 +91,11 @@ public class HoodieJavaCopyOnWriteTable<T>
                                        HoodieEngineContext context,
                                        HoodieTableMetaClient metaClient) {
     super(config, context, metaClient);
+  }
+
+  @Override
+  public void validateForLatestTimestamp(String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
@@ -31,7 +31,6 @@ import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
-import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -95,7 +94,7 @@ public class HoodieJavaCopyOnWriteTable<T>
 
   @Override
   public void validateForLatestTimestamp(String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    validateForLatestTimestampInternal(instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -1786,7 +1786,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieJavaWriteClient client = getHoodieWriteClient(config);
 
     // Write 1 (Bulk insert)
-    String newCommitTime = "0000001";
+    String newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
     client.startCommitWithTime(newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
@@ -1794,7 +1794,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // Write 2 (inserts)
-    newCommitTime = "0000002";
+    newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     client.startCommitWithTime(newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
@@ -1827,7 +1827,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
             replacedFileIds.add(new HoodieFileGroupId(partitionFiles.getKey(), file))));
 
     // trigger new write to mimic other writes succeeding before re-attempt.
-    newCommitTime = "0000003";
+    newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     client.startCommitWithTime(newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnCopyOnWriteStorage.java
@@ -1319,25 +1319,29 @@ public class TestHoodieJavaClientOnCopyOnWriteStorage extends HoodieJavaClientTe
     HoodieJavaWriteClient client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, populateMetaFields));
 
     // perform 1 successful commit
-    writeBatch(client, "100", "100", Option.of(Arrays.asList("100")), "100",
+    String commit1 = HoodieActiveTimeline.createNewInstantTime();
+    writeBatch(client, commit1, commit1, Option.of(Arrays.asList(commit1)), commit1,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, true);
 
     // Perform 2 failed writes to table
-    writeBatch(client, "200", "100", Option.of(Arrays.asList("200")), "100",
+    String commit2 = HoodieActiveTimeline.createNewInstantTime();
+    writeBatch(client, commit2, commit1, Option.of(Arrays.asList(commit2)), commit1,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
+    String commit3 = HoodieActiveTimeline.createNewInstantTime();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, populateMetaFields));
-    writeBatch(client, "300", "200", Option.of(Arrays.asList("300")), "300",
+    writeBatch(client, commit3, commit2, Option.of(Arrays.asList(commit3)), commit3,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
     // refresh data generator to delete records generated from failed commits
     dataGen = new HoodieTestDataGenerator();
     // Perform 1 successful write
+    String commit4 = HoodieActiveTimeline.createNewInstantTime();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, populateMetaFields));
-    writeBatch(client, "400", "300", Option.of(Arrays.asList("400")), "400",
+    writeBatch(client, commit4, commit3, Option.of(Arrays.asList(commit4)), commit4,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, true);
     HoodieTableMetaClient metaClient = createMetaClient();
@@ -1349,13 +1353,14 @@ public class TestHoodieJavaClientOnCopyOnWriteStorage extends HoodieJavaClientTe
     // Await till enough time passes such that the first 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("300");
+      conditionMet = client.getHeartbeatClient().isHeartbeatExpired(commit3);
       Thread.sleep(2000);
     }
     client.close();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, populateMetaFields));
     // Perform 1 successful write
-    writeBatch(client, "500", "400", Option.of(Arrays.asList("500")), "500",
+    String commit5 = HoodieActiveTimeline.createNewInstantTime();
+    writeBatch(client, commit5, commit4, Option.of(Arrays.asList(commit5)), commit5,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, true);
     client.clean();
@@ -1396,47 +1401,53 @@ public class TestHoodieJavaClientOnCopyOnWriteStorage extends HoodieJavaClientTe
     HoodieTestUtils.init(storageConf, basePath);
     HoodieFailedWritesCleaningPolicy cleaningPolicy = EAGER;
     HoodieJavaWriteClient client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
+    String commit1 = HoodieActiveTimeline.createNewInstantTime();
     // Perform 1 successful writes to table
-    writeBatch(client, "100", "100", Option.of(Arrays.asList("100")), "100",
+    writeBatch(client, commit1, commit1, Option.of(Arrays.asList(commit1)), commit1,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, true);
 
     // Perform 1 failed writes to table
-    writeBatch(client, "200", "100", Option.of(Arrays.asList("200")), "200",
+    String commit2 = HoodieActiveTimeline.createNewInstantTime();
+    writeBatch(client, commit2, commit1, Option.of(Arrays.asList(commit2)), commit2,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
     // Toggle cleaning policy to LAZY
     cleaningPolicy = HoodieFailedWritesCleaningPolicy.LAZY;
+    String commit3 = HoodieActiveTimeline.createNewInstantTime();
     // Perform 2 failed writes to table
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
-    writeBatch(client, "300", "200", Option.of(Arrays.asList("300")), "300",
+    writeBatch(client, commit3, commit2, Option.of(Arrays.asList(commit3)), commit3,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
+    String commit4 = HoodieActiveTimeline.createNewInstantTime();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
-    writeBatch(client, "400", "300", Option.of(Arrays.asList("400")), "400",
+    writeBatch(client, commit4, commit3, Option.of(Arrays.asList(commit4)), commit4,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
     // Await till enough time passes such that the 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("400");
+      conditionMet = client.getHeartbeatClient().isHeartbeatExpired(commit4);
       Thread.sleep(2000);
     }
     client.clean();
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline().reload();
     assertTrue(timeline.getTimelineOfActions(
         CollectionUtils.createSet(ROLLBACK_ACTION)).countInstants() == 3);
+    String commit5 = HoodieActiveTimeline.createNewInstantTime();
     // Perform 2 failed commits
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
-    writeBatch(client, "500", "400", Option.of(Arrays.asList("300")), "300",
+    writeBatch(client, commit5, commit4, Option.of(Arrays.asList(commit3)), commit3,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
+    String commit6 = HoodieActiveTimeline.createNewInstantTime();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
-    writeBatch(client, "600", "500", Option.of(Arrays.asList("400")), "400",
+    writeBatch(client, commit6, commit5, Option.of(Arrays.asList(commit4)), commit4,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 300,
         0, false);
     client.close();
@@ -1458,28 +1469,33 @@ public class TestHoodieJavaClientOnCopyOnWriteStorage extends HoodieJavaClientTe
     ExecutorService service = Executors.newFixedThreadPool(2);
     HoodieTestUtils.init(storageConf, basePath);
     HoodieJavaWriteClient client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
+    String commit1 = HoodieActiveTimeline.createNewInstantTime();
     // perform 1 successful write
-    writeBatch(client, "100", "100", Option.of(Arrays.asList("100")), "100",
+    writeBatch(client, commit1, commit1, Option.of(Arrays.asList(commit1)), commit1,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 100,
         0, true);
 
     // Perform 2 failed writes to table
-    writeBatch(client, "200", "100", Option.of(Arrays.asList("200")), "200",
+    String commit2 = HoodieActiveTimeline.createNewInstantTime();
+    writeBatch(client, commit2, commit1, Option.of(Arrays.asList(commit2)), commit2,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 100,
         0, false);
     client.close();
+
+    String commit3 = HoodieActiveTimeline.createNewInstantTime();
     client = new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true));
-    writeBatch(client, "300", "200", Option.of(Arrays.asList("300")), "300",
+    writeBatch(client, commit3, commit2, Option.of(Arrays.asList(commit3)), commit3,
         100, dataGen::generateInserts, HoodieJavaWriteClient::bulkInsert, false, 100, 100,
         0, false);
     client.close();
     // refresh data generator to delete records generated from failed commits
     dataGen = new HoodieTestDataGenerator();
+    String commit4 = HoodieActiveTimeline.createNewInstantTime();
     // Create a successful commit
-    Future<List<WriteStatus>> commit3 = service.submit(() -> writeBatch(new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)),
-        "400", "300", Option.of(Arrays.asList("400")), "300", 100, dataGen::generateInserts,
+    Future<List<WriteStatus>> commit4Future = service.submit(() -> writeBatch(new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)),
+        commit4, commit3, Option.of(Arrays.asList(commit4)), commit3, 100, dataGen::generateInserts,
         HoodieJavaWriteClient::bulkInsert, false, 100, 100, 0, true));
-    commit3.get();
+    commit4Future.get();
     HoodieTableMetaClient metaClient = createMetaClient();
 
     assertTrue(metaClient.getActiveTimeline().getTimelineOfActions(
@@ -1490,14 +1506,15 @@ public class TestHoodieJavaClientOnCopyOnWriteStorage extends HoodieJavaClientTe
     // Await till enough time passes such that the first 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("300");
+      conditionMet = client.getHeartbeatClient().isHeartbeatExpired(commit3);
       Thread.sleep(2000);
     }
-    Future<List<WriteStatus>> commit4 = service.submit(() -> writeBatch(new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)),
-        "500", "400", Option.of(Arrays.asList("500")), "500", 100, dataGen::generateInserts,
+    String commit5 = HoodieActiveTimeline.createNewInstantTime();
+    Future<List<WriteStatus>> commit5Future = service.submit(() -> writeBatch(new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)),
+        commit5, commit4, Option.of(Arrays.asList(commit5)), commit5, 100, dataGen::generateInserts,
         HoodieJavaWriteClient::bulkInsert, false, 100, 100, 0, true));
     Future<HoodieCleanMetadata> clean1 = service.submit(() -> new HoodieJavaWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)).clean());
-    commit4.get();
+    commit5Future.get();
     clean1.get();
     client.close();
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline().reload();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -20,7 +20,6 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
-import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.client.utils.CommitMetadataUtils;
 import org.apache.hudi.client.utils.SparkReleaseResources;
 import org.apache.hudi.common.data.HoodieData;
@@ -132,7 +131,7 @@ public class SparkRDDWriteClient<T> extends
 
   @Override
   protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    validateTimestampInternal(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -20,6 +20,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.client.utils.CommitMetadataUtils;
 import org.apache.hudi.client.utils.SparkReleaseResources;
 import org.apache.hudi.common.data.HoodieData;
@@ -127,6 +128,11 @@ public class SparkRDDWriteClient<T> extends
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config, Configuration hadoopConf, HoodieTableMetaClient metaClient) {
     return HoodieSparkTable.create(config, context, metaClient);
+  }
+
+  @Override
+  protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -31,7 +31,6 @@ import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
-import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -107,7 +106,7 @@ public class HoodieSparkCopyOnWriteTable<T>
 
   @Override
   public void validateForLatestTimestamp(String instantTime) {
-    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
+    validateForLatestTimestampInternal(instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.client.timeline.TimestampUtils;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -102,6 +103,11 @@ public class HoodieSparkCopyOnWriteTable<T>
 
   public HoodieSparkCopyOnWriteTable(HoodieWriteConfig config, HoodieEngineContext context, HoodieTableMetaClient metaClient) {
     super(config, context, metaClient);
+  }
+
+  @Override
+  public void validateForLatestTimestamp(String instantTime) {
+    TimestampUtils.validateForLatestTimestamp(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiWriterWithPreferWriterIngestion.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiWriterWithPreferWriterIngestion.java
@@ -124,7 +124,6 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     SparkRDDWriteClient client1 = getHoodieWriteClient(cfg);
     SparkRDDWriteClient client2 = getHoodieWriteClient(cfg);
     // Create upserts, schedule cleaning, schedule compaction in parallel
-    //String instant4 = HoodieActiveTimeline.createNewInstantTime();
     Future future1 = executors.submit(() -> {
       int numRecords = 100;
       String commitTimeBetweenPrevAndNew = instantTime2;
@@ -151,7 +150,7 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     Future future2 = executors.submit(() -> {
       try {
         int counter = 0;
-        while (counter++ < 5) {
+        while (counter++ < 5) { // we can't really time which writer triggers first and which one triggers later. So, lets add few rounds of retries.
           try {
             String instant5 = HoodieActiveTimeline.createNewInstantTime();
             client2.scheduleTableService(instant5, Option.empty(), TableServiceType.COMPACT);
@@ -172,7 +171,7 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     AtomicReference<String> instant6Ref = new AtomicReference<>();
     Future future3 = executors.submit(() -> {
       int counter = 0;
-      while (counter++ < 5) {
+      while (counter++ < 5) { // we can't really time which writer triggers first and which one triggers later. So, lets add few rounds of retries.
         try {
           String instant6 = HoodieActiveTimeline.createNewInstantTime();
           client2.scheduleTableService(instant6, Option.empty(), TableServiceType.CLEAN);
@@ -194,7 +193,7 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     future1 = executors.submit(() -> {
       int numRecords = 100;
       int counter = 0;
-      while (counter++ < 5) {
+      while (counter++ < 5) { // we can't really time which writer triggers first and which one triggers later. So, lets add few rounds of retries.
         try {
           String instant7 = HoodieActiveTimeline.createNewInstantTime();
           createCommitWithInserts(cfg, client1, instantTime3, instant7, numRecords);
@@ -211,7 +210,7 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     });
     future2 = executors.submit(() -> {
       int counter = 0;
-      while (counter++ < 5) {
+      while (counter++ < 5) { // we can't really time which writer triggers first and which one triggers later. So, lets add few rounds of retries.
         try {
           HoodieWriteMetadata<JavaRDD<WriteStatus>> compactionMetadata = client2.compact(instant5Ref.get());
           client2.commitCompaction(instant5Ref.get(), compactionMetadata.getCommitMetadata().get(), Option.empty());
@@ -223,9 +222,6 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
           }
         } catch (Exception e2) {
           if (tableType == HoodieTableType.MERGE_ON_READ) {
-            if (!(e2 instanceof HoodieWriteConflictException)) {
-              System.out.println("asdfad");
-            }
             Assertions.assertTrue(e2 instanceof HoodieWriteConflictException);
           }
         }
@@ -233,7 +229,7 @@ public class TestMultiWriterWithPreferWriterIngestion extends HoodieClientTestBa
     });
     future3 = executors.submit(() -> {
       int counter = 0;
-      while (counter++ < 5) {
+      while (counter++ < 5) { // we can't really time which writer triggers first and which one triggers later. So, lets add few rounds of retries.
         try {
           client2.clean(instant6Ref.get(), false);
           validInstants.add(instant6Ref.get());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -2202,7 +2202,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     SparkRDDWriteClient client = getHoodieWriteClient(config);
 
     // Write 1 (Bulk insert)
-    String newCommitTime = "0000001";
+    String newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
     client.startCommitWithTime(newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -2210,7 +2210,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // Write 2 (inserts)
-    newCommitTime = "0000002";
+    newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     client.startCommitWithTime(newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -2240,7 +2240,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
             replacedFileIds.add(new HoodieFileGroupId(partitionFiles.getKey(), file))));
 
     // trigger new write to mimic other writes succeeding before re-attempt.
-    newCommitTime = "0000003";
+    newCommitTime = HoodieActiveTimeline.createNewInstantTime();
     client.startCommitWithTime(newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -38,6 +38,7 @@ import org.apache.hudi.client.validator.SqlQueryEqualityPreCommitValidator;
 import org.apache.hudi.client.validator.SqlQuerySingleResultPreCommitValidator;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
@@ -66,6 +67,8 @@ import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimeGenerator;
+import org.apache.hudi.common.table.timeline.TimeGenerators;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
@@ -102,6 +105,7 @@ import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 import org.apache.hudi.io.HoodieMergeHandle;
@@ -942,6 +946,31 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
       BulkInsertPartitioner<JavaRDD<HoodieRecord>> partitioner = new RDDCustomColumnsSortPartitioner(new String[] {"rider"}, HoodieTestDataGenerator.AVRO_SCHEMA, config);
       List<WriteStatus> statuses = client.bulkInsert(insertRecordsRDD1, commitTime1, Option.of(partitioner)).collect();
       assertNoWriteErrors(statuses);
+    }
+  }
+
+  @Test
+  public void testOutOfOrderCommitTimestamps() {
+    HoodieWriteConfig config = getConfigBuilder()
+        .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(InProcessLockProvider.class).build())
+        .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
+        .build();
+    TimeGenerator timeGenerator = TimeGenerators
+        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
+            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String commit1 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      client.startCommitWithTime(commit1);
+      String commit2 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      client.startCommitWithTime(commit2);
+      String commit3 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      client.startCommitWithTime(commit3);
+
+      // create commit4 after commit5. commit4 creation should fail.
+      String commit4 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      String commit5 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      client.startCommitWithTime(commit5);
+      assertThrows(IllegalArgumentException.class, () -> client.startCommitWithTime(commit4));
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -38,7 +38,6 @@ import org.apache.hudi.client.validator.SqlQueryEqualityPreCommitValidator;
 import org.apache.hudi.client.validator.SqlQuerySingleResultPreCommitValidator;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
-import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
@@ -67,8 +66,6 @@ import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimeGenerator;
-import org.apache.hudi.common.table.timeline.TimeGenerators;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
@@ -105,7 +102,6 @@ import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner;
-import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 import org.apache.hudi.io.HoodieMergeHandle;
@@ -955,20 +951,17 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(InProcessLockProvider.class).build())
         .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
         .build();
-    TimeGenerator timeGenerator = TimeGenerators
-        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
-            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      String commit1 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      String commit1 = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(commit1);
-      String commit2 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      String commit2 = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(commit2);
-      String commit3 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      String commit3 = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(commit3);
 
       // create commit4 after commit5. commit4 creation should fail.
-      String commit4 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
-      String commit5 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
+      String commit4 = HoodieActiveTimeline.createNewInstantTime();
+      String commit5 = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(commit5);
       assertThrows(IllegalArgumentException.class, () -> client.startCommitWithTime(commit4));
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -154,7 +154,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
     assertNoWriteErrors(statuses.collect());
     // verify that there is a commit
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitAndReplaceTimeline();
+    HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitsTimeline();
     assertEquals(1, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(), "Expecting a single commit.");
     // Should have 100 records in table (check using Index), all in locations marked at commit
     HoodieTable table = HoodieSparkTable.create(client.getConfig(), context, metaClient);
@@ -1084,7 +1084,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       testTable.addReplaceCommit("00000000000004", Option.of(replaceMetadata.getKey()), Option.empty(), replaceMetadata.getValue());
 
       // run cleaner with failures
-      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config, true, simulateMetadataFailure, 5, true);
+      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config, true, simulateMetadataFailure, 5, true, Option.empty());
       assertTrue(testTable.baseFileExists(p0, "00000000000004", file4P0C3));
       assertTrue(testTable.baseFileExists(p0, "00000000000002", file2P0C1));
       assertTrue(testTable.baseFileExists(p1, "00000000000003", file3P1C2));
@@ -1131,16 +1131,16 @@ public class TestCleaner extends HoodieCleanerTestBase {
           put(p1, CollectionUtils.createImmutableList(file1P1, file2P1));
         }
       });
-      commitWithMdt("10", part1ToFileId, testTable, metadataWriter);
-      testTable.addClean("15");
-      commitWithMdt("20", part1ToFileId, testTable, metadataWriter);
+      commitWithMdt(makeNewCommitTime(10, "%09d"), part1ToFileId, testTable, metadataWriter);
+      testTable.addClean(makeNewCommitTime(15, "%09d"));
+      commitWithMdt(makeNewCommitTime(20, "%09d"), part1ToFileId, testTable, metadataWriter);
 
       // add clean instant
       HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan(new HoodieActionInstant("", "", ""),
           "", "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>(), new ArrayList<>(), Collections.emptyMap());
       HoodieCleanMetadata cleanMeta = new HoodieCleanMetadata("", 0L, 0,
-          "20", "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>(), Collections.emptyMap());
-      testTable.addClean("30", cleanerPlan, cleanMeta);
+          makeNewCommitTime(20, "%09d"), "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>(), Collections.emptyMap());
+      testTable.addClean(makeNewCommitTime(30, "%09d"), cleanerPlan, cleanMeta);
 
       // add file in partition "part_2"
       String file3P2 = UUID.randomUUID().toString();
@@ -1150,8 +1150,8 @@ public class TestCleaner extends HoodieCleanerTestBase {
           put(p2, CollectionUtils.createImmutableList(file3P2, file4P2));
         }
       });
-      commitWithMdt("30", part2ToFileId, testTable, metadataWriter);
-      commitWithMdt("40", part2ToFileId, testTable, metadataWriter);
+      commitWithMdt(makeNewCommitTime(30, "%09d"), part2ToFileId, testTable, metadataWriter);
+      commitWithMdt(makeNewCommitTime(40, "%09d"), part2ToFileId, testTable, metadataWriter);
 
       // empty commits
       String file5P2 = UUID.randomUUID().toString();
@@ -1161,25 +1161,25 @@ public class TestCleaner extends HoodieCleanerTestBase {
           put(p2, CollectionUtils.createImmutableList(file5P2, file6P2));
         }
       });
-      commitWithMdt("50", part2ToFileId, testTable, metadataWriter);
-      commitWithMdt("60", part2ToFileId, testTable, metadataWriter);
+      commitWithMdt(makeNewCommitTime(50, "%09d"), part2ToFileId, testTable, metadataWriter);
+      commitWithMdt(makeNewCommitTime(60, "%09d"), part2ToFileId, testTable, metadataWriter);
 
       // archive commit 1, 2
       new HoodieTimelineArchiver<>(config, HoodieSparkTable.create(config, context, metaClient))
           .archiveIfRequired(context, false);
       metaClient = HoodieTableMetaClient.reload(metaClient);
-      assertFalse(metaClient.getActiveTimeline().containsInstant("10"));
-      assertFalse(metaClient.getActiveTimeline().containsInstant("20"));
+      assertFalse(metaClient.getActiveTimeline().containsInstant(makeNewCommitTime(10, "%09d")));
+      assertFalse(metaClient.getActiveTimeline().containsInstant(makeNewCommitTime(20, "%09d")));
 
-      runCleaner(config);
-      assertFalse(testTable.baseFileExists(p1, "10", file1P1), "Clean old FileSlice in p1 by fallback to full clean");
-      assertFalse(testTable.baseFileExists(p1, "10", file2P1), "Clean old FileSlice in p1 by fallback to full clean");
-      assertFalse(testTable.baseFileExists(p2, "30", file3P2), "Clean old FileSlice in p2");
-      assertFalse(testTable.baseFileExists(p2, "30", file4P2), "Clean old FileSlice in p2");
-      assertTrue(testTable.baseFileExists(p1, "20", file1P1), "Latest FileSlice exists");
-      assertTrue(testTable.baseFileExists(p1, "20", file2P1), "Latest FileSlice exists");
-      assertTrue(testTable.baseFileExists(p2, "40", file3P2), "Latest FileSlice exists");
-      assertTrue(testTable.baseFileExists(p2, "40", file4P2), "Latest FileSlice exists");
+      runCleaner(config, false, false, 80, false, Option.empty());
+      assertFalse(testTable.baseFileExists(p1, makeNewCommitTime(10, "%09d"), file1P1), "Clean old FileSlice in p1 by fallback to full clean");
+      assertFalse(testTable.baseFileExists(p1, makeNewCommitTime(10, "%09d"), file2P1), "Clean old FileSlice in p1 by fallback to full clean");
+      assertFalse(testTable.baseFileExists(p2, makeNewCommitTime(30, "%09d"), file3P2), "Clean old FileSlice in p2");
+      assertFalse(testTable.baseFileExists(p2, makeNewCommitTime(30, "%09d"), file4P2), "Clean old FileSlice in p2");
+      assertTrue(testTable.baseFileExists(p1, makeNewCommitTime(20, "%09d"), file1P1), "Latest FileSlice exists");
+      assertTrue(testTable.baseFileExists(p1, makeNewCommitTime(20, "%09d"), file2P1), "Latest FileSlice exists");
+      assertTrue(testTable.baseFileExists(p2, makeNewCommitTime(40, "%09d"), file3P2), "Latest FileSlice exists");
+      assertTrue(testTable.baseFileExists(p2, makeNewCommitTime(40, "%09d"), file4P2), "Latest FileSlice exists");
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -141,7 +141,7 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
           ? wrapRecordsGenFunctionForPreppedCalls(basePath(), storageConf(), context(), cfg, dataGen::generateUniqueUpdates)
           : dataGen::generateUniqueUpdates;
 
-      HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.COPY_ON_WRITE);
+      HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ);
       insertFirstBigBatchForClientCleanerTest(context(), metaClient, client, recordInsertGenWrappedFunction, insertFn);
 
       Map<HoodieFileGroupId, FileSlice> compactionFileIdToLatestFileSlice = new HashMap<>();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -443,14 +443,11 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     SparkRDDWriteClient clusteringClient = getHoodieWriteClient(
         ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, properties));
 
-    // Save an older instant for us to run clustering.
-    String clusteringInstant1 = HoodieActiveTimeline.createNewInstantTime();
+    // Lets just trigger scheduling for a clustering instant.
+    String clusteringInstant1 = ClusteringTestUtils.runClustering(clusteringClient, false, false);
 
-    // Create completed clustering commit
+    // Create another clustering commit (and complete it)
     ClusteringTestUtils.runClustering(clusteringClient, false, true);
-
-    // Now execute clustering on the saved instant and do not allow it to commit.
-    ClusteringTestUtils.runClusteringOnInstant(clusteringClient, false, false, clusteringInstant1);
 
     HoodieTable table = this.getHoodieTable(metaClient, getConfigBuilder().withEmbeddedTimelineServerEnabled(false).build());
     HoodieInstant needRollBackInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, secondCommit);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/MockCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/MockCompactionStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.functional;
+
+import org.apache.hudi.avro.model.HoodieCompactionOperation;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
+
+import java.util.List;
+
+public class MockCompactionStrategy extends LogFileSizeBasedCompactionStrategy {
+
+  @Override
+  public HoodieCompactionPlan generateCompactionPlan(HoodieWriteConfig writeConfig,
+                                                     List<HoodieCompactionOperation> operations, List<HoodieCompactionPlan> pendingCompactionPlans) {
+    HoodieCompactionPlan compactionPlan = super.generateCompactionPlan(writeConfig, operations, pendingCompactionPlans);
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    return compactionPlan;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.Functions;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCleanConfig;
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -139,7 +141,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       List<HoodieCleanStat> hoodieCleanStatsOne =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 2, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 2, true, Option.empty());
       assertEquals(0, hoodieCleanStatsOne.size(), "Must not scan any partitions and clean any files");
       assertTrue(testTable.baseFileExists(p0, "00000000000001", file1P0C0));
       assertTrue(testTable.baseFileExists(p1, "00000000000001", file1P1C0));
@@ -158,7 +160,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       List<HoodieCleanStat> hoodieCleanStatsTwo =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 4, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 4, true, Option.empty());
       assertEquals(0, hoodieCleanStatsTwo.size(), "Must not scan any partitions and clean any files");
       assertTrue(testTable.baseFileExists(p0, "00000000000003", file2P0C1));
       assertTrue(testTable.baseFileExists(p1, "00000000000003", file2P1C1));
@@ -176,7 +178,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       List<HoodieCleanStat> hoodieCleanStatsThree =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 6, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 6, true, Option.empty());
       assertEquals(0, hoodieCleanStatsThree.size(),
           "Must not clean any file. We have to keep 1 version before the latest commit time to keep");
       assertTrue(testTable.baseFileExists(p0, "00000000000001", file1P0C0));
@@ -192,7 +194,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       List<HoodieCleanStat> hoodieCleanStatsFour =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 8, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 8, true, Option.empty());
       // enableBootstrapSourceClean would delete the bootstrap base file as the same time
       HoodieCleanStat partitionCleanStat = getCleanStat(hoodieCleanStatsFour, p0);
 
@@ -222,7 +224,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       List<HoodieCleanStat> hoodieCleanStatsFive =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 10, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 10, true, Option.empty());
 
       assertEquals(0, hoodieCleanStatsFive.size(), "Must not clean any files since at least 2 commits are needed from last clean operation before "
           + "clean can be scheduled again");
@@ -243,7 +245,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
           new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "00000000000011"),
           Option.of(getUTF8Bytes(commitMetadata.toJsonString())));
       List<HoodieCleanStat> hoodieCleanStatsFive2 =
-          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 12, true);
+          runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 12, true, Option.empty());
       HoodieCleanStat cleanStat = getCleanStat(hoodieCleanStatsFive2, p0);
       assertNull(cleanStat, "Must not clean any files");
       assertTrue(testTable.baseFileExists(p0, "00000000000005", file3P0C2));
@@ -455,28 +457,28 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       HoodieTestTable testTable = HoodieTestTable.of(metaClient);
       String p0 = "2020/01/01";
       // Make 3 files, one base file and 2 log files associated with base file
-      String file1P0 = testTable.addDeltaCommit("000").getFileIdsWithBaseFilesInPartitions(p0).get(p0);
+      String file1P0 = testTable.addDeltaCommit(makeNewCommitTime(0, "%09d")).getFileIdsWithBaseFilesInPartitions(p0).get(p0);
       Map<String, List<String>> part1ToFileId = Collections.unmodifiableMap(new HashMap<String, List<String>>() {
         {
           put(p0, CollectionUtils.createImmutableList(file1P0));
         }
       });
-      commitWithMdt("000", part1ToFileId, testTable, metadataWriter, true, true);
+      commitWithMdt(makeNewCommitTime(0, "%09d"), part1ToFileId, testTable, metadataWriter, true, true);
 
       // Make 2 files, one base file and 1 log files associated with base file
-      testTable.addDeltaCommit("001")
+      testTable.addDeltaCommit(makeNewCommitTime(1, "%09d"))
           .withBaseFilesInPartition(p0, file1P0).getLeft()
           .withLogFile(p0, file1P0, 3);
-      commitWithMdt("001", part1ToFileId, testTable, metadataWriter, true, true);
+      commitWithMdt(makeNewCommitTime(1, "%09d"), part1ToFileId, testTable, metadataWriter, true, true);
 
-      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config);
+      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config, 3, false);
       assertEquals(3,
           getCleanStat(hoodieCleanStats, p0).getSuccessDeleteFiles()
               .size(), "Must clean three files, one base and 2 log files");
-      assertFalse(testTable.baseFileExists(p0, "000", file1P0));
-      assertFalse(testTable.logFilesExist(p0, "000", file1P0, 1, 2));
-      assertTrue(testTable.baseFileExists(p0, "001", file1P0));
-      assertTrue(testTable.logFileExists(p0, "001", file1P0, 3));
+      assertFalse(testTable.baseFileExists(p0, makeNewCommitTime(0, "%09d"), file1P0));
+      assertFalse(testTable.logFilesExist(p0, makeNewCommitTime(0, "%09d"), file1P0, 1, 2));
+      assertTrue(testTable.baseFileExists(p0, makeNewCommitTime(1, "%09d"), file1P0));
+      assertTrue(testTable.logFileExists(p0, makeNewCommitTime(1, "%09d"), file1P0, 3));
     }
   }
 
@@ -506,30 +508,30 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
           put(p0, CollectionUtils.createImmutableList(file1P0));
         }
       });
-      commitWithMdt("000", part1ToFileId, testTable, metadataWriter, true, true);
+      commitWithMdt(makeNewCommitTime(0, "%09d"), part1ToFileId, testTable, metadataWriter, true, true);
 
       // Make 2 files, one base file and 1 log files associated with base file
-      testTable.addDeltaCommit("001")
+      testTable.addDeltaCommit(makeNewCommitTime(1, "%09d"))
           .withBaseFilesInPartition(p0, file1P0).getLeft()
           .withLogFile(p0, file1P0, 3);
-      commitWithMdt("001", part1ToFileId, testTable, metadataWriter, true, true);
+      commitWithMdt(makeNewCommitTime(1, "%09d"), part1ToFileId, testTable, metadataWriter, true, true);
 
       // Make 2 files, one base file and 1 log files associated with base file
-      testTable.addDeltaCommit("002")
+      testTable.addDeltaCommit(makeNewCommitTime(2, "%09d"))
           .withBaseFilesInPartition(p0, file1P0).getLeft()
           .withLogFile(p0, file1P0, 4);
-      commitWithMdt("002", part1ToFileId, testTable, metadataWriter, true, true);
+      commitWithMdt(makeNewCommitTime(2, "%09d"), part1ToFileId, testTable, metadataWriter, true, true);
 
-      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config);
+      List<HoodieCleanStat> hoodieCleanStats = runCleaner(config, false, false, 3, false, Option.empty());
       assertEquals(3,
           getCleanStat(hoodieCleanStats, p0).getSuccessDeleteFiles()
               .size(), "Must clean three files, one base and 2 log files");
-      assertFalse(testTable.baseFileExists(p0, "000", file1P0));
-      assertFalse(testTable.logFilesExist(p0, "000", file1P0, 1, 2));
-      assertTrue(testTable.baseFileExists(p0, "001", file1P0));
-      assertTrue(testTable.logFileExists(p0, "001", file1P0, 3));
-      assertTrue(testTable.baseFileExists(p0, "002", file1P0));
-      assertTrue(testTable.logFileExists(p0, "002", file1P0, 4));
+      assertFalse(testTable.baseFileExists(p0, makeNewCommitTime(0, "%09d"),  file1P0));
+      assertFalse(testTable.logFilesExist(p0, makeNewCommitTime(0, "%09d"), file1P0, 1, 2));
+      assertTrue(testTable.baseFileExists(p0, makeNewCommitTime(1, "%09d"), file1P0));
+      assertTrue(testTable.logFileExists(p0, makeNewCommitTime(1, "%09d"), file1P0, 3));
+      assertTrue(testTable.baseFileExists(p0, makeNewCommitTime(2, "%09d"), file1P0));
+      assertTrue(testTable.logFileExists(p0, makeNewCommitTime(2, "%09d"), file1P0, 4));
     }
   }
 
@@ -600,7 +602,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       testTable.addDeletePartitionCommit(deleteInstant1, p1, Arrays.asList(file1P1, file2P1));
       testTable.addDeletePartitionCommit(deleteInstant2, p2, Arrays.asList(file1P2, file2P2));
 
-      runCleaner(config);
+      runCleaner(config, Option.of((Functions.Function0<String>) () -> HoodieActiveTimeline.createNewInstantTime()));
 
       assertFalse(testTable.baseFileExists(p1, commitInstant, file1P1), "p1 cleaned");
       assertFalse(testTable.baseFileExists(p1, commitInstant, file2P1), "p1 cleaned");
@@ -693,7 +695,8 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       commitWithMdt(thirdCommitTs, part3ToFileId, testTable, metadataWriter, true, true);
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
-      List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config, simulateFailureRetry, simulateMetadataFailure);
+      List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 0,
+          false, Option.of((Functions.Function0) () -> HoodieActiveTimeline.createNewInstantTime()));
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       assertEquals(2, hoodieCleanStatsThree.size(), "Should clean one file each from both the partitions");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -182,7 +182,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     client = getHoodieWriteClient(config);
 
     // write data and commit
-    writeData(HoodieActiveTimeline.createNewInstantTime(), 100, true);
+    writeData(HoodieActiveTimeline.createNewInstantTime(), 100, true, false);
 
     // 2nd batch
     String commit2 = HoodieActiveTimeline.createNewInstantTime();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -47,12 +47,15 @@ import org.apache.hudi.config.HoodieLayoutConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieWriteConflictException;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner;
 import org.apache.hudi.table.action.rollback.RollbackUtils;
+import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
+import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 import org.apache.hudi.table.storage.HoodieStorageLayout;
 import org.apache.hudi.testutils.HoodieMergeOnReadTestUtils;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
@@ -61,6 +64,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -72,6 +76,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,6 +90,7 @@ import static org.apache.hudi.config.HoodieWriteConfig.AUTO_COMMIT_ENABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("functional")
 public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFunctionalTestHarness {
@@ -161,6 +171,85 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     config.setValue(AUTO_COMMIT_ENABLE, "true");
     client.compact(compactionTime);
     assertEquals(300, readTableTotalRecordsNum());
+  }
+
+  @Test
+  public void testOutOfOrderCompactionSchedules() throws IOException, ExecutionException, InterruptedException {
+    HoodieWriteConfig config = getWriteConfigWithMockCompactionStrategy();
+    HoodieWriteConfig config2 = getWriteConfig();
+
+    metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, new Properties());
+    client = getHoodieWriteClient(config);
+
+    // write data and commit
+    writeData(HoodieActiveTimeline.createNewInstantTime(), 100, true);
+
+    // 2nd batch
+    String commit2 = HoodieActiveTimeline.createNewInstantTime();
+    JavaRDD records = jsc().parallelize(dataGen.generateUniqueUpdates(commit2, 50), 2);
+    client.startCommitWithTime(commit2);
+    List<WriteStatus> writeStatuses = client.upsert(records, commit2).collect();
+    List<HoodieWriteStat> writeStats = writeStatuses.stream().map(WriteStatus::getStat).collect(Collectors.toList());
+    client.commitStats(commit2, context().parallelize(writeStatuses, 1), writeStats, Option.empty(), metaClient.getCommitActionType());
+
+    // schedule compaction
+    String compactionInstant1 = HoodieActiveTimeline.createNewInstantTime();
+    Thread.sleep(10);
+    String compactionInstant2 = HoodieActiveTimeline.createNewInstantTime();
+
+    final AtomicBoolean writer1Completed = new AtomicBoolean(false);
+    final AtomicBoolean writer2Completed = new AtomicBoolean(false);
+    final ExecutorService executors = Executors.newFixedThreadPool(2);
+    final SparkRDDWriteClient client2 = getHoodieWriteClient(config2);
+    Future future1 = executors.submit(() -> {
+      try {
+        client.scheduleCompactionAtInstant(compactionInstant1, Option.empty());
+        // since compactionInstant1 is earlier than compactionInstant2, and compaction strategy sleeps for 10s, this is expected to throw.
+        fail("Should not have reached here");
+      } catch (Exception e) {
+        writer1Completed.set(true);
+      }
+    });
+
+    Future future2 = executors.submit(() -> {
+      try {
+        Thread.sleep(10);
+        assertTrue(client2.scheduleCompactionAtInstant(compactionInstant2, Option.empty()));
+        writer2Completed.set(true);
+      } catch (Exception e) {
+        throw new HoodieException("Should not have reached here");
+      }
+    });
+
+    future1.get();
+    future2.get();
+
+    // both should have been completed successfully. I mean, we already assert for conflict for writer2 at L155.
+    assertTrue(writer1Completed.get() && writer2Completed.get());
+    client.close();
+    client2.close();
+    executors.shutdownNow();
+  }
+
+  private HoodieWriteConfig getWriteConfigWithMockCompactionStrategy() {
+    MockCompactionStrategy compactionStrategy = new MockCompactionStrategy();
+    return getWriteConfig(compactionStrategy);
+  }
+
+  private HoodieWriteConfig getWriteConfig() {
+    return getWriteConfig(new LogFileSizeBasedCompactionStrategy());
+  }
+
+  private HoodieWriteConfig getWriteConfig(CompactionStrategy compactionStrategy) {
+    return HoodieWriteConfig.newBuilder()
+        .forTable("test-trip-table")
+        .withPath(basePath())
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withAutoCommit(false)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withCompactionStrategy(compactionStrategy)
+            .withMaxNumDeltaCommitsBeforeCompaction(1).build())
+        .build();
   }
 
   @ParameterizedTest

--- a/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieBulkInsertDataInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieBulkInsertDataInternalWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.internal;
 
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -74,7 +75,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     // execute N rounds
     for (int i = 0; i < 2; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieBulkInsertDataInternalWriter writer = new HoodieBulkInsertDataInternalWriter(table, cfg, instantTime, RANDOM.nextInt(100000), RANDOM.nextLong(), RANDOM.nextLong(),
           STRUCT_TYPE, populateMetaFields, sorted);
@@ -116,7 +117,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
     HoodieWriteConfig cfg = getWriteConfig(populateMetaFields, "true");
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     for (int i = 0; i < 1; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieBulkInsertDataInternalWriter writer = new HoodieBulkInsertDataInternalWriter(table, cfg, instantTime, RANDOM.nextInt(100000), RANDOM.nextLong(), RANDOM.nextLong(),
           STRUCT_TYPE, populateMetaFields, sorted);
@@ -161,7 +162,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     String partitionPath = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0];
 
-    String instantTime = "001";
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
     HoodieBulkInsertDataInternalWriter writer = new HoodieBulkInsertDataInternalWriter(table, cfg, instantTime, RANDOM.nextInt(100000), RANDOM.nextLong(), RANDOM.nextLong(),
         STRUCT_TYPE, true, false);
 

--- a/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieDataSourceInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieDataSourceInternalWriter.java
@@ -20,6 +20,7 @@ package org.apache.hudi.internal;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -75,7 +76,7 @@ public class TestHoodieDataSourceInternalWriter extends
       throws Exception {
     // init config and table
     HoodieWriteConfig cfg = getWriteConfig(populateMetaFields);
-    String instantTime = "001";
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
     // init writer
     HoodieDataSourceInternalWriter dataSourceInternalWriter =
         new HoodieDataSourceInternalWriter(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, new DataSourceOptions(extraMetadata), populateMetaFields, false);
@@ -163,7 +164,7 @@ public class TestHoodieDataSourceInternalWriter extends
 
     // execute N rounds
     for (int i = 0; i < 2; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieDataSourceInternalWriter dataSourceInternalWriter =
           new HoodieDataSourceInternalWriter(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, new DataSourceOptions(Collections.EMPTY_MAP), populateMetaFields, false);
@@ -210,7 +211,7 @@ public class TestHoodieDataSourceInternalWriter extends
 
     // execute N rounds
     for (int i = 0; i < 3; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieDataSourceInternalWriter dataSourceInternalWriter =
           new HoodieDataSourceInternalWriter(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, new DataSourceOptions(Collections.EMPTY_MAP), populateMetaFields, false);
@@ -258,7 +259,7 @@ public class TestHoodieDataSourceInternalWriter extends
     // init config and table
     HoodieWriteConfig cfg = getWriteConfig(populateMetaFields);
 
-    String instantTime0 = "00" + 0;
+    String instantTime0 = HoodieActiveTimeline.createNewInstantTime();
     // init writer
     HoodieDataSourceInternalWriter dataSourceInternalWriter =
         new HoodieDataSourceInternalWriter(instantTime0, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, new DataSourceOptions(Collections.EMPTY_MAP), populateMetaFields, false);
@@ -298,7 +299,7 @@ public class TestHoodieDataSourceInternalWriter extends
     assertWriteStatuses(commitMessages.get(0).getWriteStatuses(), batches, size, Option.empty(), Option.empty());
 
     // 2nd batch. abort in the end
-    String instantTime1 = "00" + 1;
+    String instantTime1 = HoodieActiveTimeline.createNewInstantTime();
     dataSourceInternalWriter =
         new HoodieDataSourceInternalWriter(instantTime1, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf,
             new DataSourceOptions(Collections.EMPTY_MAP), populateMetaFields, false);

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/test/java/org/apache/hudi/spark3/internal/TestHoodieBulkInsertDataInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/test/java/org/apache/hudi/spark3/internal/TestHoodieBulkInsertDataInternalWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.spark3.internal;
 
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -77,7 +78,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     // execute N rounds
     for (int i = 0; i < 2; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieBulkInsertDataInternalWriter writer = new HoodieBulkInsertDataInternalWriter(table, cfg, instantTime, RANDOM.nextInt(100000),
           RANDOM.nextLong(), STRUCT_TYPE, populateMetaFields, sorted);
@@ -123,7 +124,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
     String partitionPath = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0];
 
-    String instantTime = "001";
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
     HoodieBulkInsertDataInternalWriter writer = new HoodieBulkInsertDataInternalWriter(table, cfg, instantTime, RANDOM.nextInt(100000),
         RANDOM.nextLong(), STRUCT_TYPE, true, false);
 

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/test/java/org/apache/hudi/spark3/internal/TestHoodieDataSourceInternalBatchWrite.java
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/test/java/org/apache/hudi/spark3/internal/TestHoodieDataSourceInternalBatchWrite.java
@@ -21,6 +21,7 @@ package org.apache.hudi.spark3.internal;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -77,8 +78,7 @@ public class TestHoodieDataSourceInternalBatchWrite extends
   private void testDataSourceWriterInternal(Map<String, String> extraMetadata, Map<String, String> expectedExtraMetadata, boolean populateMetaFields) throws Exception {
     // init config and table
     HoodieWriteConfig cfg = getWriteConfig(populateMetaFields);
-    HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
-    String instantTime = "001";
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
     // init writer
     HoodieDataSourceInternalBatchWrite dataSourceInternalBatchWrite =
         new HoodieDataSourceInternalBatchWrite(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, extraMetadata, populateMetaFields, false);
@@ -167,7 +167,7 @@ public class TestHoodieDataSourceInternalBatchWrite extends
 
     // execute N rounds
     for (int i = 0; i < 2; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieDataSourceInternalBatchWrite dataSourceInternalBatchWrite =
           new HoodieDataSourceInternalBatchWrite(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, Collections.emptyMap(), populateMetaFields, false);
@@ -214,7 +214,7 @@ public class TestHoodieDataSourceInternalBatchWrite extends
 
     // execute N rounds
     for (int i = 0; i < 3; i++) {
-      String instantTime = "00" + i;
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
       // init writer
       HoodieDataSourceInternalBatchWrite dataSourceInternalBatchWrite =
           new HoodieDataSourceInternalBatchWrite(instantTime, cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, Collections.emptyMap(), populateMetaFields, false);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -403,7 +403,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
   private HoodieWriteConfig getWriteConfig() {
     return getConfigBuilder(basePath(), metaClient)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
-        .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(5).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .build();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -105,22 +105,28 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(false).build())
         .build();
+    String commit1 = HoodieActiveTimeline.createNewInstantTime();
+    String commit2 = HoodieActiveTimeline.createNewInstantTime(10);
+    String commit3 = HoodieActiveTimeline.createNewInstantTime(100);
+    String commit4 = HoodieActiveTimeline.createNewInstantTime(200);
+    String commit5 = HoodieActiveTimeline.createNewInstantTime(300);
+    String commit6 = HoodieActiveTimeline.createNewInstantTime(400);
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
-      Pair<String, List<HoodieRecord>> inserts = writeRecords(writeClient, INSERT, null, "100");
-      Pair<String, List<HoodieRecord>> inserts2 = writeRecords(writeClient, INSERT, null, "200");
-      Pair<String, List<HoodieRecord>> inserts3 = writeRecords(writeClient, INSERT, null, "300");
-      Pair<String, List<HoodieRecord>> inserts4 = writeRecords(writeClient, INSERT, null, "400");
-      Pair<String, List<HoodieRecord>> inserts5 = writeRecords(writeClient, INSERT, null, "500");
+      Pair<String, List<HoodieRecord>> inserts = writeRecords(writeClient, INSERT, null, commit1);
+      Pair<String, List<HoodieRecord>> inserts2 = writeRecords(writeClient, INSERT, null, commit2);
+      Pair<String, List<HoodieRecord>> inserts3 = writeRecords(writeClient, INSERT, null, commit3);
+      Pair<String, List<HoodieRecord>> inserts4 = writeRecords(writeClient, INSERT, null, commit4);
+      Pair<String, List<HoodieRecord>> inserts5 = writeRecords(writeClient, INSERT, null,  commit5);
 
       // read everything upto latest
       readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT, Option.empty(), 500, inserts5.getKey());
 
-      // even if the begin timestamp is archived (100), full table scan should kick in, but should filter for records having commit time > 100
-      readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT, Option.of("100"), 400, inserts5.getKey());
+      // even if the begin timestamp is archived (commit1), full table scan should kick in, but should filter for records having commit time > 100
+      readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT, Option.of(commit1), 400, inserts5.getKey());
 
       // even if the read upto latest is set, if begin timestamp is in active timeline, only incremental should kick in.
-      readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT, Option.of("400"), 100, inserts5.getKey());
+      readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT, Option.of(commit4), 100, inserts5.getKey());
 
       // read just the latest
       readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_LATEST, Option.empty(), 100, inserts5.getKey());
@@ -128,7 +134,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
       // ensure checkpoint does not move
       readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_LATEST, Option.of(inserts5.getKey()), 0, inserts5.getKey());
 
-      Pair<String, List<HoodieRecord>> inserts6 = writeRecords(writeClient, INSERT, null, "600");
+      Pair<String, List<HoodieRecord>> inserts6 = writeRecords(writeClient, INSERT, null, commit6);
 
       // insert new batch and ensure the checkpoint moves
       readAndAssert(IncrSourceHelper.MissingCheckpointStrategy.READ_LATEST, Option.of(inserts5.getKey()), 100, inserts6.getKey());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -220,7 +220,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
   private HoodieWriteConfig getWriteConfig() {
     return getConfigBuilder(basePath(), metaClient)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
-        .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(5).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .build();


### PR DESCRIPTION
### Change Logs

When multiple writers trigger table services, there is a chance that one of them could create requested in a different ordering compared to the actual timestamp. Linked jira has more details of the scenario w/ an illustration. This patch, ensure that before creating a requested entry in the timeline, there is no other instant greater than the current instant time.

Major reason is, a writer could generate a new commit time in memory (say t10), and then take a long time to do some computation and eventually add the requested instant to timeline very late (say t100). In b/w these two time, there could be another concurrent writer choosing t25 as commit time and proceed. This might lead to unexpected behaviors as called out in the jira. 

This patch is for 0.x branch. 
here is the equivalent 1.x branch PR https://github.com/apache/hudi/pull/11344 which guarantees monotonically increasing timestamp. But 0.x branch fix is simpler and not looking to mimic exact 1.0 fix. 

For 0.x, we are adding a config for this and not enabling by default and interested users can enable it. It makes sense for multi-writer use-cases to enable it. 
"hoodie.timestamp.ordering.validate.enable" is the config of interest. 

Note on Locking : 
This patch is introducing an additional step to validate the the instant time used to generate the plan is the highest and there is no other instant time in the timeline whose time > current instant time of interest. 
Ideally, we might need to take table lock before doing this timestamp validation. But it expands the scope of the patch to take locks for every operation. With this patch, we are locking while generating instants for ingestion writes, compaction and clustering. For cleaning and rollbacks, we plan to take it up later. 

### Impact

Covered in previous section

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
