### PR TITLE
[MINOR] Add remote file system props to meta sync properties

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1034,6 +1034,10 @@ public class StreamSync implements Serializable, Closeable {
         metaProps.put(HIVE_SYNC_BUCKET_SYNC_SPEC.key(), HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key()),
             props.getInteger(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key())));
       }
+      // Pass remote file system view properties to meta sync if present
+      if (writeClient.getConfig().getViewStorageConfig() != null) {
+        metaProps.putAll(writeClient.getConfig().getViewStorageConfig().getProps());
+      }
 
       Map<String, HoodieException> failedMetaSyncs = new HashMap<>();
       for (String impl : syncClientToolClasses) {


### PR DESCRIPTION
### Change Logs

- Pass through the properties for the remote file system view configuration if present to the meta sync properties so a meta sync can leverage this view if required

### Impact

- Allows meta syncs to leverage the existing remote file system view if one exists, this can allow the syncs to avoid creating their own file system view

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
