### PR TITLE
[HUDI-8126] Persist sourceRdd to optimise writeStatus DAG

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieErrorTableConfig.java
@@ -84,6 +84,10 @@ public class HoodieErrorTableConfig extends HoodieConfig {
       .defaultValue(ErrorWriteFailureStrategy.ROLLBACK_COMMIT.name())
       .withDocumentation("The config specifies the failure strategy if error table write fails. "
           + "Use one of - " + Arrays.toString(ErrorWriteFailureStrategy.values()));
+  public static final ConfigProperty<Boolean> ERROR_TABLE_PERSIST_SOURCE_RDD = ConfigProperty
+      .key("hoodie.errortable.source.rdd.persist")
+      .defaultValue(false)
+      .withDocumentation("Enabling this config, persists the sourceRDD to disk which helps in faster processing of data table + error table write DAG");
 
   public enum ErrorWriteFailureStrategy {
     ROLLBACK_COMMIT("Rollback the corresponding base table write commit for which the error events were triggered"),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -112,6 +112,7 @@ import static org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1.STREA
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.config.HoodieCleanConfig.CLEANER_POLICY;
 import static org.apache.hudi.config.HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE;
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
 import static org.apache.hudi.table.marker.ConflictDetectionUtils.getDefaultEarlyConflictDetectionStrategy;
 
 /**
@@ -1313,6 +1314,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public String getTaggedRecordStorageLevel() {
     return getString(TAGGED_RECORD_STORAGE_LEVEL_VALUE);
+  }
+
+  public Boolean isSourceRddPersisted() {
+    return getBoolean(ERROR_TABLE_PERSIST_SOURCE_RDD);
   }
 
   public String getInternalSchema() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.table.action.commit;
 
-import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.clustering.update.strategy.SparkAllowUpdateStrategy;
 import org.apache.hudi.client.utils.SparkValidatorUtils;
@@ -44,6 +43,7 @@ import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.execution.SparkLazyInsertIterable;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.io.CreateHandleFactory;
 import org.apache.hudi.io.HoodieMergeHandle;
 import org.apache.hudi.io.HoodieMergeHandleFactory;
@@ -150,7 +150,7 @@ public abstract class BaseSparkCommitActionExecutor<T> extends
   public HoodieWriteMetadata<HoodieData<WriteStatus>> execute(HoodieData<HoodieRecord<T>> inputRecords) {
     // Cache the tagged records, so we don't end up computing both
     JavaRDD<HoodieRecord<T>> inputRDD = HoodieJavaRDD.getJavaRDD(inputRecords);
-    if (inputRDD.getStorageLevel() == StorageLevel.NONE()) {
+    if (!config.isSourceRddPersisted() || inputRDD.getStorageLevel() == StorageLevel.NONE()) {
       HoodieJavaRDD.of(inputRDD).persist(config.getTaggedRecordStorageLevel(),
           context, HoodieDataCacheKey.of(config.getBasePath(), instantTime));
     } else {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/SourceCommitCallback.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/SourceCommitCallback.java
@@ -30,4 +30,10 @@ public interface SourceCommitCallback {
    */
   default void onCommit(String lastCkptStr) {
   }
+
+  /**
+   * Release resources cached by source.
+   */
+  default void releaseResources() {
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.checkpoint.CheckpointUtils;
 import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1;
 import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Either;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.callback.SourceCommitCallback;
 import org.apache.hudi.utilities.schema.SchemaProvider;
@@ -34,14 +35,20 @@ import org.apache.hudi.utilities.streamer.DefaultStreamContext;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.hudi.utilities.streamer.StreamContext;
 
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.storage.StorageLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 
 import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.shouldTargetCheckpointV2;
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
+import static org.apache.hudi.config.HoodieWriteConfig.TAGGED_RECORD_STORAGE_LEVEL_VALUE;
 import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
 
 /**
@@ -63,6 +70,9 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
   private transient SchemaProvider overriddenSchemaProvider;
 
   private final SourceType sourceType;
+  private final StorageLevel storageLevel;
+  private final boolean persistRdd;
+  private Either<Dataset<Row>, JavaRDD<?>> cachedSourceRdd = null;
 
   protected Source(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
       SchemaProvider schemaProvider) {
@@ -81,6 +91,8 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
     this.overriddenSchemaProvider = streamContext.getSchemaProvider();
     this.sourceType = sourceType;
     this.sourceProfileSupplier = streamContext.getSourceProfileSupplier();
+    this.storageLevel = StorageLevel.fromString(ConfigUtils.getStringWithAltKeys(props, TAGGED_RECORD_STORAGE_LEVEL_VALUE, true));
+    this.persistRdd = ConfigUtils.getBooleanWithAltKeys(props, ERROR_TABLE_PERSIST_SOURCE_RDD);
     this.writeTableVersion = ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION);
   }
 
@@ -168,6 +180,7 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
   public final InputBatch<T> fetchNext(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
     Option<Checkpoint> lastCheckpointTranslated = translateCheckpoint(lastCheckpoint);
     InputBatch<T> batch = readFromCheckpoint(lastCheckpointTranslated, sourceLimit);
+    batch.getBatch().ifPresent(this::persist);
     // If overriddenSchemaProvider is passed in CLI, use it
     return overriddenSchemaProvider == null ? batch
         : new InputBatch<>(batch.getBatch(), batch.getCheckpointForNextBatch(), overriddenSchemaProvider);
@@ -179,5 +192,29 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
 
   public SparkSession getSparkSession() {
     return sparkSession;
+  }
+
+  private synchronized void persist(T data) {
+    boolean isSparkRdd = data.getClass().isAssignableFrom(Dataset.class) || data.getClass().isAssignableFrom(JavaRDD.class);
+    if (persistRdd && isSparkRdd) {
+      if (data.getClass().isAssignableFrom(Dataset.class)) {
+        Dataset<Row> df = (Dataset<Row>) data;
+        cachedSourceRdd = Either.left(df);
+        df.persist(storageLevel);
+      } else {
+        JavaRDD<?> javaRDD = (JavaRDD<?>) data;
+        cachedSourceRdd = Either.right(javaRDD);
+        javaRDD.persist(storageLevel);
+      }
+    }
+  }
+
+  @Override
+  public void releaseResources() {
+    if (cachedSourceRdd != null && cachedSourceRdd.isLeft()) {
+      cachedSourceRdd.asLeft().unpersist();
+    } else if (cachedSourceRdd != null && cachedSourceRdd.isRight()) {
+      cachedSourceRdd.asRight().unpersist();
+    }
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
@@ -305,6 +305,7 @@ public class SourceFormatAdapter implements Closeable {
 
   @Override
   public void close() {
+    source.releaseResources();
     if (source instanceof Closeable) {
       try {
         ((Closeable) source).close();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -73,6 +73,7 @@ import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HoodieHiveSyncClient;
@@ -179,6 +180,7 @@ import static org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2.STREA
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.util.StringUtils.EMPTY_STRING;
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
 import static org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1917,15 +1919,22 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     new HoodieDeltaStreamer(cfg, jsc).sync();
   }
 
-  @Test
-  public void testDistributedTestDataSource() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testDistributedTestDataSource(boolean persistSourceRdd) {
     TypedProperties props = new TypedProperties();
     props.setProperty(SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), "1000");
     props.setProperty(SourceTestConfig.NUM_SOURCE_PARTITIONS_PROP.key(), "1");
     props.setProperty(SourceTestConfig.USE_ROCKSDB_FOR_TEST_DATAGEN_KEYS.key(), "true");
+    props.setProperty(ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
     DistributedTestDataSource distributedTestDataSource = new DistributedTestDataSource(props, jsc, sparkSession, null);
     InputBatch<JavaRDD<GenericRecord>> batch = distributedTestDataSource.fetchNext(Option.empty(), 10000000);
-    batch.getBatch().get().cache();
+    if (persistSourceRdd) {
+      Exception actualException = assertThrows(UnsupportedOperationException.class, () -> batch.getBatch().get().cache());
+      assertTrue(actualException.getMessage().contains("Cannot change storage level of an RDD after it was already assigned a level"));
+    } else {
+      batch.getBatch().get().cache();
+    }
     long c = batch.getBatch().get().count();
     assertEquals(1000, c);
   }
@@ -3175,6 +3184,52 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("generateErrorTablePersistSourceRddArgs")
+  void testErrorTableSourcePersist(WriteOperationType writeOperationType, boolean persistSourceRdd) throws Exception {
+    String tableBasePath = basePath + "/test_table_error_table" + persistSourceRdd + writeOperationType;
+    TypedProperties tableProps =
+        new DFSPropertiesConfiguration(fs.getConf(), new StoragePath(basePath + "/" + PROPS_FILENAME_TEST_SOURCE)).getProps();
+    tableProps.setProperty(ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
+    switch (writeOperationType) {
+      case BULK_INSERT:
+        tableProps.setProperty("hoodie.datasource.write.partitionpath.field", "");
+        tableProps.setProperty("hoodie.datasource.write.keygenerator.class", NonpartitionedKeyGenerator.class.getName());
+        tableProps.setProperty("hoodie.bulkinsert.sort.mode", BulkInsertSortMode.GLOBAL_SORT.name());
+        break;
+      case UPSERT:
+        tableProps.setProperty("hoodie.datasource.write.recordkey.field", "_row_key");
+        tableProps.setProperty("hoodie.datasource.write.partitionpath.field", "partition_path");
+        break;
+      case INSERT:
+        tableProps.setProperty("hoodie.datasource.write.partitionpath.field", "partition_path");
+        break;
+      default:
+        throw new UnsupportedOperationException("Invalid write operationType " + writeOperationType);
+    }
+    String tablePropsFileName = "table_specific.properties";
+    UtilitiesTestBase.Helpers.savePropsToDFS(tableProps, storage, basePath + "/" + tablePropsFileName);
+    // Initialize table config.
+    HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, writeOperationType,
+        Collections.singletonList(TestHoodieDeltaStreamer.TripsWithDistanceTransformer.class.getName()), tablePropsFileName, false);
+    HoodieStreamer deltaStreamer = new HoodieStreamer(cfg, jsc);
+    HoodieStreamer.StreamSyncService streamSyncService = (HoodieStreamer.StreamSyncService) deltaStreamer.getIngestionService();
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(HoodieTestUtils.getDefaultStorageConf()).setBasePath(tableBasePath).build();
+    InputBatch inputBatch = streamSyncService.getStreamSync().readFromSource("00000", metaClient).getLeft();
+    // Read from source and validate persistRdd call.
+    JavaRDD<GenericRecord> sourceRdd = (JavaRDD<GenericRecord>) inputBatch.getBatch().get();
+    assertEquals(1000, sourceRdd.count());
+    if (persistSourceRdd) {
+      assertTrue(sourceRdd.toDebugString().contains("CachedPartitions"));
+    } else {
+      assertFalse(sourceRdd.toDebugString().contains("CachedPartitions"));
+    }
+    streamSyncService.close();
+    // Ingest data.
+    streamSyncService.ingestOnce();
+    assertRecordCount(950, tableBasePath, sqlContext);
+  }
+
   private Set<String> getAllFileIDsInTable(String tableBasePath, Option<String> partition) {
     HoodieTableMetaClient metaClient = createMetaClient(jsc, tableBasePath);
     final HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
@@ -3319,5 +3374,16 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     public Schema getSourceSchema() {
       return null;
     }
+  }
+
+  private static Stream<Arguments> generateErrorTablePersistSourceRddArgs() {
+    return Stream.of(
+        Arguments.of(WriteOperationType.BULK_INSERT, false),
+        Arguments.of(WriteOperationType.BULK_INSERT, true),
+        Arguments.of(WriteOperationType.INSERT, false),
+        Arguments.of(WriteOperationType.INSERT, true),
+        Arguments.of(WriteOperationType.UPSERT, false),
+        Arguments.of(WriteOperationType.UPSERT, true)
+    );
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -52,6 +52,7 @@ import java.util.Properties;
 
 import static org.apache.hudi.utilities.config.KafkaSourceConfig.ENABLE_KAFKA_COMMIT_OFFSET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,6 +89,18 @@ public abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarne
   protected abstract SourceFormatAdapter createSource(TypedProperties props);
 
   protected abstract void sendMessagesToKafka(String topic, int count, int numPartitions);
+  
+  protected void verifyRddsArePersisted(Source source, String sparkPlan, boolean persistSourceRdd) {
+    if (persistSourceRdd) {
+      assertTrue(sparkPlan.contains("CachedPartitions"));
+      assertEquals(1, jsc().getPersistentRDDs().size());
+    } else {
+      assertFalse(sparkPlan.contains("CachedPartitions"));
+      assertEquals(0, jsc().getPersistentRDDs().size());
+    }
+    source.releaseResources();
+    assertEquals(0, jsc().getPersistentRDDs().size());
+  }
 
   @Test
   public void testKafkaSource() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -45,6 +45,8 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.net.URL;
@@ -60,6 +62,7 @@ import java.util.stream.Collectors;
 import scala.Tuple2;
 
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_BASE_PATH;
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TARGET_TABLE;
 import static org.apache.hudi.utilities.config.KafkaSourceConfig.ENABLE_KAFKA_COMMIT_OFFSET;
 import static org.apache.hudi.utilities.schema.KafkaOffsetPostProcessor.KAFKA_SOURCE_KEY_COLUMN;
@@ -233,10 +236,11 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
     }
   }
 
-  @Test
-  public void testErrorEventsForDataInRowFormat() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testErrorEventsForDataInRowFormat(boolean persistSourceRdd) throws IOException {
     // topic setup.
-    final String topic = TEST_TOPIC_PREFIX + "testErrorEventsForDataInRowFormat";
+    final String topic = TEST_TOPIC_PREFIX + "testErrorEventsForDataInRowFormat_" + persistSourceRdd;
 
     testUtils.createTopic(topic, 2);
     List<TopicPartition> topicPartitions = new ArrayList<>();
@@ -254,12 +258,16 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
     props.put(ERROR_TARGET_TABLE.key(),"json_kafka_row_events");
     props.put("hoodie.errortable.validate.targetschema.enable", "true");
     props.put("hoodie.base.path","/tmp/json_kafka_row_events");
+    props.setProperty(ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
+
     Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
     Option<BaseErrorTableWriter> errorTableWriter = Option.of(getAnonymousErrorTableWriter(props));
     SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter, Option.of(props));
-    assertEquals(1000, kafkaSource.fetchNewDataInRowFormat(Option.empty(),Long.MAX_VALUE).getBatch().get().count());
+    InputBatch<Dataset<Row>> fetch1 = kafkaSource.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE);
+    assertEquals(1000, fetch1.getBatch().get().count());
     assertEquals(2,((JavaRDD)errorTableWriter.get().getErrorEvents(
         InProcessTimeGenerator.createNewInstantTime(), Option.empty()).get()).count());
+    verifyRddsArePersisted(kafkaSource.getSource(), fetch1.getBatch().get().rdd().toDebugString(), persistSourceRdd);
   }
 
   @Test
@@ -292,11 +300,12 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
         InProcessTimeGenerator.createNewInstantTime(), Option.empty()).get()).count());
   }
 
-  @Test
-  public void testErrorEventsForDataInAvroFormat() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testErrorEventsForDataInAvroFormat(boolean persistSourceRdd) throws IOException {
 
     // topic setup.
-    final String topic = TEST_TOPIC_PREFIX + "testErrorEventsForDataInAvroFormat";
+    final String topic = TEST_TOPIC_PREFIX + "testErrorEventsForDataInAvroFormat_" + persistSourceRdd;
 
     testUtils.createTopic(topic, 2);
     List<TopicPartition> topicPartitions = new ArrayList<>();
@@ -314,14 +323,16 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
     props.put(ERROR_TABLE_BASE_PATH.key(),"/tmp/qurantine_table_test/json_kafka_events");
     props.put(ERROR_TARGET_TABLE.key(),"json_kafka_events");
     props.put("hoodie.base.path","/tmp/json_kafka_events");
+    props.setProperty(ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
 
     Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
     Option<BaseErrorTableWriter> errorTableWriter = Option.of(getAnonymousErrorTableWriter(props));
     SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter, Option.of(props));
     InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(),Long.MAX_VALUE);
     assertEquals(1000,fetch1.getBatch().get().count());
-    assertEquals(2, ((JavaRDD)errorTableWriter.get().getErrorEvents(
+    assertEquals(2, ((JavaRDD) errorTableWriter.get().getErrorEvents(
         InProcessTimeGenerator.createNewInstantTime(), Option.empty()).get()).count());
+    verifyRddsArePersisted(kafkaSource.getSource(), fetch1.getBatch().get().rdd().toDebugString(), persistSourceRdd);
   }
 
   private BaseErrorTableWriter getAnonymousErrorTableWriter(TypedProperties props) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestProtoKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestProtoKafkaSource.java
@@ -20,6 +20,8 @@ package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieErrorTableConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.utilities.config.KafkaSourceConfig;
 import org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig;
 import org.apache.hudi.utilities.schema.ProtoClassBasedSchemaProvider;
@@ -57,6 +59,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -103,9 +107,10 @@ public class TestProtoKafkaSource extends BaseTestKafkaSource {
     return new SourceFormatAdapter(protoKafkaSource);
   }
 
-  @Test
-  public void testProtoKafkaSourceWithConfluentProtoDeserialization() {
-    final String topic = TEST_TOPIC_PREFIX + "testProtoKafkaSourceWithConfluentDeserializer";
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testProtoKafkaSourceWithConfluentProtoDeserialization(boolean persistSourceRdd) {
+    final String topic = TEST_TOPIC_PREFIX + "testProtoKafkaSourceWithConfluentDeserializer_" + persistSourceRdd;
     testUtils.createTopic(topic, 2);
     TypedProperties props = createPropsForKafkaSource(topic, null, "earliest");
     props.put(KAFKA_PROTO_VALUE_DESERIALIZER_CLASS.key(),
@@ -113,6 +118,8 @@ public class TestProtoKafkaSource extends BaseTestKafkaSource {
     props.put("schema.registry.url", MOCK_REGISTRY_URL);
     props.put("hoodie.streamer.schemaprovider.registry.url", MOCK_REGISTRY_URL);
     props.setProperty(ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_WRAPPED_PRIMITIVES_AS_RECORDS.key(), "true");
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
+    props.setProperty(HoodieWriteConfig.TAGGED_RECORD_STORAGE_LEVEL_VALUE.key(), "MEMORY_ONLY");
     // class name is not required so we'll remove it
     props.remove(ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_CLASS_NAME.key());
     SchemaProvider schemaProvider = new SchemaRegistryProvider(props, jsc());
@@ -123,6 +130,7 @@ public class TestProtoKafkaSource extends BaseTestKafkaSource {
     JavaRDD<Message> messagesRead = protoKafkaSource.fetchNext(Option.empty(), 1000).getBatch().get();
     assertEquals(messages.stream().map(this::protoToJson).collect(Collectors.toSet()),
         new HashSet<>(messagesRead.map(message -> PRINTER.print(message)).collect()));
+    verifyRddsArePersisted(protoKafkaSource, messagesRead.rdd().toDebugString(), persistSourceRdd);
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsSource.java
@@ -30,15 +30,19 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
 import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_FS;
 import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_REGION;
 import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Basic tests for {@link S3EventsSource}.
@@ -64,10 +68,11 @@ public class TestS3EventsSource extends AbstractCloudObjectsSourceTestBase {
    *
    * @throws IOException
    */
-  @Test
-  public void testReadingFromSource() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testReadingFromSource(boolean persistSourceRdd) throws IOException {
 
-    SourceFormatAdapter sourceFormatAdapter = new SourceFormatAdapter(prepareCloudObjectSource());
+    SourceFormatAdapter sourceFormatAdapter = new SourceFormatAdapter(prepareCloudObjectSource(generateProperties(persistSourceRdd)));
 
     // 1. Extract without any checkpoint => (no data available)
     generateMessageInQueue(null);
@@ -82,6 +87,7 @@ public class TestS3EventsSource extends AbstractCloudObjectsSourceTestBase {
     InputBatch<JavaRDD<GenericRecord>> fetch1 =
         sourceFormatAdapter.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE);
     assertEquals(1, fetch1.getBatch().get().count());
+    verifyRddsArePersisted(sourceFormatAdapter, fetch1, persistSourceRdd);
 
     // 3. Produce new data, extract new data
     generateMessageInQueue("2");
@@ -94,17 +100,36 @@ public class TestS3EventsSource extends AbstractCloudObjectsSourceTestBase {
     GenericRecord s3 = (GenericRecord) fetch2.getBatch().get().rdd().first().get("s3");
     GenericRecord s3Object = (GenericRecord) s3.get("object");
     assertEquals("2.parquet", s3Object.get("key").toString());
+    verifyRddsArePersisted(sourceFormatAdapter, fetch2, persistSourceRdd);
   }
 
   @Override
-  public Source prepareCloudObjectSource() {
+  public Source prepareCloudObjectSource(TypedProperties props) {
+    S3EventsSource dfsSource = new S3EventsSource(props, jsc, sparkSession, schemaProvider);
+    dfsSource.sqs = this.sqs;
+    return dfsSource;
+  }
+
+  private TypedProperties generateProperties(boolean persistSourceRdd) {
     TypedProperties props = new TypedProperties();
     props.setProperty(S3_SOURCE_QUEUE_URL.key(), sqsUrl);
     props.setProperty(S3_SOURCE_QUEUE_REGION.key(), regionName);
     props.setProperty(S3_SOURCE_QUEUE_FS.key(), "hdfs");
-    S3EventsSource dfsSource = new S3EventsSource(props, jsc, sparkSession, schemaProvider);
-    dfsSource.sqs = this.sqs;
-    return dfsSource;
+    props.setProperty(ERROR_TABLE_PERSIST_SOURCE_RDD.key(), String.valueOf(persistSourceRdd));
+    return props;
+  }
+
+  private void verifyRddsArePersisted(SourceFormatAdapter sourceFormatAdapter,
+                                      InputBatch<JavaRDD<GenericRecord>> inputBatch,
+                                      boolean persistSourceRdd) {
+    if (persistSourceRdd) {
+      assertTrue(inputBatch.getBatch().get().rdd().toDebugString().contains("CachedPartitions"));
+      assertEquals(1, jsc.getPersistentRDDs().size());
+    } else {
+      assertFalse(inputBatch.getBatch().get().rdd().toDebugString().contains("CachedPartitions"));
+      assertEquals(0, jsc.getPersistentRDDs().size());
+    }
+    sourceFormatAdapter.getSource().releaseResources();
   }
 
   @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractCloudObjectsSourceTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractCloudObjectsSourceTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities.testutils.sources;
 
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
@@ -79,7 +80,7 @@ public abstract class AbstractCloudObjectsSourceTestBase extends UtilitiesTestBa
    *
    * @return A {@link Source} using DFS as the file system.
    */
-  protected abstract Source prepareCloudObjectSource();
+  protected abstract Source prepareCloudObjectSource(TypedProperties props);
 
   /**
    * Writes test data, i.e., a {@link List} of {@link HoodieRecord}, to a file on DFS.


### PR DESCRIPTION
### Change Logs

Persist the sourceRDD in fetchNext method for optimising error table DAG. It helps in avoiding expensive source reads when writing to the error table.

### Impact

Cuts down the overall e2e sync latency when `hoodie.errortable.enable` is enabled  as we will avoid reading from the source twice.

Ran a load test by ingesting 15GB to see the improvements for the three approaches.
Union DAG Optimisation PR -> https://github.com/apache/hudi/pull/11843/files
```
1. Current version ➝ 1h 29min. 

2. Union DAG Optimisation ➝ 1h 9min. 

3. Source RDD Persist + Union DAG Optimisation ➝ 43min.

```


### Risk level (write none, low medium or high below)

Medium.

### Documentation Update

```
  public static final ConfigProperty<Boolean> ERROR_TABLE_PERSIST_SOURCE_RDD = ConfigProperty
      .key("hoodie.errortable.source.rdd.persist")
      .defaultValue(false)
      .withDocumentation("Enabling this config, persists the sourceRDD to disk which helps in faster processing of data table + error table write DAG");

```


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
