### PR TITLE
[MINOR] fix the target location for auxlib download in hudi CLI

### DIFF
--- a/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+++ b/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
@@ -38,9 +38,9 @@ HUDI_CONF_DIR="${DIR}"/conf
 HUDI_AUX_LIB="${DIR}"/auxlib
 
 if [ ! -d $HUDI_AUX_LIB ]; then
-  echo "Downloading necessary auxiliary jars for Hudi CLI"
-  wget https://repo1.maven.org/maven2/org/glassfish/jakarta.el/$JAKARTA_EL_VERSION/jakarta.el-$JAKARTA_EL_VERSION.jar -P auxlib
-  wget https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/$JAKARTA_EL_VERSION/jakarta.el-api-$JAKARTA_EL_VERSION.jar -P auxlib
+  echo "Downloading necessary auxiliary jars for Hudi CLI to $HUDI_AUX_LIB"
+  wget https://repo1.maven.org/maven2/org/glassfish/jakarta.el/$JAKARTA_EL_VERSION/jakarta.el-$JAKARTA_EL_VERSION.jar -P $HUDI_AUX_LIB
+  wget https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/$JAKARTA_EL_VERSION/jakarta.el-api-$JAKARTA_EL_VERSION.jar -P $HUDI_AUX_LIB
 fi
 
 . "${DIR}"/conf/hudi-env.sh

--- a/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+++ b/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
@@ -41,6 +41,12 @@ if [ ! -d $HUDI_AUX_LIB ]; then
   echo "Downloading necessary auxiliary jars for Hudi CLI to $HUDI_AUX_LIB"
   wget https://repo1.maven.org/maven2/org/glassfish/jakarta.el/$JAKARTA_EL_VERSION/jakarta.el-$JAKARTA_EL_VERSION.jar -P $HUDI_AUX_LIB
   wget https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/$JAKARTA_EL_VERSION/jakarta.el-api-$JAKARTA_EL_VERSION.jar -P $HUDI_AUX_LIB
+
+  if [ "$IS_S3_ENABLED" = "true" ]; then
+    echo "Adding hadoop-aws jars to auxlib"
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P $HUDI_AUX_LIB
+    wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar -P $HUDI_AUX_LIB
+  fi
 fi
 
 . "${DIR}"/conf/hudi-env.sh


### PR DESCRIPTION
### Change Logs

I noticed that although the variable for path to `auxlib` is defined, it is not being used correctly. So running the CLI from repo-root kept redownloading the `jakarta` jars. The expected `auxlib` points to `<repo_root>/packaging/hudi-cli-bundle/auxlib` as defined in the `$HUDI_AUX_LIB` variable. However, the `wget` kept downloading to `$PWD/auxlib` which is incorrect.

Also, using Hudi CLI to access tables on S3 has some limitations as the relevant `hadoop` jars are not defined in the path by default. I have updated the CLI utility to facilitate adding the hadoop s3 jars as well. For compatibility purpose, I have made this facility behind a flag called `IS_S3_ENABLED` which can be set to `true`. Enabling this flag, will add the hadoop jars to the `auxlib` as well.

### Impact

NA

### Risk level (write none, low medium or high below)

none

### Documentation Update

This page can be updated to highlight that the flag can be set to access `s3a` buckets path:
https://hudi.apache.org/docs/next/cli/#using-hudi-cli

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
