### PR TITLE
[HUDI-8096] Improve OverwriteNonDefaultsWithLatestAvroPayload Java Doc

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteNonDefaultsWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteNonDefaultsWithLatestAvroPayload.java
@@ -33,8 +33,8 @@ import java.util.List;
  *
  * <ol>
  * <li>preCombine - Picks the latest delta record for a key, based on an ordering field;
- * <li>combineAndGetUpdateValue/getInsertValue - overwrite storage for specified fields
- * that doesn't equal defaultValue.
+ * <li>combineAndGetUpdateValue/getInsertValue - overwrite the storage for the specified fields
+ * with the fields from the latest delta record that doesn't equal defaultValue.
  * </ol>
  */
 public class OverwriteNonDefaultsWithLatestAvroPayload extends OverwriteWithLatestAvroPayload {


### PR DESCRIPTION
### Change Logs

The Java Doc of OverwriteNonDefaultsWithLatestAvroPayload is ambiguous and users cannot understand it. 

Modify it to: combineAndGetUpdateValue/getInsertValue - overwrite the storage for the specified fields with the fields from the latest delta record that are not default values.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
