### PR TITLE
[HUDI-8137] Support time travel query on MDT in Spark Datasource

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -438,6 +438,25 @@ public interface HoodieTimeline extends Serializable {
   }
 
   /**
+   * Returns smaller of the two given timestamps. Returns the non null argument if one of the argument is null.
+   */
+  static String minTimestamp(String commit1, String commit2) {
+    if (StringUtils.isNullOrEmpty(commit1)) {
+      return commit2;
+    } else if (StringUtils.isNullOrEmpty(commit2)) {
+      return commit1;
+    }
+    return minInstant(commit1, commit2);
+  }
+
+  /**
+   * Returns the smaller of the given two instants.
+   */
+  static String minInstant(String instant1, String instant2) {
+    return compareTimestamps(instant1, LESSER_THAN, instant2) ? instant1 : instant2;
+  }
+
+  /**
    * Return true if specified timestamp is in range (startTs, endTs].
    */
   static boolean isInRange(String timestamp, String startTs, String endTs) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
@@ -436,7 +437,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       // Open the log record scanner using the log files from the latest file slice
       List<HoodieLogFile> logFiles = slice.getLogFiles().collect(Collectors.toList());
       Pair<HoodieMetadataLogRecordReader, Long> logRecordScannerOpenTimePair =
-          getLogRecordScanner(logFiles, partitionName, Option.empty());
+          getLogRecordScanner(logFiles, partitionName, Option.empty(), Option.empty());
       HoodieMetadataLogRecordReader logRecordScanner = logRecordScannerOpenTimePair.getKey();
       final long logScannerOpenMs = logRecordScannerOpenTimePair.getValue();
 
