### PR TITLE
[HUDI-7993] Apply record index if _hoodie_record_key meta field in filter

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -206,7 +206,7 @@ object RecordLevelIndexSupport {
     if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
       true
     } else {
-      HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == recordKeyOpt.get
+      HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == attributeName
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -23,13 +23,18 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, FromUnixTime, GreaterThan, In, Literal, Not}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.TimeZone
 
 class TestRecordLevelIndexSupport {
-  @Test
-  def testFilterQueryWithRecordKey(): Unit = {
+  // dummy record key field
+  val recordKeyField = "_row_key"
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("_row_key", "_hoodie_record_key"))
+  def testFilterQueryWithRecordKey(filterColumnName: String): Unit = {
     // Case 1: EqualTo filters not on simple AttributeReference and non-Literal should return empty result
     val fmt = "yyyy-MM-dd HH:mm:ss"
     val fromUnixTime = FromUnixTime(Literal(0L), Literal(fmt), Some(TimeZone.getDefault.getID))
@@ -43,50 +48,61 @@ class TestRecordLevelIndexSupport {
     assertTrue(result.isEmpty)
 
     // Case 3: EqualTo filters on simple AttributeReference and non-Literal should return empty result
-    testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), fromUnixTime)
+    testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), fromUnixTime)
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty)
     assertTrue(result.isEmpty)
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
-    testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
+    testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("row1")))
 
-    // case 5: EqualTo on fields other than record key should return empty result
+    // case 5: EqualTo on fields other than record key should return empty result unless it's _hoodie_record_key
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"))
-    assertTrue(result.isEmpty)
+    if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
+      assertTrue(result.isDefined)
+      assertEquals(result, Option.apply(testFilter, List.apply("row1")))
+    } else {
+      assertTrue(result.isEmpty)
+    }
 
-    // Case 6: In filter on fields other than record key should return empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
+    // Case 6: In filter on fields other than record key should return empty result unless it's _hoodie_record_key
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"))
-    assertTrue(result.isEmpty)
+    if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
+      assertTrue(result.isDefined)
+      assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
+    } else {
+      assertTrue(result.isEmpty)
+    }
 
     // Case 7: In filter on record key should return non-empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
     assertTrue(result.isDefined)
+    assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(fromUnixTime))
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
     // Case 9: Anything other than EqualTo and In predicate is not supported. Hence it returns empty result
-    testFilter = Not(In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
+    testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
-    testFilter = Not(In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(fromUnixTime)))
+    testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime)))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
-    testFilter = GreaterThan(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
+    testFilter = GreaterThan(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
     testFilter = EqualTo(AttributeReference(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("row1")))
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -49,7 +49,7 @@ class TestRecordLevelIndexSupport {
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
     testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("row1")))
 
@@ -64,7 +64,7 @@ class TestRecordLevelIndexSupport {
 
     // Case 7: In filter on record key should return non-empty result
     testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
     assertTrue(result.isDefined)
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result
@@ -84,5 +84,10 @@ class TestRecordLevelIndexSupport {
     testFilter = GreaterThan(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
+
+    testFilter = EqualTo(AttributeReference(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName, StringType, nullable = true)(), Literal("row1"))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("_row_key"))
+    assertTrue(result.isDefined)
+    assertEquals(result, Option.apply(testFilter, List.apply("row1")))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -100,10 +100,5 @@ class TestRecordLevelIndexSupport {
     testFilter = GreaterThan(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
-
-    testFilter = EqualTo(AttributeReference(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
-    assertTrue(result.isDefined)
-    assertEquals(result, Option.apply(testFilter, List.apply("row1")))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
@@ -51,7 +51,7 @@ class TestSecondaryIndexSupport {
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
     testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
-    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
+    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("_row_key"))._2
     assertTrue(result.nonEmpty)
     assertEquals(result, List.apply("row1"))
 
@@ -66,7 +66,7 @@ class TestSecondaryIndexSupport {
 
     // Case 7: In filter on record key should return non-empty result
     testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
+    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("_row_key"))._2
     assertTrue(result.nonEmpty)
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
@@ -24,14 +24,18 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, FromUnixTime, GreaterThan, In, Literal, Not}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.TimeZone
 
 class TestSecondaryIndexSupport {
+  // dummy record key field
+  val recordKeyField = "_row_key"
 
-  @Test
-  def testFilterQueryWithSecondaryKey(): Unit = {
+  @ParameterizedTest
+  @ValueSource(strings = Array("_row_key", "_hoodie_record_key"))
+  def testFilterQueryWithSecondaryKey(filterColumnName: String): Unit = {
     // Case 1: EqualTo filters not on simple AttributeReference and non-Literal should return empty result
     val fmt = "yyyy-MM-dd HH:mm:ss"
     val fromUnixTime = FromUnixTime(Literal(0L), Literal(fmt), Some(TimeZone.getDefault.getID))
@@ -45,45 +49,55 @@ class TestSecondaryIndexSupport {
     assertTrue(result.isEmpty)
 
     // Case 3: EqualTo filters on simple AttributeReference and non-Literal should return empty result
-    testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), fromUnixTime)
+    testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), fromUnixTime)
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.empty)._2
     assertTrue(result.isEmpty)
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
-    testFilter = EqualTo(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
-    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("_row_key"))._2
+    testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
+    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(recordKeyField))._2
     assertTrue(result.nonEmpty)
     assertEquals(result, List.apply("row1"))
 
     // case 5: EqualTo on fields other than record key should return empty result
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("blah"))._2
-    assertTrue(result.isEmpty)
+    if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
+      assertTrue(result.nonEmpty)
+      assertEquals(result, List.apply("row1"))
+    } else {
+      assertTrue(result.isEmpty)
+    }
 
     // Case 6: In filter on fields other than record key should return empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("blah"))._2
-    assertTrue(result.isEmpty)
+    if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
+      assertTrue(result.nonEmpty)
+      assertEquals(result, List.apply("xyz", "abc"))
+    } else {
+      assertTrue(result.isEmpty)
+    }
 
     // Case 7: In filter on record key should return non-empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply("_row_key"))._2
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
+    result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(recordKeyField))._2
     assertTrue(result.nonEmpty)
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result
-    testFilter = In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(fromUnixTime))
+    testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime))
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
 
     // Case 9: Anything other than EqualTo and In predicate is not supported. Hence it returns empty result
