### PR TITLE
[HUDI-7908] Hotfix: HoodieFileGroupReader fails if preCombine and partition fields are the same

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -109,8 +109,8 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tableState: HoodieTableState,
     //dataSchema is not always right due to spark bugs
     val partitionColumns = partitionSchema.fieldNames
     val preCombineField = options.getOrElse(HoodieTableConfig.PRECOMBINE_FIELD.key, "")
-    val dataSchema = StructType(tableSchema.structTypeSchema.fields.filterNot(f => partitionColumns.contains(f.name)
-      && preCombineField.equals(f.name)))
+    val dataSchema = StructType(tableSchema.structTypeSchema.fields.filter(f => !partitionColumns.contains(f.name)
+      || preCombineField.equals(f.name)))
     val outputSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val isCount = requiredSchema.isEmpty && !isMOR && !isIncremental
     val augmentedStorageConf = new HadoopStorageConfiguration(hadoopConf).getInline


### PR DESCRIPTION
### Change Logs

From previous PR:
HoodieFileGroupReader failed if preCombine and partition fields are the same with IllegalArgumentException: Field: ts does not exist in the table schema. precombineField is required but it was filtered from dataSchema as other partition fields.

To fix this I made HoodieFileGroupReaderBasedParquetFileFormat do not filter partitionColumn from dataSchema if it is the same as preCombine field.

But I did it wrong, as you can see from this discussion:  https://github.com/apache/hudi/pull/11473/files#r1681098941

There were 2 mistakes:   
- filtering condition was wrong during evaluation of dataSchema;  
- options did not contain precombineField.  

With this PR I fixed it.

### Impact

precombineField and partition field may be the same, and it works with local spark and on cluster.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
