### PR TITLE
[HUDI-8088] Fix documentation: filename of Externalized Config file

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -100,7 +100,7 @@ public class ConfigGroups {
         break;
       case ENVIRONMENT_CONFIG:
         description = "Hudi supports passing configurations via a configuration file "
-            + "`hudi-default.conf` in which each line consists of a key and a value "
+            + "`hudi-defaults.conf` in which each line consists of a key and a value "
             + "separated by whitespace or = sign. For example:\n"
             + "```\n"
             + "hoodie.datasource.hive_sync.mode               jdbc\n"


### PR DESCRIPTION
### Change Logs

Fixed Externalized Config filename in documentation: from `hudi-default.conf` to `hudi-defaults.conf`

### Impact

documentation on site will be correct

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
