### PR TITLE
[HUDI-7709] Pass partition paths as partition column values if `TimestampBasedKeyGenerator` is used

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -76,6 +76,7 @@ import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAM
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD;
 import static org.apache.hudi.common.util.ConfigUtils.fetchConfigs;
 import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -284,6 +285,7 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
 
   public static final List<ConfigProperty<String>> PERSISTED_CONFIG_LIST = Arrays.asList(
+      TIMESTAMP_TYPE_FIELD,
       INPUT_TIME_UNIT,
       TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX,
       TIMESTAMP_INPUT_DATE_FORMAT,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -243,8 +243,6 @@ object DefaultSource {
     val queryType = parameters(QUERY_TYPE.key)
     val isCdcQuery = queryType == QUERY_TYPE_INCREMENTAL_OPT_VAL &&
       parameters.get(INCREMENTAL_FORMAT.key).contains(INCREMENTAL_FORMAT_CDC_VAL)
-    val isMultipleBaseFileFormatsEnabled = metaClient.getTableConfig.isMultipleBaseFileFormatsEnabled
-
 
     val createTimeLineRln = parameters.get(DataSourceReadOptions.CREATE_TIMELINE_RELATION.key())
     val createFSRln = parameters.get(DataSourceReadOptions.CREATE_FILESYSTEM_RELATION.key())

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.DataSourceReadOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.SparkHoodieTableFileIndex.{deduceQueryType, extractEqualityPredicatesLiteralValues, generateFieldMap, haveProperPartitionValues, shouldListLazily, shouldUsePartitionPathPrefixAnalysis, shouldValidatePartitionColumns}
 import org.apache.hudi.client.common.HoodieSparkEngineContext
-import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.common.config.{TimestampKeyGeneratorConfig, TypedProperties}
 import org.apache.hudi.common.model.{FileSlice, HoodieTableQueryType}
 import org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS_WITH_OPERATION
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
@@ -32,23 +32,23 @@ import org.apache.hudi.config.HoodieBootstrapConfig.DATA_QUERIES_ONLY
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.internal.schema.Types.RecordType
 import org.apache.hudi.internal.schema.utils.Conversions
+import org.apache.hudi.keygen.constant.KeyGeneratorType
 import org.apache.hudi.keygen.{StringPartitionPathFormatter, TimestampBasedAvroKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.storage.{StoragePath, StoragePathInfo}
 import org.apache.hudi.util.JFunction
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.{expressions, InternalRow}
+import org.apache.spark.sql.catalyst.{InternalRow, expressions}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, EmptyRow, EqualTo, Expression, InterpretedPredicate, Literal}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.{FileStatusCache, NoopCache}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, DateType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 
 import javax.annotation.concurrent.NotThreadSafe
-
 import java.util.Collections
-
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 import scala.util.{Success, Try}
@@ -400,9 +400,19 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
   }
 
   protected def doParsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
-    HoodieSparkUtils.parsePartitionColumnValues(partitionColumns, partitionPath, getBasePath, schema,
-      configProperties.getString(DateTimeUtils.TIMEZONE_OPTION, SQLConf.get.sessionLocalTimeZone),
-      sparkParsePartitionUtil, shouldValidatePartitionColumns(spark))
+    val tableConfig = metaClient.getTableConfig
+    if (null != tableConfig.getKeyGeneratorClassName
+      && tableConfig.getKeyGeneratorClassName.equals(KeyGeneratorType.TIMESTAMP.getClassName)
+      && tableConfig.propsMap.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key()).matches("SCALAR|UNIX_TIMESTAMP|EPOCHMILLISECONDS")) {
+      // For TIMESTAMP key generator when TYPE is SCALAR, UNIX_TIMESTAMP or EPOCHMILLISECONDS,
+      // we couldn't reconstruct initial partition column values from partition paths due to lost data after formatting in most cases.
+      // But the output for these cases is in a string format, so we can pass partitionPath as UTF8String
+      Array.fill(partitionColumns.length)(UTF8String.fromString(partitionPath))
+    } else {
+      HoodieSparkUtils.parsePartitionColumnValues(partitionColumns, partitionPath, getBasePath, schema,
+        configProperties.getString(DateTimeUtils.TIMEZONE_OPTION, SQLConf.get.sessionLocalTimeZone),
+        sparkParsePartitionUtil, shouldValidatePartitionColumns(spark))
+    }
   }
 
   private def arePartitionPathsUrlEncoded: Boolean =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.functional.TestSparkSqlWithTimestampKeyGenerator._
