### PR TITLE
[HUDI-7976] Fix BUG introduced in HUDI-7955 due to usage of wrong class

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HiveAvroSerializer.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HiveAvroSerializer.java
@@ -304,8 +304,7 @@ public class HiveAvroSerializer {
       case DATE:
         return HoodieHiveUtils.getDays(structFieldData);
       case TIMESTAMP:
-        Object timestamp = HoodieHiveUtils.getTimestamp(structFieldData);
-        return HoodieHiveUtils.getMills(timestamp);
+        return HoodieHiveUtils.getMills(structFieldData);
       case INT:
         if (schema.getLogicalType() != null && schema.getLogicalType().getName().equals("date")) {
           return new WritableDateObjectInspector().getPrimitiveWritableObject(structFieldData).getDays();

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
@@ -182,15 +182,11 @@ public class HoodieHiveUtils {
     return HIVE_SHIM.getDateWriteable(value);
   }
 
-  public static Object getTimestamp(Object fieldData) {
-    return HIVE_SHIM.unwrapTimestampAsPrimitive(fieldData);
-  }
-
   public static int getDays(Object dateWritable) {
     return HIVE_SHIM.getDays(dateWritable);
   }
 
-  public static long getMills(Object timestamp) {
-    return HIVE_SHIM.getMills(timestamp);
+  public static long getMills(Object timestampWritable) {
+    return HIVE_SHIM.getMills(timestampWritable);
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive2Shim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive2Shim.java
@@ -42,11 +42,6 @@ public class Hive2Shim implements HiveShim {
     return new TimestampWritable(timestamp);
   }
 
-  @Override
-  public Object unwrapTimestampAsPrimitive(Object o) {
-    return o == null ? null : ((TimestampWritable) o).getTimestamp();
-  }
-
   public Writable getDateWriteable(int value) {
     return new DateWritable(value);
   }
@@ -55,7 +50,7 @@ public class Hive2Shim implements HiveShim {
     return ((DateWritable) dateWritable).getDays();
   }
 
-  public long getMills(Object timestamp) {
-    return ((Timestamp) timestamp).getTime();
+  public long getMills(Object timestampWritable) {
+    return ((TimestampWritable) timestampWritable).getTimestamp().getTime();
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
@@ -36,12 +36,12 @@ public class Hive3Shim implements HiveShim {
 
   public static final Logger LOG = LoggerFactory.getLogger(Hive3Shim.class);
 
-  public static final String HIVE_TIMESTAMP_TYPE_CLASS = "org.apache.hadoop.hive.common.type.Timestamp";
-  public static final String TIMESTAMP_WRITEABLE_V2_CLASS = "org.apache.hadoop.hive.serde2.io.TimestampWritableV2";
-  public static final String DATE_WRITEABLE_V2_CLASS = "org.apache.hadoop.hive.serde2.io.DateWritableV2";
+  public static final String TIMESTAMP_CLASS_NAME = "org.apache.hadoop.hive.common.type.Timestamp";
+  public static final String TIMESTAMP_WRITEABLE_V2_CLASS_NAME = "org.apache.hadoop.hive.serde2.io.TimestampWritableV2";
+  public static final String DATE_WRITEABLE_V2_CLASS_NAME = "org.apache.hadoop.hive.serde2.io.DateWritableV2";
 
-  private static Class<?> TIMESTAMP_CLZZ = null;
-  private static Class<?> TIMESTAMP_WRITABLE_V2_CLZZ = null;
+  private static Class<?> TIMESTAMP_CLASS = null;
+  private static Class<?> TIMESTAMP_WRITABLE_V2_CLASS = null;
   private static Method SET_TIME_IN_MILLIS = null;
   private static Method TO_SQL_TIMESTAMP = null;
   private static Method GET_TIMESTAMP = null;
@@ -55,14 +55,14 @@ public class Hive3Shim implements HiveShim {
     // timestamp
     try {
       // Hive.Timestamp methods
-      TIMESTAMP_CLZZ = Class.forName(HIVE_TIMESTAMP_TYPE_CLASS);
-      SET_TIME_IN_MILLIS = TIMESTAMP_CLZZ.getDeclaredMethod("setTimeInMillis", long.class);
-      TO_SQL_TIMESTAMP = TIMESTAMP_CLZZ.getDeclaredMethod("toSqlTimestamp");
+      TIMESTAMP_CLASS = Class.forName(TIMESTAMP_CLASS_NAME);
+      SET_TIME_IN_MILLIS = TIMESTAMP_CLASS.getDeclaredMethod("setTimeInMillis", long.class);
+      TO_SQL_TIMESTAMP = TIMESTAMP_CLASS.getDeclaredMethod("toSqlTimestamp");
 
       // Hive.TimestampWritable methods
-      TIMESTAMP_WRITABLE_V2_CLZZ = Class.forName(TIMESTAMP_WRITEABLE_V2_CLASS);
-      GET_TIMESTAMP = TIMESTAMP_WRITABLE_V2_CLZZ.getDeclaredMethod("getTimestamp");
-      TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR = TIMESTAMP_WRITABLE_V2_CLZZ.getConstructor(TIMESTAMP_CLZZ);
+      TIMESTAMP_WRITABLE_V2_CLASS = Class.forName(TIMESTAMP_WRITEABLE_V2_CLASS_NAME);
+      GET_TIMESTAMP = TIMESTAMP_WRITABLE_V2_CLASS.getDeclaredMethod("getTimestamp");
+      TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR = TIMESTAMP_WRITABLE_V2_CLASS.getConstructor(TIMESTAMP_CLASS);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
       // This will be printed out when Hive3Shim initialization as a singleton fails
       LOG.warn("cannot find hive3 timestampv2 class or method, use hive2 class!", e);
@@ -70,7 +70,7 @@ public class Hive3Shim implements HiveShim {
 
     // date
     try {
-      DATE_WRITEABLE_CLASS = Class.forName(DATE_WRITEABLE_V2_CLASS);
+      DATE_WRITEABLE_CLASS = Class.forName(DATE_WRITEABLE_V2_CLASS_NAME);
       GET_DAYS = DATE_WRITEABLE_CLASS.getDeclaredMethod("getDays");
       DATE_WRITEABLE_V2_CONSTRUCTOR = DATE_WRITEABLE_CLASS.getConstructor(int.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
@@ -95,7 +95,7 @@ public class Hive3Shim implements HiveShim {
    */
   public Writable getTimestampWriteable(long value, boolean timestampMillis) {
     try {
-      Object timestamp = TIMESTAMP_CLZZ.newInstance();
+      Object timestamp = TIMESTAMP_CLASS.newInstance();
       SET_TIME_IN_MILLIS.invoke(timestamp, timestampMillis ? value : value / 1000);
       return (Writable) TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR.newInstance(timestamp);
     } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/Hive3Shim.java
@@ -64,7 +64,7 @@ public class Hive3Shim implements HiveShim {
       GET_TIMESTAMP = TIMESTAMP_WRITABLE_V2_CLZZ.getDeclaredMethod("getTimestamp");
       TIMESTAMP_WRITEABLE_V2_CONSTRUCTOR = TIMESTAMP_WRITABLE_V2_CLZZ.getConstructor(TIMESTAMP_CLZZ);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      // This will be printed out Hive3Shim is initialized as a singleton
+      // This will be printed out when Hive3Shim initialization as a singleton fails
       LOG.warn("cannot find hive3 timestampv2 class or method, use hive2 class!", e);
     }
 
@@ -74,7 +74,7 @@ public class Hive3Shim implements HiveShim {
       GET_DAYS = DATE_WRITEABLE_CLASS.getDeclaredMethod("getDays");
       DATE_WRITEABLE_V2_CONSTRUCTOR = DATE_WRITEABLE_CLASS.getConstructor(int.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      // This will be printed out Hive3Shim is initialized as a singleton
+      // This will be printed out when Hive3Shim initialization as a singleton fails
       LOG.warn("cannot find hive3 datev2 class or method, use hive2 class!", e);
     }
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/HiveShim.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/shims/HiveShim.java
@@ -27,11 +27,9 @@ public interface HiveShim {
 
   Writable getTimestampWriteable(long value, boolean timestampMillis);
 
-  Object unwrapTimestampAsPrimitive(Object o);
-
   Writable getDateWriteable(int value);
 
   int getDays(Object dateWritable);
 
-  long getMills(Object timestamp);
+  long getMills(Object timestampWritable);
 }


### PR DESCRIPTION
### Change Logs

In the bugfix for [HUDI-7955](https://issues.apache.org/jira/browse/HUDI-7955), the wrong class for invoking {{getTimestamp }}was used.

1. **Wrong**: org.apache.hadoop.hive.common.type.Timestamp
2. **Correct**: org.apache.hadoop.hive.serde2.io.TimestampWritableV2

![image](https://github.com/apache/hudi/assets/6312314/3d1bca3a-2ad4-4e25-b421-daec91d7c65c)

Submitting a bugfix to fix this bugfix... 

Log levels for the exception block is also changed to warn so errors will be printed out.
However, false positives might be printed when the environment is indeed in Hive2.

On top of that, we have simplified the `getMillis` shim to remove the method that was added in [HUDI-7955](https://issues.apache.org/jira/browse/HUDI-7955) to standardise it with how `getDays` is written.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
