### PR TITLE
[MINOR] avoid repeated write behavior in ut

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/RunCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/RunCompactionActionExecutor.java
@@ -125,6 +125,7 @@ public class RunCompactionActionExecutor<T> extends
       compactionMetadata.setWriteStatuses(statuses);
       compactionMetadata.setCommitted(false);
       compactionMetadata.setCommitMetadata(Option.of(metadata));
+      compactionMetadata.setWriteStats(updateStatusMap);
     } catch (Exception e) {
       throw new HoodieCompactionException("Could not compact " + config.getBasePath(), e);
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
@@ -20,11 +20,8 @@ package org.apache.hudi.table.action.compact;
 
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.SparkRDDWriteClient;
-import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
-import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -48,6 +45,7 @@ import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
 import com.codahale.metrics.Counter;
@@ -235,7 +233,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
         updateRecords(config, newCommitTime, records);
         assertLogFilesNumEqualsTo(config, i);
       }
-      HoodieData<WriteStatus> result = compact(writeClient, String.format("10%s", i));
+      HoodieWriteMetadata result = compact(writeClient, String.format("10%s", i));
       verifyCompaction(result);
 
       // Verify compaction.requested, compaction.completed metrics counts.
@@ -270,7 +268,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
 
         assertLogFilesNumEqualsTo(config, 1);
 
-        HoodieData<WriteStatus> result = compact(writeClient, "10" + (i + 1));
+        HoodieWriteMetadata result = compact(writeClient, "10" + (i + 1));
         verifyCompaction(result);
 
         // Verify compaction.requested, compaction.completed metrics counts.
@@ -317,26 +315,28 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
   /**
    * Do a compaction.
    */
-  private HoodieData<WriteStatus> compact(SparkRDDWriteClient writeClient, String compactionInstantTime) {
+  private HoodieWriteMetadata compact(SparkRDDWriteClient writeClient, String compactionInstantTime) {
     writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty());
-    JavaRDD<WriteStatus> writeStatusJavaRDD = (JavaRDD<WriteStatus>) writeClient.compact(compactionInstantTime).getWriteStatuses();
-    return HoodieListData.eager(writeStatusJavaRDD.collect());
+    HoodieWriteMetadata compactMetadata = writeClient.compact(compactionInstantTime);
+    return compactMetadata;
   }
 
   /**
-   * Verify that all partition paths are present in the WriteStatus result.
+   * Verify that all partition paths are present in the HoodieWriteMetadata result.
    */
-  private void verifyCompaction(HoodieData<WriteStatus> result) {
-    List<WriteStatus> writeStatuses = result.collectAsList();
+  private void verifyCompaction(HoodieWriteMetadata compactionMetadata) {
+    assertTrue(compactionMetadata.getWriteStats().isPresent());
+    List<HoodieWriteStat> stats = (List<HoodieWriteStat>) compactionMetadata.getWriteStats().get();
+    assertEquals(dataGen.getPartitionPaths().length, stats.size());
     for (String partitionPath : dataGen.getPartitionPaths()) {
-      assertTrue(writeStatuses.stream().anyMatch(writeStatus -> writeStatus.getStat().getPartitionPath().contentEquals(partitionPath)));
+      assertTrue(stats.stream().anyMatch(stat -> stat.getPartitionPath().contentEquals(partitionPath)));
     }
-    writeStatuses.forEach(writeStatus -> {
-      final HoodieWriteStat.RuntimeStats stats = writeStatus.getStat().getRuntimeStats();
-      assertNotNull(stats);
-      assertEquals(stats.getTotalCreateTime(), 0);
-      assertTrue(stats.getTotalUpsertTime() > 0);
-      assertTrue(stats.getTotalScanTime() > 0);
+    stats.forEach(stat -> {
+      HoodieWriteStat.RuntimeStats runtimeStats = stat.getRuntimeStats();
+      assertNotNull(runtimeStats);
+      assertEquals(0, runtimeStats.getTotalCreateTime());
+      assertTrue(runtimeStats.getTotalUpsertTime() > 0);
+      assertTrue(runtimeStats.getTotalScanTime() > 0);
     });
   }
 }


### PR DESCRIPTION
> case  


When I run a ut in `TestHoodieCompactor`, I found that every compaction will write a same merged file 2 times.
<img width="547" alt="image" src="https://github.com/user-attachments/assets/21818578-b514-43a4-8358-138b40b2ae69">
> reason
1. `WriteStatus::collect` is called after compaction.
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/4e0e7017-c02e-4cab-8d58-b6caa13a768d">
2. `collect` will cause RDD computation again.     
3.  But RDD cache about this RDD id has been removed when compaction is completed.
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/14558ed1-fd70-4db7-99d5-59bfe490176d">
<img width="674" alt="image" src="https://github.com/user-attachments/assets/f4cef1cd-5170-4809-99cd-281b57878f52">

4. So it will cause computation again from this stage. `HoodieCompactor::compact`
<img width="1164" alt="image" src="https://github.com/user-attachments/assets/e1e34ad8-255c-402c-b485-222d8d92b2f7">



### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

1. set stats in metadata after compaction
6. fix wrong usage about HoodieWriteMetadata which cause the repeated write behavior in ut

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none
### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
