### PR TITLE
[HUDI-8037] allow filter query of timestamp partition column for mor rt if timestamp keygen is used to change the pattern 

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -22,11 +22,12 @@ import org.apache.hudi.DataSourceWriteOptions.{PARTITIONPATH_FIELD, PRECOMBINE_F
 import org.apache.hudi.HoodieFileIndex.{DataSkippingFailureMode, collectReferencedColumns, convertFilterForTimestampKeyGenerator, getConfigProperties}
 import org.apache.hudi.HoodieSparkConfUtils.getConfigValue
 import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT}
-import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, TimestampKeyGeneratorConfig, TypedProperties}
 import org.apache.hudi.common.model.{FileSlice, HoodieBaseFile, HoodieLogFile}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
-import org.apache.hudi.common.util.StringUtils
+import org.apache.hudi.common.util.{DateTimeUtils, StringUtils}
 import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.keygen.parser.HoodieDateTimeParser
 import org.apache.hudi.keygen.{TimestampBasedAvroKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.storage.{StoragePath, StoragePathInfo}
 import org.apache.hudi.util.JFunction
@@ -35,14 +36,18 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Expression, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal}
 import org.apache.spark.sql.execution.datasources.{FileIndex, FileStatusCache, NoopCache, PartitionDirectory}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
 
+import java.sql.Timestamp
 import java.text.SimpleDateFormat
+import java.util.TimeZone
 import java.util.stream.Collectors
 import javax.annotation.concurrent.NotThreadSafe
 
