### PR TITLE
[HUDI-8067] Use exec to run the IT

### DIFF
--- a/docker/setup_demo.sh
+++ b/docker/setup_demo.sh
@@ -24,13 +24,13 @@ if [ "$HUDI_DEMO_ENV" = "--mac-aarch64" ]; then
   COMPOSE_FILE_NAME="docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml"
 fi
 # restart cluster
-HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} down
+HUDI_WS=${WS_ROOT} docker compose down -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME}
 if [ "$HUDI_DEMO_ENV" != "dev" ]; then
   echo "Pulling docker demo images ..."
-  HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} pull
+  HUDI_WS=${WS_ROOT} docker compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} pull
 fi
 sleep 5
-HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} up -d
+HUDI_WS=${WS_ROOT} docker compose up -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME}  -d
 sleep 15
 
 docker exec -it adhoc-1 /bin/bash /var/hoodie/ws/docker/demo/setup_demo_container.sh

--- a/docker/stop_demo.sh
+++ b/docker/stop_demo.sh
@@ -25,7 +25,7 @@ if [ "$HUDI_DEMO_ENV" = "--mac-aarch64" ]; then
   COMPOSE_FILE_NAME="docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml"
 fi
 # shut down cluster
-HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} down
+HUDI_WS=${WS_ROOT} docker compose down -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME}
 
 # remove houst mount directory
 rm -rf /tmp/hadoop_data

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -450,6 +450,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <longModulepath>false</longModulepath>
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
@@ -465,6 +466,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <longModulepath>false</longModulepath>
               <timeout>30000</timeout>
               <skip>${docker.compose.skip}</skip>
               <executable>/bin/bash</executable>
@@ -484,6 +486,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <longModulepath>false</longModulepath>
               <skip>${docker.compose.skip}</skip>
               <executable>/bin/bash</executable>
               <arguments>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -441,21 +441,43 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.4.0</version>
         <executions>
-          <execution><!-- setup HUDI_WS variable in docker compose env file -->
-            <id>Setup HUDI_WS</id>
-            <phase>generate-sources</phase>
+          <execution>
+            <id>up</id>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>exec</goal>
             </goals>
             <configuration>
+              <timeout>30000</timeout>
+              <skip>${docker.compose.skip}</skip>
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>echo HUDI_WS=`dirname ${project.basedir}`</argument>
+                <argument>docker compose -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock up</argument>
               </arguments>
-              <outputFile>${dockerCompose.envFile}</outputFile>
+              <environmentVariables>
+                <HUDI_WS>${project.parent.basedir}</HUDI_WS>
+              </environmentVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>down</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <skip>${docker.compose.skip}</skip>
+              <executable>/bin/bash</executable>
+              <arguments>
+                <argument>-c</argument>
+                <argument>docker compose -v -f ${dockerCompose.file} down</argument>
+              </arguments>
+              <environmentVariables>
+                <HUDI_WS>${project.parent.basedir}</HUDI_WS>
+              </environmentVariables>
             </configuration>
           </execution>
         </executions>
@@ -471,39 +493,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>com.dkanejs.maven.plugins</groupId>
-        <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>2.0.1</version>
-        <executions>
-          <execution>
-            <id>up</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>up</goal>
-            </goals>
-            <configuration>
-              <skip>${docker.compose.skip}</skip>
-              <host>unix:///var/run/docker.sock</host>
-              <composeFile>${dockerCompose.file}</composeFile>
-              <detachedMode>true</detachedMode>
-              <envFile>${dockerCompose.envFile}</envFile>
-            </configuration>
-          </execution>
-          <execution>
-            <id>down</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>down</goal>
-            </goals>
-            <configuration>
-              <skip>${docker.compose.skip}</skip>
-              <composeFile>${dockerCompose.file}</composeFile>
-              <removeVolumes>true</removeVolumes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose up -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} up -d</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose down -v -f ${dockerCompose.file}</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} down -v</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock up</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose up -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -v -f ${dockerCompose.file} down</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose down -v -f ${dockerCompose.file}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -443,6 +443,21 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.2.0</version>
         <executions>
+          <execution><!-- setup HUDI_WS variable in docker compose env file -->
+            <id>Setup HUDI_WS</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>/bin/bash</executable>
+              <arguments>
+                <argument>-c</argument>
+                <argument>echo HUDI_WS=`dirname ${project.basedir}`</argument>
+              </arguments>
+              <outputFile>${dockerCompose.envFile}</outputFile>
+            </configuration>
+          </execution>
           <execution>
             <id>up</id>
             <phase>pre-integration-test</phase>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -471,9 +471,6 @@
                 <argument>-c</argument>
                 <argument>docker compose -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock up</argument>
               </arguments>
-              <environmentVariables>
-                <HUDI_WS>${project.parent.basedir}</HUDI_WS>
-              </environmentVariables>
             </configuration>
           </execution>
           <execution>
@@ -489,9 +486,6 @@
                 <argument>-c</argument>
                 <argument>docker compose -v -f ${dockerCompose.file} down</argument>
               </arguments>
-              <environmentVariables>
-                <HUDI_WS>${project.parent.basedir}</HUDI_WS>
-              </environmentVariables>
             </configuration>
           </execution>
         </executions>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>docker compose -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock up</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -d -f ${dockerCompose.file} -H unix:///var/run/docker.sock up</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>docker compose -v -f ${dockerCompose.file} down</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -v -f ${dockerCompose.file} down</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -441,7 +441,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>up</id>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -441,7 +441,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>1.6.0</version>
         <executions>
           <execution><!-- setup HUDI_WS variable in docker compose env file -->
             <id>Setup HUDI_WS</id>
@@ -450,7 +450,6 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <longModulepath>false</longModulepath>
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
@@ -466,8 +465,6 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <longModulepath>false</longModulepath>
-              <timeout>30000</timeout>
               <skip>${docker.compose.skip}</skip>
               <executable>/bin/bash</executable>
               <arguments>
@@ -486,7 +483,6 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <longModulepath>false</longModulepath>
               <skip>${docker.compose.skip}</skip>
               <executable>/bin/bash</executable>
               <arguments>


### PR DESCRIPTION
### Change Logs

Run IT's using the command line to do docker compose instead of the plugin. The plugin we were using https://github.com/Systemmanic/docker-compose-maven-plugin is pretty much just calling cli. So I tried to replicate the same command. The only thing that does not translate directly is the timeout. We will see if the exec timeout feature will deliver the same result.

### Impact

Get CI to work again so we can land prs

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
