### PR TITLE
[HUDI-8030] Fix for add missing table configurations to payloadProps (fixes #11685)

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -88,6 +88,7 @@ public abstract class AbstractRealtimeRecordReader {
     try {
       metaClient = HoodieTableMetaClient.builder()
           .setConf(HadoopFSUtils.getStorageConfWithCopy(jobConf)).setBasePath(split.getBasePath()).build();
+      payloadProps.putAll(metaClient.getTableConfig().getProps(true));
       if (metaClient.getTableConfig().getPreCombineField() != null) {
         this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineField());
       }


### PR DESCRIPTION
### Change Logs

fix for add missing table configurations to payloadProps (fixes #11685)

### Impact

Add table configurations to the `payloadProps` of `AbstractRealtimeRecordReader` so that they can be used in custom payload.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