-    testFilter = Not(In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
+    testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
 
-    testFilter = Not(In(AttributeReference("_row_key", StringType, nullable = true)(), List.apply(fromUnixTime)))
+    testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime)))
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
 
-    testFilter = GreaterThan(AttributeReference("_row_key", StringType, nullable = true)(), Literal("row1"))
+    testFilter = GreaterThan(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -42,6 +42,7 @@ import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 import scala.collection.{JavaConverters, mutable}
+import scala.util.Using
 
 class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   var spark: SparkSession = _
@@ -282,8 +283,9 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   }
 
   protected def getFileGroupCountForRecordIndex(writeConfig: HoodieWriteConfig): Long = {
-    val tableMetadata = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata]
-    tableMetadata.getMetadataFileSystemView.getAllFileGroups(MetadataPartitionType.RECORD_INDEX.getPartitionPath).count
+    Using(getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata]) { metadataTable =>
+      metadataTable.getMetadataFileSystemView.getAllFileGroups(MetadataPartitionType.RECORD_INDEX.getPartitionPath).count
+    }.get
   }
 
   protected def validateDataAndRecordIndices(hudiOpts: Map[String, String],

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -17,19 +17,21 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.RECORD_KEY_METADATA_FIELD
 import org.apache.hudi.common.model.{FileSlice, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView
 import org.apache.hudi.util.JFunction
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieFileIndex, RecordLevelIndexSupport}
-
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, Literal, Or}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
+import scala.util.Using
 
 @Tag("functional")
 class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
@@ -55,12 +57,17 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
       onlyUpdates = true)
 
     createTempTable(hudiOpts)
-    verifyInQuery(hudiOpts)
-    verifyEqualToQuery(hudiOpts)
-    verifyNegativeTestCases(hudiOpts)
+    val latestSnapshotDf = spark.read.format("hudi").options(hudiOpts).load(basePath)
+    verifyInQuery(hudiOpts, "_row_key", latestSnapshotDf)
+    verifyEqualToQuery(hudiOpts, "_row_key", latestSnapshotDf)
+    verifyNegativeTestCases(hudiOpts, "_row_key", latestSnapshotDf)
+    // verify the same for _hoodie_record_key
+    verifyInQuery(hudiOpts, RECORD_KEY_METADATA_FIELD.getFieldName, latestSnapshotDf)
+    verifyEqualToQuery(hudiOpts, RECORD_KEY_METADATA_FIELD.getFieldName, latestSnapshotDf)
+    verifyNegativeTestCases(hudiOpts, RECORD_KEY_METADATA_FIELD.getFieldName, latestSnapshotDf)
   }
 
