### PR TITLE
[HUDI-8029] Enforce s3 base path format for partition key calculation

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import static org.apache.hudi.aws.utils.S3Utils.s3aToS3;
 import static org.apache.hudi.common.util.StringUtils.concatenateWithThreshold;
 import static org.apache.hudi.config.DynamoDbBasedLockConfig.MAX_PARTITION_KEY_SIZE_BYTE;
 
@@ -54,7 +55,7 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   public static String generatePartitionKey(String basePath, String tableName) {
     String hashPart = '-' + HashID.generateXXHashAsString(basePath, HashID.Size.BITS_64);
     String partitionKey = concatenateWithThreshold(tableName, hashPart, MAX_PARTITION_KEY_SIZE_BYTE);
-    LOG.info(String.format("Partition key for base path %s is %s", basePath, partitionKey));
+    LOG.info(String.format("The DynamoDB partition key of the lock provider for the base path %s is %s", basePath, partitionKey));
     return partitionKey;
   }
 
@@ -62,6 +63,7 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   public String getDynamoDBPartitionKey(LockConfiguration lockConfiguration) {
     String hudiTableBasePath = lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key());
     String hudiTableName = lockConfiguration.getConfig().getString(HoodieTableConfig.HOODIE_TABLE_NAME_KEY);
-    return generatePartitionKey(hudiTableBasePath, hudiTableName);
+    // Ensure consistent format for S3 URI.
+    return generatePartitionKey(s3aToS3(hudiTableBasePath), hudiTableName);
   }
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/utils/S3UtilsTest.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/utils/S3UtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.apache.hudi.aws.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class S3UtilsTest {
+
+  @Test
+  void testS3aToS3_AWS() {
+    // Test cases for AWS S3 URLs
+    assertEquals("s3://my-bucket/path/to/object", S3Utils.s3aToS3("s3a://my-bucket/path/to/object"));
+    assertEquals("s3://my-bucket", S3Utils.s3aToS3("s3a://my-bucket"));
+    assertEquals("s3://MY-BUCKET/PATH/TO/OBJECT", S3Utils.s3aToS3("s3a://MY-BUCKET/PATH/TO/OBJECT"));
+    assertEquals("s3://my-bucket/path/to/object", S3Utils.s3aToS3("S3a://my-bucket/path/to/object"));
+    assertEquals("s3://my-bucket/path/to/object", S3Utils.s3aToS3("s3A://my-bucket/path/to/object"));
+    assertEquals("s3://my-bucket/path/to/object", S3Utils.s3aToS3("S3A://my-bucket/path/to/object"));
+    assertEquals("s3://my-bucket/s3a://another-bucket/another/path", S3Utils.s3aToS3("s3a://my-bucket/s3a://another-bucket/another/path"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "gs://my-bucket/path/to/object",
+      "gs://my-bucket",
+      "gs://MY-BUCKET/PATH/TO/OBJECT",
+      "https://myaccount.blob.core.windows.net/mycontainer/path/to/blob",
+      "https://myaccount.blob.core.windows.net/MYCONTAINER/PATH/TO/BLOB",
+      "https://example.com/path/to/resource",
+      "http://example.com",
+      "ftp://example.com/resource",
+      "",
+      "gs://my-bucket/path/to/s3a://object",
+      "gs://my-bucket s3a://my-object",
+
+  })
+  void testUriDoesNotChange(String uri) {
+    assertEquals(uri, S3Utils.s3aToS3(uri));
+  }
+}

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/utils/TestS3Utils.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/utils/TestS3Utils.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class S3UtilsTest {
+class TestS3Utils {
 
   @Test
   void testS3aToS3_AWS() {


### PR DESCRIPTION
DynamoDBBasedImplicitPartitionKeyLockProvider as a lock provider derives its partition key from hudi table name and hudi table base path. Considering the s3 uri can be of prefix s3:// or s3a://. It is enforced that we always use s3:// version when doing the partition key calculation.

### Change Logs

Implementation + test

### Impact

None

### Risk level (write none, low medium or high below)

None as this lock provider is not in use yet.

### Documentation Update

Regarding the implicit partition key calculation, we should explicitly mention that if the base path of the hudi table is a s3 uri and it's prefix is "s3a", before calculating the hash value the prefix is replaced with "s3".

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
