### PR TITLE
[HUDI-8035] Fetching commit metadata from timeline fails during upgrade

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -275,8 +275,8 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
   }
 
   private String getCompleteFileName(String completionTime) {
-    String timestampWithCompletionTime = timestamp +
-        (StringUtils.isNullOrEmpty(completionTime) ? "" : "_" + completionTime);
+    String timestampWithCompletionTime = timestamp
+        + (StringUtils.isNullOrEmpty(completionTime) ? "" : "_" + completionTime);
     switch (action) {
       case HoodieTimeline.COMMIT_ACTION:
       case HoodieTimeline.COMPACTION_ACTION:

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -719,6 +719,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     assertNull(instants.get(0).getCompletionTime(), "Requested instant does not have completion time");
     assertNull(instants.get(1).getCompletionTime(), "Inflight instant does not have completion time");
     assertNotNull(instants.get(2).getCompletionTime(), "Completed instant has modification time as completion time for 0.x release");
+    assertEquals(instants.get(2).getTimestamp() + HoodieTimeline.COMMIT_EXTENSION, instants.get(2).getFileName(), "Instant file name should not have completion time");
   }
 
   /**


### PR DESCRIPTION
### Change Logs

If the table has all timeline instants files with the older format without completion time, the upgrade fails because org.apache.hudi.common.table.timeline.HoodieActiveTimeline#getInstantDetails is trying to read file with completion time.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
