### PR TITLE
[HUDI-8001] Insert overwrite failed due to missing 'path' property when using Spark 3.5.1 and Hudi 1.0.0

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -145,8 +145,8 @@ object CreateHoodieTableCommand {
     var newTblProperties =
       hoodieCatalogTable.catalogProperties.--(needFilterProps) ++ HoodieOptionConfig.extractSqlOptions(properties)
 
-    // Add provider -> hudi as a table property
-    newTblProperties = newTblProperties + ("provider" -> "hudi")
+    // Add provider -> hudi and path as a table property
+    newTblProperties = newTblProperties + ("provider" -> "hudi") + ("path" -> path)
 
     val newTable = table.copy(
       identifier = newTableIdentifier,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.sql.hudi.ddl
 
+import org.apache.hadoop.fs.Path
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.TableSchemaResolver
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
-
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
@@ -282,10 +282,12 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
         spark.sql(s"alter table $locTableName rename to $newLocTableName")
         val newLocation2 = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(newLocTableName))
           .properties.get("path")
-        // only hoodieCatalog will set path to tblp
         if (oldLocation2.nonEmpty) {
+          // Remove the impact of the schema.
+          val oldLocation2Path = new Path(oldLocation2.get.stripPrefix("file:"))
+          val newLocation2Path = new Path(newLocation2.get.stripPrefix("file:"))
           assertResult(true)(
-            newLocation2.equals(oldLocation2)
+            newLocation2Path.equals(oldLocation2Path)
           )
         } else {
           assertResult(None) (newLocation2)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -533,7 +533,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
             )(table.schema.fields)
 
             // Should not include non.hoodie.property
-            assertResult(3)(table.properties.size)
+            assertResult(4)(table.properties.size)
             assertResult("cow")(table.properties("type"))
             assertResult("id,name")(table.properties("primaryKey"))
             assertResult("hudi")(table.properties("provider"))


### PR DESCRIPTION
The issue with Spark 3.5.1 arises because the InsertIntoHoodieTableCommand chain calls the initialization of the HoodieFileIndex class. For v1 tables, the path is stored in CatalogTable#CatalogStorageFormat#storageProperties, but not in CatalogTable#properties. 
![image](https://github.com/user-attachments/assets/660d3c1a-745f-456c-ae52-ca6dc75c1467)


When Spark reloads the table, it removes the path key from CatalogTable#CatalogStorageFormat#storageProperties. 

![image](https://github.com/user-attachments/assets/50d2268c-a1d2-422c-882a-c101e5c4c9ea)
![image](https://github.com/user-attachments/assets/1a5c4543-6094-4110-8714-61c898a00051)

Consequently, InsertIntoHoodieTableCommand in Hudi cannot retrieve the path from either CatalogTable#CatalogStorageFormat#storageProperties or CatalogTable#properties during deduceOverwriteConfig. This absence of the path key in combinedOpts leads to an error when initializing HoodieFileIndex.
![image](https://github.com/user-attachments/assets/b042afbd-faff-4a93-bb74-eed59fa49e5d)

### Change Logs

None

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
