### PR TITLE
[HUDI-8006] Fix glue sync async call to update table

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -497,7 +497,11 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           .tableInput(updatedTableInput)
           .build();
 
-      awsGlue.updateTable(request);
+      try {
+        awsGlue.updateTable(request).get();
+      } catch (Exception e) {
+        throw new HoodieGlueSyncException("Fail to update table comments " + tableId(databaseName, table.name()), e);
+      }
       return true;
     }
   }
@@ -529,7 +533,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           .tableInput(updatedTableInput)
           .build();
 
-      awsGlue.updateTable(request);
+      awsGlue.updateTable(request).get();
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update definition for table " + tableId(databaseName, tableName), e);
     }
@@ -572,7 +576,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           .skipArchive(skipTableArchive)
           .tableInput(updatedTableInput)
           .build();
-      awsGlue.updateTable(request);
+      awsGlue.updateTable(request).get();
       dropTable(tempTableName);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to recreate the table" + tableId(databaseName, tableName), e);
@@ -986,7 +990,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           .tableInput(updatedTableInput)
           .build();
 
-      awsGlue.updateTable(updateTableRequest);
+      awsGlue.updateTable(updateTableRequest).get();
       return true;
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Failed to update table serde info for table: "
@@ -1069,7 +1073,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           .tableInput(updatedTableInput)
           .skipArchive(skipTableArchive)
           .build();
-      awsGlue.updateTable(request);
+      awsGlue.updateTable(request).get();
       return true;
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update params for table " + tableId(databaseName, tableName) + ": " + updatingParams, e);

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -115,6 +115,7 @@ class TestAWSGlueSyncClient {
     CompletableFuture<DeleteTableResponse> deleteTableResponse = CompletableFuture.completedFuture(DeleteTableResponse.builder().build());
     Mockito.when(mockAwsGlue.deleteTable(any(DeleteTableRequest.class))).thenReturn(deleteTableResponse);
 
+    Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(CompletableFuture.completedFuture(null));
     awsGlueSyncClient.createOrReplaceTable(tableName, storageSchema, inputFormatClass, outputFormatClass, serdeClass, serdeProperties, tableProperties);
 
     // Verify that awsGlue.updateTable() is called exactly once


### PR DESCRIPTION
### Change Logs

When multiple updateTable are chained, the async call may overlap and some intermediary table changes may be lost. By forcing the future, it fixes this behavior.
 
related to #11599

### Impact

Low

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
