### PR TITLE
[MINOR][DO NOT MERGE] Turn on 1.0.0 features by default

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -432,7 +432,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> INSTANT_STATE_TIMELINE_SERVER_BASED = ConfigProperty
       .key("hoodie.instant_state.timeline_server_based.enabled")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("1.0.0")
       .withDocumentation("If enabled, writers get instant state from timeline server rather than requesting DFS directly");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
@@ -66,7 +66,9 @@ public class HoodieIndexingConfig extends HoodieConfig {
       .withValidValues(
           MetadataPartitionType.COLUMN_STATS.name(),
           MetadataPartitionType.BLOOM_FILTERS.name(),
-          MetadataPartitionType.SECONDARY_INDEX.name()
+          MetadataPartitionType.SECONDARY_INDEX.name(),
+          MetadataPartitionType.RECORD_INDEX.name(),
+          MetadataPartitionType.PARTITION_STATS.name()
       )
       .sinceVersion("1.0.0")
       .withDocumentation("Type of the functional index. Default is `column_stats` if there are no functions and expressions in the command. "

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -144,7 +144,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_COLUMN_STATS = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("0.11.0")
       .withDocumentation("Enable indexing column ranges of user data files under metadata table key lookups. When "
           + "enabled, metadata table will have a partition to store the column ranges and will be "
@@ -237,7 +237,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> RECORD_INDEX_ENABLE_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Create the HUDI Record Index within the Metadata Table");
@@ -353,7 +353,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> SECONDARY_INDEX_ENABLE_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".index.secondary.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("1.0.0")
       .withDocumentation("Enable secondary index within the Metadata Table.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 public class HoodieReaderConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> USE_NATIVE_HFILE_READER = ConfigProperty
       .key("_hoodie.hfile.use.native.reader")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("When enabled, the native HFile reader is used to read HFiles.  This is an internal config.");
@@ -68,7 +68,7 @@ public class HoodieReaderConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> MERGE_USE_RECORD_POSITIONS = ConfigProperty
       .key("hoodie.merge.use.record.positions")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("Whether to use positions in the block header for data blocks containing updates and delete blocks for merging.");

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -157,7 +157,7 @@ object DataSourceReadOptions {
 
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty
     .key("hoodie.enable.data.skipping")
-    .defaultValue(false)
+    .defaultValue(true)
     .markAdvanced()
     .sinceVersion("0.10.0")
     .withDocumentation("Enables data-skipping allowing queries to leverage indexes to reduce the search space by " +


### PR DESCRIPTION
### Change Logs

**Do not merge**

The purpose of this PR is to enable 1.0.0 features, including indexes, native hfile reader, instant state from timeline, by default and identify failures.

### Impact

Stability for 1.0.0

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
