### PR TITLE
[HUDI-8134] Prevent mac m1 activation of profile without specifying spark version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2366,6 +2366,9 @@
           <family>mac</family>
           <arch>aarch64</arch>
         </os>
+        <property>
+          <name>spark2.4</name>
+        </property>
       </activation>
     </profile>
 


### PR DESCRIPTION
### Change Logs

mac m1 profile requires spark version so that it does not block activate by default profiles

### Impact

easier for users who can't bother to set profiles that they expect

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
