### PR TITLE
[HUDI-7979] Adjusting defaults with spillable map memory

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig.Builder;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
@@ -551,6 +552,20 @@ public class TestHoodieWriteConfig {
             .withWriteConcurrencyMode(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL)
             .build(),
         "Non-blocking concurrency control requires the MOR table with simple bucket index");
+  }
+
+  @Test
+  public void testFileSystemViewStorageConfigDefaults() {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp").build();
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.BOOTSTRAP_BASE_FILE_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForBootstrapBaseFile());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_COMPACTION_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingCompaction());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_LOG_COMPACTION_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingLogCompaction());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_CLUSTERING_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingClusteringFileGroups());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_REPLACED_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() - writeConfig.getViewStorageConfig().getMaxMemoryForBootstrapBaseFile()
+        - writeConfig.getViewStorageConfig().getMaxMemoryForPendingCompaction() - writeConfig.getViewStorageConfig().getMaxMemoryForPendingLogCompaction()
+        - writeConfig.getViewStorageConfig().getMaxMemoryForPendingClusteringFileGroups()
+        - writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups(), writeConfig.getViewStorageConfig().getMaxMemoryForFileGroupMap());
   }
 
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -557,15 +557,21 @@ public class TestHoodieWriteConfig {
   @Test
   public void testFileSystemViewStorageConfigDefaults() {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp").build();
-    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.BOOTSTRAP_BASE_FILE_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForBootstrapBaseFile());
-    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_COMPACTION_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingCompaction());
-    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_LOG_COMPACTION_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingLogCompaction());
-    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_CLUSTERING_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForPendingClusteringFileGroups());
-    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_REPLACED_MEM_FRACTION.defaultValue(), writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.BOOTSTRAP_BASE_FILE_MEM_FRACTION.defaultValue(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForBootstrapBaseFile());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_COMPACTION_MEM_FRACTION.defaultValue(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForPendingCompaction());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_LOG_COMPACTION_MEM_FRACTION.defaultValue(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForPendingLogCompaction());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_CLUSTERING_MEM_FRACTION.defaultValue(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForPendingClusteringFileGroups());
+    assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() * FileSystemViewStorageConfig.SPILLABLE_REPLACED_MEM_FRACTION.defaultValue(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups());
     assertEquals(FileSystemViewStorageConfig.SPILLABLE_MEMORY.defaultValue() - writeConfig.getViewStorageConfig().getMaxMemoryForBootstrapBaseFile()
         - writeConfig.getViewStorageConfig().getMaxMemoryForPendingCompaction() - writeConfig.getViewStorageConfig().getMaxMemoryForPendingLogCompaction()
         - writeConfig.getViewStorageConfig().getMaxMemoryForPendingClusteringFileGroups()
-        - writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups(), writeConfig.getViewStorageConfig().getMaxMemoryForFileGroupMap());
+        - writeConfig.getViewStorageConfig().getMaxMemoryForReplacedFileGroups(),
+        writeConfig.getViewStorageConfig().getMaxMemoryForFileGroupMap());
   }
 
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/SerializableConfiguration.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/SerializableConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * A wrapped configuration which can be serialized.
+ */
+public class SerializableConfiguration implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private transient Configuration configuration;
+
+  public SerializableConfiguration(Configuration configuration) {
+    this.configuration = new Configuration(configuration);
+  }
+
+  public SerializableConfiguration(SerializableConfiguration configuration) {
+    this.configuration = configuration.newCopy();
+  }
+
+  public Configuration newCopy() {
+    return new Configuration(configuration);
+  }
+
+  public Configuration get() {
+    return configuration;
+  }
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    configuration.write(out);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    configuration = new Configuration(false);
+    configuration.readFields(in);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder str = new StringBuilder();
+    configuration.iterator().forEachRemaining(e -> str.append(String.format("%s => %s \n", e.getKey(), e.getValue())));
+    return configuration.toString();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -89,13 +89,13 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public static final ConfigProperty<Double> SPILLABLE_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.compaction.mem.fraction")
-      .defaultValue(0.15)
+      .defaultValue(0.1)
       .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding compaction related metadata.");
 
   public static final ConfigProperty<Double> SPILLABLE_LOG_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.log.compaction.mem.fraction")
