### PR TITLE
[HUDI-7978][DOCS] Add a note on field oldering in partitioned by clause of create sql

### DIFF
--- a/website/docs/sql_ddl.md
+++ b/website/docs/sql_ddl.md
@@ -67,7 +67,10 @@ PARTITIONED BY (dt);
 ```
 
 :::note
-You can also create a table partitioned by multiple fields by supplying comma-separated field names. For, e.g., "partitioned by dt, hh"
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause 
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields 
+should be specified as `PARTITIONED BY (dt, hh)`.
 :::
 
 ### Create table with record keys and ordering fields

--- a/website/versioned_docs/version-0.11.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/quick-start-guide.md
@@ -298,6 +298,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -296,6 +296,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -322,6 +322,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -322,6 +322,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -327,6 +327,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.12.3/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.3/quick-start-guide.md
@@ -327,6 +327,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.13.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.0/quick-start-guide.md
@@ -331,6 +331,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.13.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.1/quick-start-guide.md
@@ -331,6 +331,13 @@ partitioned by (dt, hh)
 location '/tmp/hudi/hudi_cow_pt_tbl';
 ```
 
+:::note
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
+:::
+
 **Create Table for an existing Hudi Table**
 
 We can create a table on an existing hudi table(created with spark-shell or deltastreamer). This is useful to

--- a/website/versioned_docs/version-0.14.0/sql_ddl.md
+++ b/website/versioned_docs/version-0.14.0/sql_ddl.md
@@ -67,7 +67,10 @@ PARTITIONED BY (dt);
 ```
 
 :::note
-You can also create a table partitioned by multiple fields by supplying comma-separated field names. For, e.g., "partitioned by dt, hh"
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
 :::
 
 ### Create table with record keys and ordering fields

--- a/website/versioned_docs/version-0.14.1/sql_ddl.md
+++ b/website/versioned_docs/version-0.14.1/sql_ddl.md
@@ -67,7 +67,10 @@ PARTITIONED BY (dt);
 ```
 
 :::note
-You can also create a table partitioned by multiple fields by supplying comma-separated field names. For, e.g., "partitioned by dt, hh"
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
 :::
 
 ### Create table with record keys and ordering fields

--- a/website/versioned_docs/version-0.15.0/sql_ddl.md
+++ b/website/versioned_docs/version-0.15.0/sql_ddl.md
@@ -67,7 +67,10 @@ PARTITIONED BY (dt);
 ```
 
 :::note
-You can also create a table partitioned by multiple fields by supplying comma-separated field names. For, e.g., "partitioned by dt, hh"
+You can also create a table partitioned by multiple fields by supplying comma-separated field names.
+When creating a table partitioned by multiple fields, ensure that you specify the columns in the `PARTITIONED BY` clause
+in the same order as they appear in the `CREATE TABLE` schema. For example, for the above table, the partition fields
+should be specified as `PARTITIONED BY (dt, hh)`.
 :::
 
 ### Create table with record keys and ordering fields


### PR DESCRIPTION
### Change Logs

If we specify partition fields in an order different from the order in create table schema, then query does not fail and the whole partitioning is incorrect. This has been an issue even in 0.15 and 0.14. We will fix this in HUDI-7964. Meanwhile, it's important we update the docs. 

### Impact

Docs improvement.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
