### PR TITLE
[HUDI-8034] Support custom key generator with HoodieCatalogTable

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -66,21 +66,12 @@ public class KeyGenUtils {
   public static KeyGeneratorType inferKeyGeneratorType(
       Option<String> recordsKeyFields, String partitionFields) {
     boolean autoGenerateRecordKeys = !recordsKeyFields.isPresent();
-    if (autoGenerateRecordKeys) {
-      return inferKeyGeneratorTypeFromPartitionFields(partitionFields);
-    } else {
-      if (!StringUtils.isNullOrEmpty(partitionFields)) {
-        int numRecordKeyFields = recordsKeyFields.get().split(",").length;
-        KeyGeneratorType recordKeyGeneratorType = numRecordKeyFields == 1 ? KeyGeneratorType.SIMPLE : KeyGeneratorType.COMPLEX;
-        KeyGeneratorType partitionKeyGeneratorType = inferKeyGeneratorTypeFromPartitionFields(partitionFields);
-        if (partitionKeyGeneratorType == KeyGeneratorType.SIMPLE && recordKeyGeneratorType == KeyGeneratorType.COMPLEX) {
-          return recordKeyGeneratorType;
-        } else {
-          return partitionKeyGeneratorType;
-        }
-      }
-      return KeyGeneratorType.NON_PARTITION;
+    KeyGeneratorType partitionKeyGeneratorType = inferKeyGeneratorTypeFromPartitionFields(partitionFields);
+    if (autoGenerateRecordKeys || partitionKeyGeneratorType != KeyGeneratorType.SIMPLE) {
+      return partitionKeyGeneratorType;
     }
+    int numRecordKeyFields = recordsKeyFields.get().split(",").length;
+    return numRecordKeyFields == 1 ? KeyGeneratorType.SIMPLE : KeyGeneratorType.COMPLEX;
   }
 
   // When auto record key gen is enabled, our inference will be based on partition path only.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -84,7 +84,7 @@ public class KeyGenUtils {
   }
 
   // When auto record key gen is enabled, our inference will be based on partition path only.
-  private static KeyGeneratorType inferKeyGeneratorTypeFromPartitionFields(String partitionFields) {
+  static KeyGeneratorType inferKeyGeneratorTypeFromPartitionFields(String partitionFields) {
     if (!StringUtils.isNullOrEmpty(partitionFields)) {
       String[] partitonFields = partitionFields.split(",");
       if (partitonFields[0].contains(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX)) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -36,6 +36,7 @@ public class TestKeyGenUtils {
     assertEquals(
         KeyGeneratorType.SIMPLE,
         KeyGenUtils.inferKeyGeneratorType(Option.of("col1"), "partition1"));
+
     assertEquals(
         KeyGeneratorType.COMPLEX,
         KeyGenUtils.inferKeyGeneratorType(Option.of("col1"), "partition1,partition2"));
@@ -45,12 +46,68 @@ public class TestKeyGenUtils {
     assertEquals(
         KeyGeneratorType.COMPLEX,
         KeyGenUtils.inferKeyGeneratorType(Option.of("col1,col2"), "partition1,partition2"));
+
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorType(Option.of("col1"), "partition1:simple,partition2:timestamp"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorType(Option.of("col1,col2"), "partition1:simple"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorType(Option.of("col1,col2"), "partition1:simple,partition2:timestamp"));
+
     assertEquals(
         KeyGeneratorType.NON_PARTITION,
         KeyGenUtils.inferKeyGeneratorType(Option.of("col1,col2"), ""));
     assertEquals(
         KeyGeneratorType.NON_PARTITION,
         KeyGenUtils.inferKeyGeneratorType(Option.of("col1,col2"), null));
+
+    // Test key generator type with auto generation of record keys
+    assertEquals(
+        KeyGeneratorType.SIMPLE,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), "partition1"));
+    assertEquals(
+        KeyGeneratorType.COMPLEX,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), "partition1,partition2"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), "partition1:simple"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), "partition1:simple,partition2:timestamp"));
+    assertEquals(
+        KeyGeneratorType.NON_PARTITION,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), ""));
+    assertEquals(
+        KeyGeneratorType.NON_PARTITION,
+        KeyGenUtils.inferKeyGeneratorType(Option.empty(), null));
+  }
+
+  @Test
+  public void testInferKeyGeneratorTypeFromPartitionFields() {
+    assertEquals(
+        KeyGeneratorType.SIMPLE,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1"));
+    assertEquals(
+        KeyGeneratorType.COMPLEX,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1,partition1"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:simple"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:timestamp"));
+    assertEquals(
+        KeyGeneratorType.CUSTOM,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:simple,partition1:timestamp"));
+    assertEquals(
+        KeyGeneratorType.NON_PARTITION,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields(""));
+    assertEquals(
+        KeyGeneratorType.NON_PARTITION,
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields(null));
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -92,7 +92,7 @@ public class TestKeyGenUtils {
         KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1"));
     assertEquals(
         KeyGeneratorType.COMPLEX,
-        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1,partition1"));
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1,partition2"));
     assertEquals(
         KeyGeneratorType.CUSTOM,
         KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:simple"));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -101,7 +101,7 @@ public class TestKeyGenUtils {
         KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:timestamp"));
     assertEquals(
         KeyGeneratorType.CUSTOM,
-        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:simple,partition1:timestamp"));
+        KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields("partition1:simple,partition2:timestamp"));
     assertEquals(
         KeyGeneratorType.NON_PARTITION,
         KeyGenUtils.inferKeyGeneratorTypeFromPartitionFields(""));

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -238,9 +238,22 @@ public class ConfigUtils {
    */
   public static boolean containsConfigProperty(Map<String, Object> props,
                                                ConfigProperty<?> configProperty) {
-    if (!props.containsKey(configProperty.key())) {
+    return containsConfigProperty(props::containsKey, configProperty);
+  }
+
+  /**
+   * Whether the properties contain a config. If any of the key or alternative keys of the
+   * {@link ConfigProperty} exists, this method returns {@code true}.
+   *
+   * @param keyExistsFn    Function to check if key exists
+   * @param configProperty Config to look up.
+   * @return {@code true} if exists; {@code false} otherwise.
+   */
+  public static boolean containsConfigProperty(Function<String, Boolean> keyExistsFn,
+                                               ConfigProperty<?> configProperty) {
+    if (!keyExistsFn.apply(configProperty.key())) {
       for (String alternative : configProperty.getAlternatives()) {
-        if (props.containsKey(alternative)) {
+        if (keyExistsFn.apply(alternative)) {
           return true;
         }
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.USE_NATIVE_HFILE_READER;
@@ -374,12 +375,27 @@ public class ConfigUtils {
    */
   public static String getStringWithAltKeys(Map<String, Object> props,
                                             ConfigProperty<String> configProperty) {
-    Object value = props.get(configProperty.key());
+    return getStringWithAltKeys(props::get, configProperty);
+  }
+
+  /**
+   * Gets the String value for a {@link ConfigProperty} config using a key mapping function. The key
+   * and alternative keys are used to fetch the config. The default value of {@link ConfigProperty}
+   * config, if exists, is returned if the config is not found in the properties.
+   *
+   * @param keyMapper      Mapper function to map the key to values.
+   * @param configProperty {@link ConfigProperty} config of String type to fetch.
+   * @return String value if the config exists; default String value if the config does not exist
+   * and there is default value defined in the {@link ConfigProperty} config; {@code null} otherwise.
+   */
+  public static String getStringWithAltKeys(Function<String, Object> keyMapper,
+                                            ConfigProperty<String> configProperty) {
+    Object value = keyMapper.apply(configProperty.key());
     if (value != null) {
       return value.toString();
     }
     for (String alternative : configProperty.getAlternatives()) {
-      value = props.get(alternative);
+      value = keyMapper.apply(alternative);
       if (value != null) {
         LOG.warn(String.format("The configuration key '%s' has been deprecated "
                 + "and may be removed in the future. Please use the new key '%s' instead.",

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/SparkConfigUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/SparkConfigUtils.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util
+
+import org.apache.hudi.common.config.ConfigProperty
+import org.apache.hudi.common.util.ConfigUtils
+
+object SparkConfigUtils {
+
+  /**
+   * Gets the String value for a {@link ConfigProperty} config using ConfigUtils utility class. It checks
+   * the alternate config keys for the specified key as well.
+   *
+   * @param props          Configs in scala map
+   * @param configProperty {@link ConfigProperty} config of String type to fetch.
+   * @return String value if the config exists; default String value if the config does not exist
+   *         and there is default value defined in the {@link ConfigProperty} config; {@code null} otherwise.
+   */
+  def getStringWithAltKeys(props: Map[String, String], configProperty: ConfigProperty[String]): String = {
+    ConfigUtils.getStringWithAltKeys(JFunction.toJavaFunction[String, Object](key => props.getOrElse(key, null)), configProperty)
+  }
+
+  /**
+   * Whether the properties contain a config. If any of the key or alternative keys of the
+   * {@link ConfigProperty} exists in the properties, this method returns {@code true}.
+   *
+   * @param props          Configs in scala map
+   * @param configProperty Config to look up.
+   * @return {@code true} if exists; {@code false} otherwise.
+   */
+  def containsConfigProperty(props: Map[String, String], configProperty: ConfigProperty[_]): Boolean = {
+    ConfigUtils.containsConfigProperty(JFunction.toJavaFunction[String, java.lang.Boolean](key => props.contains(key)), configProperty)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING
 import org.apache.hudi.common.table.timeline.TimelineUtils
-import org.apache.hudi.common.util.StringUtils
+import org.apache.hudi.common.util.{ConfigUtils, StringUtils}
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.constant.{KeyGeneratorOptions, KeyGeneratorType}
@@ -212,7 +212,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       val (recordName, namespace) = AvroConversionUtils.getAvroRecordNameAndNamespace(table.identifier.table)
       val schema = SchemaConverters.toAvroType(dataSchema, nullable = false, recordName, namespace)
       val partitionColumns = if (tableConfigs.contains(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())) {
-        tableConfigs(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())
+        ConfigUtils.getStringWithAltKeys(tableConfigs.asJava.asInstanceOf[java.util.Map[String, Object]], KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
       } else if (table.partitionColumnNames.isEmpty) {
         null
       } else {
@@ -315,7 +315,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
           KeyGeneratorType.valueOf(originTableConfig(HoodieTableConfig.KEY_GENERATOR_TYPE.key)).getClassName)
     } else {
       val primaryKeys = table.properties.getOrElse(SQL_KEY_TABLE_PRIMARY_KEY.sqlKeyName, table.storage.properties.get(SQL_KEY_TABLE_PRIMARY_KEY.sqlKeyName)).toString
-      val partitionFieldsOpt = originTableConfig.get(HoodieTableConfig.PARTITION_FIELDS.key)
+      val partitionFieldsOpt = Option.apply(ConfigUtils.getStringWithAltKeys(originTableConfig.asJava.asInstanceOf[java.util.Map[String, Object]], HoodieTableConfig.PARTITION_FIELDS))
         .orElse(sqlOptions.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()))
       val partitions = partitionFieldsOpt.getOrElse(table.partitionColumnNames.mkString(","))
       extraConfig(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key) =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.constant.{KeyGeneratorOptions, KeyGeneratorType}
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
+import org.apache.hudi.util.JFunction
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.avro.SchemaConverters
@@ -212,7 +213,8 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       val (recordName, namespace) = AvroConversionUtils.getAvroRecordNameAndNamespace(table.identifier.table)
       val schema = SchemaConverters.toAvroType(dataSchema, nullable = false, recordName, namespace)
       val partitionColumns = if (tableConfigs.contains(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())) {
-        ConfigUtils.getStringWithAltKeys(tableConfigs.asJava.asInstanceOf[java.util.Map[String, Object]], KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
+        ConfigUtils.getStringWithAltKeys(JFunction.toJavaFunction[String, Object](key => tableConfigs.getOrElse(key, null)),
+          KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
       } else if (table.partitionColumnNames.isEmpty) {
         null
       } else {
@@ -315,7 +317,8 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
           KeyGeneratorType.valueOf(originTableConfig(HoodieTableConfig.KEY_GENERATOR_TYPE.key)).getClassName)
     } else {
       val primaryKeys = table.properties.getOrElse(SQL_KEY_TABLE_PRIMARY_KEY.sqlKeyName, table.storage.properties.get(SQL_KEY_TABLE_PRIMARY_KEY.sqlKeyName)).toString
-      val partitionFieldsOpt = Option.apply(ConfigUtils.getStringWithAltKeys(originTableConfig.asJava.asInstanceOf[java.util.Map[String, Object]], HoodieTableConfig.PARTITION_FIELDS))
+      val partitionFieldsOpt = Option.apply(ConfigUtils.getStringWithAltKeys(JFunction.toJavaFunction[String, Object](key => originTableConfig.getOrElse(key, null)),
+          HoodieTableConfig.PARTITION_FIELDS))
         .orElse(sqlOptions.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()))
       val partitions = partitionFieldsOpt.getOrElse(table.partitionColumnNames.mkString(","))
       extraConfig(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key) =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -557,14 +557,10 @@ object ProvidesHoodieConfig {
       if (classOf[CustomKeyGenerator].equals(keyGenClass)
         || classOf[CustomAvroKeyGenerator].equals(keyGenClass)) {
         val partitionFieldWithKeyGenType = HoodieTableConfig.getPartitionFieldPropForKeyGenerator(catalogTable.tableConfig).orElse("")
-        if (partitionFieldWithKeyGenType.contains(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX)) {
-          partitionFieldWithKeyGenType
-        } else if (writeConfigPartitionField.isDefined) {
-          // For custom key generator, we have to take the write config value from
-          // "hoodie.datasource.write.partitionpath.field" which contains the key generator
-          // type, whereas the table config only contains the prtition field names without
-          // key generator types.
+        if (writeConfigPartitionField.isDefined) {
           writeConfigPartitionField.get
+        } else if (StringUtils.nonEmpty(partitionFieldWithKeyGenType)) {
+          partitionFieldWithKeyGenType
         } else {
           log.warn("Write config \"hoodie.datasource.write.partitionpath.field\" is not set for "
             + "custom key generator. This may fail the write operation.")

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
@@ -42,6 +42,8 @@ class TestProvidesHoodieConfig {
     val mockTable = mock(classOf[HoodieCatalogTable])
     val partitionFieldNames = "ts,segment"
     val customKeyGenPartitionFieldWriteConfig = "ts:timestamp,segment:simple"
+    val tableConfig = new HoodieTableConfig()
+    when(mockTable.tableConfig).thenReturn(tableConfig)
 
     mockPartitionWriteConfigInCatalogProps(mockTable, None)
     assertEquals(
@@ -66,6 +68,16 @@ class TestProvidesHoodieConfig {
       partitionFieldNames,
       ProvidesHoodieConfig.getPartitionPathFieldWriteConfig(
         classOf[ComplexKeyGenerator].getName, partitionFieldNames, mockTable))
+    assertEquals(
+      customKeyGenPartitionFieldWriteConfig,
+      ProvidesHoodieConfig.getPartitionPathFieldWriteConfig(
+        classOf[CustomKeyGenerator].getName, partitionFieldNames, mockTable))
+
+    // catalog props do not have write partition path field config set but table config has the
+    // partition type in partition field
+    mockPartitionWriteConfigInCatalogProps(mockTable, Option.empty)
+    tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, customKeyGenPartitionFieldWriteConfig)
+    when(mockTable.tableConfig).thenReturn(tableConfig)
     assertEquals(
       customKeyGenPartitionFieldWriteConfig,
       ProvidesHoodieConfig.getPartitionPathFieldWriteConfig(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
@@ -477,10 +477,6 @@ class TestSparkSqlWithCustomKeyGenerator extends HoodieSparkSqlTestBase {
            """.stripMargin)
 
       testInserts(tableName, tsGenFunc, customPartitionFunc)
-      assertEquals(7, spark.sql(
-        s"""
-           | SELECT * from $tableName
-           | """.stripMargin).count())
 
       // Validate ts field is still of type int in the table
       validateTsFieldSchema(tablePath, "ts", Schema.Type.INT)


### PR DESCRIPTION
### Change Logs

Currently KeyGenUtils#inferKeyGeneratorTypeForAutoKeyGen  does not support custom key generators but supports the other key generator types. This PR aims to add support for it.
Also HoodieCatalogTable should be modified to add support for storing partition fields with key generator partition type. This was left out in [HUDI-7996](https://issues.apache.org/jira/browse/HUDI-7996) because of no support for custom keygen with HoodieCatalogTable

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
