### PR TITLE
[HUDI-8125] Update handling of non-string inputs for string fields in MercifulJsonConverter

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -847,12 +847,24 @@ public class MercifulJsonConverter {
     }
 
     private static JsonToAvroFieldProcessor generateStringTypeHandler() {
-      return new JsonToAvroFieldProcessor() {
-        @Override
-        public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
-          return Pair.of(true, value.toString());
+      return new StringProcessor();
+    }
+
+    private static class StringProcessor extends JsonToAvroFieldProcessor {
+      private static final ObjectMapper STRING_MAPPER = new ObjectMapper();
+
+      @Override
+      protected Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
+        if (value instanceof String) {
+          return Pair.of(true, value);
+        } else {
+          try {
+            return Pair.of(true, STRING_MAPPER.writeValueAsString(value));
+          } catch (IOException ex) {
+            return Pair.of(false, null);
+          }
         }
-      };
+      }
     }
 
     private static JsonToAvroFieldProcessor generateBytesTypeHandler() {

--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -460,26 +460,26 @@ public class MercifulJsonConverter {
     };
   }
 
-    private static JsonFieldProcessor generateStringTypeHandler() {
-      return new StringProcessor();
-    }
+  private static JsonFieldProcessor generateStringTypeHandler() {
+    return new StringProcessor();
+  }
 
-    private static class StringProcessor extends JsonFieldProcessor {
-      private static final ObjectMapper STRING_MAPPER = new ObjectMapper();
+  private static class StringProcessor extends JsonFieldProcessor {
+    private static final ObjectMapper STRING_MAPPER = new ObjectMapper();
 
-      @Override
-      protected Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
-        if (value instanceof String) {
-          return Pair.of(true, value);
-        } else {
-          try {
-            return Pair.of(true, STRING_MAPPER.writeValueAsString(value));
-          } catch (IOException ex) {
-            return Pair.of(false, null);
-          }
+    @Override
+    public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      if (value instanceof String) {
+        return Pair.of(true, value);
+      } else {
+        try {
+          return Pair.of(true, STRING_MAPPER.writeValueAsString(value));
+        } catch (IOException ex) {
+          return Pair.of(false, null);
         }
       }
     }
+  }
 
   protected JsonFieldProcessor generateBytesTypeHandler() {
     return new JsonFieldProcessor() {

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
@@ -86,7 +86,7 @@ public class TestMercifulJsonConverter {
     rec.put("favorite_number", 1337);
     rec.put("favorite_color", "10");
 
-    assertEquals(rec, CONVERTER.convert(json, simpleSchema));
+    Assertions.assertEquals(rec, CONVERTER.convert(json, simpleSchema));
   }
 
   private static final String DECIMAL_AVRO_FILE_INVALID_PATH = "/decimal-logical-type-invalid.avsc";

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -68,6 +69,24 @@ public class TestMercifulJsonConverter {
     rec.put("favorite_color", color);
 
     Assertions.assertEquals(rec, CONVERTER.convert(json, simpleSchema));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "{\"first\":\"John\",\"last\":\"Smith\"}",
+      "[{\"first\":\"John\",\"last\":\"Smith\"}]",
+      "{\"first\":\"John\",\"last\":\"Smith\",\"suffix\":3}",
+  })
+  void nestedJsonAsString(String nameInput) throws IOException {
+    Schema simpleSchema = SchemaTestUtil.getSimpleSchema();
+    String json = String.format("{\"name\": %s, \"favorite_number\": 1337, \"favorite_color\": 10}", nameInput);
+
+    GenericRecord rec = new GenericData.Record(simpleSchema);
+    rec.put("name", nameInput);
+    rec.put("favorite_number", 1337);
+    rec.put("favorite_color", "10");
+
+    assertEquals(rec, CONVERTER.convert(json, simpleSchema));
   }
 
   private static final String DECIMAL_AVRO_FILE_INVALID_PATH = "/decimal-logical-type-invalid.avsc";


### PR DESCRIPTION
### Change Logs

- When the `MercifulJsonConverter` is meant to write a value as a string, it writes out the value using the `ObjectMapper` if the input value is not a string. This allows us to simply pass through values without manipulating them.

### Impact

- If a user has a string field that can be json, it would end up translating this field to a map and writing as the `Map`'s `toString` output instead of simply passing through the original value.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
