### PR TITLE
[HUDI-7969] Fix data loss caused by concurrent write and clean

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -453,8 +453,10 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    */
   private boolean mayHavePendingFiles(String partitionPath) {
     try {
-      // As long as there are pending commits never delete empty partitions, because they may write files to any partitions.
-      if (!hoodieTable.getMetaClient().getCommitsTimeline().filterInflightsAndRequested().empty()) {
+      // For concurrency mode, as long as there are pending commits never delete empty partitions,
+      // because they may write files to any partitions.
+      if (hoodieTable.getConfig().getWriteConcurrencyMode().supportsMultiWriter()
+          && !hoodieTable.getMetaClient().getCommitsTimeline().filterInflightsAndRequested().empty()) {
         return true;
       }
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(hoodieTable.getMetaClient(), hoodieTable.getActiveTimeline());


### PR DESCRIPTION
### Change Logs

Suppose we have two concurrent jobs, write and clean, here is the problem flow:

1. insert job: write partition p1, but has not started writing files
2. clean job: through list partitions, get p1, and finds that there are no files in p1, then adds p1 to the partitions list to be deleted
3. insert job, starts writing files to partition p1 and commits
4. clean job, deletes partition p1, data is lost

### Impact

fix it

### Risk level (write none, low medium or high below)

medium

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
