### PR TITLE
[HUDI-7975] Provide an API to create empty commit

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -589,6 +589,14 @@ public class HoodieWriteConfig extends HoodieConfig {
       .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of times to retry a batch on conflict failure.");
 
+  public static final ConfigProperty<Long> MAX_DURATION_TO_TRANSFER_EXTRA_METADATA = ConfigProperty
+      .key("hoodie.write.empty.commit.create.duration")
+      .defaultValue(-1L)
+      .withDocumentation("In some cases empty commit needs to be created to ensure the offsets/checkpoint "
+          + "info stored in the timeline is not lost and also the commit could trigger post commit operations "
+          + "like archival and cleaner or pre write operations like compaction on metadata table etc. "
+          + "This config determines how frequently these empty commits needs to be created.");
+
   public static final ConfigProperty<String> WRITE_SCHEMA_OVERRIDE = ConfigProperty
       .key("hoodie.write.schema")
       .noDefaultValue()
@@ -2577,6 +2585,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(SKIP_DEFAULT_PARTITION_VALIDATION);
   }
 
+  public long maxDurationToTransferExtraMetadata() {
+    return getLong(MAX_DURATION_TO_TRANSFER_EXTRA_METADATA);
+  }
+
   /**
    * Are any table services configured to run inline for both scheduling and execution?
    *
@@ -3173,6 +3185,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withWriteConcurrencyMode(WriteConcurrencyMode concurrencyMode) {
       writeConfig.setValue(WRITE_CONCURRENCY_MODE, concurrencyMode.name());
+      return this;
+    }
+
+    public Builder withMaxDurationToTransferExtraMetadata(long duration) {
+      writeConfig.setValue(MAX_DURATION_TO_TRANSFER_EXTRA_METADATA, String.valueOf(duration));
       return this;
     }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkCommitUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkCommitUtils.java
@@ -1,0 +1,83 @@
+package org.apache.hudi.client.utils;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ClusteringUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.spark.api.java.JavaRDD;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Map;
+
+public class SparkCommitUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(SparkCommitUtils.class);
+
+  /**
+   * If last completed commit is older than a certain duration.
+   * New empty commit will be created by using th extrametadata from the previous completed commit.
+   * By doing so, checkpoint information stored in the commit files can be transferred.
+   */
+  public static void checkAndCreateEmptyCommit(SparkRDDWriteClient writeClient, HoodieTableMetaClient metaClient,
+                                               Option<HoodieInstant> lastInstant) throws IOException, ParseException {
+    long currentCommitTimeInMillis = System.currentTimeMillis();
+
+    if (!lastInstant.isPresent()) {
+      boolean isCOWTableType = metaClient.getTableType().equals(HoodieTableType.COPY_ON_WRITE);
+      // Consider only ingestion commits i.e. .commit, .deltacommit or .replacecommit excluding clustering operations.
+      // For MOR table type exclude .commit action as it is not an ingestion commit.
+      HoodieTimeline activeTimeline = metaClient.getActiveTimeline();
+      lastInstant = metaClient.getActiveTimeline().getCommitsTimeline()
+          .filterCompletedInstants()
+          .filter(instant -> !ClusteringUtils.isClusteringInstant(activeTimeline, instant))
+          .filter(instant -> isCOWTableType || !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION))
+          .lastInstant();
+      ValidationUtils.checkState(lastInstant.isPresent(), "No completed commit present in the timeline.");
+    } else {
+      ValidationUtils.checkState(lastInstant.get().isCompleted(), "Provided last instant is not completed.");
+    }
+
+    // Check if the last commit is created before the allowed duration.
+    long lastCommitTimeInMillis = HoodieInstantTimeGenerator
+        .parseDateFromInstantTime(lastInstant.get().getTimestamp())
+        .getTime();
+    long duration = writeClient.getConfig().maxDurationToTransferExtraMetadata();
+    if (duration < 0 || currentCommitTimeInMillis - lastCommitTimeInMillis <= duration) {
+      return;
+    }
+
+    // Fetch the commit metadata from last commit and create a dummy commit.
+    HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+        metaClient.getActiveTimeline().getInstantDetails(lastInstant.get()).get(), HoodieCommitMetadata.class);
+    createEmptyCommitWithMetadata(writeClient, metaClient, commitMetadata.getExtraMetadata());
+  }
+
+  /**
+   * Create commit with an empty RDD by copying the metadata info to new commit metadata
+   */
+  public static void createEmptyCommitWithMetadata(SparkRDDWriteClient writeClient, HoodieTableMetaClient metaClient,
+                                                   Map<String, String> extraMetadata) {
+    LOG.info("Creating an empty commit with extraMetadata " + extraMetadata);
+    ValidationUtils.checkState(!writeClient.getConfig().shouldAutoCommit(),
+        "Auto commit should not be true, since we are creating a dummy commit to transfer the offsets.");
+    String instantTime = writeClient.startCommit();
+    metaClient.reloadActiveTimeline();
+
+    // Create empty commit with metadata
+    HoodieSparkEngineContext engineContext = (HoodieSparkEngineContext) writeClient.getEngineContext();
+    JavaRDD<WriteStatus> emptyHoodieData1 = engineContext.getJavaSparkContext().emptyRDD();
+    JavaRDD<WriteStatus> writeStatusRDD = writeClient.bulkInsert(emptyHoodieData1, instantTime);
+
+    writeClient.commit(instantTime, writeStatusRDD, Option.of(extraMetadata));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/utils/TestSparkUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/utils/TestSparkUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.utils;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+import org.apache.hudi.testutils.HoodieSparkWriteableTestTable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+
+public class TestSparkUtils extends HoodieClientTestBase {
+  private HoodieTestTable testTable;
+
+  @BeforeEach
+  public void setUpTestTable() {
+    testTable = HoodieSparkWriteableTestTable.of(metaClient);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testEmptyCommitCreation(boolean autoCommit) throws Exception {
+    HoodieWriteConfig writeConfig = getConfigBuilder().withAutoCommit(autoCommit).build();
+    SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig);
+
+    long goBackMs = Duration.ofHours(25).getSeconds() * 1000;
+    String firstCommit = HoodieInstantTimeGenerator.formatDate(new Date(System.currentTimeMillis() - goBackMs));
+
+    final Function2<List<HoodieRecord>, String, Integer> recordGenFunction =
+        generateWrapRecordsFn(false, writeConfig, dataGen::generateInserts);
+    writeBatch(writeClient, firstCommit, "000", Option.empty(), "000", 10,
+        recordGenFunction, SparkRDDWriteClient::bulkInsert, true, 10, 10,
+        1, !autoCommit, false);
+
+    metaClient.reloadActiveTimeline();
+    if (autoCommit) {
+      Assertions.assertThrows(IllegalStateException.class,
+          () -> SparkCommitUtils.checkAndCreateEmptyCommit(writeClient, metaClient, Option.empty()));
+    } else {
+      SparkCommitUtils.checkAndCreateEmptyCommit(writeClient, metaClient, Option.empty());
+      metaClient.reloadActiveTimeline();
+      Assertions.assertTrue(metaClient.getActiveTimeline().countInstants() == 2);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -84,6 +84,10 @@ public class ClusteringUtils {
    * @return whether the instant is a clustering operation.
    */
   public static boolean isClusteringInstant(HoodieTimeline timeline, HoodieInstant replaceInstant) {
+    if (replaceInstant == null
+        || !HoodieTimeline.REPLACE_COMMIT_ACTION.equals(replaceInstant.getAction())) {
+      return false;
+    }
     return getClusteringPlan(timeline, replaceInstant).isPresent();
   }
 


### PR DESCRIPTION
Summary: By creating empty commit, checkpoints from the commit files can be transferred to new instants. So, this change is used to create emptyCommit by copying the extrametadata from the last completed non-table service commit in the timeline. Generally, empty commits are created max one instant per day per dataset, the cadence to transfer metadata can be configured that way bloating of the commit timeline can be avoided. whenever there is no new data to be written.

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
