### PR TITLE
[HUDI-8126] Use union to parallelize data and error table writes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
@@ -85,6 +85,12 @@ public class HoodieErrorTableConfig extends HoodieConfig {
       .withDocumentation("The config specifies the failure strategy if error table write fails. "
           + "Use one of - " + Arrays.toString(ErrorWriteFailureStrategy.values()));
 
+  public static final ConfigProperty<Boolean> ERROR_ENABLE_UNION_WITH_DATA_TABLE = ConfigProperty
+      .key("hoodie.errortable.write.union.enable")
+      .defaultValue(false)
+      .withDocumentation("Enable error table union with data table when writing for improved commit performance. "
+          + "By default it is disabled meaning data table and error table writes are sequential");
+
   public enum ErrorWriteFailureStrategy {
     ROLLBACK_COMMIT("Rollback the corresponding base table write commit for which the error events were triggered"),
     LOG_ERROR("Error is logged but the base table write succeeds");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
@@ -85,7 +85,7 @@ public class HoodieErrorTableConfig extends HoodieConfig {
       .withDocumentation("The config specifies the failure strategy if error table write fails. "
           + "Use one of - " + Arrays.toString(ErrorWriteFailureStrategy.values()));
 
-  public static final ConfigProperty<Boolean> ERROR_ENABLE_UNION_WITH_DATA_TABLE = ConfigProperty
+  public static final ConfigProperty<Boolean> ENABLE_ERROR_TABLE_WRITE_UNIFICATION = ConfigProperty
       .key("hoodie.errortable.write.union.enable")
       .defaultValue(false)
       .withDocumentation("Enable error table union with data table when writing for improved commit performance. "

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieErrorTableConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.config;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_ENABLE_UNION_WITH_DATA_TABLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestHoodieErrorTableConfig {
+
+  @Test
+  void testErrorAndBaseTableUnionConfig() {
+    // documentation is not null
+    assertNotNull(ERROR_ENABLE_UNION_WITH_DATA_TABLE.doc());
+    assertNotEquals("", ERROR_ENABLE_UNION_WITH_DATA_TABLE.doc());
+
+    // disabled by default
+    assertFalse(ERROR_ENABLE_UNION_WITH_DATA_TABLE.defaultValue());
+
+    // enabled when set to true
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.errortable.write.union.enable", "true");
+    assertTrue(props.getBoolean(ERROR_ENABLE_UNION_WITH_DATA_TABLE.key(), ERROR_ENABLE_UNION_WITH_DATA_TABLE.defaultValue()));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieErrorTableConfig.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_ENABLE_UNION_WITH_DATA_TABLE;
+import static org.apache.hudi.config.HoodieErrorTableConfig.ENABLE_ERROR_TABLE_WRITE_UNIFICATION;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,15 +34,15 @@ class TestHoodieErrorTableConfig {
   @Test
   void testErrorAndBaseTableUnionConfig() {
     // documentation is not null
-    assertNotNull(ERROR_ENABLE_UNION_WITH_DATA_TABLE.doc());
-    assertNotEquals("", ERROR_ENABLE_UNION_WITH_DATA_TABLE.doc());
+    assertNotNull(ENABLE_ERROR_TABLE_WRITE_UNIFICATION.doc());
+    assertNotEquals("", ENABLE_ERROR_TABLE_WRITE_UNIFICATION.doc());
 
     // disabled by default
-    assertFalse(ERROR_ENABLE_UNION_WITH_DATA_TABLE.defaultValue());
+    assertFalse(ENABLE_ERROR_TABLE_WRITE_UNIFICATION.defaultValue());
 
     // enabled when set to true
     TypedProperties props = new TypedProperties();
     props.setProperty("hoodie.errortable.write.union.enable", "true");
-    assertTrue(props.getBoolean(ERROR_ENABLE_UNION_WITH_DATA_TABLE.key(), ERROR_ENABLE_UNION_WITH_DATA_TABLE.defaultValue()));
+    assertTrue(props.getBoolean(ENABLE_ERROR_TABLE_WRITE_UNIFICATION.key(), ENABLE_ERROR_TABLE_WRITE_UNIFICATION.defaultValue()));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.streamer;
 import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.PublicAPIMethod;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -76,4 +77,8 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> implements Seri
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract boolean upsertAndCommit(String baseTableInstantTime, Option<String> commitedInstantTime);
+
+  public abstract JavaRDD<WriteStatus> upsert(String errorTableInstantTime, String baseTableInstantTime, Option<String> commitedInstantTime);
+
+  public abstract boolean commit(String errorTableInstantTime, JavaRDD<WriteStatus> writeStatuses);
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -844,14 +844,14 @@ public class StreamSync implements Serializable, Closeable {
                                                                               Timer.Context overallTimerContext) {
     Option<String> scheduledCompactionInstant = Option.empty();
     // write to hudi and fetch result
-    WriteClientWriteResult  writeClientWriteResult = writeToSink(inputBatch, instantTime, useRowWriter);
+    WriteClientWriteResult  writeClientWriteResult = writeToSink(inputBatch, instantTime);
     Map<String, List<String>> partitionToReplacedFileIds = writeClientWriteResult.getPartitionToReplacedFileIds();
     Option<String> commitedInstantTime = getLatestInstantWithValidCheckpointInfo(commitsTimelineOpt);
 
     // write to error table
     JavaRDD<WriteStatus> dataTableWriteStatusRDD = writeClientWriteResult.getWriteStatusRDD();
     JavaRDD<WriteStatus> writeStatusRDD = dataTableWriteStatusRDD;
-    String errorTableInstantTime = HoodieActiveTimeline.createNewInstantTime();
+    String errorTableInstantTime = writeClient.createNewInstantTime();
     Option<JavaRDD<WriteStatus>> errorTableWriteStatusRDDOpt = Option.empty();
     if (errorTableWriter.isPresent() && isErrorTableUnionWithDataTableEnabled) {
       errorTableWriteStatusRDDOpt = errorTableWriter.map(w -> w.upsert(errorTableInstantTime, instantTime, commitedInstantTime));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -308,7 +308,23 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
   }
 
   protected static void prepareParquetDFSFiles(int numRecords, String baseParquetPath) throws IOException {
-    prepareParquetDFSFiles(numRecords, baseParquetPath, FIRST_PARQUET_FILE_NAME, false, null, null);
+    prepareParquetDFSFiles(numRecords, baseParquetPath, FIRST_PARQUET_FILE_NAME, false, null, null).close();
+  }
+
+  protected static void prepareParquetDFSMultiFiles(int numRecords, String baseParquetPath, int numFiles) throws IOException {
+    if (numFiles <= 0) {
+      throw new IllegalArgumentException("Number of files must be greater than zero");
+    }
+    int recordsPerFile = numRecords / numFiles;
+    int extraRecords = numRecords % numFiles;
+    for (int i = 0; i < numFiles; i++) {
+      String fileName = String.format("%05d", i) + ".parquet";
+      // Add remaining records to the last file
+      int recordsInThisFile = (i == numFiles - 1) ? recordsPerFile + extraRecords : recordsPerFile;
+      if (recordsInThisFile > 0) {
+        prepareParquetDFSFiles(recordsInThisFile, baseParquetPath, fileName, false, null, null).close();
+      }
+    }
   }
 
   protected static HoodieTestDataGenerator prepareParquetDFSFiles(int numRecords, String baseParquetPath, String fileName, boolean useCustomSchema,

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerErrorTableWriteFlow.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerErrorTableWriteFlow.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.collection.Tuple3;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.functions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestHoodieDeltaStreamerErrorTableWriteFlow extends TestHoodieDeltaStreamerSchemaEvolutionBase {
+  protected void testBase(Tuple3<Integer, Integer, Integer> sourceGenInfo) throws Exception {
+    int totalRecords = sourceGenInfo.f0;
+    int errorRecords = sourceGenInfo.f1;
+    int numFiles = sourceGenInfo.f2;
+    boolean shouldCreateMultipleSourceFiles = numFiles > 1;
+
+    PARQUET_SOURCE_ROOT = basePath + "parquetFilesDfs" + testNum++;
+
+    if (totalRecords > 0) {
+      if (shouldCreateMultipleSourceFiles) {
+        prepareParquetDFSMultiFiles(totalRecords - errorRecords, PARQUET_SOURCE_ROOT, numFiles);
+      } else {
+        prepareParquetDFSFiles(totalRecords - errorRecords, PARQUET_SOURCE_ROOT);
+      }
+
+      // Add error data to the source
+      if (errorRecords > 0) {
+        String errorDataSourceRoot = basePath + "parquetErrorFilesDfs" + testNum++;
+        prepareParquetDFSFiles(errorRecords, errorDataSourceRoot);
+        Dataset<Row> df = sparkSession.read().parquet(errorDataSourceRoot);
+        df = df.withColumn("_row_key", functions.lit(""));
+        // add error records to PARQUET_SOURCE_ROOT
+        addParquetData(df, false);
+      }
+    } else {
+      fs.mkdirs(new Path(PARQUET_SOURCE_ROOT));
+    }
+
+    tableName = "test_parquet_table" + testNum;
+    tableBasePath = basePath + tableName;
+    this.deltaStreamer = new HoodieDeltaStreamer(getDeltaStreamerConfig(), jsc);
+    this.deltaStreamer.sync();
+
+    // base table validation
+    Dataset<Row> baseDf = sparkSession.read().format("hudi").load(tableBasePath);
+    assertEquals(totalRecords - errorRecords, baseDf.count());
+
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setConf(jsc.hadoopConfiguration())
+        .setBasePath(tableBasePath).build();
+    assertEquals(1, metaClient.getActiveTimeline().getInstants().size());
+
+    // error table validation
+    if (withErrorTable) {
+      TestHoodieDeltaStreamerSchemaEvolutionExtensive.validateErrorTable(errorRecords, this.writeErrorTableInParallelWithBaseTable);
+    }
+  }
+
+  protected static Stream<Arguments> testErrorTableWriteFlowArgs() {
+    Stream.Builder<Arguments> b = Stream.builder();
+    // totalRecords, numErrorRecords, numSourceFiles, WriteOperationType, shouldWriteErrorTableInUnionWithBaseTable
+
+    // empty source, error table union enabled, INSERT
+    b.add(Arguments.of(0, 0, 0, WriteOperationType.INSERT, true));
+    // empty source, error table union disabled, INSERT
+    b.add(Arguments.of(0, 0, 0, WriteOperationType.INSERT, false));
+    // non-empty source, error table union enabled, INSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.INSERT, true));
+    // non-empty source, error table union disabled, INSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.INSERT, false));
+    // non-empty source, error table union enabled, UPSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.UPSERT, true));
+    // non-empty source, error table union disabled, UPSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.UPSERT, false));
+    // non-empty source, error table union enabled, BULK_INSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.BULK_INSERT, true));
+    // non-empty source, error table union disabled, BULK_INSERT
+    b.add(Arguments.of(100, 5, 1, WriteOperationType.BULK_INSERT, false));
+    return b.build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testErrorTableWriteFlowArgs")
+  void testErrorTableWriteFlow(
+      int totalRecords,
+      int numErrorRecords,
+      int numSourceFiles,
+      WriteOperationType wopType,
+      boolean writeErrorTableInParallel) throws Exception {
+    this.withErrorTable = true;
+    this.writeErrorTableInParallelWithBaseTable = writeErrorTableInParallel;
+    this.writeOperationType = wopType;
+    this.useSchemaProvider = false;
+    this.useTransformer = false;
+    this.tableType = "COPY_ON_WRITE";
+    this.shouldCluster = false;
+    this.shouldCompact = false;
+    this.rowWriterEnable = false;
+    this.addFilegroups = false;
+    this.multiLogFiles = false;
+    this.dfsSourceLimitBytes = 100000000; // set source limit to 100mb
+    testBase(Tuple3.of(totalRecords, numErrorRecords, numSourceFiles));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerErrorTableWriteFlow.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerErrorTableWriteFlow.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.collection.Tuple3;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
@@ -74,7 +75,7 @@ class TestHoodieDeltaStreamerErrorTableWriteFlow extends TestHoodieDeltaStreamer
     assertEquals(totalRecords - errorRecords, baseDf.count());
 
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
-        .setConf(jsc.hadoopConfiguration())
+        .setConf(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()))
         .setBasePath(tableBasePath).build();
     assertEquals(1, metaClient.getActiveTimeline().getInstants().size());
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -24,6 +24,7 @@ import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
@@ -69,6 +70,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -102,6 +104,9 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   protected boolean withErrorTable;
   protected boolean useTransformer;
   protected boolean userProvidedSchema;
+  protected boolean writeErrorTableInParallelWithBaseTable;
+  protected int dfsSourceLimitBytes = 100000;
+  protected WriteOperationType writeOperationType = WriteOperationType.UPSERT;
 
   protected Map<String, String> readOpts = new HashMap<String, String>() {
     {
@@ -193,6 +198,9 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
       extraProps.setProperty(HoodieErrorTableConfig.ERROR_TABLE_BASE_PATH.key(), basePath + tableName + "ERROR");
       extraProps.setProperty(HoodieErrorTableConfig.ERROR_TABLE_WRITE_CLASS.key(), TestErrorTable.class.getName());
       extraProps.setProperty("hoodie.base.path", tableBasePath);
+      if (writeErrorTableInParallelWithBaseTable) {
+        extraProps.setProperty(HoodieErrorTableConfig.ERROR_ENABLE_UNION_WITH_DATA_TABLE.key(), "true");
+      }
     }
 
     List<String> transformerClassNames = new ArrayList<>();
@@ -208,7 +216,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
           PARQUET_SOURCE_ROOT, false, "partition_path", "", extraProps, false);
       cfg = TestHoodieDeltaStreamer.TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT, ParquetDFSSource.class.getName(),
           transformerClassNames, PROPS_FILENAME_TEST_PARQUET, false,
-          useSchemaProvider, 100000, false, null, tableType, "timestamp", null);
+          useSchemaProvider, dfsSourceLimitBytes, false, null, tableType, "timestamp", null);
     }
     cfg.forceDisableCompaction = !shouldCompact;
     return cfg;
@@ -331,8 +339,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   public static class TestErrorTable extends BaseErrorTableWriter {
 
     public static List<JavaRDD> errorEvents = new ArrayList<>();
-    public static Map<String,Option<JavaRDD>> commited = new HashMap<>();
-
+    public static Map<String, Option<JavaRDD>> commited = new HashMap<>();
     public TestErrorTable(HoodieStreamer.Config cfg, SparkSession sparkSession, TypedProperties props, HoodieSparkEngineContext hoodieSparkContext,
                           FileSystem fileSystem) {
       super(cfg, sparkSession, props, hoodieSparkContext, fileSystem);
@@ -341,6 +348,44 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     @Override
     public void addErrorEvents(JavaRDD errorEvent) {
       errorEvents.add(errorEvent);
+    }
+
+    @Override
+    public boolean commit(String errorTableInstantTime, JavaRDD writeStatuses) {
+      if (writeStatuses == null) {
+        throw new IllegalArgumentException("writeStatuses cannot be null");
+      }
+      commited.clear();
+      commited.put(errorTableInstantTime, Option.of(writeStatuses));
+      return true;
+    }
+
+    @Override
+    public JavaRDD<WriteStatus> upsert(String errorTableInstantTime, String baseTableInstantTime, Option commitedInstantTime) {
+      if (errorEvents.size() > 0) {
+        JavaRDD errorsCombined = errorEvents.get(0);
+        for (int i = 1; i < errorEvents.size(); i++) {
+          errorsCombined = errorsCombined.union(errorEvents.get(i));
+        }
+        JavaRDD writeStatus = errorsCombined.mapPartitions(partition -> {
+          Iterator itr = (Iterator) partition;
+          long count = 0;
+          while (itr.hasNext()) {
+            itr.next();
+            count++;
+          }
+          List<WriteStatus> result = new ArrayList<>();
+          if (count > 0) {
+            WriteStatus status = new WriteStatus();
+            status.setTotalRecords(count);
+            result.add(status);
+          }
+          return result.iterator();
+        });
+        errorEvents = new ArrayList<>();
+        return writeStatus;
+      }
+      return null;
     }
 
     @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -199,7 +199,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
       extraProps.setProperty(HoodieErrorTableConfig.ERROR_TABLE_WRITE_CLASS.key(), TestErrorTable.class.getName());
       extraProps.setProperty("hoodie.base.path", tableBasePath);
       if (writeErrorTableInParallelWithBaseTable) {
-        extraProps.setProperty(HoodieErrorTableConfig.ERROR_ENABLE_UNION_WITH_DATA_TABLE.key(), "true");
+        extraProps.setProperty(HoodieErrorTableConfig.ENABLE_ERROR_TABLE_WRITE_UNIFICATION.key(), "true");
       }
     }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.TestHoodieSparkUtils;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.streamer.ErrorEvent;
 
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -178,17 +180,40 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
     }
 
     if (withErrorTable) {
-      List<ErrorEvent> recs = new ArrayList<>();
-      for (String key : TestErrorTable.commited.keySet()) {
-        Option<JavaRDD> errors = TestErrorTable.commited.get(key);
-        if (errors.isPresent()) {
-          if (!errors.get().isEmpty()) {
-            recs.addAll(errors.get().collect());
-          }
+      validateErrorTable(1, this.writeErrorTableInParallelWithBaseTable, reason);
+    }
+  }
+
+  protected static void validateErrorTable(int numErrorRecords, boolean isErrorTableUnionWriteEnabled) {
+    validateErrorTable(numErrorRecords, isErrorTableUnionWriteEnabled, null);
+  }
+
+  protected static void validateErrorTable(int numErrorRecords, boolean isErrorTableUnionWriteEnabled, ErrorEvent.ErrorReason reason) {
+    List recs = new ArrayList<>();
+    for (String key : TestErrorTable.commited.keySet()) {
+      Option<JavaRDD> errors = TestErrorTable.commited.get(key);
+      if (errors.isPresent()) {
+        if (!errors.get().isEmpty()) {
+          List collect = errors.get().collect();
+          recs.addAll(collect);
         }
       }
-      assertEquals(1, recs.size());
-      assertEquals(recs.get(0).getReason(), reason);
+    }
+    if (numErrorRecords > 0) {
+      if (isErrorTableUnionWriteEnabled) {
+        // Union (parallel execution) is executed if values in committed map are of type WriteStatus
+        assertTrue(recs.get(0) instanceof WriteStatus);
+        assertEquals(numErrorRecords, recs.stream().mapToLong(e -> ((WriteStatus) e).getTotalRecords()).sum());
+      } else {
+        // sequential flow is executed if values in committed map are of type ErrorEvent
+        assertTrue(recs.get(0) instanceof ErrorEvent);
+        assertEquals(numErrorRecords, recs.size());
+        if (reason != null) {
+          assertEquals(((List<ErrorEvent>) recs).get(0).getReason(), reason);
+        }
+      }
+    } else {
+      assertEquals(0, recs.size());
     }
   }
 
@@ -212,15 +237,39 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
     return b.build();
   }
 
+  protected static Stream<Arguments> testErrorTableArgs() {
+    Stream.Builder<Arguments> b = Stream.builder();
+    //only testing row-writer enabled for now
+    for (Boolean writeErrorTableInParallel: new Boolean[]{false, true}) {
+      for (Boolean rowWriterEnable : new Boolean[]{false, true}) {
+        for (Boolean addFilegroups : new Boolean[]{false, true}) {
+          for (Boolean multiLogFiles : new Boolean[]{false, true}) {
+            for (Boolean shouldCluster : new Boolean[]{false, true}) {
+              for (String tableType : new String[]{"COPY_ON_WRITE", "MERGE_ON_READ"}) {
+                if (!multiLogFiles || tableType.equals("MERGE_ON_READ")) {
+                  b.add(Arguments.of(tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, writeErrorTableInParallel));
+                }
+              }
+            }
+            b.add(Arguments.of("MERGE_ON_READ", false, true, rowWriterEnable, addFilegroups, multiLogFiles, writeErrorTableInParallel));
+          }
+        }
+      }
+    }
+    return b.build();
+  }
+
   @ParameterizedTest
-  @MethodSource("testArgs")
+  @MethodSource("testErrorTableArgs")
   public void testErrorTable(String tableType,
                              Boolean shouldCluster,
                              Boolean shouldCompact,
                              Boolean rowWriterEnable,
                              Boolean addFilegroups,
-                             Boolean multiLogFiles) throws Exception {
+                             Boolean multiLogFiles,
+                             Boolean writeErrorTableInParallel) throws Exception {
     this.withErrorTable = true;
+    this.writeErrorTableInParallelWithBaseTable = writeErrorTableInParallel;
     this.useSchemaProvider = false;
     this.useTransformer = false;
     this.tableType = tableType;
@@ -233,14 +282,16 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
   }
 
   @ParameterizedTest
-  @MethodSource("testArgs")
+  @MethodSource("testErrorTableArgs")
   public void testErrorTableWithSchemaProvider(String tableType,
                                                Boolean shouldCluster,
                                                Boolean shouldCompact,
                                                Boolean rowWriterEnable,
                                                Boolean addFilegroups,
-                                               Boolean multiLogFiles) throws Exception {
+                                               Boolean multiLogFiles,
+                                               Boolean writeErrorTableInParallel) throws Exception {
     this.withErrorTable = true;
+    this.writeErrorTableInParallelWithBaseTable = writeErrorTableInParallel;
     this.useSchemaProvider = true;
     this.useTransformer = false;
     this.tableType = tableType;
@@ -253,14 +304,16 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
   }
 
   @ParameterizedTest
-  @MethodSource("testArgs")
+  @MethodSource("testErrorTableArgs")
   public void testErrorTableWithTransformer(String tableType,
                              Boolean shouldCluster,
                              Boolean shouldCompact,
                              Boolean rowWriterEnable,
                              Boolean addFilegroups,
-                             Boolean multiLogFiles) throws Exception {
+                             Boolean multiLogFiles,
+                             Boolean writeErrorTableInParallel) throws Exception {
     this.withErrorTable = true;
+    this.writeErrorTableInParallelWithBaseTable = writeErrorTableInParallel;
     this.useSchemaProvider = true;
     this.useTransformer = true;
     this.tableType = tableType;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -18,6 +18,9 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.HoodieSchemaUtils;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -297,6 +300,17 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
   private BaseErrorTableWriter getAnonymousErrorTableWriter(TypedProperties props) {
     return new BaseErrorTableWriter<ErrorEvent<String>>(new HoodieDeltaStreamer.Config(),
         spark(), props, new HoodieSparkEngineContext(jsc()), fs()) {
+
+      @Override
+      public JavaRDD<WriteStatus> upsert(String errorTableInstantTime, String baseTableInstantTime, Option<String> commitedInstantTime) {
+        return null;
+      }
+
+      @Override
+      public boolean commit(String errorTableInstantTime, JavaRDD<WriteStatus> writeStatuses) {
+        return false;
+      }
+
       List<JavaRDD<HoodieAvroRecord>> errorEvents = new LinkedList();
 
       @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.utilities.sources;
 
-import org.apache.hudi.HoodieSchemaUtils;
-import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;


### PR DESCRIPTION
### Change Logs

Enable writing of error and data table in parallel. This behavior is disabled by default and can enabled by setting error table config property: `hoodie.errortable.write.union.enable` to true

### Impact

Improved overall write performance and commit times when error table writer is enabled

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

A new config (`hoodie.errortable.write.union.enable`) is being added to **HoodieErrorTableConfig** as part of this PR


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
