### PR TITLE
[WIP]: [HUDI-7947][RFC-80] Support column families (configuration part)

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -44,9 +44,9 @@ public class HoodieConfig implements Serializable {
 
   protected static final String CONFIG_VALUES_DELIMITER = ",";
   // Number of retries while reading the properties file to deal with parallel updates
-  protected static final int MAX_READ_RETRIES = 5;
+  public static final int MAX_READ_RETRIES = 5;
   // Delay between retries while reading the properties file
-  protected static final int READ_RETRY_DELAY_MSEC = 1000;
+  public static final int READ_RETRY_DELAY_MSEC = 1000;
 
   protected TypedProperties props;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -42,7 +42,7 @@ public class HoodieConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieConfig.class);
 
-  protected static final String CONFIG_VALUES_DELIMITER = ",";
+  public static final String CONFIG_VALUES_DELIMITER = ",";
   // Number of retries while reading the properties file to deal with parallel updates
   public static final int MAX_READ_RETRIES = 5;
   // Delay between retries while reading the properties file

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +60,7 @@ public class ColumnFamilyDefinition implements Serializable {
       String[] fieldStrings = configValue.split(PRE_COMBINE_DELIMITER);
       String preCombine = null;
       if (fieldStrings.length > 2) {
-        throw new HoodieValidationException("Only one semicolon delimiter allowed to separate precombine column");
+        throw new HoodieValidationException("Only one semicolon delimiter allowed to separate preCombine column");
       } else if (fieldStrings.length == 2) {
         preCombine = fieldStrings[1].trim();
       }
@@ -106,6 +107,23 @@ public class ColumnFamilyDefinition implements Serializable {
 
   public String getPreCombine() {
     return preCombine;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnFamilyDefinition that = (ColumnFamilyDefinition) o;
+    return Objects.equals(name, that.name) && Objects.equals(columns, that.columns) && Objects.equals(preCombine, that.preCombine);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, columns, preCombine);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
@@ -131,7 +131,11 @@ public class ColumnFamilyDefinition implements Serializable {
     final StringBuilder sb = new StringBuilder("HoodieColumnFamilyDefinition {");
     sb.append("name='").append(name);
     sb.append("', columns=").append(columns);
-    sb.append(", preCombine='").append(preCombine).append('\'');
+    if (preCombine != null) {
+      sb.append(", preCombine='").append(preCombine).append('\'');
+    } else {
+      sb.append(", preCombine=null");
+    }
     sb.append('}');
     return sb.toString();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/ColumnFamilyDefinition.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.exception.HoodieValidationException;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class representing the Column Family definition.
+ */
+public class ColumnFamilyDefinition implements Serializable {
+
+  private static final String COLUMNS_DELIMITER = ",";
+  private static final String PRE_COMBINE_DELIMITER = ";";
+
+  // Name of the family
+  private final String name;
+
+  // Columns this family consists of
+  private final List<String> columns;
+
+  // preCombine column of this family
+  private final String preCombine;
+
+  private ColumnFamilyDefinition(String name, List<String> columns, String preCombine) {
+    this.name = name;
+    this.columns = columns;
+    this.preCombine = preCombine;
+    validate();
+  }
+
+  public static ColumnFamilyDefinition fromConfig(String name, String configValue) {
+    if (StringUtils.isNullOrEmpty(configValue)) {
+      throw new HoodieValidationException("Column family must contain more than 1 column");
+    } else {
+      String[] fieldStrings = configValue.split(PRE_COMBINE_DELIMITER);
+      String preCombine = null;
+      if (fieldStrings.length > 2) {
+        throw new HoodieValidationException("Only one semicolon delimiter allowed to separate precombine column");
+      } else if (fieldStrings.length == 2) {
+        preCombine = fieldStrings[1].trim();
+      }
+      return new ColumnFamilyDefinition(
+          name,
+          Arrays.stream(fieldStrings[0].split(COLUMNS_DELIMITER)).map(String::trim).collect(Collectors.toList()),
+          preCombine
+      );
+    }
+  }
+
+  public String toConfigValue() {
+    return String.join(COLUMNS_DELIMITER, columns)
+        + (!StringUtils.isNullOrEmpty(preCombine) ? PRE_COMBINE_DELIMITER + preCombine : "");
+  }
+
+  private void validate() {
+    if (StringUtils.isNullOrEmpty(name)) {
+      throw new HoodieValidationException("Column family name must not be empty");
+    }
+    if (columns == null || columns.size() < 2) {
+      throw new HoodieValidationException("Column family must contain more than 1 column");
+    }
+    columns.forEach(column -> {
+      if (StringUtils.isNullOrEmpty(column)) {
+        throw new HoodieValidationException("Column name must not be empty");
+      }
+    });
+    if (columns.size() > new HashSet<>(columns).size()) {
+      throw new HoodieValidationException("Family's columns must not contain duplicates");
+    }
+    if (!StringUtils.isNullOrEmpty(preCombine) && !columns.contains(preCombine)) {
+      throw new HoodieValidationException("Family's columns must contain preCombine column: " + preCombine);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<String> getColumns() {
+    return columns;
+  }
+
+  public String getPreCombine() {
+    return preCombine;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("HoodieColumnFamilyDefinition {");
+    sb.append("name='").append(name);
+    sb.append("', columns=").append(columns);
+    sb.append(", preCombine='").append(preCombine).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/ColumnFamilyDefinitionHelper.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/ColumnFamilyDefinitionHelper.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.avro.Schema;
+import org.apache.hudi.common.model.ColumnFamilyDefinition;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.hudi.common.config.HoodieConfig.MAX_READ_RETRIES;
+import static org.apache.hudi.common.config.HoodieConfig.READ_RETRY_DELAY_MSEC;
+import static org.apache.hudi.common.util.ConfigUtils.fetchConfigs;
+import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
+/**
+ * Helper class for all operations on column family definitions (create, modify, validate)
+ */
+public class ColumnFamilyDefinitionHelper {
+
+  public static final String COLUMN_FAMILIES_FILE_NAME = "column-families.properties";
+  public static final String COLUMN_FAMILIES_BACKUP_NAME = "column-families.backup";
+
+  private final HoodieStorage storage;
+  private final StoragePath metaPath;
+
+  public ColumnFamilyDefinitionHelper(HoodieStorage storage, StoragePath metaPath) {
+    this.storage = storage;
+    this.metaPath = metaPath;
+  }
+
+  /**
+   * Builds column family definitions and writes to file
+   *
+   * @throws IOException
+   */
+  public void persistColumnFamilyDefinitions(Schema schema, Map<String, String> conf) throws IOException {
+    StoragePath cfdPath = new StoragePath(metaPath, COLUMN_FAMILIES_FILE_NAME);
+    checkState(!storage.exists(cfdPath), "Column families are already defined in " + cfdPath);
+    Map<String, ColumnFamilyDefinition> cfDefinitions = validateInitialDefinitions(schema, conf);
+    if (!cfDefinitions.isEmpty()) {
+      Properties properties = new Properties();
+      for (Map.Entry<String, ColumnFamilyDefinition> entry : cfDefinitions.entrySet()) {
+        properties.put(entry.getKey(), entry.getValue().toConfigValue());
+      }
+      saveToFile(cfdPath, properties, true);
+    }
+  }
+
+  private Map<String, ColumnFamilyDefinition> validateInitialDefinitions(Schema schema, Map<String, String> conf) {
+    Map<String, ColumnFamilyDefinition> cfDefinitions = HoodieTableConfig.getColumnFamilyDefinitions(conf);
+    // todo
+
+    return cfDefinitions;
+  }
+
+  /**
+   * Returns Option with Map of column definitions
+   *
+   * @throws IOException
+   */
+  public Option<Map<String, ColumnFamilyDefinition>> getColumnFamilyDefinitions() throws IOException {
+    StoragePath cfdPath = new StoragePath(metaPath, COLUMN_FAMILIES_FILE_NAME);
+    StoragePath cfdBackupPath = new StoragePath(metaPath, COLUMN_FAMILIES_BACKUP_NAME);
+    if (storage.exists(cfdPath) || storage.exists(cfdBackupPath)) {
+      Properties cfProps = fetchConfigs(storage, metaPath, COLUMN_FAMILIES_FILE_NAME, COLUMN_FAMILIES_BACKUP_NAME, MAX_READ_RETRIES, READ_RETRY_DELAY_MSEC);
+      Map<String, ColumnFamilyDefinition> cfd = new HashMap<>();
+      for (Map.Entry<Object, Object> entry : cfProps.entrySet()) {
+        String cfName = String.valueOf(entry.getKey());
+        cfd.put(cfName, ColumnFamilyDefinition.fromConfig(cfName, String.valueOf(entry.getValue())));
+      }
+      return Option.of(cfd);
+    } else {
+      return Option.empty();
+    }
+  }
+
+  /**
+   * Merges existing column family definitions with provided column family's changes and saves results to file
+   *
+   * @param newCfConf only changes in column families definitions
+   * @throws IOException
+   */
+  public void updateColumnFamilyDefinitions(Schema schema, Map<String, String> newCfConf) throws IOException {
+    if (!newCfConf.isEmpty()) {
+      Option<Map<String, ColumnFamilyDefinition>> cfdOpt = getColumnFamilyDefinitions();
+      if (cfdOpt.isPresent()) {
+        // validate changes and get resulting map of column family definitions
+        Map<String, ColumnFamilyDefinition> cfDefinitions = validateColumnFamilyDefinitions(schema, cfdOpt.get(), newCfConf);
+
+        if (!cfDefinitions.isEmpty()) {
+          StoragePath cfdPath = new StoragePath(metaPath, COLUMN_FAMILIES_FILE_NAME);
+          StoragePath cfdBackupPath = new StoragePath(metaPath, COLUMN_FAMILIES_BACKUP_NAME);
+          try {
+            // do any recovery from prior attempts
+            recoverIfNeeded(storage, cfdPath, cfdBackupPath);
+            // read the existing column family properties
+            Properties currentProps = fetchConfigs(storage, metaPath, COLUMN_FAMILIES_FILE_NAME, COLUMN_FAMILIES_BACKUP_NAME,
+                MAX_READ_RETRIES, READ_RETRY_DELAY_MSEC);
+            // backup the existing properties
+            saveToFile(cfdBackupPath, currentProps, false);
+            // delete the properties file, reads will go to the backup, until we are done
+            storage.deleteFile(cfdPath);
+            // save new column family definitions
+            Properties newProps = new Properties();
+            for (Map.Entry<String, ColumnFamilyDefinition> entry : cfDefinitions.entrySet()) {
+              newProps.put(entry.getKey(), entry.getValue().toConfigValue());
+            }
+            saveToFile(cfdPath, newProps, true);
+            // delete the backup
+            storage.deleteFile(cfdBackupPath);
+          } catch (IOException e) {
+            throw new HoodieIOException("Could not save Column Family definitions to " + cfdPath);
+          }
+        }
+      }
+    }
+  }
+
+  private Map<String, ColumnFamilyDefinition> validateColumnFamilyDefinitions(Schema schema, Map<String, ColumnFamilyDefinition> currentDefinitions, Map<String, String> conf) {
+    Map<String, ColumnFamilyDefinition> cfdUpdates = HoodieTableConfig.getColumnFamilyDefinitions(conf);
+    // todo
+
+    for (Map.Entry<String, ColumnFamilyDefinition> cfdUpdate: cfdUpdates.entrySet()) {
+      if (cfdUpdate.getValue() == null) {
+        currentDefinitions.remove(cfdUpdate.getKey());
+      } else {
+        currentDefinitions.put(cfdUpdate.getKey(), cfdUpdate.getValue());
+      }
+    }
+    return currentDefinitions;
+  }
+
+  private void saveToFile(StoragePath cfdPath, Properties properties, boolean overwrite) {
+    try (OutputStream out = storage.create(cfdPath, overwrite)) {
+      properties.store(out, "Column family definitions saved on " + Instant.now());
+    } catch (IOException e) {
+      throw new HoodieIOException("Could not save Column Family definitions to " + cfdPath);
+    }
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -340,7 +340,11 @@ public class HoodieTableConfig extends HoodieConfig {
     for (Map.Entry<String, String> entry: conf.entrySet()) {
       if (entry.getKey().startsWith(COLUMN_FAMILY_PREFIX)) {
         String name = entry.getKey().replace(COLUMN_FAMILY_PREFIX, "");
-        definitionsMap.put(name, ColumnFamilyDefinition.fromConfig(name, entry.getValue()));
+        if (StringUtils.isNullOrEmpty(entry.getValue())) {
+          definitionsMap.put(name, null); // mark family to be deleted
+        } else {
+          definitionsMap.put(name, ColumnFamilyDefinition.fromConfig(name, entry.getValue()));
+        }
       }
     }
     return definitionsMap;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.config.OrderedProperties;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.BootstrapIndexType;
+import org.apache.hudi.common.model.ColumnFamilyDefinition;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -61,6 +62,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -330,6 +332,19 @@ public class HoodieTableConfig extends HoodieConfig {
       .withDocumentation("Absolute path where the index definitions are stored");
 
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
+
+  public static final String COLUMN_FAMILY_PREFIX = "hoodie.columnFamily.";
+
+  public static Map<String, ColumnFamilyDefinition> getColumnFamilyDefinitions(Map<String, String> conf) {
+    Map<String, ColumnFamilyDefinition> definitionsMap = new HashMap<>();
+    for (Map.Entry<String, String> entry: conf.entrySet()) {
+      if (entry.getKey().startsWith(COLUMN_FAMILY_PREFIX)) {
+        String name = entry.getKey().replace(COLUMN_FAMILY_PREFIX, "");
+        definitionsMap.put(name, ColumnFamilyDefinition.fromConfig(name, entry.getValue()));
+      }
+    }
+    return definitionsMap;
+  }
 
   public HoodieTableConfig(HoodieStorage storage, StoragePath metaPath, String payloadClassName, String recordMergerStrategyId) {
     super();

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestColumnFamilyDefinition.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestColumnFamilyDefinition.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
 /**
  * Tests hoodie write stat {@link ColumnFamilyDefinition}.
  */
@@ -50,8 +49,8 @@ public class TestColumnFamilyDefinition {
         Arguments.of("cf", "id,col1,ts,ts", "Family's columns must not contain duplicates"),
         Arguments.of("cf", "id,col1,col2;ts", "Family's columns must contain preCombine column: ts"),
         Arguments.of("cf", "id,col1,ts;ts,", "Family's columns must contain preCombine column: ts,"),
-        Arguments.of("cf", "id,col1,ts;;ts", "Only one semicolon delimiter allowed to separate precombine column"),
-        Arguments.of("cf", "id,col1,ts;ts; ", "Only one semicolon delimiter allowed to separate precombine column")
+        Arguments.of("cf", "id,col1,ts;;ts", "Only one semicolon delimiter allowed to separate preCombine column"),
+        Arguments.of("cf", "id,col1,ts;ts; ", "Only one semicolon delimiter allowed to separate preCombine column")
     );
   }
 
@@ -66,7 +65,7 @@ public class TestColumnFamilyDefinition {
 
   @Test
   public void testFromConfigSuccess() {
-    // without precombine column
+    // without preCombine column
     ColumnFamilyDefinition cfd = fromConfig("cf", "id , col1, col2  ");
     assertEquals("cf", cfd.getName());
     assertEquals(3, cfd.getColumns().size());
@@ -81,7 +80,7 @@ public class TestColumnFamilyDefinition {
     assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2;;").toConfigValue());
     assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2; ;").toConfigValue());
 
-    // with precombine column
+    // with preCombine column
     cfd = fromConfig("cf", " id, col1 , ts ; ts ");
     assertEquals("cf", cfd.getName());
     assertEquals(3, cfd.getColumns().size());

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestColumnFamilyDefinition.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestColumnFamilyDefinition.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.exception.HoodieValidationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.model.ColumnFamilyDefinition.fromConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+/**
+ * Tests hoodie write stat {@link ColumnFamilyDefinition}.
+ */
+public class TestColumnFamilyDefinition {
+
+  static Stream<Object> configValueBadCases() {
+    return Stream.of(
+        Arguments.of(null, "id,col1,ts;ts", "Column family name must not be empty"),
+        Arguments.of("", "id,col1,ts;ts", "Column family name must not be empty"),
+        Arguments.of("cf", null, "Column family must contain more than 1 column"),
+        Arguments.of("cf", "", "Column family must contain more than 1 column"),
+        Arguments.of("cf", "id", "Column family must contain more than 1 column"),
+        Arguments.of("cf", ";ts", "Column family must contain more than 1 column"),
+        Arguments.of("cf", "id;ts", "Column family must contain more than 1 column"),
+        Arguments.of("cf", "id,col1,,ts;ts", "Column name must not be empty"),
+        Arguments.of("cf", "id,col1,ts,ts", "Family's columns must not contain duplicates"),
+        Arguments.of("cf", "id,col1,col2;ts", "Family's columns must contain preCombine column: ts"),
+        Arguments.of("cf", "id,col1,ts;ts,", "Family's columns must contain preCombine column: ts,"),
+        Arguments.of("cf", "id,col1,ts;;ts", "Only one semicolon delimiter allowed to separate precombine column"),
+        Arguments.of("cf", "id,col1,ts;ts; ", "Only one semicolon delimiter allowed to separate precombine column")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("configValueBadCases")
+  public void testFromConfigFailure(String name, String configValue, String expectedExceptionMsg) {
+    Exception ex = assertThrows(HoodieValidationException.class,
+        () -> fromConfig(name, configValue)
+    );
+    assertEquals(expectedExceptionMsg, ex.getMessage());
+  }
+
+  @Test
+  public void testFromConfigSuccess() {
+    // without precombine column
+    ColumnFamilyDefinition cfd = fromConfig("cf", "id , col1, col2  ");
+    assertEquals("cf", cfd.getName());
+    assertEquals(3, cfd.getColumns().size());
+    assertEquals("id", cfd.getColumns().get(0));
+    assertEquals("col1", cfd.getColumns().get(1));
+    assertEquals("col2", cfd.getColumns().get(2));
+    assertNull(cfd.getPreCombine());
+    // check toConfigValue()
+    assertEquals("id,col1,col2", cfd.toConfigValue());
+    assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2;").toConfigValue());
+    assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2; ").toConfigValue());
+    assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2;;").toConfigValue());
+    assertEquals("id,col1,col2", fromConfig("cf", "id,col1,col2; ;").toConfigValue());
+
+    // with precombine column
+    cfd = fromConfig("cf", " id, col1 , ts ; ts ");
+    assertEquals("cf", cfd.getName());
+    assertEquals(3, cfd.getColumns().size());
+    assertEquals("id", cfd.getColumns().get(0));
+    assertEquals("col1", cfd.getColumns().get(1));
+    assertEquals("ts", cfd.getColumns().get(2));
+    assertEquals("ts", cfd.getPreCombine());
+    // check toConfigValue()
+    assertEquals("id,col1,ts;ts", cfd.toConfigValue());
+    assertEquals("id,col1,ts;ts", fromConfig("cf", "id,col1,ts;ts;").toConfigValue());
+  }
+
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestColumnFamilyDefinitionHelper.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestColumnFamilyDefinitionHelper.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.avro.Schema;
+import org.apache.hudi.common.model.ColumnFamilyDefinition;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.StoragePath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.hudi.common.table.ColumnFamilyDefinitionHelper.COLUMN_FAMILIES_FILE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestColumnFamilyDefinitionHelper extends HoodieCommonTestHarness {
+
+  private static final String SCHEMA = "{\"type\":\"record\",\"name\":\"cf_schema\",\"fields\":["
+      + "{\"name\":\"id\",\"type\":\"long\"},{\"name\":\"col1\",\"type\":\"string\"},{\"name\":\"col2\",\"type\":\"string\"},"
+      + "{\"name\":\"col3\",\"type\":\"string\"},{\"name\":\"col4\",\"type\":\"string\"},"
+      + "{\"name\":\"ts\",\"type\":\"long\"},{\"name\":\"dt\",\"type\":\"string\"}]}";
+
+  private ColumnFamilyDefinitionHelper cfdHelper;
+
+  @BeforeEach
+  public void init() throws IOException {
+    if (basePath == null) {
+      initPath();
+    }
+    Properties properties = new Properties();
+    properties.put(HoodieTableConfig.CREATE_SCHEMA.key(), SCHEMA);
+    metaClient = HoodieTestUtils.init(basePath, HoodieTableType.MERGE_ON_READ, properties);
+    cfdHelper = new ColumnFamilyDefinitionHelper(metaClient.getStorage(), metaClient.getMetaPath());
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanMetaClient();
+    cfdHelper = null;
+  }
+
+  @Test
+  public void testPersistColumnFamilyDefinitions() throws Exception {
+    // prepare some config with column families
+    Map<String, String> config = buildColumnFamilyConfigExample();
+
+    // check defaults - no families
+    Option<Map<String, ColumnFamilyDefinition>> cfdOpt = cfdHelper.getColumnFamilyDefinitions();
+    assertTrue(cfdOpt.isEmpty());
+
+    Schema schema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    // persist families and get them from file
+    cfdHelper.persistColumnFamilyDefinitions(schema, config);
+    cfdOpt = cfdHelper.getColumnFamilyDefinitions();
+    assertFalse(cfdOpt.isEmpty());
+    assertColumnFamilyExample(cfdOpt.get());
+
+    // failed to persist once more
+    Exception ex = assertThrows(IllegalStateException.class, () -> cfdHelper.persistColumnFamilyDefinitions(schema, config));
+    StoragePath cfdPath = new StoragePath(metaClient.getMetaPath(), COLUMN_FAMILIES_FILE_NAME);
+    assertEquals("Column families are already defined in " + cfdPath, ex.getMessage());
+  }
+
+  @Test
+  public void testUpdateColumnFamilyDefinitions() throws Exception {
+    // prepare some config with column families
+    Map<String, String> config = buildColumnFamilyConfigExample();
+    Schema schema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    // persist first version of families
+    cfdHelper.persistColumnFamilyDefinitions(schema, config);
+
+    schema = null; // new TableSchemaResolver(metaClient).getTableAvroSchema();
+    // add 1 column to existing family cf1, add new family cf3
+    config.put("hoodie.columnFamily.cf1", "id, col1, col2, col5");
+    config.put("hoodie.columnFamily.cf3", "id, col6, col7;col7");
+    cfdHelper.updateColumnFamilyDefinitions(schema, config);
+    // check definitions were updated
+    Option<Map<String, ColumnFamilyDefinition>> cfdOpt = cfdHelper.getColumnFamilyDefinitions();
+    assertFalse(cfdOpt.isEmpty());
+    Map<String, ColumnFamilyDefinition> cfDefinitions = cfdOpt.get();
+    assertEquals(3, cfDefinitions.size());
+    assertEquals(ColumnFamilyDefinition.fromConfig("cf1","id,col1,col2,col5"), cfDefinitions.get("cf1"));
+    assertEquals(ColumnFamilyDefinition.fromConfig("cf3","id,col6,col7;col7"), cfDefinitions.get("cf3"));
+
+    schema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    // delete previously added column and family
+    config.put("hoodie.columnFamily.cf1", "id, col1, col2");
+    config.put("hoodie.columnFamily.cf3", "");
+    cfdHelper.updateColumnFamilyDefinitions(schema, config);
+    // check definitions were updated
+    cfdOpt = cfdHelper.getColumnFamilyDefinitions();
+    assertFalse(cfdOpt.isEmpty());
+    assertColumnFamilyExample(cfdOpt.get());
+  }
+
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.model.ColumnFamilyDefinition;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -37,6 +38,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -235,5 +237,12 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
     assertArrayEquals(Arrays.stream(partitionFields.split(BaseKeyGenerator.FIELD_SEPARATOR)).toArray(), HoodieTableConfig.getPartitionFieldsForKeyGenerator(config).get().toArray());
     assertArrayEquals(new String[] {"p1", "p2"}, HoodieTableConfig.getPartitionFields(config).get());
     assertEquals("p1", HoodieTableConfig.getPartitionFieldWithoutKeyGenPartitionType(partitionFields.split(",")[0], config));
+  }
+
+  @Test
+  public void testGetColumnFamilyDefinitions() {
+    Map<String, String> tableConfig = buildColumnFamilyConfigExample();
+    Map<String, ColumnFamilyDefinition> cfDefinitions = HoodieTableConfig.getColumnFamilyDefinitions(tableConfig);
+    assertColumnFamilyExample(cfDefinitions);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.testutils;
 
+import org.apache.hudi.common.model.ColumnFamilyDefinition;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -33,6 +34,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * The common hoodie test harness to provide the basic infrastructure.
@@ -158,5 +165,29 @@ public class HoodieCommonTestHarness {
    */
   protected HoodieTableType getTableType() {
     return HoodieTableType.COPY_ON_WRITE;
+  }
+
+  protected Map<String, String> buildColumnFamilyConfigExample() {
+    Map<String, String> config = new HashMap<>();
+    config.put("hoodie.some.property", "val1");
+    config.put("hoodie.columnFamily.cf1", "id, col1, col2");
+    config.put("hoodie.some.property2", "val2");
+    config.put("hoodie.columnFamily.cf2", "id, col3, col4,ts;ts");
+    config.put("hoodie.some.property3", "val3");
+    return config;
+  }
+
+  protected void assertColumnFamilyExample(Map<String, ColumnFamilyDefinition> cfDefinitions) {
+    assertEquals(2, cfDefinitions.size());
+    ColumnFamilyDefinition cfd = cfDefinitions.get("cf1");
+    assertNotNull(cfd);
+    assertEquals("cf1", cfd.getName());
+    assertEquals("id,col1,col2", cfd.toConfigValue());
+    assertNull(cfd.getPreCombine());
+    cfd = cfDefinitions.get("cf2");
+    assertNotNull(cfd);
+    assertEquals("cf2", cfd.getName());
+    assertEquals("id,col3,col4,ts;ts", cfd.toConfigValue());
+    assertEquals("ts", cfd.getPreCombine());
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -173,7 +173,7 @@ public class HoodieCommonTestHarness {
     config.put("hoodie.columnFamily.cf1", "id, col1, col2");
     config.put("hoodie.some.property2", "val2");
     config.put("hoodie.columnFamily.cf2", "id, col3, col4,ts;ts");
-    config.put("hoodie.some.property3", "val3");
+    config.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id");
     return config;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.COLUMN_FAMILY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -170,10 +171,11 @@ public class HoodieCommonTestHarness {
   protected Map<String, String> buildColumnFamilyConfigExample() {
     Map<String, String> config = new HashMap<>();
     config.put("hoodie.some.property", "val1");
-    config.put("hoodie.columnFamily.cf1", "id, col1, col2");
+    config.put(COLUMN_FAMILY_PREFIX + "cf1", "id1, id2, col1, col2");
     config.put("hoodie.some.property2", "val2");
-    config.put("hoodie.columnFamily.cf2", "id, col3, col4,ts;ts");
-    config.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id");
+    config.put(COLUMN_FAMILY_PREFIX + "cf2", "id1, id2, col3, col4,ts;ts");
+    config.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id1,id2");
+    config.put(HoodieTableConfig.PARTITION_FIELDS.key(), "par1,par2");
     return config;
   }
 
@@ -182,12 +184,12 @@ public class HoodieCommonTestHarness {
     ColumnFamilyDefinition cfd = cfDefinitions.get("cf1");
     assertNotNull(cfd);
     assertEquals("cf1", cfd.getName());
-    assertEquals("id,col1,col2", cfd.toConfigValue());
+    assertEquals("id1,id2,col1,col2", cfd.toConfigValue());
     assertNull(cfd.getPreCombine());
     cfd = cfDefinitions.get("cf2");
     assertNotNull(cfd);
     assertEquals("cf2", cfd.getName());
-    assertEquals("id,col3,col4,ts;ts", cfd.toConfigValue());
+    assertEquals("id1,id2,col3,col4,ts;ts", cfd.toConfigValue());
     assertEquals("ts", cfd.getPreCombine());
   }
 }


### PR DESCRIPTION
### Change Logs

RFC-80: https://github.com/apache/hudi/blob/master/rfc/rfc-80/rfc-80.md 
In this PR will be implemented configuration part of Column Families feature: introducing config params, persisting and validation logic, setting up and using all these things during create/alter table routines.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

We need a separate page for configuration ang usage of ColumnFamily feature

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
