### PR TITLE
[HUDI-8040] Fix SimpleConcurrentFileWritesConflictResolutionStrategy get pending clustering wrong

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieWriteConflictException;
@@ -62,6 +63,8 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
 
     Stream<HoodieInstant> compactionAndClusteringPendingTimeline = activeTimeline
         .filterPendingReplaceClusteringAndCompactionTimeline()
+        .filter(instant -> ClusteringUtils.isClusteringInstant(activeTimeline, instant)
+            || HoodieTimeline.COMPACTION_ACTION.equals(instant.getAction()))
         .findInstantsAfter(currentInstant.getTimestamp())
         .getInstantsAsStream();
     return Stream.concat(completedCommitsInstantStream, compactionAndClusteringPendingTimeline);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -144,6 +144,19 @@ public class TestConflictResolutionStrategyUtil {
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
   }
 
+  public static void createPendingInsertOverwrite(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {
+    //insert_overwrite
+    String fileId1 = "file-1";
+    String fileId2 = "file-2";
+
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
+    HoodieReplaceCommitMetadata replaceMetadata = new HoodieReplaceCommitMetadata();
+
+    HoodieTestTable.of(metaClient)
+        .addPendingReplace(instantTime, Option.of(requestedReplaceMetadata), Option.empty())
+        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+  }
+
   public static void createReplace(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {
     String fileId1 = "file-1";
     String fileId2 = "file-2";


### PR DESCRIPTION

### Change Logs

Because replacecommit can be clustering, insert overwrite and delete partition. In SimpleConcurrentFileWritesConflictResolutionStrategy funciton getCandidateInstants, here only want to get pending clustering but actually it get pending replacommit(contains insert overwrite).   when we get insert overwrite, it will case BucketIndexConcurrentFileWritesConflictResolutionStrategy hasConflict function BucketIdentifier.bucketIdFromFileId throw arrayIndexOutofBound Exception.  （see the discussion in https://github.com/apache/hudi/issues/11516）

So, in SimpleConcurrentFileWritesConflictResolutionStrategy getCandidateInstants, we filter real clustring instant.


### Impact

NA 

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA 

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
