### PR TITLE
[HUDI-4625] Clean up KafkaOffsetGen: introduce retrying KafkaConsumer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -76,7 +76,7 @@ public class KafkaSourceConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Schema to deserialize the records.");
 
-
+  @Deprecated
   public static final ConfigProperty<Long> KAFKA_FETCH_PARTITION_TIME_OUT = ConfigProperty
       .key(PREFIX + "fetch_partition.time.out")
       .defaultValue(300 * 1000L)
@@ -137,6 +137,35 @@ public class KafkaSourceConfig extends HoodieConfig {
       .defaultValue(ByteArrayDeserializer.class.getName())
       .sinceVersion("0.15.0")
       .withDocumentation("Kafka Proto Payload Deserializer Class");
+
+  public static final ConfigProperty<Long> INITIAL_RETRY_INTERVAL_MS = ConfigProperty
+      .key(PREFIX + "retry.initial_interval_ms")
+      .defaultValue(100L)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Amount of time (in ms) to wait, before retry to do operations on KafkaConsumer.");
+
+  public static final ConfigProperty<Long> MAX_RETRY_INTERVAL_MS = ConfigProperty
+      .key(PREFIX + "retry.max_interval_ms")
+      .defaultValue(2000L)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Maximum amount of time (in ms), to wait for next retry.");
+
+  public static final ConfigProperty<Integer> MAX_RETRY_COUNT = ConfigProperty
+      .key(PREFIX + "retry.max_count")
+      .defaultValue(4)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Maximum number of retry actions to perform, with exponential backoff.");
+
+  public static final ConfigProperty<String> RETRY_EXCEPTIONS = ConfigProperty
+      .key(PREFIX + "retry.exceptions")
+      .defaultValue("")
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("The class name of the Exception that needs to be retried, separated by commas. "
+          + "Default is empty which means retry all the IOException and RuntimeException from KafkaConsumer");
 
   /**
    * Kafka reset offset strategies.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieRetryingKafkaConsumer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieRetryingKafkaConsumer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.RetryHelper;
+import org.apache.hudi.utilities.config.KafkaSourceConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Retrying client for {@link KafkaConsumer} operations.
+ */
+public class HoodieRetryingKafkaConsumer extends KafkaConsumer {
+
+  private final long maxRetryIntervalMs;
+  private final int maxRetryCount;
+  private final long initialRetryIntervalMs;
+  private final String retryExceptionsList;
+
+  public HoodieRetryingKafkaConsumer(TypedProperties config, Map<String, Object> kafkaParams) {
+    super(kafkaParams);
+    this.maxRetryIntervalMs = config.getLong(KafkaSourceConfig.MAX_RETRY_INTERVAL_MS.key(),
+        KafkaSourceConfig.MAX_RETRY_INTERVAL_MS.defaultValue());
+    this.maxRetryCount = config.getInteger(KafkaSourceConfig.MAX_RETRY_COUNT.key(),
+        KafkaSourceConfig.MAX_RETRY_COUNT.defaultValue());
+    this.initialRetryIntervalMs = config.getLong(KafkaSourceConfig.INITIAL_RETRY_INTERVAL_MS.key(),
+        KafkaSourceConfig.INITIAL_RETRY_INTERVAL_MS.defaultValue());
+    this.retryExceptionsList = config.getString(KafkaSourceConfig.RETRY_EXCEPTIONS.key(),
+        KafkaSourceConfig.RETRY_EXCEPTIONS.defaultValue());
+  }
+
+  @Override
+  public Map<TopicPartition, Long> beginningOffsets(Collection partitions) {
+    return new RetryHelper<Map<TopicPartition, Long>, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.beginningOffsets(partitions));
+  }
+
+  @Override
+  public Map<TopicPartition, Long> endOffsets(Collection partitions) {
+    return new RetryHelper<Map<TopicPartition, Long>, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.endOffsets(partitions));
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    return new RetryHelper<List<PartitionInfo>, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.partitionsFor(topic));
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map timestampsToSearch) {
+    return new RetryHelper<Map<TopicPartition, OffsetAndTimestamp>, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.offsetsForTimes(timestampsToSearch));
+  }
+
+  @Override
+  public Map<String, List<PartitionInfo>> listTopics() {
+    return new RetryHelper<Map<String, List<PartitionInfo>>, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.listTopics());
+  }
+
+  @Override
+  public OffsetAndMetadata committed(TopicPartition partition) {
+    return new RetryHelper<OffsetAndMetadata, KafkaException>(
+        maxRetryIntervalMs, maxRetryCount, initialRetryIntervalMs, retryExceptionsList)
+        .start(() -> super.committed(partition));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -27,6 +27,7 @@ import org.apache.hudi.utilities.config.KafkaSourceConfig;
 import org.apache.hudi.utilities.exception.HoodieStreamerException;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
 import org.apache.hudi.utilities.streamer.SourceFormatAdapter;
 import org.apache.hudi.utilities.streamer.SourceProfile;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
@@ -214,7 +215,7 @@ public abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarne
     InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(), 599);
     // commit to kafka after first batch
     kafkaSource.getSource().onCommit(fetch1.getCheckpointForNextBatch());
-    try (KafkaConsumer consumer = new KafkaConsumer(props)) {
+    try (KafkaConsumer consumer = new HoodieRetryingKafkaConsumer(props, KafkaOffsetGen.excludeHoodieConfigs(props))) {
       consumer.assign(topicPartitions);
 
       OffsetAndMetadata offsetAndMetadata = consumer.committed(topicPartition0);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -259,6 +259,8 @@ public class TestKafkaOffsetGen {
     assertEquals(300, nextOffsetRanges[0].untilOffset());
 
     props.put(KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS.key(), 2L);
+    // just to check warn-message manually if props contains deprecated config
+    props.put(KafkaSourceConfig.KAFKA_FETCH_PARTITION_TIME_OUT.key(), 1L);
     kafkaOffsetGen = new KafkaOffsetGen(props);
     nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
     assertEquals(0, nextOffsetRanges[0].fromOffset());


### PR DESCRIPTION
### Change Logs

Cleanup KafkaOffsetGen: introduced retrying configurable KafkaConsumer.

### Impact

Using proper retrying client

### Risk level (write none, low medium or high below)

none

### Documentation Update

Documentation update is needed in part of KafkaSourceConfig:  
- remove KAFKA_FETCH_PARTITION_TIME_OUT;  
- add INITIAL_RETRY_INTERVAL_MS, MAX_RETRY_INTERVAL_MS, MAX_RETRY_COUNT, RETRY_EXCEPTIONS.


- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
