### PR TITLE
[HUDI-7980] Optimize the configuration content when performing clustering with row writer

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -93,7 +93,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.client.utils.SparkPartitionUtils.getPartitionFieldVals;
-import static org.apache.hudi.common.config.HoodieCommonConfig.TIMESTAMP_AS_OF;
 import static org.apache.hudi.config.HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS;
 import static org.apache.hudi.io.storage.HoodieSparkIOFactory.getHoodieSparkIOFactory;
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -438,8 +438,11 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
         .toArray(StoragePath[]::new);
 
     HashMap<String, String> params = new HashMap<>();
-    params.put("hoodie.datasource.query.type", "snapshot");
-    params.put(TIMESTAMP_AS_OF.key(), instantTime);
+    if (hasLogFiles) {
+      params.put("hoodie.datasource.query.type", "snapshot");
+    } else {
+      params.put("hoodie.datasource.query.type", "read_optimized");
+    }
 
     StoragePath[] paths;
     if (hasLogFiles) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -61,14 +61,14 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
   private static Stream<Arguments> testClustering() {
     // enableClusteringAsRow, doUpdates, populateMetaFields, preserveCommitMetadata
     return Stream.of(
-        Arguments.of(false, true, true),
-        Arguments.of(true, true, false),
-        Arguments.of(true, false, true),
-        Arguments.of(true, false, false),
-        Arguments.of(false, true, true),
-        Arguments.of(false, true, false),
-        Arguments.of(false, false, true),
-        Arguments.of(false, false, false)
+//        Arguments.of(false, true, true),
+//        Arguments.of(true, true, false),
+//        Arguments.of(true, false, true),
+        Arguments.of(true, false, false)
+//        Arguments.of(false, true, true),
+//        Arguments.of(false, true, false),
+//        Arguments.of(false, false, true),
+//        Arguments.of(false, false, false)
     );
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -61,14 +61,14 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
   private static Stream<Arguments> testClustering() {
     // enableClusteringAsRow, doUpdates, populateMetaFields, preserveCommitMetadata
     return Stream.of(
-//        Arguments.of(false, true, true),
-//        Arguments.of(true, true, false),
-//        Arguments.of(true, false, true),
-        Arguments.of(true, false, false)
-//        Arguments.of(false, true, true),
-//        Arguments.of(false, true, false),
-//        Arguments.of(false, false, true),
-//        Arguments.of(false, false, false)
+        Arguments.of(false, true, true),
+        Arguments.of(true, true, false),
+        Arguments.of(true, false, true),
+        Arguments.of(true, false, false),
+        Arguments.of(false, true, true),
+        Arguments.of(false, true, false),
+        Arguments.of(false, false, true),
+        Arguments.of(false, false, false)
     );
   }
 


### PR DESCRIPTION
Currently, the row writer defaults to snapshot reads for all tables. However, this method is relatively inefficient for MOR  tables when there are no logs. Additionally, we have already configured the glob path for queries. We need to read all the files from the glob path without requiring additional configurations for time travel queries. I believe the parameter 
 TIMESTAMP_AS_OF is unnecessary and may lead to inconsistencies between the instant and the selected files, potentially causing data loss. Therefore, we should optimize this part of the configuration.

### Change Logs

None

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
