### PR TITLE
[MINOR] Fixed checkstyle in HoodieJavaWriteClientExample

### DIFF
--- a/hudi-examples/hudi-examples-java/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
+++ b/hudi-examples/hudi-examples-java/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
@@ -58,7 +58,7 @@ public class HoodieJavaWriteClientExample {
 
   private static String tableType = HoodieTableType.COPY_ON_WRITE.name();
 
-  private static final String morStr = "mor";
+  private static final String MOR_STR = "mor";
 
   public static void main(String[] args) throws Exception {
     if (args.length < 3) {
@@ -68,11 +68,11 @@ public class HoodieJavaWriteClientExample {
     String tablePath = args[0];
     String tableName = args[1];
     String tableTypeStr = args[2];
-    if (tableTypeStr != null && tableTypeStr.equals(morStr)) {
+    if (tableTypeStr != null && tableTypeStr.equals(MOR_STR)) {
       tableType = HoodieTableType.MERGE_ON_READ.name();
     }
 
-    LOG.info("Start JavaWriteClient example with tablePath: " + tablePath + ", tableName: " + tableName + ", tableType: " + tableType);
+    LOG.info("Start JavaWriteClient example with tablePath: {}, tableName: {}, tableType: {}", tablePath, tableName, tableType);
 
     // Generator of some records to be loaded in.
     HoodieExampleDataGenerator<HoodieAvroPayload> dataGen = new HoodieExampleDataGenerator<>();
@@ -101,27 +101,27 @@ public class HoodieJavaWriteClientExample {
 
       // inserts
       String newCommitTime = client.startCommit();
-      LOG.info("Starting commit " + newCommitTime);
+      LOG.info("Starting commit {}", newCommitTime);
 
       List<HoodieRecord<HoodieAvroPayload>> records = dataGen.generateInserts(newCommitTime, 10);
       List<HoodieRecord<HoodieAvroPayload>> recordsSoFar = new ArrayList<>(records);
       List<HoodieRecord<HoodieAvroPayload>> writeRecords =
-          recordsSoFar.stream().map(r -> new HoodieAvroRecord<HoodieAvroPayload>(r)).collect(Collectors.toList());
+          recordsSoFar.stream().map(HoodieAvroRecord::new).collect(Collectors.toList());
       client.insert(writeRecords, newCommitTime);
 
       // updates
       newCommitTime = client.startCommit();
-      LOG.info("Starting commit " + newCommitTime);
+      LOG.info("Starting commit {}", newCommitTime);
       List<HoodieRecord<HoodieAvroPayload>> toBeUpdated = dataGen.generateUpdates(newCommitTime, 2);
       records.addAll(toBeUpdated);
       recordsSoFar.addAll(toBeUpdated);
       writeRecords =
-          recordsSoFar.stream().map(r -> new HoodieAvroRecord<HoodieAvroPayload>(r)).collect(Collectors.toList());
+          recordsSoFar.stream().map(HoodieAvroRecord::new).collect(Collectors.toList());
       client.upsert(writeRecords, newCommitTime);
 
       // Delete
       newCommitTime = client.startCommit();
-      LOG.info("Starting commit " + newCommitTime);
+      LOG.info("Starting commit {}", newCommitTime);
       // just delete half of the records
       int numToDelete = recordsSoFar.size() / 2;
       List<HoodieKey> toBeDeleted =


### PR DESCRIPTION
### Change Logs

Build fails locally because of checkstyle issue in hudi-examples-java:  
(naming) ConstantName: Name 'morStr' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.  

Fixed checkstyle in HoodieJavaWriteClientExample.

### Impact

Now checkstyle is not failing

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