@@ -534,23 +539,31 @@ object HoodieFileIndex extends Logging {
         partitionFilters
       } else {
         try {
-          val inDateFormat = new SimpleDateFormat(inputFormat)
-          val outDateFormat = new SimpleDateFormat(outputFormat)
+          val propsForTimestampParser = new TypedProperties(tableConfig.getProps)
+          propsForTimestampParser.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key,
+            TimestampBasedAvroKeyGenerator.TimestampType.DATE_STRING.name())
+          val dtParser = new HoodieDateTimeParser(propsForTimestampParser)
+          val inDateFormatter = dtParser.getInputFormatter.get()
+          val outTimeZone = if (dtParser.getOutputDateTimeZone == null) {
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT"))
+          } else {
+            dtParser.getOutputDateTimeZone
+          }
+          val outDateFormatter = DateTimeFormat.forPattern(dtParser.getOutputDateFormat).withZone(outTimeZone)
           partitionFilters.toArray.map {
-            _.transformDown {
+            _.transformUp {
               case Literal(value, dataType) if dataType.isInstanceOf[StringType] =>
-                try {
-                  val converted = outDateFormat.format(inDateFormat.parse(value.toString))
-                  Literal(UTF8String.fromString(converted), StringType)
-                } catch {
-                  case _: java.text.ParseException =>
-                    try {
-                      outDateFormat.parse(value.toString)
-                    } catch {
-                      case e: Exception => throw new HoodieException("Partition filter for TimestampKeyGenerator cannot be converted to format " + outDateFormat.toString, e)
-                    }
-                    Literal(UTF8String.fromString(value.toString), StringType)
-                }
+                val dateObj = inDateFormatter.parseDateTime(value.toString)
+                val converted = dateObj.withZone(outTimeZone).toString(outputFormat)
+                Literal(UTF8String.fromString(converted), StringType)
+              case Literal(value, dataType) if dataType.isInstanceOf[TimestampType] =>
+                val javaTime = Timestamp.from(DateTimeUtils.microsToInstant(value.asInstanceOf[Long]))
+                val dateObj = new DateTime(javaTime.getTime, outTimeZone)
+                val converted = dateObj.toString(outputFormat)
+                val dateObjRounded = outDateFormatter.parseDateTime(converted)
+                Literal(DateTimeUtils.instantToMicros(new Timestamp(dateObjRounded.getMillis).toInstant), TimestampType)
+              case GreaterThan(left, right) => GreaterThanOrEqual(left, right)
+              case LessThan(left, right) => LessThanOrEqual(left, right)
             }
           }
         } catch {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
@@ -52,7 +52,9 @@ case class HoodiePruneFileSourcePartitions(spark: SparkSession) extends Rule[Log
 
       // [[HudiFileIndex]] is a caching one, therefore we don't need to reconstruct new relation,
       // instead we simply just refresh the index and update the stats
-      fileIndex.filterFileSlices(dataFilters, partitionPruningFilters, isPartitionPruned = true)
+      fileIndex.filterFileSlices(dataFilters,
+        HoodieFileIndex.convertFilterForTimestampKeyGenerator(fileIndex.metaClient, partitionPruningFilters),
+        isPartitionPruned = true)
 
       if (partitionPruningFilters.nonEmpty) {
         // Change table stats based on the sizeInBytes of pruned files

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -20,8 +20,8 @@ package org.apache.hudi.functional
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.client.SparkRDDWriteClient
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TIMEZONE_FORMAT, TIMESTAMP_TYPE_FIELD}
-import org.apache.hudi.common.config.{HoodieMemoryConfig, HoodieMetadataConfig, HoodieStorageConfig}
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_INPUT_TIMEZONE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_TIMEZONE_FORMAT, TIMESTAMP_TIMEZONE_FORMAT, TIMESTAMP_TYPE_FIELD}
+import org.apache.hudi.common.config.{HoodieMemoryConfig, HoodieMetadataConfig, HoodieReaderConfig, HoodieStorageConfig}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -41,13 +41,15 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.{BooleanType, StringType, StructField, StructType}
+import org.joda.time.{DateTime, DateTimeZone}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
 import org.slf4j.LoggerFactory
 
+import java.util.TimeZone
 import java.util.function.Consumer
 
 import scala.collection.JavaConverters._
@@ -1210,6 +1212,131 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .load(basePath)
     assertEquals(0, incrementalQueryRes.where("partition = '2022-01-01'").count)
     assertEquals(20, incrementalQueryRes.where("partition = '2022-01-02'").count)
+  }
+
+  @ParameterizedTest
+  @CsvSource(Array("true,AVRO,yyyy-MM-dd,UTC,UTC,UTC,UTC", "true,SPARK,yyyy-MM,EDT,CST,EDT,EDT",
+    "false,AVRO,yyyy,EST,IST,IST,IST", "false,SPARK,yyyy/MM/dd,EST,MST,SGT,GMT", "false,SPARK,yyyy/MM/dd,EST,,SGT,GMT"))
+  def testPrunePartitionForTimestampBasedKeyGeneratorWithInformationLoss(enableFileIndex: Boolean,
+                                                                         recordType: HoodieRecordType,
+                                                                         timestampOutputFormat: String,
+                                                                         timestampInputTimezone: String,
+                                                                         timestampOutputTimezone: String,
+                                                                         writeTimezone: String,
+                                                                         readTimezone: String): Unit = {
+    val (writeOpts, readOpts) = getWriterReaderOpts(recordType, enableFileIndex = enableFileIndex)
+    val outputTimezone = if (timestampOutputTimezone == null) {
+      DateTimeZone.UTC
+    } else {
+      DateTimeZone.forTimeZone(TimeZone.getTimeZone(timestampOutputTimezone))
+    }
+
+    val writeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(writeTimezone))
+    val readZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(readTimezone))
+
+    val inputFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"
+    var options = commonOpts ++ Map(
+      "hoodie.compact.inline" -> "false",
+      DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+      DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.TimestampBasedKeyGenerator",
+      TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING",
+      TIMESTAMP_OUTPUT_DATE_FORMAT.key -> timestampOutputFormat,
+      TIMESTAMP_INPUT_TIMEZONE_FORMAT.key -> timestampInputTimezone,
+      TIMESTAMP_INPUT_DATE_FORMAT.key -> inputFormat
+    ) ++ writeOpts + (PARTITIONPATH_FIELD.key() -> "extra_partition_field")
+    if (timestampOutputTimezone != null) {
+      options = options + (TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key -> timestampOutputTimezone)
+    }
+
+    val readerOpts = readOpts + (HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key() -> "false")
+
+    val dataGen = new HoodieTestDataGenerator()
+    val records1 = recordsToStrings(dataGen.generateInserts("001", 96)).asScala
+    var inputDF1 = spark.read.json(spark.sparkContext.parallelize(records1, 1)).orderBy("_row_key")
+    val timestampColumnValues = Seq.range(0, 96).map(i => Row(new DateTime(2024, 7, 29, i / 4, 15 * (i % 4), outputTimezone).withZone(writeZone).toString(inputFormat)))
+    var timestampDf = spark.createDataFrame(spark.sparkContext.parallelize(timestampColumnValues, 1), StructType(Seq(StructField("extra_partition_field", StringType))))
+    timestampDf = timestampDf.withColumn("dateid", monotonically_increasing_id())
+
+    inputDF1 = inputDF1.withColumn("dateid", monotonically_increasing_id())
+    inputDF1 = inputDF1.join(timestampDf, "dateid").repartition(6)
+
+    inputDF1.write.format("org.apache.hudi")
+      .options(options)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    spark.read.format("hudi").options(readerOpts).load(basePath).createTempView("firstwrite")
+
+    val fiveFourFiveTS = new DateTime(2024, 7, 29, 5, 45, outputTimezone).withZone(readZone).toString(inputFormat)
+    val sixFourFiveTS = new DateTime(2024, 7, 29, 6, 45, outputTimezone).withZone(readZone).toString(inputFormat)
+
+    val fiveFourFourTS = new DateTime(2024, 7, 29, 5, 44, 59, 999, outputTimezone).withZone(readZone).toString(inputFormat)
+    val sixFourFivePlusTS = new DateTime(2024, 7, 29, 6, 45, 0, 1, outputTimezone).withZone(readZone).toString(inputFormat)
+
+    val id545 = 23L
+    val id600 = 24L
+    val id615 = 25L
+    val id630 = 26L
+    val id645 = 27L
+
+    assertEquals(id600 + id615 + id630, spark.sql(s"""select * from firstwrite where firstwrite.extra_partition_field > to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and firstwrite.extra_partition_field < to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id600 + id615 + id630, spark.sql(s"""select * from firstwrite where to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") < firstwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") > firstwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from firstwrite where firstwrite.extra_partition_field > to_timestamp("$fiveFourFourTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and firstwrite.extra_partition_field < to_timestamp("$sixFourFivePlusTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from firstwrite where to_timestamp("$fiveFourFourTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") < firstwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFivePlusTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") > firstwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from firstwrite where firstwrite.extra_partition_field >= to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and firstwrite.extra_partition_field <= to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from firstwrite where to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") <= firstwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") >= firstwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+    val records2 = recordsToStrings(dataGen.generateUniqueUpdates("002", 96)).asScala
+    var inputDF2 = spark.read.json(spark.sparkContext.parallelize(records2, 1)).orderBy("_row_key")
+    var timestampDf2 = spark.createDataFrame(spark.sparkContext.parallelize(timestampColumnValues, 1), StructType(Seq(StructField("extra_partition_field", StringType))))
+    timestampDf2 = timestampDf2.withColumn("dateid", monotonically_increasing_id())
+
+    inputDF2 = inputDF2.withColumn("dateid", monotonically_increasing_id())
+    inputDF2 = inputDF2.join(timestampDf2, "dateid").filter("dateid % 2 == 0").repartition(6)
+
+    inputDF2.write.format("org.apache.hudi")
+      .options(options)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+
+    spark.read.format("hudi").options(readerOpts).load(basePath).createTempView("secondwrite")
+
+    assertEquals(id600 + id615 + id630, spark.sql(s"""select * from secondwrite where secondwrite.extra_partition_field > to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and secondwrite.extra_partition_field < to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id600 + id615 + id630, spark.sql(s"""select * from secondwrite where to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") < secondwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") > secondwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from secondwrite where secondwrite.extra_partition_field > to_timestamp("$fiveFourFourTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and secondwrite.extra_partition_field < to_timestamp("$sixFourFivePlusTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from secondwrite where to_timestamp("$fiveFourFourTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") < secondwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFivePlusTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") > secondwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from secondwrite where secondwrite.extra_partition_field >= to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and secondwrite.extra_partition_field <= to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id545 + id600 + id615 + id630 + id645, spark.sql(s"""select * from secondwrite where to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") <= secondwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") >= secondwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
+
+
+    assertEquals(id600 + id630, spark.sql(s"""select * from secondwrite where secondwrite.driver = 'driver-002' and secondwrite.extra_partition_field > to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") """
+      + s""" and secondwrite.extra_partition_field < to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")""").agg(sum("dateid")).first.get(0))
+
+    assertEquals(id600 + id630, spark.sql(s"""select * from secondwrite where secondwrite.driver = 'driver-002' and  to_timestamp("$fiveFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") < secondwrite.extra_partition_field"""
+      + s""" and to_timestamp("$sixFourFiveTS", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ") > secondwrite.extra_partition_field""").agg(sum("dateid")).first.get(0))
   }
 
   /**


### PR DESCRIPTION
### Change Logs

With timestamp keygen you can have a partition column with timestamps, but then use the keygen so it will create partitions based on days so that all records that have a timestamp on 7-31-2024 will go to the same parititon even though the values in the partition column differ by hours and minutes etc.

This causes a problem with partition pruning. lets say you query "select * from table where partition < 7-31-2024 at 7am and partition > 7-31-2024 at 6am ". Since the file structure has the partition of just 7-31-2024, that will be interpreted as 7-31-2024 at 12am. So the partition will be pruned from the search space.

This pr fixes the issue by rounding the query values based on the output format. The format of this is year month day, so it will round to the nearest day. The query for partition pruning will then be "select * from table where partition < 7-31-2024 and partition > 7-31-2024 ". This will still not yield any results because it requires the partition to be less than and greater than the same day.

To fix that, we also replace any < or > with <= and >=. So now the query is "select * from table where partition <= 7-31-2024 and partition => 7-31-2024 ". 7-31-2024 will now not be pruned, and the original filter will be applied by spark.

(we can replace all < and > because we are only looking at partition filters in a simple timestamp keygen scenario.)

This does not fix cow or mor ro queries, because we treat those as just plain parquet tables and spark will handle the partition pruning.

### Impact

fix bug for some scenarios

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