-  private def verifyNegativeTestCases(hudiOpts: Map[String, String]): Unit = {
+  private def verifyNegativeTestCases(hudiOpts: Map[String, String], colName: String, latestSnapshotDf: DataFrame): Unit = {
     val commonOpts = hudiOpts + ("path" -> basePath)
     metaClient = HoodieTableMetaClient.reload(metaClient)
     val fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts, includeLogFiles = true)
@@ -70,45 +77,45 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     assertEquals(5, spark.sql("select * from " + sqlTempTable).count())
 
     // non existing entries in EqualTo query
-    var dataFilter: Expression = EqualTo(attribute("_row_key"), Literal("xyz"))
+    var dataFilter: Expression = EqualTo(attribute(colName), Literal("xyz"))
     assertEquals(0, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     assertEquals(0, fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size)
 
     // non existing entries in IN query
-    dataFilter = In(attribute("_row_key"), List.apply(Literal("xyz"), Literal("abc")))
+    dataFilter = In(attribute(colName), List.apply(Literal("xyz"), Literal("abc")))
     assertEquals(0, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     assertEquals(0, fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size)
 
     // not supported GreaterThan query
-    val reckey = mergedDfList.last.limit(2).collect().map(row => row.getAs("_row_key").toString)
-    dataFilter = GreaterThan(attribute("_row_key"), Literal(reckey(0)))
+    val reckey = latestSnapshotDf.limit(2).collect().map(row => row.getAs(colName).toString)
+    dataFilter = GreaterThan(attribute(colName), Literal(reckey(0)))
     assertTrue(fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size >= 3)
 
     // not supported OR query
-    dataFilter = Or(EqualTo(attribute("_row_key"), Literal(reckey(0))), GreaterThanOrEqual(attribute("timestamp"), Literal(0)))
+    dataFilter = Or(EqualTo(attribute(colName), Literal(reckey(0))), GreaterThanOrEqual(attribute("timestamp"), Literal(0)))
     assertEquals(5, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     assertTrue(fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size >= 3)
   }
 
-  def verifyEqualToQuery(hudiOpts: Map[String, String]): Unit = {
-    val reckey = mergedDfList.last.limit(1).collect().map(row => row.getAs("_row_key").toString)
-    val dataFilter = EqualTo(attribute("_row_key"), Literal(reckey(0)))
+  def verifyEqualToQuery(hudiOpts: Map[String, String], colName: String, latestSnapshotDf: DataFrame): Unit = {
+    val reckey = latestSnapshotDf.limit(1).collect().map(row => row.getAs(colName).toString)
+    val dataFilter = EqualTo(attribute(colName), Literal(reckey(0)))
     assertEquals(1, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     val numFiles = if (isTableMOR()) 2 else 1
     verifyPruningFileCount(hudiOpts, dataFilter, numFiles)
   }
 
-  def verifyInQuery(hudiOpts: Map[String, String]): Unit = {
-    var reckey = mergedDfList.last.limit(1).collect().map(row => row.getAs("_row_key").toString)
-    var dataFilter = In(attribute("_row_key"), reckey.map(l => literal(l)).toList)
+  def verifyInQuery(hudiOpts: Map[String, String], colName: String, latestSnapshotDf: DataFrame): Unit = {
+    var reckey = latestSnapshotDf.limit(1).collect().map(row => row.getAs(colName).toString)
+    var dataFilter = In(attribute(colName), reckey.map(l => literal(l)).toList)
     assertEquals(1, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     var numFiles = if (isTableMOR()) 2 else 1
     verifyPruningFileCount(hudiOpts, dataFilter, numFiles)
 
     val partitions = Seq("2015/03/16", "2015/03/17")
-    reckey = mergedDfList.last.collect().filter(row => partitions.contains(row.getAs("partition").toString))
-      .map(row => row.getAs("_row_key").toString)
-    dataFilter = In(attribute("_row_key"), reckey.map(l => literal(l)).toList)
+    reckey = latestSnapshotDf.collect().filter(row => partitions.contains(row.getAs("partition").toString))
+      .map(row => row.getAs(colName).toString)
+    dataFilter = In(attribute(colName), reckey.map(l => literal(l)).toList)
     assertEquals(reckey.length, spark.sql("select * from " + sqlTempTable + " where " + dataFilter.sql).count())
     numFiles = if (isTableMOR()) 4 else 2
     verifyPruningFileCount(hudiOpts, dataFilter, numFiles)
@@ -144,13 +151,15 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
 
   private def getLatestDataFilesCount(opts: Map[String, String], includeLogFiles: Boolean = true) = {
     var totalLatestDataFiles = 0L
-    getTableFileSystenView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
-      .values()
-      .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
-        (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
-          slice => totalLatestDataFiles += (if (includeLogFiles) slice.getLogFiles.count() else 0)
-            + (if (slice.getBaseFile.isPresent) 1 else 0)))))
-    totalLatestDataFiles
+    Using(getTableFileSystenView(opts)) { fsView =>
+      fsView.getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
+        .values()
+        .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
+          (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
+            slice => totalLatestDataFiles += (if (includeLogFiles) slice.getLogFiles.count() else 0)
+              + (if (slice.getBaseFile.isPresent) 1 else 0)))))
+      totalLatestDataFiles
+    }.get
   }
 
   private def getTableFileSystenView(opts: Map[String, String]): HoodieMetadataFileSystemView = {


### PR DESCRIPTION
### Change Logs

Apply data skipping with record index if the query contains filter on `_hoodie_record_key`. This PR assumes that the literal in the predicate expression will be correctly specified by the user if the table has mutliple record key fields.

### Impact

Data skipping with record key meta field.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
