### PR TITLE
[HUDI-8008] Handle proto schema references in returned schema

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -383,6 +383,10 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-json-schema-serializer</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.kjetland</groupId>
+      <artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
+    </dependency>
 
     <!-- Httpcomponents -->
     <dependency>

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -379,6 +379,10 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-protobuf-serializer</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-json-schema-serializer</artifactId>
+    </dependency>
 
     <!-- Httpcomponents -->
     <dependency>

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 
 import java.io.IOException;
 import java.net.URI;
@@ -59,8 +61,9 @@ public class JsonToAvroSchemaConverter implements SchemaRegistryProvider.SchemaC
   private static final Pattern SYMBOL_REGEX = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
 
   @Override
-  public String convert(String jsonSchema) throws IOException {
-    JsonNode jsonNode = MAPPER.readTree(jsonSchema);
+  public String convert(ParsedSchema parsedSchema) throws IOException {
+    JsonSchema jsonSchema = (JsonSchema) parsedSchema;
+    JsonNode jsonNode = MAPPER.readTree(jsonSchema.canonicalString());
     ObjectNode avroRecord = MAPPER.createObjectNode()
         .put("type", "record")
         .put("name", getAvroSchemaRecordName(jsonNode))

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.schema.converter;
 
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
@@ -59,6 +60,10 @@ public class JsonToAvroSchemaConverter implements SchemaRegistryProvider.SchemaC
       {"number", "double"}
   }).collect(Collectors.collectingAndThen(Collectors.toMap(p -> p[0], p -> p[1]), Collections::<String, String>unmodifiableMap));
   private static final Pattern SYMBOL_REGEX = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+
+  public JsonToAvroSchemaConverter(TypedProperties properties) {
+    // properties unused in this converter
+  }
 
   @Override
   public String convert(ParsedSchema parsedSchema) throws IOException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/ProtoSchemaToAvroSchemaConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/ProtoSchemaToAvroSchemaConverter.java
@@ -21,6 +21,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 import org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 
 import java.io.IOException;
@@ -35,9 +36,8 @@ public class ProtoSchemaToAvroSchemaConverter implements SchemaRegistryProvider.
     this.schemaConfig = ProtoConversionUtil.SchemaConfig.fromProperties(config);
   }
 
