### PR TITLE
[MINOR] improve performance of generateBucketKey

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -314,7 +314,7 @@ public class StreamerUtil {
    * Generates the bucket ID using format {partition path}_{fileID}.
    */
   public static String generateBucketKey(String partitionPath, String fileId) {
-    return String.format("%s_%s", partitionPath, fileId);
+    return partitionPath + "_" + fileId;
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Replace String.format with concatenation for better performance

### Impact

Over 7 seconds of 2 minute job is spent for bucket key generation for flink on MOR table.
![Selection_288](https://github.com/user-attachments/assets/dfbd184a-c3c0-4a01-b4bb-f5bd14d2f7c2)
![Selection_289](https://github.com/user-attachments/assets/79c67287-617e-4fe2-ae09-20207e202bb8)
![Selection_290](https://github.com/user-attachments/assets/ce6b0410-3f39-4c0c-96d9-b0b4ea47006c)

Replacing String.format with concat is 10x times faster.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
