### PR TITLE
[MINOR] improve comaction operator shuffle

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanEvent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanEvent.java
@@ -32,12 +32,20 @@ public class CompactionPlanEvent implements Serializable {
 
   private CompactionOperation operation;
 
+  private int index;
+
   public CompactionPlanEvent() {
   }
 
   public CompactionPlanEvent(String instantTime, CompactionOperation operation) {
     this.compactionInstantTime = instantTime;
     this.operation = operation;
+  }
+
+  public CompactionPlanEvent(String instantTime, CompactionOperation operation, int index) {
+    this.compactionInstantTime = instantTime;
+    this.operation = operation;
+    this.index = index;
   }
 
   public void setCompactionInstantTime(String compactionInstantTime) {
@@ -54,5 +62,9 @@ public class CompactionPlanEvent implements Serializable {
 
   public CompactionOperation getOperation() {
     return operation;
+  }
+
+  public int getIndex() {
+    return index;
   }
 }


### PR DESCRIPTION
### Change Logs

I found a skew in the flink compaction task.

<img width="1552" alt="微信图片_20240812172514" src="https://github.com/user-attachments/assets/5263e4ca-4af1-4f2f-b581-e1c716527b21">

Compaction task shuffle the compaction operation with ***keyby***,  A series of hash mods results in skew.

One file group on compaction operator, so we don't need keyby, just rebalance is OK.

This is the result of rebanlace.

<img width="507" alt="微信图片_20240812172545" src="https://github.com/user-attachments/assets/e19ec957-565f-4a83-a971-d489341c2e55">


### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