-  @Override
-  public String convert(String schema) throws IOException {
-    ProtobufSchema protobufSchema = new ProtobufSchema(schema);
+  public String convert(ParsedSchema schema) throws IOException {
+    ProtobufSchema protobufSchema = (ProtobufSchema) schema;
     return ProtoConversionUtil.getAvroSchemaForMessageDescriptor(protobufSchema.toDescriptor(), schemaConfig).toString();
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -19,33 +19,30 @@
 package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.function.SerializableFunctionUnchecked;
+import org.apache.hudi.common.util.Option;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
+import java.util.Base64;
+import java.util.Collections;
 
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TestSchemaRegistryProvider {
 
   private static final String BASIC_AUTH = "foo:bar";
-
-  private static final String REGISTRY_RESPONSE = "{\"schema\":\"{\\\"type\\\": \\\"record\\\", \\\"namespace\\\": \\\"example\\\", "
-      + "\\\"name\\\": \\\"FullName\\\",\\\"fields\\\": [{ \\\"name\\\": \\\"first\\\", \\\"type\\\": "
-      + "\\\"string\\\" }]}\"}";
   private static final String RAW_SCHEMA = "{\"type\": \"record\", \"namespace\": \"example\", "
       + "\"name\": \"FullName\",\"fields\": [{ \"name\": \"first\", \"type\": "
       + "\"string\" }]}";
@@ -64,93 +61,100 @@ class TestSchemaRegistryProvider {
   private static TypedProperties getProps() {
     return new TypedProperties() {
       {
-        put("hoodie.streamer.schemaprovider.registry.baseUrl", "http://" + BASIC_AUTH + "@localhost");
-        put("hoodie.streamer.schemaprovider.registry.urlSuffix", "-value");
-        put("hoodie.streamer.schemaprovider.registry.url", "http://foo:bar@localhost");
-        put("hoodie.streamer.source.kafka.topic", "foo");
+        put("hoodie.deltastreamer.schemaprovider.registry.baseUrl", "http://" + BASIC_AUTH + "@localhost");
+        put("hoodie.deltastreamer.schemaprovider.registry.urlSuffix", "-value");
+        put("hoodie.deltastreamer.schemaprovider.registry.url", "http://foo:bar@localhost/subjects/test/versions/latest");
+        put("hoodie.deltastreamer.source.kafka.topic", "foo");
       }
     };
   }
 
-  private static SchemaRegistryProvider getUnderTest(TypedProperties props) throws IOException {
-    InputStream is = new ByteArrayInputStream(getUTF8Bytes(REGISTRY_RESPONSE));
-    SchemaRegistryProvider spyUnderTest = Mockito.spy(new SchemaRegistryProvider(props, null));
-    Mockito.doReturn(is).when(spyUnderTest).getStream(Mockito.any());
-    return spyUnderTest;
-  }
+  private final SchemaRegistryProvider.SchemaConverter mockSchemaConverter = mock(SchemaRegistryProvider.SchemaConverter.class);
+  private final RestService mockRestService = mock(RestService.class);
+  private final SchemaRegistryClient mockRegistryClient = mock(SchemaRegistryClient.class);
 
-  @Test
-  public void testGetSourceSchemaShouldRequestSchemaWithCreds() throws IOException {
-    SchemaRegistryProvider spyUnderTest = getUnderTest(getProps());
-    Schema actual = spyUnderTest.getSourceSchema();
-    assertNotNull(actual);
-    assertEquals(getExpectedSchema(), actual);
-    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(BASIC_AUTH),
-        Mockito.any(HttpURLConnection.class));
-  }
-
-  @Test
-  public void testGetTargetSchemaShouldRequestSchemaWithCreds() throws IOException {
-    SchemaRegistryProvider spyUnderTest = getUnderTest(getProps());
-    Schema actual = spyUnderTest.getTargetSchema();
-    assertNotNull(actual);
-    assertEquals(getExpectedSchema(), actual);
-    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(BASIC_AUTH),
-        Mockito.any(HttpURLConnection.class));
-  }
-
-  @Test
-  public void testGetSourceSchemaShouldRequestSchemaWithoutCreds() throws IOException {
-    TypedProperties props = getProps();
-    props.put("hoodie.streamer.schemaprovider.registry.url", "http://localhost");
-    props.put("hoodie.streamer.schemaprovider.registry.schemaconverter", DummySchemaConverter.class.getName());
-    SchemaRegistryProvider spyUnderTest = getUnderTest(props);
-    Schema actual = spyUnderTest.getSourceSchema();
-    assertNotNull(actual);
-    assertEquals(getExpectedConvertedSchema(), actual);
-    verify(spyUnderTest, times(0)).setAuthorizationHeader(Mockito.any(), Mockito.any());
-  }
-
-  @Test
-  public void testGetTargetSchemaShouldRequestSchemaWithoutCreds() throws IOException {
-    TypedProperties props = getProps();
-    props.put("hoodie.streamer.schemaprovider.registry.url", "http://localhost");
-    props.put("hoodie.streamer.schemaprovider.registry.schemaconverter", DummySchemaConverter.class.getName());
-    SchemaRegistryProvider spyUnderTest = getUnderTest(props);
-    Schema actual = spyUnderTest.getTargetSchema();
-    assertNotNull(actual);
-    assertEquals(getExpectedConvertedSchema(), actual);
-    verify(spyUnderTest, times(0)).setAuthorizationHeader(Mockito.any(), Mockito.any());
-  }
-
-  public static class DummySchemaConverter implements SchemaRegistryProvider.SchemaConverter {
-
-    @Override
-    public String convert(String schema) throws IOException {
-      return ((ObjectNode) new ObjectMapper()
-          .readTree(schema))
-          .set("namespace", TextNode.valueOf("com.example.hoodie"))
-          .toString();
+  private SchemaRegistryProvider getUnderTest(TypedProperties props, int version, boolean useConverter) throws Exception {
+    SerializableFunctionUnchecked<String, RestService> mockRestServiceFactory = mock(SerializableFunctionUnchecked.class);
+    when(mockRestServiceFactory.apply("http://localhost/")).thenReturn(mockRestService);
+    SerializableFunctionUnchecked<RestService, SchemaRegistryClient> mockRegistryClientFactory = mock(SerializableFunctionUnchecked.class);
+    when(mockRegistryClientFactory.apply(mockRestService)).thenReturn(mockRegistryClient);
+    SchemaRegistryProvider underTest = new SchemaRegistryProvider(props, null, useConverter ? Option.of(mockSchemaConverter) : Option.empty(),
+        mockRestServiceFactory, mockRegistryClientFactory);
+    SchemaMetadata metadata = new SchemaMetadata(1, 1, RAW_SCHEMA);
+    if (version == -1) {
+      when(mockRegistryClient.getLatestSchemaMetadata("test")).thenReturn(metadata);
+    } else {
+      when(mockRegistryClient.getSchemaMetadata("test", version)).thenReturn(metadata);
     }
+    ParsedSchema mockParsedSchema = mock(ParsedSchema.class);
+    when(mockRegistryClient.parseSchema("AVRO", RAW_SCHEMA, Collections.emptyList())).thenReturn(java.util.Optional.of(mockParsedSchema));
+    if (useConverter) {
+      when(mockSchemaConverter.convert(mockParsedSchema)).thenReturn(CONVERTED_SCHEMA);
+    } else {
+      when(mockParsedSchema.canonicalString()).thenReturn(RAW_SCHEMA);
+    }
+    return underTest;
   }
 
-  // The SR is checked when cachedSchema is empty, when not empty, the cachedSchema is used.
   @Test
-  public void testGetSourceSchemaUsesCachedSchema() throws IOException {
-    TypedProperties props = getProps();
-    SchemaRegistryProvider spyUnderTest = getUnderTest(props);
-
-    // Call when cachedSchema is empty
-    Schema actual = spyUnderTest.getSourceSchema();
+  public void testGetSourceSchemaShouldRequestSchemaWithCreds() throws Exception {
+    SchemaRegistryProvider underTest = getUnderTest(getProps(), -1, true);
+    Schema actual = underTest.getSourceSchema();
     assertNotNull(actual);
-    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+    assertEquals(getExpectedConvertedSchema(), actual);
+    verify(mockRestService).setHttpHeaders(Collections.singletonMap("Authorization", "Basic " + Base64.getEncoder().encodeToString(BASIC_AUTH.getBytes())));
+  }
 
-    assert spyUnderTest.cachedSourceSchema != null;
+  @Test
+  public void testGetTargetSchemaShouldRequestSchemaWithCreds() throws Exception {
+    SchemaRegistryProvider underTest = getUnderTest(getProps(), -1, true);
+    Schema actual = underTest.getTargetSchema();
+    assertNotNull(actual);
+    assertEquals(getExpectedConvertedSchema(), actual);
+    verify(mockRestService).setHttpHeaders(Collections.singletonMap("Authorization", "Basic " + Base64.getEncoder().encodeToString(BASIC_AUTH.getBytes())));
+  }
 
-    Schema actualTwo = spyUnderTest.getSourceSchema();
-    
-    // cachedSchema should now be set, a subsequent call should not call parseSchemaFromRegistry
-    // Assuming this verify() has the scope of the whole test? so it should still be 1 from previous call?
-    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+  @Test
+  public void testGetSourceSchemaShouldRequestSchemaWithoutCreds() throws Exception {
+    TypedProperties props = getProps();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url", "http://localhost/subjects/test/versions/latest");
+    SchemaRegistryProvider underTest = getUnderTest(props, -1, true);
+    Schema actual = underTest.getSourceSchema();
+    assertNotNull(actual);
+    assertEquals(getExpectedConvertedSchema(), actual);
+    verify(mockRestService, never()).setHttpHeaders(any());
+  }
+
+  @Test
+  public void testGetTargetSchemaShouldRequestSchemaWithoutCreds() throws Exception {
+    TypedProperties props = getProps();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url", "http://localhost/subjects/test/versions/latest");
+    SchemaRegistryProvider underTest = getUnderTest(props, -1, true);
+    Schema actual = underTest.getTargetSchema();
+    assertNotNull(actual);
+    assertEquals(getExpectedConvertedSchema(), actual);
+    verify(mockRestService, never()).setHttpHeaders(any());
+  }
+
+  @Test
+  public void testGetTargetSchemaWithoutConverter() throws Exception {
+    TypedProperties props = getProps();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url", "http://localhost/subjects/test/versions/latest");
+    SchemaRegistryProvider underTest = getUnderTest(props, -1, false);
+    Schema actual = underTest.getTargetSchema();
+    assertNotNull(actual);
+    assertEquals(getExpectedSchema(), actual);
+    verify(mockRestService, never()).setHttpHeaders(any());
+  }
+
+  @Test
+  public void testUrlWithSpecificSchemaVerson() throws Exception {
+    TypedProperties props = getProps();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url", "http://localhost/subjects/test/versions/3");
+    SchemaRegistryProvider underTest = getUnderTest(props, 3, false);
+    Schema actual = underTest.getTargetSchema();
+    assertNotNull(actual);
+    assertEquals(getExpectedSchema(), actual);
+    verify(mockRestService, never()).setHttpHeaders(any());
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.schema.converter;
 
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import org.apache.avro.Schema;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,7 +44,7 @@ class TestJsonToAvroSchemaConverter {
   })
   void testConvertJsonSchemaToAvroSchema(String inputCase) throws IOException {
     String jsonSchema = loadJsonSchema(inputCase);
-    String avroSchema = new JsonToAvroSchemaConverter().convert(jsonSchema);
+    String avroSchema = new JsonToAvroSchemaConverter().convert(new JsonSchema(jsonSchema));
     Schema schema = new Schema.Parser().parse(avroSchema);
     Schema expected = new Schema.Parser().parse(loadAvroSchema(inputCase));
     assertEquals(expected, schema);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
@@ -44,7 +44,7 @@ class TestJsonToAvroSchemaConverter {
   })
   void testConvertJsonSchemaToAvroSchema(String inputCase) throws IOException {
     String jsonSchema = loadJsonSchema(inputCase);
-    String avroSchema = new JsonToAvroSchemaConverter().convert(new JsonSchema(jsonSchema));
+    String avroSchema = new JsonToAvroSchemaConverter(null).convert(new JsonSchema(jsonSchema));
     Schema schema = new Schema.Parser().parse(avroSchema);
     Schema expected = new Schema.Parser().parse(loadAvroSchema(inputCase));
     assertEquals(expected, schema);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestProtoSchemaToAvroSchemaConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestProtoSchemaToAvroSchemaConverter.java
@@ -21,6 +21,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig;
 import org.apache.hudi.utilities.test.proto.Parent;
 
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,8 @@ class TestProtoSchemaToAvroSchemaConverter {
     TypedProperties properties = new TypedProperties();
     properties.setProperty(ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_CLASS_NAME.key(), Parent.class.getName());
     Schema.Parser parser = new Schema.Parser();
-    String actual = new ProtoSchemaToAvroSchemaConverter(properties).convert(getProtoSchemaString());
+    ProtobufSchema protobufSchema = new ProtobufSchema(getProtoSchemaString());
+    String actual = new ProtoSchemaToAvroSchemaConverter(properties).convert(protobufSchema);
     Schema actualSchema = new Schema.Parser().parse(actual);
 
     Schema expectedSchema = parser.parse(getClass().getClassLoader().getResourceAsStream("schema-provider/proto/parent_schema_recursive_default_limit.avsc"));

--- a/pom.xml
+++ b/pom.xml
@@ -1814,6 +1814,12 @@
         <groupId>io.confluent</groupId>
         <artifactId>kafka-json-schema-serializer</artifactId>
         <version>${confluent.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.kjetland</groupId>
+            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.kjetland</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1815,6 +1815,11 @@
         <artifactId>kafka-json-schema-serializer</artifactId>
         <version>${confluent.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.kjetland</groupId>
+        <artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
+        <version>1.0.39</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1810,6 +1810,11 @@
         <artifactId>kafka-protobuf-serializer</artifactId>
         <version>${confluent.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-json-schema-serializer</artifactId>
+        <version>${confluent.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <repositories>


### PR DESCRIPTION
### Change Logs

- Migrates to using the Confluent registry client in order to properly resolve the proto schema references
- Updates schema converters to operate on the `ParsedSchema` returned by the SDK

### Impact

- Allows users to properly resolve the schemas returned by the confluent registry

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
