### PR TITLE
[MINOR] make the read and write behavior consistent in spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -502,6 +502,8 @@ object HoodieFileIndex extends Logging {
     val isMetadataTableEnabled = getConfigValue(options, sqlConf, HoodieMetadataConfig.ENABLE.key, null)
     if (isMetadataTableEnabled != null) {
       properties.setProperty(HoodieMetadataConfig.ENABLE.key(), String.valueOf(isMetadataTableEnabled))
+    } else {
+      properties.setProperty(HoodieMetadataConfig.ENABLE.key(), String.valueOf(HoodieMetadataConfig.ENABLE.defaultValue()))
     }
 
     val listingModeOverride = getConfigValue(options, sqlConf,


### PR DESCRIPTION
### Change Logs

for spark, the `hoodie.metadata.enable` is enable when writer side, but it is disable in read side, I think need make these two behavior consistent. If enable, read and writer all need enable in spark.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