+
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.slf4j.LoggerFactory
+
+/**
+ * Tests of timestamp key generator using Spark SQL
+ */
+class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
+  private val LOG = LoggerFactory.getLogger(getClass)
+
+  test("Test Spark SQL with timestamp key generator") {
+    withTempDir { tmp =>
+      Seq(
+        Seq("COPY_ON_WRITE", "true"),
+        Seq("COPY_ON_WRITE", "false"),
+        Seq("MERGE_ON_READ", "true"),
+        Seq("MERGE_ON_READ", "false")
+      ).foreach { testParams =>
+        val tableType = testParams(0)
+        // enables use of engine agnostic file group reader
+        val shouldUseFileGroupReader = testParams(1)
+
+        timestampKeyGeneratorSettings.foreach { keyGeneratorSettings =>
+          withTable(generateTableName) { tableName =>
+            // Warning level is used due to CI run with warn-log profile for quick failed cases identification
+            LOG.warn(s"Table '${tableName}' with parameters: ${testParams}. Timestamp key generator settings: ${keyGeneratorSettings}")
+            val tablePath = tmp.getCanonicalPath + "/" + tableName
+            val tsType = if (keyGeneratorSettings.contains("DATE_STRING")) "string" else "long"
+            spark.sql(
+              s"""
+                 | CREATE TABLE $tableName (
+                 |   id int,
+                 |   name string,
+                 |   precomb long,
+                 |   ts ${tsType}
+                 | ) USING HUDI
+                 | PARTITIONED BY (ts)
+                 | LOCATION '${tablePath}'
+                 | TBLPROPERTIES (
+                 |   type = '${tableType}',
+                 |   primaryKey = 'id',
+                 |   preCombineField = 'precomb',
+                 |   hoodie.datasource.write.partitionpath.field = 'ts',
+                 |   hoodie.datasource.write.hive_style_partitioning = 'false',
+                 |   hoodie.file.group.reader.enabled = '${shouldUseFileGroupReader}',
+                 |   hoodie.table.keygenerator.class = 'org.apache.hudi.keygen.TimestampBasedKeyGenerator',
+                 |   ${keyGeneratorSettings}
+                 | )
+                 |""".stripMargin)
+            // TODO: couldn't set `TIMESTAMP` for `hoodie.table.keygenerator.type`, it's overwritten by `SIMPLE`, only `hoodie.table.keygenerator.class` works
+
+            val (dataBatches, expectedQueryResult) = if (keyGeneratorSettings.contains("DATE_STRING"))
+              (dataBatchesWithString, queryResultWithString)
+            else if (keyGeneratorSettings.contains("EPOCHMILLISECONDS"))
+              (dataBatchesWithLongOfMilliseconds, queryResultWithLongOfMilliseconds)
+            else // UNIX_TIMESTAMP, and SCALAR with SECONDS
+              (dataBatchesWithLongOfSeconds, queryResultWithLongOfSeconds)
+
+            withSQLConf("hoodie.file.group.reader.enabled" -> s"${shouldUseFileGroupReader}",
+              "hoodie.datasource.query.type" -> "snapshot") {
+              // two partitions, one contains parquet file only, the second one contains parquet and log files for MOR, and two parquets for COW
+              spark.sql(s"INSERT INTO ${tableName} VALUES ${dataBatches(0)}")
+              spark.sql(s"INSERT INTO ${tableName} VALUES ${dataBatches(1)}")
+
+              val queryResult = spark.sql(s"SELECT id, name, precomb, ts FROM ${tableName} ORDER BY id").collect().mkString("; ")
+              LOG.warn(s"Query result: ${queryResult}")
+              // TODO: use `shouldExtractPartitionValuesFromPartitionPath` uniformly, and get `expectedQueryResult` for all cases instead of `expectedQueryResultWithLossyString` for some cases
+              //   After it we could properly process filters like "WHERE ts BETWEEN 1078016000 and 1718953003" and add tests with partition pruning.
+              //   COW: Fix for [HUDI-3896] overwrites `shouldExtractPartitionValuesFromPartitionPath` in `BaseFileOnlyRelation`, therefore for COW we extracting from partition paths and get nulls
+              //   shouldUseFileGroupReader: [HUDI-7925] Currently there is no logic for `shouldExtractPartitionValuesFromPartitionPath` in `HoodieBaseHadoopFsRelationFactory`
+              if (tableType == "COPY_ON_WRITE" || shouldUseFileGroupReader.toBoolean)
+                assertResult(expectedQueryResultWithLossyString)(queryResult)
+              else
+                assertResult(expectedQueryResult)(queryResult)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+object TestSparkSqlWithTimestampKeyGenerator {
+  val outputDateformat = "yyyy-MM-dd HH"
+  val timestampKeyGeneratorSettings: Array[String] = Array(
+    s"""
+       |   hoodie.keygen.timebased.timestamp.type = 'UNIX_TIMESTAMP',
+       |   hoodie.keygen.timebased.output.dateformat = '${outputDateformat}'""",
+    s"""
+       |   hoodie.keygen.timebased.timestamp.type = 'EPOCHMILLISECONDS',
+       |   hoodie.keygen.timebased.output.dateformat = '${outputDateformat}'""",
+    s"""
+       |   hoodie.keygen.timebased.timestamp.type = 'SCALAR',
+       |   hoodie.keygen.timebased.timestamp.scalar.time.unit = 'SECONDS',
+       |   hoodie.keygen.timebased.output.dateformat = '${outputDateformat}'""",
+    s"""
+       |   hoodie.keygen.timebased.timestamp.type = 'DATE_STRING',
+       |   hoodie.keygen.timebased.input.dateformat = 'yyyy-MM-dd HH:mm:ss',
+       |   hoodie.keygen.timebased.output.dateformat = '${outputDateformat}'"""
+  )
+
+  // All data batches should correspond to 2004-02-29 01:02:03 and 2024-06-21 06:50:03
+  val dataBatchesWithLongOfSeconds: Array[String] = Array(
+    "(1, 'a1', 1, 1078016523), (2, 'a2', 1, 1718952603)",
+    "(2, 'a3', 1, 1718952603)"
+  )
+  val dataBatchesWithLongOfMilliseconds: Array[String] = Array(
+    "(1, 'a1', 1, 1078016523000), (2, 'a2', 1, 1718952603000)",
+    "(2, 'a3', 1, 1718952603000)"
+  )
+  val dataBatchesWithString: Array[String] = Array(
+    "(1, 'a1', 1, '2004-02-29 01:02:03'), (2, 'a2', 1, '2024-06-21 06:50:03')",
+    "(2, 'a3', 1, '2024-06-21 06:50:03')"
+  )
+  val queryResultWithLongOfSeconds: String = "[1,a1,1,1078016523]; [2,a3,1,1718952603]"
+  val queryResultWithLongOfMilliseconds: String = "[1,a1,1,1078016523000]; [2,a3,1,1718952603000]"
+  val queryResultWithString: String = "[1,a1,1,2004-02-29 01:02:03]; [2,a3,1,2024-06-21 06:50:03]"
+  val expectedQueryResultWithLossyString: String = "[1,a1,1,2004-02-29 01]; [2,a3,1,2024-06-21 06]"
+}


### PR DESCRIPTION
### Change Logs

This MR fixes `ClassCastException` while reading by Spark, when `TimestampBasedKeyGenerator` is used.
Previous fix https://github.com/apache/hudi/pull/11501 has been reverted by https://github.com/apache/hudi/pull/11586.
In the previous fix nulls have been passed instead of parsing partition paths.
Anyway, we shouldn't parse partition paths, but in this fix partition paths are passed as it is. `UTF8String`s are passed instead of nulls as I mentioned in the discussion under https://github.com/apache/hudi/pull/11501.

### Impact

Fixes `ClassCastException`. Save previous behavior for unaffected cases.

### Risk level (write none, low medium or high below)

Low. Affects only if `TimestampBasedKeyGenerator` of `SCALAR`, `UNIX_TIMESTAMP` or `EPOCHMILLISECONDS` types is used. There is added `TestSparkSqlWithTimestampKeyGenerator`.

### Documentation Update

No need.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
