### PR TITLE
[HUDI-7025] Consolidate index and functional index config groups

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -41,8 +41,7 @@ public class ConfigGroups {
     RECORD_PAYLOAD("Record Payload Config"),
     KAFKA_CONNECT("Kafka Connect Configs"),
     AWS("Amazon Web Services Configs"),
-    HUDI_STREAMER("Hudi Streamer Configs"),
-    INDEXING("Indexing Configs");
+    HUDI_STREAMER("Hudi Streamer Configs");
 
     public final String name;
 
@@ -78,10 +77,7 @@ public class ConfigGroups {
         "Configurations controlling the behavior of reading source data."),
     NONE(
         "None",
-        "No subgroup. This description should be hidden."),
-    FUNCTIONAL_INDEX(
-        "Functional Index Configs",
-        "Configurations controlling the behavior of functional index.");
+        "No subgroup. This description should be hidden.");
 
     public final String name;
     private final String description;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
@@ -46,8 +46,8 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 @Immutable
 @ConfigClassProperty(name = "Common Index Configs",
-    groupName = ConfigGroups.Names.INDEXING,
-    subGroupName = ConfigGroups.SubGroupNames.FUNCTIONAL_INDEX,
+    groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.SubGroupNames.INDEX,
     areCommonConfigs = true,
     description = "")
 public class HoodieIndexingConfig extends HoodieConfig {


### PR DESCRIPTION
### Change Logs

Subsume FUNCTIONAL_INDEX config subgroup in the INDEX subgroup and remove INDEXING group.

### Impact

All index configs will be listed together.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
