### PR TITLE
[HUDI-8087] don't start docker in the build phase in integration tests

### DIFF
--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} up -d</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} up -d; fi</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} down -v</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} down -v; fi</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} up -d; set +x</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} up -d</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; then docker compose -f ${dockerCompose.file} down -v; set +x</argument>
+                <argument>export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} down -v</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} up -d; fi; set +x</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if [ "${docker.compose.skip}" = "false" ]; then docker compose -f ${dockerCompose.file} up -d; fi; set +x</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} down -v; fi; set +x</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if [ "${docker.compose.skip}" = "false" ]; then docker compose -f ${dockerCompose.file} down -v; fi; set +x</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if [ "${docker.compose.skip}" = "false" ]; then docker compose -f ${dockerCompose.file} up -d; fi; set +x</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; docker compose -f ${dockerCompose.file} up -d; set +x</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if [ "${docker.compose.skip}" = "false" ]; then docker compose -f ${dockerCompose.file} down -v; fi; set +x</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; then docker compose -f ${dockerCompose.file} down -v; set +x</argument>
               </arguments>
             </configuration>
           </execution>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -469,7 +469,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} up -d; fi</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} up -d; fi; set +x</argument>
               </arguments>
             </configuration>
           </execution>
@@ -484,7 +484,7 @@
               <executable>/bin/bash</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} down -v; fi</argument>
+                <argument>set -x; export HUDI_WS=`dirname ${project.basedir}`; if ${docker.compose.skip}; then docker compose -f ${dockerCompose.file} down -v; fi; set +x</argument>
               </arguments>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2357,7 +2357,6 @@
         <fasterxml.jackson.module.scala.version>2.6.7.1</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>2.7.4</fasterxml.jackson.dataformat.yaml.version>
         <skip.hudi-spark3.unit.tests>true</skip.hudi-spark3.unit.tests>
-        <skipITs>false</skipITs>
       </properties>
       <activation>
         <property>


### PR DESCRIPTION
### Change Logs

Prevent docker from starting up and then stopping in the build phase of integration tests when -DskipTests is set. Also print. Out the bash commands.

### Impact
Should prevent some flakiness in the gh actions ci

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
