### PR TITLE
[HUDI-7881] Compare bigquery table base path via source-uris if hive partitioning options are not available

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -335,6 +335,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
         LOG.warn("Base path in table source uris: {}, new base path: {}", sourceUris, basePathWithTrailingSlash);
       }
       return isTableBasePathUpdated;
+    }
     String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
     basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
     boolean isTableBasePathUpdated = !basePathInTableDefinition.equals(basePath);

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -335,15 +335,13 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
         LOG.warn("Base path in table source uris: {}, new base path: {}", sourceUris, basePathWithTrailingSlash);
       }
       return isTableBasePathUpdated;
-    } else {
-      String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
-      basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
-      boolean isTableBasePathUpdated = !basePathInTableDefinition.equals(basePath);
-      if (isTableBasePathUpdated) {
-        LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);
-      }
-      return isTableBasePathUpdated;
+    String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
+    basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
+    boolean isTableBasePathUpdated = !basePathInTableDefinition.equals(basePath);
+    if (isTableBasePathUpdated) {
+      LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);
     }
+    return isTableBasePathUpdated;
   }
 
   @Override

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -327,7 +327,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     String basePath = StringUtils.stripEnd(getBasePath(), "/");
     if (externalTableDefinition.getHivePartitioningOptions() == null) {
       List<String> sourceUris = Option.ofNullable(externalTableDefinition.getSourceUris()).orElse(Collections.emptyList());
-      // compare source uris with trailing slash to make sure it unwanted prefix matches are avoided
+      // compare source uris with trailing slash to make sure the unwanted prefix matches are avoided
       String basePathWithTrailingSlash = String.format("%s/", basePath);
       boolean isTableBasePathUpdated = sourceUris.stream()
           .noneMatch(sourceUri -> sourceUri.startsWith(basePathWithTrailingSlash));

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.gcp.bigquery;
 
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.sync.common.HoodieSyncClient;
@@ -52,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID;
@@ -326,7 +326,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
   private boolean isBasePathUpdated(ExternalTableDefinition externalTableDefinition) {
     String basePath = StringUtils.stripEnd(getBasePath(), "/");
     if (externalTableDefinition.getHivePartitioningOptions() == null) {
-      List<String> sourceUris = Optional.ofNullable(externalTableDefinition.getSourceUris()).orElse(Collections.emptyList());
+      List<String> sourceUris = Option.ofNullable(externalTableDefinition.getSourceUris()).orElse(Collections.emptyList());
       // compare source uris with trailing slash to make sure it unwanted prefix matches are avoided
       String basePathWithTrailingSlash = String.format("%s/", basePath);
       boolean isTableBasePathUpdated = sourceUris.stream()

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID;
@@ -297,6 +298,7 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
 
   /**
    * Checks for the existence of a table that uses the manifest file approach and matches other requirements.
+   *
    * @param tableName name of the table
    * @return Returns true if the table does not exist or if the table does exist but does not use the manifest file or table base path is outdated. False otherwise.
    */
@@ -310,15 +312,8 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
     boolean manifestDoesNotExist =
         externalTableDefinition.getSourceUris() == null
             || externalTableDefinition.getSourceUris().stream().noneMatch(uri -> uri.contains(ManifestFileWriter.ABSOLUTE_PATH_MANIFEST_FOLDER_NAME));
-    String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions() == null ? "" :
-        externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
-    // remove trailing slash
-    basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
-    String basePath = getBasePath();
-    basePath = StringUtils.stripEnd(basePath, "/");
-    if (!basePathInTableDefinition.equals(basePath)) {
+    if (isBasePathUpdated(externalTableDefinition)) {
       // if table base path is outdated, we need to replace the table.
-      LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);
       return true;
     }
     if (!StringUtils.isNullOrEmpty(config.getString(BIGQUERY_SYNC_BIG_LAKE_CONNECTION_ID))) {
@@ -326,6 +321,29 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
       return manifestDoesNotExist || externalTableDefinition.getConnectionId() == null;
     }
     return manifestDoesNotExist;
+  }
+
+  private boolean isBasePathUpdated(ExternalTableDefinition externalTableDefinition) {
+    String basePath = StringUtils.stripEnd(getBasePath(), "/");
+    if (externalTableDefinition.getHivePartitioningOptions() == null) {
+      List<String> sourceUris = Optional.ofNullable(externalTableDefinition.getSourceUris()).orElse(Collections.emptyList());
+      // compare source uris with trailing slash to make sure it unwanted prefix matches are avoided
+      String basePathWithTrailingSlash = String.format("%s/", basePath);
+      boolean isTableBasePathUpdated = sourceUris.stream()
+          .noneMatch(sourceUri -> sourceUri.startsWith(basePathWithTrailingSlash));
+      if (isTableBasePathUpdated) {
+        LOG.warn("Base path in table source uris: {}, new base path: {}", sourceUris, basePathWithTrailingSlash);
+      }
+      return isTableBasePathUpdated;
+    } else {
+      String basePathInTableDefinition = externalTableDefinition.getHivePartitioningOptions().getSourceUriPrefix();
+      basePathInTableDefinition = StringUtils.stripEnd(basePathInTableDefinition, "/");
+      boolean isTableBasePathUpdated = !basePathInTableDefinition.equals(basePath);
+      if (isTableBasePathUpdated) {
+        LOG.warn("Base path in table definition: {}, new base path: {}", basePathInTableDefinition, basePath);
+      }
+      return isTableBasePathUpdated;
+    }
   }
 
   @Override

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -187,6 +187,11 @@ public class TestHoodieBigQuerySyncClient {
     assertTrue(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
 
     // manifest exists but base path is outdated
+    when(externalTableDefinition.getSourceUris()).thenReturn(Collections.singletonList(
+        basePath + "/.hoodie/" + ManifestFileWriter.ABSOLUTE_PATH_MANIFEST_FOLDER_NAME));
+    assertFalse(client.tableNotExistsOrDoesNotMatchSpecification(TEST_TABLE));
+
+    // manifest exists but base path is outdated
     when(externalTableDefinition.getSourceUris()).thenReturn(Collections.singletonList(ManifestFileWriter.ABSOLUTE_PATH_MANIFEST_FOLDER_NAME));
     when(externalTableDefinition.getHivePartitioningOptions()).thenReturn(
         HivePartitioningOptions.newBuilder().setSourceUriPrefix(basePath + "1").build());


### PR DESCRIPTION
### Change Logs

To verify if the bigquery table basepath is updated or not, use source-uris as well if hive partitioning options are not available.

### Impact

This will fix the issue with bigquery sync always creating the same table where hive partitioning options are not available.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