@@ -471,7 +472,8 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
 
   public Pair<HoodieMetadataLogRecordReader, Long> getLogRecordScanner(List<HoodieLogFile> logFiles,
                                                                        String partitionName,
-                                                                       Option<Boolean> allowFullScanOverride) {
+                                                                       Option<Boolean> allowFullScanOverride,
+                                                                       Option<String> timeTravelInstant) {
     HoodieTimer timer = HoodieTimer.start();
     List<String> sortedLogFilePaths = logFiles.stream()
         .sorted(HoodieLogFile.getLogFileComparator())
@@ -485,6 +487,9 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
 
     Option<HoodieInstant> latestMetadataInstant = metadataMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
     String latestMetadataInstantTime = latestMetadataInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+    if (timeTravelInstant.isPresent()) {
+      latestMetadataInstantTime = HoodieTimeline.minTimestamp(latestMetadataInstantTime, timeTravelInstant.get());
+    }
 
     boolean allowFullScan = allowFullScanOverride.orElseGet(() -> isFullScanAllowedForPartition(partitionName));
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
@@ -367,7 +367,7 @@ object LogFileIterator extends SparkAdapterSupport {
         new StoragePath(tablePath), partitionPath)
 
       val logRecordReader =
-        metadataTable.getLogRecordScanner(logFiles.asJava, relativePartitionPath, toJavaOption(Some(forceFullScan)))
+        metadataTable.getLogRecordScanner(logFiles.asJava, relativePartitionPath, toJavaOption(Some(forceFullScan)), toJavaOption(Some(tableState.latestCommitTimestamp.get)))
           .getLeft
 
       val recordList = closing(logRecordReader) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -244,7 +244,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     // Insert T0
     val newRecords = dataGen.generateInserts("000", 100)
-    val newRecordsDF = parseRecords(recordsToStrings(newRecords).asScala)
+    val newRecordsDF = parseRecords(recordsToStrings(newRecords).asScala.toSeq)
     newRecordsDF.write.format(hudi)
       .options(combinedOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
@@ -274,7 +274,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     // Update T1
     val updatedRecords = dataGen.generateUpdates("001", newRecords)
-    val updatedRecordsDF = parseRecords(recordsToStrings(updatedRecords).asScala)
+    val updatedRecordsDF = parseRecords(recordsToStrings(updatedRecords).asScala.toSeq)
     updatedRecordsDF.write.format(hudi)
       .options(combinedOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
@@ -301,7 +301,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     //Update T2
     val updatedRecords2 = dataGen.generateUpdates("002", updatedRecords)
-    val updatedRecords2DF = parseRecords(recordsToStrings(updatedRecords2).asScala)
+    val updatedRecords2DF = parseRecords(recordsToStrings(updatedRecords2).asScala.toSeq)
     updatedRecords2DF.write.format(hudi)
       .options(combinedOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
@@ -332,7 +332,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     //Update T3
     val updatedRecords3 = dataGen.generateUpdates("003", updatedRecords2)
-    val updatedRecords3DF = parseRecords(recordsToStrings(updatedRecords3).asScala)
+    val updatedRecords3DF = parseRecords(recordsToStrings(updatedRecords3).asScala.toSeq)
     updatedRecords3DF.write.format(hudi)
       .options(combinedOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -36,6 +36,7 @@ import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+import org.apache.hudi.util.JavaScalaConverters.convertJavaListToScalaSeq
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
@@ -47,6 +48,7 @@ import org.junit.jupiter.params.provider.CsvSource
 
 import java.util
 import java.util.Collections
+import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 
@@ -384,10 +386,10 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
     val fsview = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
       metaClient, HoodieMetadataConfig.newBuilder.enable(false).build())
     fsview.loadAllPartitions()
-    fsview.getAllFileGroups.forEach(fg => {
-      fg.getAllFileSlices.forEach(fileSlice => {
+    convertJavaListToScalaSeq(fsview.getAllFileGroups.collect(Collectors.toList())).foreach(fg => {
+      convertJavaListToScalaSeq(fg.getAllFileSlices.collect(Collectors.toList)).foreach(fileSlice => {
         fileSlice.getBaseFile.ifPresent(baseFile => files.add(baseFile.getFileName))
-        fileSlice.getLogFiles.forEach(logFile => files.add(logFile.getFileName))
+        convertJavaListToScalaSeq(fileSlice.getLogFiles.collect(Collectors.toList)).foreach(logFile => files.add(logFile.getFileName))
       })
     })
     files.toArray.toSet

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -387,9 +387,9 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
       metaClient, HoodieMetadataConfig.newBuilder.enable(false).build())
     fsview.loadAllPartitions()
     convertJavaListToScalaSeq(fsview.getAllFileGroups.collect(Collectors.toList())).foreach(fg => {
-      convertJavaListToScalaSeq(fg.getAllFileSlices.collect(Collectors.toList)).foreach(fileSlice => {
+      convertJavaListToScalaSeq(fg.getAllFileSlices.collect(Collectors.toList())).foreach(fileSlice => {
         fileSlice.getBaseFile.ifPresent(baseFile => files.add(baseFile.getFileName))
-        convertJavaListToScalaSeq(fileSlice.getLogFiles.collect(Collectors.toList)).foreach(logFile => files.add(logFile.getFileName))
+        convertJavaListToScalaSeq(fileSlice.getLogFiles.collect(Collectors.toList())).foreach(logFile => files.add(logFile.getFileName))
       })
     })
     files.toArray.toSet

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -35,7 +35,6 @@ import org.apache.hudi.storage.hadoop.HoodieHadoopStorage
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.functions.{col, explode}
@@ -265,7 +264,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     val firstRead = getFiles(basePath)
     val metaClient = HoodieTableMetaClient.builder
-      .setConf(storageConf().unwrapAs(Class[Configuration]))
+      .setConf(storageConf())
       .setBasePath(basePath)
       .build
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -344,8 +344,8 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
     //Validate T3
     val timelineT3 = metaClient.reloadActiveTimeline()
     assertEquals(7, timelineT3.countInstants())
-    assertEquals(HoodieTimeline.DELTA_COMMIT_ACTION, timelineT3.getInstants.get(5).getAction)
-    assertEquals(HoodieTimeline.COMMIT_ACTION, timelineT3.lastInstant().get().getAction)
+    assertEquals(HoodieTimeline.COMMIT_ACTION, timelineT3.getInstants.get(5).getAction)
+    assertEquals(HoodieTimeline.DELTA_COMMIT_ACTION, timelineT3.lastInstant().get().getAction)
 
     val filesT3 = getFiles(basePath)
     assertEquals(12, filesT3.size)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -388,7 +388,9 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
     fsview.loadAllPartitions()
     convertJavaListToScalaSeq(fsview.getAllFileGroups.collect(Collectors.toList())).foreach(fg => {
       convertJavaListToScalaSeq(fg.getAllFileSlices.collect(Collectors.toList())).foreach(fileSlice => {
-        fileSlice.getBaseFile.ifPresent(baseFile => files.add(baseFile.getFileName))
+        if (fileSlice.getBaseFile.isPresent) {
+          files.add(fileSlice.getBaseFile.get().getFileName)
+        }
         convertJavaListToScalaSeq(fileSlice.getLogFiles.collect(Collectors.toList())).foreach(logFile => files.add(logFile.getFileName))
       })
     })

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -244,7 +244,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     // Insert records
     val newRecords = dataGen.generateInserts("001", 100)
-    val newRecordsDF = parseRecords(recordsToStrings(newRecords).asScala)
+    val newRecordsDF = parseRecords(recordsToStrings(newRecords).asScala.toSeq)
 
     newRecordsDF.write.format(hudi)
       .options(combinedOpts)
@@ -254,7 +254,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     // Update records
     val updatedRecords = dataGen.generateUpdates("002", newRecords)
-    val updatedRecordsDF = parseRecords(recordsToStrings(updatedRecords).asScala)
+    val updatedRecordsDF = parseRecords(recordsToStrings(updatedRecords).asScala.toSeq)
 
     updatedRecordsDF.write.format(hudi)
       .options(combinedOpts)
@@ -278,7 +278,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
 
     // more update records
     val updatedRecords2 = dataGen.generateUpdates("003", updatedRecords)
-    val updatedRecords2DF = parseRecords(recordsToStrings(updatedRecords2).asScala)
+    val updatedRecords2DF = parseRecords(recordsToStrings(updatedRecords2).asScala.toSeq)
 
     updatedRecords2DF.write.format(hudi)
       .options(combinedOpts)


### PR DESCRIPTION
### Change Logs

Datasource read of MDT does not correctly use the time travel timestamp

### Impact

MDT validation relies on time travel query

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
