### PR TITLE
[HUDI-8088][DOCS] Fix documentation: filename of Externalized Config file

### DIFF
--- a/hudi-utils/src/main/java/org/apache/hudi/utils/HoodieConfigDocGenerator.java
+++ b/hudi-utils/src/main/java/org/apache/hudi/utils/HoodieConfigDocGenerator.java
@@ -74,7 +74,7 @@ public class HoodieConfigDocGenerator {
   private static final String BASIC_CONFIGS_PATH = "/tmp/basic_configurations.md";
   private static final String EXTERNALIZED_CONFIGS = "## Externalized Config File\n" +
           "Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration\n" +
-          "file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can\n" +
+          "file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can\n" +
           "specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be\n" +
           "useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.";
   private static final String DEFAULT_FOOTER_MARKUP = new StringBuilder().append(NEWLINE).append(new HorizontalRule(3)).append(DOUBLE_NEWLINE).toString();

--- a/website/docs/configurations.md
+++ b/website/docs/configurations.md
@@ -5,14 +5,14 @@ permalink: /docs/configurations.html
 summary: This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 toc_min_heading_level: 2
 toc_max_heading_level: 4
-last_modified_at: 2024-07-26T12:54:21.684
+last_modified_at: 2024-08-16T12:54:21.684
 ---
 
 
 This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 
 - [**Hudi Table Config**](#TABLE_CONFIG): Basic Hudi Table configuration parameters.
-- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000
@@ -38,7 +38,7 @@ In the tables below **(N/A)** means there is no default value set
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/releases/release-0.10.0.md
+++ b/website/releases/release-0.10.0.md
@@ -107,7 +107,7 @@ With this capability, we can continuously capture row-level changes that insert,
 
 ### External config file support
 
-Instead of directly and sometimes passing configurations to every Hudi job, since 0.10.0 users can now pass in configuration via a configuration file `hudi-default.conf`.
+Instead of directly and sometimes passing configurations to every Hudi job, since 0.10.0 users can now pass in configuration via a configuration file `hudi-defaults.conf`.
 By default, Hudi would load the configuration file under /etc/hudi/conf directory. You can specify a different configuration directory location
 by setting the **HUDI_CONF_DIR** environment variable. This can be useful for uniformly enforcing often repeated configs
 like Hive sync settings, write/index tuning parameters, across your entire data lake.

--- a/website/versioned_docs/version-0.10.0/configurations.md
+++ b/website/versioned_docs/version-0.10.0/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.10.1/configurations.md
+++ b/website/versioned_docs/version-0.10.1/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.11.0/configurations.md
+++ b/website/versioned_docs/version-0.11.0/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.12.0/configurations.md
+++ b/website/versioned_docs/version-0.12.0/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -529,7 +529,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.12.1/configurations.md
+++ b/website/versioned_docs/version-0.12.1/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -529,7 +529,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.12.2/configurations.md
+++ b/website/versioned_docs/version-0.12.2/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -535,7 +535,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.12.3/configurations.md
+++ b/website/versioned_docs/version-0.12.3/configurations.md
@@ -19,7 +19,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.12.3/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.3/quick-start-guide.md
@@ -535,7 +535,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.13.0/configurations.md
+++ b/website/versioned_docs/version-0.13.0/configurations.md
@@ -11,7 +11,7 @@ last_modified_at: 2023-02-22T16:51:12.818
 
 This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 
-- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000
@@ -31,12 +31,12 @@ By default, Hudi would load the configuration file under `/etc/hudi/conf` direct
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 
 ## Environment Config {#ENVIRONMENT_CONFIG}
-Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000

--- a/website/versioned_docs/version-0.13.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.0/quick-start-guide.md
@@ -539,7 +539,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.13.1/configurations.md
+++ b/website/versioned_docs/version-0.13.1/configurations.md
@@ -11,7 +11,7 @@ last_modified_at: 2023-02-22T16:51:12.818
 
 This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 
-- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000
@@ -31,12 +31,12 @@ By default, Hudi would load the configuration file under `/etc/hudi/conf` direct
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 
 ## Environment Config {#ENVIRONMENT_CONFIG}
-Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000

--- a/website/versioned_docs/version-0.13.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.1/quick-start-guide.md
@@ -539,7 +539,7 @@ complex, custom, NonPartitioned Key gen, etc.
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job, 
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 ## Query data 

--- a/website/versioned_docs/version-0.14.0/configurations.md
+++ b/website/versioned_docs/version-0.14.0/configurations.md
@@ -14,7 +14,7 @@ This page covers the different ways of configuring your job to write/read Hudi t
 :::tip
 With [externalized config file](/docs/configurations#externalized-config-file),
 instead of directly passing configuration settings to every Hudi job,
-you can also centrally set them in a configuration file `hudi-default.conf`.
+you can also centrally set them in a configuration file `hudi-defaults.conf`.
 :::
 
 By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable.
@@ -34,7 +34,7 @@ In the tables below **(N/A)** means there is no default value set
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.14.1/configurations.md
+++ b/website/versioned_docs/version-0.14.1/configurations.md
@@ -11,7 +11,7 @@ last_modified_at: 2024-01-03T18:52:29.379
 
 This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 
-- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000
@@ -36,7 +36,7 @@ In the tables below **(N/A)** means there is no default value set
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 

--- a/website/versioned_docs/version-0.15.0/configurations.md
+++ b/website/versioned_docs/version-0.15.0/configurations.md
@@ -12,7 +12,7 @@ last_modified_at: 2024-06-06T12:05:06.405
 This page covers the different ways of configuring your job to write/read Hudi tables. At a high level, you can control behaviour at few levels.
 
 - [**Hudi Table Config**](#TABLE_CONFIG): Basic Hudi Table configuration parameters.
-- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-default.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
+- [**Environment Config**](#ENVIRONMENT_CONFIG): Hudi supports passing configurations via a configuration file `hudi-defaults.conf` in which each line consists of a key and a value separated by whitespace or = sign. For example:
 ```
 hoodie.datasource.hive_sync.mode               jdbc
 hoodie.datasource.hive_sync.jdbcurl            jdbc:hive2://localhost:10000
@@ -38,7 +38,7 @@ In the tables below **(N/A)** means there is no default value set
 
 ## Externalized Config File
 Instead of directly passing configuration settings to every Hudi job, you can also centrally set them in a configuration
-file `hudi-default.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
+file `hudi-defaults.conf`. By default, Hudi would load the configuration file under `/etc/hudi/conf` directory. You can
 specify a different configuration directory location by setting the `HUDI_CONF_DIR` environment variable. This can be
 useful for uniformly enforcing repeated configs (like Hive sync or write/index tuning), across your entire data lake.
 


### PR DESCRIPTION
### Change Logs

Fixed Externalized Config filename in documentation: from hudi-default.conf to hudi-defaults.conf

### Impact

fixed documentation

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
