### PR TITLE
[HUDI-7997] Hivesync to support promotion type correctly

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveSchemaUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveSchemaUtil.java
@@ -112,12 +112,6 @@ public class HiveSchemaUtil {
         expectedType = expectedType.replaceAll("`", "");
 
         if (!tableColumnType.equalsIgnoreCase(expectedType)) {
-          // check for incremental queries, the schema type change is allowed as per evolution
-          // rules
-          if (!isSchemaTypeUpdateAllowed(tableColumnType, expectedType)) {
-            throw new HoodieHiveSyncException("Could not convert field Type from " + tableColumnType + " to "
-                + expectedType + " for field " + fieldName);
-          }
           schemaDiffBuilder.updateTableColumn(fieldName, getExpectedType(newTableSchema, tickSurroundedFieldName));
         }
       }
@@ -419,23 +413,6 @@ public class HiveSchemaUtil {
     }
     array.append(">");
     return array.toString();
-  }
-
-  public static boolean isSchemaTypeUpdateAllowed(String prevType, String newType) {
-    if (prevType == null || prevType.trim().isEmpty() || newType == null || newType.trim().isEmpty()) {
-      return false;
-    }
-    prevType = prevType.toLowerCase();
-    newType = newType.toLowerCase();
-    if (prevType.equals(newType)) {
-      return true;
-    } else if (prevType.equalsIgnoreCase(INT_TYPE_NAME) && newType.equalsIgnoreCase(BIGINT_TYPE_NAME)) {
-      return true;
-    } else if (prevType.equalsIgnoreCase(FLOAT_TYPE_NAME) && newType.equalsIgnoreCase(DOUBLE_TYPE_NAME)) {
-      return true;
-    } else {
-      return prevType.contains("struct") && newType.toLowerCase().contains("struct");
-    }
   }
 
   public static String generateSchemaString(MessageType storageSchema) throws IOException {


### PR DESCRIPTION
### Change Logs

Currently hudi supports several type promotion. However hive sync (including glue sync by inheritance) will fail.

More details in #11599

Fixes #11599

### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