-      .defaultValue(0.1)
+      .defaultValue(0.02)
       .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Fraction of the file system view memory, to be used for holding log compaction related metadata.");
@@ -108,13 +108,13 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public static final ConfigProperty<Double> SPILLABLE_REPLACED_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.replaced.mem.fraction")
-      .defaultValue(0.01)
+      .defaultValue(0.05)
       .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding replace commit related metadata.");
 
   public static final ConfigProperty<Double> SPILLABLE_CLUSTERING_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.clustering.mem.fraction")
-      .defaultValue(0.01)
+      .defaultValue(0.02)
       .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding clustering related metadata.");
 
@@ -223,7 +223,8 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public long getMaxMemoryForFileGroupMap() {
     long totalMemory = getLong(SPILLABLE_MEMORY);
-    return totalMemory - getMaxMemoryForPendingCompaction() - getMaxMemoryForBootstrapBaseFile();
+    return totalMemory - getMaxMemoryForPendingCompaction() - getMaxMemoryForBootstrapBaseFile() - getMaxMemoryForPendingLogCompaction()
+        - getMaxMemoryForPendingClusteringFileGroups() - getMaxMemoryForReplacedFileGroups();
   }
 
   public long getMaxMemoryForPendingCompaction() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -89,13 +89,13 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public static final ConfigProperty<Double> SPILLABLE_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.compaction.mem.fraction")
-      .defaultValue(0.8)
+      .defaultValue(0.15)
       .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding compaction related metadata.");
 
   public static final ConfigProperty<Double> SPILLABLE_LOG_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.log.compaction.mem.fraction")
-      .defaultValue(0.8)
+      .defaultValue(0.1)
       .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Fraction of the file system view memory, to be used for holding log compaction related metadata.");

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+/**
+ * <p>
+ * Exception thrown for Hoodie failures. The root of the exception hierarchy.
+ * </p>
+ * <p>
+ * Hoodie Write/Read clients will throw this exception if any of its operations fail. This is a runtime (unchecked)
+ * exception.
+ * </p>
+ */
+public class HoodieException extends RuntimeException {
+
+  public HoodieException() {
+    super();
+  }
+
+  public HoodieException(String message) {
+    super(message);
+  }
+
+  public HoodieException(String message, Throwable t) {
+    super(message, t);
+  }
+
+  public HoodieException(Throwable t) {
+    super(t);
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieIOException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieIOException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * Exception thrown for table IO-related failures.
+ * </p>
+ */
+public class HoodieIOException extends HoodieException {
+
+  private IOException ioException;
+
+  public HoodieIOException(String msg, IOException t) {
+    super(msg, t);
+    this.ioException = t;
+  }
+
+  public HoodieIOException(String msg) {
+    super(msg);
+  }
+
+  public IOException getIOException() {
+    return ioException;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieIncompatibleSchemaException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieIncompatibleSchemaException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+/**
+ * Exception for incompatible schema.
+ */
+public class HoodieIncompatibleSchemaException extends RuntimeException {
+
+  public HoodieIncompatibleSchemaException(String msg, Throwable e) {
+    super(msg, e);
+  }
+
+  public HoodieIncompatibleSchemaException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
### Change Logs

Adjusting defaults with spillable map memory. Looks like we were allocating 80% of memory to pending compactions, giving only 15Mb to file groups. Also found some gaps around memory computation which was missed when new actions were added. 

After the fix, here is what the default looks like
total memory for spillable: 100Mb
pending compaction: 10Mb
pending clustering: 2Mb
pending log compaction: 2Mb
completed replace commits: 5Mb
bootstrap files: 5M 
actual file groups: 76Mb. 

### Impact

More memory for file groups in FSVs when spillable map is enabled. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
