### PR TITLE
[HUDI-8103] Introduce Table Write Version and version table configs

### DIFF
--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/ITTestGluePartitionPushdown.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/ITTestGluePartitionPushdown.java
@@ -90,7 +90,7 @@ public class ITTestGluePartitionPushdown {
     fileSystem = hiveSyncConfig.getHadoopFileSystem();
     fileSystem.mkdirs(new Path(tablePath));
     StorageConfiguration<?> configuration = HadoopFSUtils.getStorageConf(new Configuration());
-    HoodieTableMetaClient metaClient = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
@@ -104,7 +104,7 @@ public class GlueTestUtil {
     if (fileSystem.exists(path)) {
       fileSystem.delete(path, true);
     }
-    metaClient = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -267,10 +267,10 @@ public class SparkMain {
 
   protected static int deleteMarker(JavaSparkContext jsc, String instantTime, String basePath) {
     try (SparkRDDWriteClient client = createHoodieClient(jsc, basePath, false)) {
-
       HoodieWriteConfig config = client.getConfig();
       HoodieEngineContext context = client.getEngineContext();
       HoodieSparkTable table = HoodieSparkTable.create(config, context);
+      client.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), config);
       WriteMarkersFactory.get(config.getMarkersType(), table, instantTime)
           .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism());
       return 0;

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -112,6 +113,16 @@ public class TableCommand {
     return "Metadata for table " + HoodieCLI.getTableMetaClient().getTableConfig().getTableName() + " loaded";
   }
 
+  public String createTable(
+      final String path,
+      final String name,
+      final String tableTypeStr,
+      String archiveFolder,
+      Integer layoutVersion,
+      final String payloadClass) throws IOException {
+    return createTable(path, name, tableTypeStr, archiveFolder, layoutVersion, HoodieTableVersion.current().versionCode(), payloadClass);
+  }
+
   /**
    * Create a Hoodie Table if it does not exist.
    *
@@ -130,6 +141,8 @@ public class TableCommand {
           defaultValue = ShellOption.NULL) String archiveFolder,
       @ShellOption(value = {"--layoutVersion"}, help = "Specific Layout Version to use",
           defaultValue = ShellOption.NULL) Integer layoutVersion,
+      @ShellOption(value = {"--tableVersion"}, help = "Specific table Version to create table as",
+          defaultValue = ShellOption.NULL) Integer tableVersion,
       @ShellOption(value = {"--payloadClass"}, defaultValue = "org.apache.hudi.common.model.HoodieAvroPayload",
           help = "Payload Class") final String payloadClass) throws IOException {
 
@@ -155,6 +168,7 @@ public class TableCommand {
         .setArchiveLogFolder(archiveFolder)
         .setPayloadClassName(payloadClass)
         .setTimelineLayoutVersion(layoutVersion)
+        .setTableVersion(tableVersion == null ? HoodieTableVersion.current().versionCode() : tableVersion)
         .initTable(HoodieCLI.conf.newInstance(), path);
     // Now connect to ensure loading works
     return connect(path, layoutVersion, false, 0, 0, 0,

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -149,7 +149,7 @@ public class TableCommand {
       throw new IllegalStateException("Table already existing in path : " + path);
     }
 
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(tableTypeStr)
         .setTableName(name)
         .setArchiveLogFolder(archiveFolder)

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/UpgradeOrDowngradeCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/UpgradeOrDowngradeCommand.java
@@ -89,7 +89,7 @@ public class UpgradeOrDowngradeCommand {
 
     try {
       int versionCode = Integer.parseInt(versionOption);
-      return HoodieTableVersion.versionFromCode(versionCode).name();
+      return HoodieTableVersion.fromVersionCode(versionCode).name();
     } catch (NumberFormatException e) {
       // The version option from the CLI is not a number, returns the original String
       return versionOption;

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
@@ -68,7 +68,7 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
 
   @Test
   public void testMetadataDelete() throws Exception {
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE.name())
         .setTableName(tableName())
         .setArchiveLogFolder(HoodieTableConfig.ARCHIVELOG_FOLDER.defaultValue())

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
@@ -318,7 +318,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
   @Test
   public void testRepairDeprecatedPartition() throws IOException {
     tablePath = tablePath + "/repair_test/";
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE.name())
         .setTableName(tableName())
         .setArchiveLogFolder(HoodieTableConfig.ARCHIVELOG_FOLDER.defaultValue())
@@ -386,7 +386,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
   @Test
   public void testRenamePartition() throws IOException {
     tablePath = tablePath + "/rename_partition_test/";
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE.name())
         .setTableName(tableName())
         .setArchiveLogFolder(HoodieTableConfig.ARCHIVELOG_FOLDER.defaultValue())

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -159,13 +159,14 @@ public class TestTableCommand extends CLIFunctionalTestHarness {
   public void testCreateWithSpecifiedValues() {
     // Test create with specified values
     Object result = shell.evaluate(() -> "create --path " + tablePath + " --tableName " + tableName
-            + " --tableType MERGE_ON_READ --archiveLogFolder archive");
+            + " --tableType MERGE_ON_READ --archiveLogFolder archive --tableVersion 6");
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
     assertEquals("Metadata for table " + tableName + " loaded", result.toString());
     HoodieTableMetaClient client = HoodieCLI.getTableMetaClient();
     assertEquals(metaPath + StoragePath.SEPARATOR + "archive", client.getArchivePath());
     assertEquals(tablePath, client.getBasePath().toString());
     assertEquals(metaPath, client.getMetaPath().toString());
+    assertEquals(HoodieTableVersion.SIX, client.getTableConfig().getTableVersion());
     assertEquals(HoodieTableType.MERGE_ON_READ, client.getTableType());
   }
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimeGeneratorType;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -237,7 +238,8 @@ public class TestTableCommand extends CLIFunctionalTestHarness {
     HoodieCLI.conf = storageConf();
     new TableCommand().createTable(
         tablePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     String schemaStr = "{\n"
         + "         \"type\" : \"record\",\n"

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
@@ -28,6 +28,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -77,7 +78,8 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
     // Create table and connect
     new TableCommand().createTable(
         basePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     initMetaClient();
   }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
@@ -24,6 +24,7 @@ import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -76,7 +77,8 @@ public class ITTestCommitsCommand extends HoodieCLIIntegrationTestBase {
     // Create table and connect
     new TableCommand().createTable(
         basePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     initMetaClient();
   }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -83,7 +84,8 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
     // Create table and connect
     new TableCommand().createTable(
         basePath, tableName, HoodieTableType.MERGE_ON_READ.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     initMetaClient();
   }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestMarkersCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestMarkersCommand.java
@@ -23,6 +23,7 @@ import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.IOType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.FileCreateUtils;
 import org.apache.hudi.storage.StoragePath;
@@ -59,7 +60,8 @@ public class ITTestMarkersCommand extends HoodieCLIIntegrationTestBase {
     // Create table and connect
     new TableCommand().createTable(
         tablePath, "test_table", HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -101,7 +102,8 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // Create cow table and connect
     new TableCommand().createTable(
         cowTablePath, "cow_table", HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     HoodieSparkWriteableTestTable cowTable = HoodieSparkWriteableTestTable.of(HoodieCLI.getTableMetaClient(), schema);
 
@@ -124,7 +126,8 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // Create mor table and connect
     new TableCommand().createTable(
         morTablePath, "mor_table", HoodieTableType.MERGE_ON_READ.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
     HoodieSparkWriteableTestTable morTable = HoodieSparkWriteableTestTable.of(HoodieCLI.getTableMetaClient(), schema);
 
     morTable.addDeltaCommit("20160401010101");
@@ -146,7 +149,8 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // Create cow table and connect
     new TableCommand().createTable(
         cowNonPartitionedTablePath, "cow_table_non_partitioned", HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
 
     HoodieSparkWriteableTestTable cowNonPartitionedTable = HoodieSparkWriteableTestTable.of(HoodieCLI.getTableMetaClient(), schema);
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestSavepointsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestSavepointsCommand.java
@@ -25,6 +25,7 @@ import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -71,7 +72,8 @@ public class ITTestSavepointsCommand extends HoodieCLIIntegrationTestBase {
     // Create table and connect
     new TableCommand().createTable(
         tablePath, "test_table", HoodieTableType.COPY_ON_WRITE.name(),
-        "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+        "", TimelineLayoutVersion.VERSION_1, HoodieTableVersion.current().versionCode(),
+        "org.apache.hudi.common.model.HoodieAvroPayload");
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -33,15 +33,18 @@ import org.apache.hudi.client.heartbeat.HeartbeatUtils;
 import org.apache.hudi.client.utils.TransactionUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.TableSchemaResolver;
@@ -74,6 +77,7 @@ import org.apache.hudi.internal.schema.io.FileBasedInternalSchemaStorageManager;
 import org.apache.hudi.internal.schema.utils.AvroSchemaEvolutionUtils;
 import org.apache.hudi.internal.schema.utils.InternalSchemaUtils;
 import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.metadata.MetadataPartitionType;
@@ -86,6 +90,7 @@ import org.apache.hudi.table.action.savepoint.SavepointHelpers;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
 import org.apache.hudi.table.upgrade.SupportsUpgradeDowngrade;
 import org.apache.hudi.table.upgrade.UpgradeDowngrade;
+import org.apache.hudi.util.CommonClientUtils;
 
 import com.codahale.metrics.Timer;
 import org.apache.avro.Schema;
@@ -99,8 +104,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.AvroSchemaUtils.getAvroRecordQualifiedName;
@@ -318,6 +325,27 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       // update SCHEMA_KEY
       metadata.addMetadata(SCHEMA_KEY, AvroInternalSchemaConverter.convert(evolvedSchema, avroSchema.getFullName()).toString());
     }
+  }
+
+  protected HoodieTable createTableAndValidate(HoodieWriteConfig writeConfig,
+                                               BiFunction<HoodieWriteConfig, HoodieEngineContext, HoodieTable> createTableFn) {
+    HoodieTable table = createTableFn.apply(writeConfig, context);
+    CommonClientUtils.validateTableVersion(table.getMetaClient().getTableConfig(), writeConfig);
+    return table;
+  }
+
+  @FunctionalInterface
+  protected interface TriFunction<T, U, V, R> {
+    R apply(T t, U u, V v);
+  }
+
+  protected HoodieTable createTableAndValidate(HoodieWriteConfig writeConfig,
+                                               HoodieTableMetaClient metaClient,
+                                               TriFunction<HoodieWriteConfig, HoodieEngineContext,
+                                                   HoodieTableMetaClient, HoodieTable> createTableFn) {
+    HoodieTable table = createTableFn.apply(writeConfig, context, metaClient);
+    CommonClientUtils.validateTableVersion(table.getMetaClient().getTableConfig(), writeConfig);
+    return table;
   }
 
   protected abstract HoodieTable<T, I, K, O> createTable(HoodieWriteConfig config);
@@ -742,14 +770,14 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   public boolean rollback(final String commitInstantTime) throws HoodieRollbackException {
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty());
     Option<HoodiePendingRollbackInfo> pendingRollbackInfo = tableServiceClient.getPendingRollbackInfo(table.getMetaClient(), commitInstantTime);
-    return tableServiceClient.rollback(commitInstantTime, pendingRollbackInfo, false);
+    return tableServiceClient.rollback(commitInstantTime, pendingRollbackInfo, false, false);
   }
 
   @Deprecated
   public boolean rollback(final String commitInstantTime, String rollbackInstantTimestamp) throws HoodieRollbackException {
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty());
     Option<HoodiePendingRollbackInfo> pendingRollbackInfo = tableServiceClient.getPendingRollbackInfo(table.getMetaClient(), commitInstantTime);
-    return tableServiceClient.rollback(commitInstantTime, pendingRollbackInfo, rollbackInstantTimestamp, false);
+    return tableServiceClient.rollback(commitInstantTime, pendingRollbackInfo, rollbackInstantTimestamp, false, false);
   }
 
   /**
@@ -881,6 +909,10 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * Provides a new commit time for a write operation (insert/update/delete/insert_overwrite/insert_overwrite_table) with specified action.
    */
   public String startCommit(String actionType, HoodieTableMetaClient metaClient) {
+    if (needsUpgradeOrDowngrade(metaClient)) {
+      executeUsingTxnManager(Option.empty(), () -> tryUpgrade(metaClient, Option.empty()));
+    }
+
     CleanerUtils.rollbackFailedWrites(config.getFailedWritesCleanPolicy(),
         HoodieTimeline.COMMIT_ACTION, () -> tableServiceClient.rollbackFailedWrites());
 
@@ -907,22 +939,26 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   }
 
   /**
-   * Completes a new commit time for a write operation (insert/update/delete) with specified action.
+   * Starts a new commit time for a write operation (insert/update/delete) with specified action.
    */
   private void startCommitWithTime(String instantTime, String actionType, HoodieTableMetaClient metaClient) {
+    if (needsUpgradeOrDowngrade(metaClient)) {
+      //TODO(vc): is the first argument correct?
+      executeUsingTxnManager(Option.empty(), () -> tryUpgrade(metaClient, Option.empty()));
+    }
     CleanerUtils.rollbackFailedWrites(config.getFailedWritesCleanPolicy(),
         HoodieTimeline.COMMIT_ACTION, () -> tableServiceClient.rollbackFailedWrites());
     startCommit(instantTime, actionType, metaClient);
   }
 
   private void startCommit(String instantTime, String actionType, HoodieTableMetaClient metaClient) {
-    LOG.info("Generate a new instant time: " + instantTime + " action: " + actionType);
+    LOG.info("Generate a new instant time: {} action: {}", instantTime, actionType);
     // check there are no inflight restore before starting a new commit.
     HoodieTimeline inflightRestoreTimeline = metaClient.getActiveTimeline().getRestoreTimeline().filterInflightsAndRequested();
     ValidationUtils.checkArgument(inflightRestoreTimeline.countInstants() == 0,
         "Found pending restore in active timeline. Please complete the restore fully before proceeding. As of now, "
             + "table could be in an inconsistent state. Pending restores: " + Arrays.toString(inflightRestoreTimeline.getInstantsAsStream()
-            .map(instant -> instant.getTimestamp()).collect(Collectors.toList()).toArray()));
+            .map(HoodieInstant::getTimestamp).collect(Collectors.toList()).toArray()));
 
     if (config.getFailedWritesCleanPolicy().isLazy()) {
       this.heartbeatClient.start(instantTime);
@@ -1224,10 +1260,16 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     if (instantTime.isPresent()) {
       ownerInstant = Option.of(new HoodieInstant(true, CommitUtils.getCommitActionType(operationType, metaClient.getTableType()), instantTime.get()));
     }
-    this.txnManager.beginTransaction(ownerInstant, Option.empty());
-    try {
+    executeUsingTxnManager(ownerInstant, () -> {
       tryUpgrade(metaClient, instantTime);
       initMetadataTable(instantTime, metaClient);
+    });
+  }
+
+  private void executeUsingTxnManager(Option<HoodieInstant> ownerInstant, Runnable r) {
+    this.txnManager.beginTransaction(ownerInstant, Option.empty());
+    try {
+      r.run();
     } finally {
       this.txnManager.endTransaction(ownerInstant);
     }
@@ -1271,7 +1313,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     HoodieTable table = createTable(config, metaClient);
 
     // Validate table properties
-    metaClient.validateTableProperties(config.getProps());
+    validateAgainstTableProperties(table.getMetaClient().getTableConfig(), config);
 
     switch (operationType) {
       case INSERT:
@@ -1293,6 +1335,42 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     }
 
     return table;
+  }
+
+  public void validateAgainstTableProperties(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
+    // mismatch of table versions.
+    CommonClientUtils.validateTableVersion(tableConfig, writeConfig);
+
+    Properties properties = writeConfig.getProps();
+    // Once meta fields are disabled, it cant be re-enabled for a given table.
+    if (!tableConfig.populateMetaFields() && writeConfig.populateMetaFields()) {
+      throw new HoodieException(HoodieTableConfig.POPULATE_META_FIELDS.key() + " already disabled for the table. Can't be re-enabled back");
+    }
+
+    // Meta fields can be disabled only when either {@code SimpleKeyGenerator}, {@code ComplexKeyGenerator},
+    // {@code NonpartitionedKeyGenerator} is used
+    if (!tableConfig.populateMetaFields()) {
+      String keyGenClass = KeyGeneratorType.getKeyGeneratorClassName(new HoodieConfig(properties));
+      if (StringUtils.isNullOrEmpty(keyGenClass)) {
+        keyGenClass = "org.apache.hudi.keygen.SimpleKeyGenerator";
+      }
+      if (!keyGenClass.equals("org.apache.hudi.keygen.SimpleKeyGenerator")
+          && !keyGenClass.equals("org.apache.hudi.keygen.NonpartitionedKeyGenerator")
+          && !keyGenClass.equals("org.apache.hudi.keygen.ComplexKeyGenerator")) {
+        throw new HoodieException("Only simple, non-partitioned or complex key generator are supported when meta-fields are disabled. Used: " + keyGenClass);
+      }
+    }
+
+    //Check to make sure it's not a COW table with consistent hashing bucket index
+    if (tableConfig.getTableType() == HoodieTableType.COPY_ON_WRITE) {
+      HoodieIndex.IndexType indexType = writeConfig.getIndexType();
+      if (indexType != null && indexType.equals(HoodieIndex.IndexType.BUCKET)) {
+        String bucketEngine = properties.getProperty("hoodie.index.bucket.engine");
+        if (bucketEngine != null && bucketEngine.equals("CONSISTENT_HASHING")) {
+          throw new HoodieException("Consistent hashing bucket index does not work with COW table. Use simple bucket index or an MOR table.");
+        }
+      }
+    }
   }
 
   /**
@@ -1365,7 +1443,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       if (!instantsToRollback.isEmpty()) {
         Map<String, Option<HoodiePendingRollbackInfo>> pendingRollbacks = tableServiceClient.getPendingRollbackInfos(metaClient);
         instantsToRollback.forEach(entry -> pendingRollbacks.putIfAbsent(entry, Option.empty()));
-        tableServiceClient.rollbackFailedWrites(pendingRollbacks, true);
+        tableServiceClient.rollbackFailedWrites(pendingRollbacks, true, true);
       }
 
       new UpgradeDowngrade(metaClient, config, context, upgradeDowngradeHelper)
@@ -1373,6 +1451,11 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
 
       metaClient.reloadActiveTimeline();
     }
+  }
+
+  private boolean needsUpgradeOrDowngrade(HoodieTableMetaClient metaClient) {
+    UpgradeDowngrade upgradeDowngrade = new UpgradeDowngrade(metaClient, config, context, upgradeDowngradeHelper);
+    return upgradeDowngrade.needsUpgradeOrDowngrade(config.getWriteVersion());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -943,7 +943,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   private void startCommitWithTime(String instantTime, String actionType, HoodieTableMetaClient metaClient) {
     if (needsUpgradeOrDowngrade(metaClient)) {
-      //TODO(vc): is the first argument correct?
+      // unclear what instant to use, since upgrade does have a given instant.
       executeUsingTxnManager(Option.empty(), () -> tryUpgrade(metaClient, Option.empty()));
     }
     CleanerUtils.rollbackFailedWrites(config.getFailedWritesCleanPolicy(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1262,6 +1262,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     }
     executeUsingTxnManager(ownerInstant, () -> {
       tryUpgrade(metaClient, instantTime);
+      // TODO: this also does MT table management..
       initMetadataTable(instantTime, metaClient);
     });
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -150,7 +150,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       .defaultValue(true)
       .sinceVersion("1.0.0")
       .withDocumentation("If enabled, writers automatically migrate the table to the specified write table version "
-          + "if the current table version is not lower.");
+          + "if the current table version is lower.");
 
   public static final ConfigProperty<String> TAGGED_RECORD_STORAGE_LEVEL_VALUE = ConfigProperty
       .key("hoodie.write.tagged.record.storage.level")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -138,7 +138,6 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> WRITE_TABLE_VERSION = ConfigProperty
       .key("hoodie.write.table.version")
       .defaultValue(HoodieTableVersion.current().versionCode())
-      // TODO(vc) does this validation actually work.
       .withValidValues(
           String.valueOf(HoodieTableVersion.SIX.versionCode()),
           String.valueOf(HoodieTableVersion.current().versionCode())
@@ -1277,6 +1276,10 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public HoodieTableVersion getWriteVersion() {
+    Integer versionCode = getInt(WRITE_TABLE_VERSION);
+    if (versionCode != null) {
+      WRITE_TABLE_VERSION.checkValues(versionCode.toString());
+    }
     return HoodieTableVersion.fromVersionCode(getIntOrDefault(WRITE_TABLE_VERSION));
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -50,6 +50,7 @@ import org.apache.hudi.common.model.RecordPayloadType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -133,6 +134,12 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key(HoodieTableConfig.HOODIE_TABLE_NAME_KEY)
       .noDefaultValue()
       .withDocumentation("Table name that will be used for registering with metastores like HMS. Needs to be same across runs.");
+
+  public static final ConfigProperty<HoodieTableVersion> WRITE_TABLE_VERSION = ConfigProperty
+      .key("hoodie.write.table.version")
+      .defaultValue(HoodieTableVersion.current())
+      .sinceVersion("1.0.0")
+      .withDocumentation("The table version this writer must be producing in storage.");
 
   public static final ConfigProperty<String> TAGGED_RECORD_STORAGE_LEVEL_VALUE = ConfigProperty
       .key("hoodie.write.tagged.record.storage.level")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieUpgradeDowngradeException.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieUpgradeDowngradeException.java
@@ -24,6 +24,10 @@ public class HoodieUpgradeDowngradeException extends HoodieException {
     super(msg, t);
   }
 
+  public HoodieUpgradeDowngradeException(String msg) {
+    super(msg);
+  }
+
   public HoodieUpgradeDowngradeException(int fromVersion, int toVersion, boolean upgrade) {
     this(fromVersion, toVersion, upgrade, null);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieUpgradeDowngradeException.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieUpgradeDowngradeException.java
@@ -20,10 +20,6 @@ package org.apache.hudi.exception;
 
 public class HoodieUpgradeDowngradeException extends HoodieException {
 
-  public HoodieUpgradeDowngradeException(String msg, Throwable t) {
-    super(msg, t);
-  }
-
   public HoodieUpgradeDowngradeException(String msg) {
     super(msg);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -730,7 +730,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   }
 
   private HoodieTableMetaClient initializeMetaClient() throws IOException {
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setTableName(dataWriteConfig.getTableName() + METADATA_TABLE_NAME_SUFFIX)
         .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -185,9 +185,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     ValidationUtils.checkArgument(!initialized || this.metadata != null, "MDT Reader should have been opened post initialization");
   }
 
-  protected HoodieTable getHoodieTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
-    return null;
-  }
+  abstract HoodieTable getTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient);
 
   private void initMetadataReader() {
     if (this.metadata != null) {
@@ -591,7 +589,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   private Pair<Integer, HoodieData<HoodieRecord>> initializeRecordIndexPartition() throws IOException {
     final HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(dataMetaClient,
         dataMetaClient.getActiveTimeline(), metadata);
-    final HoodieTable hoodieTable = getHoodieTable(dataWriteConfig, dataMetaClient);
+    final HoodieTable hoodieTable = getTable(dataWriteConfig, dataMetaClient);
 
     // Collect the list of latest base files present in each partition
     List<String> partitions = metadata.getAllPartitionPaths();
@@ -733,6 +731,8 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setTableName(dataWriteConfig.getTableName() + METADATA_TABLE_NAME_SUFFIX)
+        // MT version should match DT, such that same readers can read both.
+        .setTableVersion(dataWriteConfig.getWriteVersion())
         .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
         .setPayloadClassName(HoodieMetadataPayload.class.getName())
         .setBaseFileFormat(HoodieFileFormat.HFILE.toString())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -106,6 +106,7 @@ public class HoodieMetadataWriteUtils {
     HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()
         .withEngineType(writeConfig.getEngineType())
         .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
+        .withWriteTableVersion(writeConfig.getWriteVersion().versionCode())
         .withMergeAllowDuplicateOnInserts(false)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder()
             .withConsistencyCheckEnabled(writeConfig.getConsistencyGuardConfig().isConsistencyCheckEnabled())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -820,7 +820,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   }
 
   private boolean waitForCondition(String partitionPath, Stream<Pair<String, String>> partitionFilePaths, FileVisibility visibility) {
-    final HoodieStorage storage = metaClient.getRawHoodieStorage();
+    final HoodieStorage storage = metaClient.getRawStorage();
     List<String> fileList = partitionFilePaths.map(Pair::getValue).collect(Collectors.toList());
     try {
       getConsistencyGuard(storage, config.getConsistencyGuardConfig())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToSixDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToSixDowngradeHandler.java
@@ -20,7 +20,9 @@ package org.apache.hudi.table.upgrade;
 
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -35,6 +37,8 @@ public class SevenToSixDowngradeHandler implements DowngradeHandler {
 
   @Override
   public Map<ConfigProperty, String> downgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
+    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+    UpgradeDowngradeUtils.updateMetadataTableVersion(context, HoodieTableVersion.SIX, table.getMetaClient());
     return Collections.emptyMap();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+
+public class CommonClientUtils {
+  public static void validateTableVersion(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
+    // mismatch of table versions.
+    if (!tableConfig.getTableVersion().equals(writeConfig.getWriteVersion())) {
+      throw new HoodieNotSupportedException(String.format("Table version (%s) and Writer version (%s) do not match.",
+          tableConfig.getTableVersion(), writeConfig.getWriteVersion()));
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
@@ -65,7 +65,7 @@ public class HoodieMetadataTestTable extends HoodieTestTable {
                                    HoodieTableMetadataWriter writer,
                                    Option<HoodieEngineContext> context) {
     testTableState = HoodieTestTableState.of();
-    return new HoodieMetadataTestTable(metaClient.getBasePath().toString(), metaClient.getRawHoodieStorage(),
+    return new HoodieMetadataTestTable(metaClient.getBasePath().toString(), metaClient.getRawStorage(),
         metaClient,
         writer, context);
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -1088,7 +1088,10 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder();
     addConfigsForPopulateMetaFields(cfgBuilder, populateMetaFields);
     HoodieWriteConfig hoodieWriteConfig = cfgBuilder.withMergeAllowDuplicateOnInserts(true).withTimelineLayoutVersion(VERSION_0).build();
-    HoodieTableMetaClient.withPropertyBuilder().fromMetaClient(metaClient).setTimelineLayoutVersion(VERSION_0)
+
+    HoodieTableMetaClient.newTableBuilder()
+        .fromMetaClient(metaClient)
+        .setTimelineLayoutVersion(VERSION_0)
         .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());
 
     BaseHoodieWriteClient client = getHoodieWriteClient(hoodieWriteConfig);
@@ -1153,8 +1156,11 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     addConfigsForPopulateMetaFields(cfgBuilder, populateMetaFields);
     // Force using older timeline layout
     HoodieWriteConfig config = cfgBuilder.withTimelineLayoutVersion(VERSION_0).build();
-    HoodieTableMetaClient.withPropertyBuilder().fromMetaClient(metaClient).setTimelineLayoutVersion(VERSION_0)
-        .setPopulateMetaFields(populateMetaFields).initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());
+    HoodieTableMetaClient.newTableBuilder()
+        .fromMetaClient(metaClient)
+        .setTimelineLayoutVersion(VERSION_0)
+        .setPopulateMetaFields(populateMetaFields)
+        .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());
 
     BaseHoodieWriteClient client = getHoodieWriteClient(config);
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -72,7 +72,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
   @Override
   protected HoodieWriteMetadata<List<WriteStatus>> compact(String compactionInstantTime, boolean shouldComplete) {
     // only used for metadata table, the compaction happens in single thread
-    HoodieWriteMetadata<List<WriteStatus>> compactionMetadata = getHoodieTable().compact(context, compactionInstantTime);
+    HoodieWriteMetadata<List<WriteStatus>> compactionMetadata = createTable(config, storageConf).compact(context, compactionInstantTime);
     commitCompaction(compactionInstantTime, compactionMetadata.getCommitMetadata().get(), Option.empty());
     return compactionMetadata;
   }
@@ -186,12 +186,8 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
   }
 
   @Override
-  protected HoodieTable<T, List<HoodieRecord<T>>, List<HoodieKey>, List<WriteStatus>> createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf) {
-    return HoodieFlinkTable.create(config, context);
-  }
-
-  public HoodieFlinkTable<?> getHoodieTable() {
-    return HoodieFlinkTable.create(config, context);
+  protected HoodieTable createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf, boolean skipValidation) {
+    return createTableAndValidate(config, HoodieFlinkTable::create, skipValidation);
   }
 
   /**
@@ -204,7 +200,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
   }
 
   public void initMetadataTable() {
-    HoodieFlinkTable<?> table = getHoodieTable();
+    HoodieFlinkTable<?> table = (HoodieFlinkTable<?>) createTable(config, storageConf, false);
     if (config.isMetadataTableEnabled()) {
       Option<String> latestPendingInstant = table.getActiveTimeline()
           .filterInflightsAndRequested().lastInstant().map(HoodieInstant::getTimestamp);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -114,12 +114,12 @@ public class HoodieFlinkWriteClient<T> extends
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config) {
-    return HoodieFlinkTable.create(config, (HoodieFlinkEngineContext) context);
+    return createTableAndValidate(config, HoodieFlinkTable::create);
   }
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config, HoodieTableMetaClient metaClient) {
-    return HoodieFlinkTable.create(config, (HoodieFlinkEngineContext) context, metaClient);
+    return createTableAndValidate(config, metaClient, HoodieFlinkTable::create);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -195,7 +195,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected HoodieTable getHoodieTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
+  protected HoodieTable getTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
     return HoodieFlinkTable.create(writeConfig, engineContext, metaClient);
   }
 

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieFlinkWriteableTestTable.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieFlinkWriteableTestTable.java
@@ -66,7 +66,7 @@ public class HoodieFlinkWriteableTestTable extends HoodieWriteableTestTable {
   public static HoodieFlinkWriteableTestTable of(HoodieTableMetaClient metaClient, Schema schema,
                                                  BloomFilter filter) {
     return new HoodieFlinkWriteableTestTable(metaClient.getBasePath().toString(),
-        metaClient.getRawHoodieStorage(), metaClient, schema, filter);
+        metaClient.getRawStorage(), metaClient, schema, filter);
   }
 
   public static HoodieFlinkWriteableTestTable of(HoodieTableMetaClient metaClient, Schema schema) {

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
@@ -70,7 +70,7 @@ public class HoodieJavaTableServiceClient<T> extends BaseHoodieTableServiceClien
   }
 
   @Override
-  protected HoodieTable<?, List<HoodieRecord<T>>, ?, List<WriteStatus>> createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf) {
-    return HoodieJavaTable.create(config, context);
+  protected HoodieTable<?, List<HoodieRecord<T>>, ?, List<WriteStatus>> createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf, boolean skipValidation) {
+    return createTableAndValidate(config, HoodieJavaTable::create, skipValidation);
   }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -94,12 +94,12 @@ public class HoodieJavaWriteClient<T> extends
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config) {
-    return HoodieJavaTable.create(config, context);
+    return createTableAndValidate(config, HoodieJavaTable::create);
   }
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config, HoodieTableMetaClient metaClient) {
-    return HoodieJavaTable.create(config, context, metaClient);
+    return createTableAndValidate(config, metaClient, HoodieJavaTable::create);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -34,6 +34,8 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.table.HoodieJavaTable;
+import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.Schema;
 
@@ -58,6 +60,11 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
                                                 HoodieEngineContext engineContext,
                                                 Option<String> inflightInstantTimestamp) {
     super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp);
+  }
+
+  @Override
+  HoodieTable getTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
+    return HoodieJavaTable.create(writeConfig, engineContext, metaClient);
   }
 
   public static HoodieTableMetadataWriter create(StorageConfiguration<?> conf,

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/common/TestMultipleHoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/common/TestMultipleHoodieJavaWriteClient.java
@@ -78,7 +78,7 @@ public class TestMultipleHoodieJavaWriteClient {
     final String tableName = "hudiTestTable";
     final String basePath = tablePath.toAbsolutePath().toString() + "/" + tableTypeName;
 
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(tableTypeName)
         .setTableName(tableName)
         .setPayloadClassName(HoodieAvroPayload.class.getName())

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/hadoop/TestHoodieFileGroupReaderOnHive.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/hadoop/TestHoodieFileGroupReaderOnHive.java
@@ -193,7 +193,7 @@ public class TestHoodieFileGroupReaderOnHive extends TestHoodieFileGroupReaderBa
             recordMergerStrategy = HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID;
           }
           Map<String, Object> initConfigs = new HashMap<>(writeConfigs);
-          HoodieTableMetaClient.withPropertyBuilder()
+          HoodieTableMetaClient.newTableBuilder()
               .setTableType(writeConfigs.getOrDefault("hoodie.datasource.write.table.type", "MERGE_ON_READ"))
               .setTableName(writeConfigs.get("hoodie.table.name"))
               .setPartitionFields(writeConfigs.getOrDefault("hoodie.datasource.write.partitionpath.field", ""))

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -70,8 +70,8 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
   }
 
   @Override
-  protected HoodieTable<?, HoodieData<HoodieRecord<T>>, ?, HoodieData<WriteStatus>> createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf) {
-    return HoodieSparkTable.create(config, context);
+  protected HoodieTable<?, HoodieData<HoodieRecord<T>>, ?, HoodieData<WriteStatus>> createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf, boolean skipValidation) {
+    return createTableAndValidate(config, HoodieSparkTable::create, skipValidation);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -70,17 +70,6 @@ public class SparkRDDWriteClient<T> extends
     this(context, clientConfig, Option.empty());
   }
 
-  @Deprecated
-  public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig, boolean rollbackPending) {
-    this(context, writeConfig, Option.empty());
-  }
-
-  @Deprecated
-  public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig, boolean rollbackPending,
-                             Option<EmbeddedTimelineService> timelineService) {
-    this(context, writeConfig, timelineService);
-  }
-
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig,
                              Option<EmbeddedTimelineService> timelineService) {
     super(context, writeConfig, timelineService, SparkUpgradeDowngradeHelper.getInstance());
@@ -106,12 +95,12 @@ public class SparkRDDWriteClient<T> extends
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config) {
-    return HoodieSparkTable.create(config, context);
+    return createTableAndValidate(config, HoodieSparkTable::create);
   }
 
   @Override
   protected HoodieTable createTable(HoodieWriteConfig config, HoodieTableMetaClient metaClient) {
-    return HoodieSparkTable.create(config, context, metaClient);
+    return createTableAndValidate(config, metaClient, HoodieSparkTable::create);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -216,13 +216,13 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected HoodieTable getHoodieTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
+  protected HoodieTable getTable(HoodieWriteConfig writeConfig, HoodieTableMetaClient metaClient) {
     return HoodieSparkTable.create(writeConfig, engineContext, metaClient);
   }
 
   @Override
   public BaseHoodieWriteClient<?, JavaRDD<HoodieRecord>, ?, ?> initializeWriteClient() {
-    return new SparkRDDWriteClient(engineContext, metadataWriteConfig, true);
+    return new SparkRDDWriteClient(engineContext, metadataWriteConfig, Option.empty());
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
@@ -103,7 +103,7 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
   @Test
   public void readLocalWriteHDFS() throws Exception {
     // Initialize table and filesystem
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(TABLE_TYPE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)
@@ -113,7 +113,7 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
     HoodieWriteConfig cfg = getHoodieWriteConfig(dfsBasePath);
     HoodieWriteConfig localConfig = getHoodieWriteConfig(tablePath);
 
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(TABLE_TYPE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)
@@ -140,7 +140,7 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
       assertEquals(readRecords.count(), records.size());
 
       // Write to local
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
           .setTableType(TABLE_TYPE)
           .setTableName(TABLE_NAME)
           .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
@@ -165,7 +165,7 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
     tableType = HoodieTableType.MERGE_ON_READ;
 
     // Create the table
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .fromMetaClient(metaClient)
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setRecordMergeMode(RecordMergeMode.valueOf(RECORD_MERGE_MODE.defaultValue()))
@@ -255,7 +255,7 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
   @ValueSource(booleans = {false, true})
   public void testCopyOnWriteTable(boolean shouldAllowDroppedColumns) throws Exception {
     // Create the table
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .fromMetaClient(metaClient)
         .setTimelineLayoutVersion(VERSION_1)
         .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -2736,7 +2736,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext,
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
-        true)) {
+        Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
@@ -2769,7 +2769,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext,
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
-        true)) {
+        Option.empty())) {
       String newCommitTime = client.startCommit();
       // Next insert
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
@@ -2969,7 +2969,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // should be rolled back to last valid commit.
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext,
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
-        true)) {
+        Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
@@ -2995,7 +2995,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext,
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
-        true)) {
+        Option.empty())) {
       String newCommitTime = client.startCommit();
       // Next insert
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 5);
@@ -3410,7 +3410,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     metadataProps.setProperty(INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "3");
     HoodieWriteConfig metadataWriteConfig = HoodieWriteConfig.newBuilder()
         .withProperties(metadataProps).build();
-    try (SparkRDDWriteClient metadataWriteClient = new SparkRDDWriteClient(context, metadataWriteConfig, true)) {
+    try (SparkRDDWriteClient metadataWriteClient = new SparkRDDWriteClient(context, metadataWriteConfig, Option.empty())) {
       final String compactionInstantTime = client.createNewInstantTime();
       assertTrue(metadataWriteClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty()));
       metadataWriteClient.compact(compactionInstantTime);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -513,7 +513,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         .withProps(config.getProps()).withTimelineLayoutVersion(
             VERSION_0).build();
 
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .fromMetaClient(metaClient)
         .setTimelineLayoutVersion(VERSION_0)
         .setPopulateMetaFields(config.populateMetaFields())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -43,6 +43,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 import org.apache.hudi.keygen.TimestampBasedKeyGenerator;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
@@ -169,6 +170,17 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
   @AfterEach
   public void cleanUp() throws Exception {
     cleanupResources();
+  }
+
+  @Test
+  public void testAutoUpgradeFailure() throws IOException {
+    Map<String, String> params = new HashMap<>();
+    addNewTableParamsToProps(params);
+    HoodieWriteConfig cfg = getConfigBuilder().withAutoUpgradeVersion(false).withProps(params).build();
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE, HoodieTableVersion.SIX);
+    assertThrows(HoodieUpgradeDowngradeException.class, () ->
+        new UpgradeDowngrade(metaClient, cfg, context, SparkUpgradeDowngradeHelper.getInstance()).run(HoodieTableVersion.EIGHT, null)
+    );
   }
 
   @Test

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
@@ -123,13 +123,12 @@ public class FunctionalTestHarness implements SparkProvider, DFSProvider, Hoodie
 
   @Override
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
-    props = HoodieTableMetaClient.withPropertyBuilder()
+    return HoodieTableMetaClient.newTableBuilder()
       .setTableName(RAW_TRIPS_TEST_NAME)
       .setTableType(COPY_ON_WRITE)
       .setPayloadClass(HoodieAvroPayload.class)
       .fromProperties(props)
-      .build();
-    return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, props);
+      .initTable(storageConf.newInstance(), basePath);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
@@ -67,7 +67,7 @@ public class HoodieSparkWriteableTestTable extends HoodieWriteableTestTable {
 
   public static HoodieSparkWriteableTestTable of(HoodieTableMetaClient metaClient, Schema schema, BloomFilter filter, Option<HoodieEngineContext> context) {
     return new HoodieSparkWriteableTestTable(metaClient.getBasePath().toString(),
-        metaClient.getRawHoodieStorage(),
+        metaClient.getRawStorage(),
         metaClient, schema, filter, null, context);
   }
 
@@ -79,7 +79,7 @@ public class HoodieSparkWriteableTestTable extends HoodieWriteableTestTable {
   public static HoodieSparkWriteableTestTable of(HoodieTableMetaClient metaClient, Schema schema, BloomFilter filter,
                                                  HoodieTableMetadataWriter metadataWriter, Option<HoodieEngineContext> context) {
     return new HoodieSparkWriteableTestTable(metaClient.getBasePath().toString(),
-        metaClient.getRawHoodieStorage(),
+        metaClient.getRawStorage(),
         metaClient, schema, filter, metadataWriter, context);
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -175,13 +175,12 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
   }
 
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType, Properties props) throws IOException {
-    props = HoodieTableMetaClient.withPropertyBuilder()
+    return HoodieTableMetaClient.newTableBuilder()
         .setTableName(RAW_TRIPS_TEST_NAME)
         .setTableType(tableType)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
-    return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, props);
+        .initTable(storageConf.newInstance(), basePath);
   }
 
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath) throws IOException {
@@ -190,13 +189,12 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
 
   @Override
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
-    props = HoodieTableMetaClient.withPropertyBuilder()
+    return HoodieTableMetaClient.newTableBuilder()
         .setTableName(RAW_TRIPS_TEST_NAME)
         .setTableType(COPY_ON_WRITE)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
-    return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, props);
+        .initTable(storageConf.newInstance(), basePath);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BootstrapIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BootstrapIndexType.java
@@ -34,7 +34,7 @@ public enum BootstrapIndexType {
   @EnumFieldDescription("Maintains mapping in HFile format.")
   HFILE(HFileBootstrapIndex.class.getName()),
   @EnumFieldDescription("No-op, an empty implementation.")
-  NO_OP(NoOpBootstrapIndex.class.getName());
+  NONE(NoOpBootstrapIndex.class.getName());
 
   private final String className;
 
@@ -57,7 +57,7 @@ public enum BootstrapIndexType {
 
   public static String getBootstrapIndexClassName(HoodieConfig config) {
     if (!config.getBooleanOrDefault(BOOTSTRAP_INDEX_ENABLE)) {
-      return BootstrapIndexType.NO_OP.getClassName();
+      return BootstrapIndexType.NONE.getClassName();
     }
     if (config.contains(BOOTSTRAP_INDEX_CLASS_NAME)) {
       return config.getString(BOOTSTRAP_INDEX_CLASS_NAME);
@@ -68,9 +68,13 @@ public enum BootstrapIndexType {
   }
 
   public static String getDefaultBootstrapIndexClassName(HoodieConfig config) {
+    return getBootstrapIndexType(config).getClassName();
+  }
+
+  public static BootstrapIndexType getBootstrapIndexType(HoodieConfig config) {
     if (!config.getBooleanOrDefault(BOOTSTRAP_INDEX_ENABLE)) {
-      return BootstrapIndexType.NO_OP.getClassName();
+      return BootstrapIndexType.NONE;
     }
-    return BootstrapIndexType.valueOf(BOOTSTRAP_INDEX_TYPE.defaultValue()).getClassName();
+    return BootstrapIndexType.valueOf(BOOTSTRAP_INDEX_TYPE.defaultValue());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -587,7 +587,7 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public static HoodieTableVersion getTableVersion(HoodieConfig config) {
     return contains(VERSION, config)
-        ? HoodieTableVersion.versionFromCode(config.getInt(VERSION))
+        ? HoodieTableVersion.fromVersionCode(config.getInt(VERSION))
         : VERSION.defaultValue();
   }
 
@@ -616,7 +616,7 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public HoodieTableVersion getTableInitialVersion() {
     return contains(INITIAL_VERSION)
-            ? HoodieTableVersion.versionFromCode(getInt(INITIAL_VERSION))
+            ? HoodieTableVersion.fromVersionCode(getInt(INITIAL_VERSION))
             : INITIAL_VERSION.defaultValue();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -81,7 +81,6 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID;
 import static org.apache.hudi.common.model.HoodieRecordMerger.OVERWRITE_MERGER_STRATEGY_UUID;
-import static org.apache.hudi.common.table.HoodieTableConfig.INITIAL_VERSION;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
 import static org.apache.hudi.common.table.HoodieTableConfig.VERSION;
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
@@ -909,8 +908,7 @@ public class HoodieTableMetaClient implements Serializable {
      */
     private Properties others = new Properties();
 
-    private TableBuilder() {
-
+    TableBuilder() {
     }
 
     public TableBuilder setTableType(HoodieTableType tableType) {
@@ -1244,7 +1242,6 @@ public class HoodieTableMetaClient implements Serializable {
       checkArgument(tableType != null, "tableType is null");
       checkArgument(tableName != null, "tableName is null");
 
-      // TODO(vc): This is where we need to make these table configs be version specific..,
       HoodieTableConfig tableConfig = new HoodieTableConfig();
 
       tableConfig.setAll(others);
@@ -1257,10 +1254,10 @@ public class HoodieTableMetaClient implements Serializable {
 
       if (null != tableVersion) {
         tableConfig.setTableVersion(tableVersion);
-        tableConfig.setValue(INITIAL_VERSION, Integer.toString(tableVersion.versionCode()));
+        tableConfig.setInitialVersion(tableVersion);
       } else {
         tableConfig.setTableVersion(HoodieTableVersion.current());
-        tableConfig.setValue(INITIAL_VERSION, Integer.toString(HoodieTableVersion.current().versionCode()));
+        tableConfig.setInitialVersion(HoodieTableVersion.current());
       }
 
       if (tableType == HoodieTableType.MERGE_ON_READ) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -50,6 +50,7 @@ import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.TableNotFoundException;
@@ -82,6 +83,7 @@ import static org.apache.hudi.common.model.HoodieRecordMerger.DEFAULT_MERGER_STR
 import static org.apache.hudi.common.model.HoodieRecordMerger.OVERWRITE_MERGER_STRATEGY_UUID;
 import static org.apache.hudi.common.table.HoodieTableConfig.INITIAL_VERSION;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
+import static org.apache.hudi.common.table.HoodieTableConfig.VERSION;
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -577,19 +579,19 @@ public class HoodieTableMetaClient implements Serializable {
 
   public static HoodieTableMetaClient initTableAndGetMetaClient(StorageConfiguration<?> storageConf, StoragePath basePath,
                                                                 Properties props) throws IOException {
-    initTableMetaClient(storageConf, basePath, props);
-    // We should not use fs.getConf as this might be different from the original configuration
-    // used to create the fs in unit tests
+    createTableLayoutOnStorage(storageConf, basePath, props);
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(storageConf).setBasePath(basePath)
             .setMetaserverConfig(props)
             .build();
-    LOG.info("Finished initializing Table of type " + metaClient.getTableConfig().getTableType() + " from " + basePath);
+    LOG.info("Finished initializing Table of type {} from {}", metaClient.getTableConfig().getTableType(), basePath);
     return metaClient;
   }
 
-  private static void initTableMetaClient(StorageConfiguration<?> storageConf, StoragePath basePath,
-                                          Properties props) throws IOException {
-    LOG.info("Initializing " + basePath + " as hoodie table " + basePath);
+  // TODO: is this idempotent, in face of failures?
+  private static void createTableLayoutOnStorage(StorageConfiguration<?> storageConf,
+                                                 StoragePath basePath,
+                                                 Properties props) throws IOException {
+    LOG.info("Initializing {} as hoodie table", basePath);
     final HoodieStorage storage = HoodieStorageUtils.getStorage(basePath, storageConf);
     if (!storage.exists(basePath)) {
       storage.createDirectory(basePath);
@@ -627,6 +629,7 @@ public class HoodieTableMetaClient implements Serializable {
 
     initializeBootstrapDirsIfNotExists(basePath, storage);
     // When the table is initialized, set the initial version to be the current version.
+    // TODO: this needs to change to the actual configured table version?
     props.put(INITIAL_VERSION.key(), String.valueOf(HoodieTableVersion.current().versionCode()));
     HoodieTableConfig.create(storage, metaPathDir, props);
   }
@@ -801,14 +804,16 @@ public class HoodieTableMetaClient implements Serializable {
                                                      String payloadClassName, String recordMergerStrategy,
                                                      HoodieTimeGeneratorConfig timeGeneratorConfig, FileSystemRetryConfig fileSystemRetryConfig,
                                                      HoodieMetaserverConfig metaserverConfig) {
-    return metaserverConfig.isMetaserverEnabled() ? (HoodieTableMetaClient) ReflectionUtils.loadClass(
-        "org.apache.hudi.common.table.HoodieTableMetaserverClient",
-        new Class<?>[] {HoodieStorage.class, String.class, ConsistencyGuardConfig.class, String.class, HoodieTimeGeneratorConfig.class,
-            FileSystemRetryConfig.class, Option.class, Option.class, HoodieMetaserverConfig.class},
-        storage, basePath, consistencyGuardConfig, recordMergerStrategy, timeGeneratorConfig, fileSystemRetryConfig,
-        Option.ofNullable(metaserverConfig.getDatabaseName()), Option.ofNullable(metaserverConfig.getTableName()), metaserverConfig)
-        : new HoodieTableMetaClient(storage, basePath, loadActiveTimelineOnLoad, consistencyGuardConfig, layoutVersion, payloadClassName, recordMergerStrategy,
-        timeGeneratorConfig, fileSystemRetryConfig);
+    if (metaserverConfig.isMetaserverEnabled()) {
+      return (HoodieTableMetaClient) ReflectionUtils.loadClass("org.apache.hudi.common.table.HoodieTableMetaserverClient",
+          new Class<?>[] {HoodieStorage.class, String.class, ConsistencyGuardConfig.class, String.class, HoodieTimeGeneratorConfig.class,
+              FileSystemRetryConfig.class, Option.class, Option.class, HoodieMetaserverConfig.class},
+          storage, basePath, consistencyGuardConfig, recordMergerStrategy, timeGeneratorConfig, fileSystemRetryConfig,
+          Option.ofNullable(metaserverConfig.getDatabaseName()), Option.ofNullable(metaserverConfig.getTableName()), metaserverConfig);
+    } else {
+      return new HoodieTableMetaClient(storage, basePath, loadActiveTimelineOnLoad, consistencyGuardConfig, layoutVersion, payloadClassName, recordMergerStrategy,
+          timeGeneratorConfig, fileSystemRetryConfig);
+    }
   }
 
   public static Builder builder() {
@@ -914,19 +919,20 @@ public class HoodieTableMetaClient implements Serializable {
     }
   }
 
-  public static PropertyBuilder withPropertyBuilder() {
-    return new PropertyBuilder();
+  public static TableBuilder newTableBuilder() {
+    return new TableBuilder();
   }
 
   /**
    * Builder for {@link Properties}.
    */
-  public static class PropertyBuilder {
+  public static class TableBuilder {
 
     private HoodieTableType tableType;
     private String databaseName;
     private String tableName;
     private String tableCreateSchema;
+    private HoodieTableVersion tableVersion;
     private String recordKeyFields;
     private String secondaryKeyFields;
     private String archiveLogFolder;
@@ -964,184 +970,193 @@ public class HoodieTableMetaClient implements Serializable {
      */
     private Properties others = new Properties();
 
-    private PropertyBuilder() {
+    private TableBuilder() {
 
     }
 
-    public PropertyBuilder setTableType(HoodieTableType tableType) {
+    public TableBuilder setTableType(HoodieTableType tableType) {
       this.tableType = tableType;
       return this;
     }
 
-    public PropertyBuilder setTableType(String tableType) {
+    public TableBuilder setTableType(String tableType) {
       return setTableType(HoodieTableType.valueOf(tableType));
     }
 
-    public PropertyBuilder setDatabaseName(String databaseName) {
+    public TableBuilder setDatabaseName(String databaseName) {
       this.databaseName = databaseName;
       return this;
     }
 
-    public PropertyBuilder setTableName(String tableName) {
+    public TableBuilder setTableName(String tableName) {
       this.tableName = tableName;
       return this;
     }
 
-    public PropertyBuilder setTableCreateSchema(String tableCreateSchema) {
+    public TableBuilder setTableVersion(HoodieTableVersion tableVersion) {
+      this.tableVersion = tableVersion;
+      return this;
+    }
+
+    public TableBuilder setTableVersion(String tableVersion) {
+      return setTableVersion(HoodieTableVersion.versionFromCode(Integer.parseInt(tableVersion)));
+    }
+
+    public TableBuilder setTableCreateSchema(String tableCreateSchema) {
       this.tableCreateSchema = tableCreateSchema;
       return this;
     }
 
-    public PropertyBuilder setRecordKeyFields(String recordKeyFields) {
+    public TableBuilder setRecordKeyFields(String recordKeyFields) {
       this.recordKeyFields = recordKeyFields;
       return this;
     }
 
-    public PropertyBuilder setSecondaryKeyFields(String secondaryKeyFields) {
+    public TableBuilder setSecondaryKeyFields(String secondaryKeyFields) {
       this.secondaryKeyFields = secondaryKeyFields;
       return this;
     }
 
-    public PropertyBuilder setArchiveLogFolder(String archiveLogFolder) {
+    public TableBuilder setArchiveLogFolder(String archiveLogFolder) {
       this.archiveLogFolder = archiveLogFolder;
       return this;
     }
 
-    public PropertyBuilder setRecordMergeMode(RecordMergeMode recordMergeMode) {
+    public TableBuilder setRecordMergeMode(RecordMergeMode recordMergeMode) {
       this.recordMergeMode = recordMergeMode;
       return this;
     }
 
-    public PropertyBuilder setPayloadClassName(String payloadClassName) {
+    public TableBuilder setPayloadClassName(String payloadClassName) {
       this.payloadClassName = payloadClassName;
       return this;
     }
 
-    public PropertyBuilder setPayloadType(String payloadType) {
+    public TableBuilder setPayloadType(String payloadType) {
       this.payloadType = payloadType;
       return this;
     }
 
-    public PropertyBuilder setRecordMergerStrategy(String recordMergerStrategy) {
+    public TableBuilder setRecordMergerStrategy(String recordMergerStrategy) {
       this.recordMergerStrategy = recordMergerStrategy;
       return this;
     }
 
-    public PropertyBuilder setPayloadClass(Class<? extends HoodieRecordPayload> payloadClass) {
+    public TableBuilder setPayloadClass(Class<? extends HoodieRecordPayload> payloadClass) {
       return setPayloadClassName(payloadClass.getName());
     }
 
-    public PropertyBuilder setTimelineLayoutVersion(Integer timelineLayoutVersion) {
+    public TableBuilder setTimelineLayoutVersion(Integer timelineLayoutVersion) {
       this.timelineLayoutVersion = timelineLayoutVersion;
       return this;
     }
 
-    public PropertyBuilder setBaseFileFormat(String baseFileFormat) {
+    public TableBuilder setBaseFileFormat(String baseFileFormat) {
       this.baseFileFormat = baseFileFormat;
       return this;
     }
 
-    public PropertyBuilder setPreCombineField(String preCombineField) {
+    public TableBuilder setPreCombineField(String preCombineField) {
       this.preCombineField = preCombineField;
       return this;
     }
 
-    public PropertyBuilder setPartitionFields(String partitionFields) {
+    public TableBuilder setPartitionFields(String partitionFields) {
       this.partitionFields = partitionFields;
       return this;
     }
 
-    public PropertyBuilder setCDCEnabled(boolean cdcEnabled) {
+    public TableBuilder setCDCEnabled(boolean cdcEnabled) {
       this.cdcEnabled = cdcEnabled;
       return this;
     }
 
-    public PropertyBuilder setCDCSupplementalLoggingMode(String cdcSupplementalLoggingMode) {
+    public TableBuilder setCDCSupplementalLoggingMode(String cdcSupplementalLoggingMode) {
       this.cdcSupplementalLoggingMode = cdcSupplementalLoggingMode.toUpperCase();
       return this;
     }
 
-    public PropertyBuilder setBootstrapIndexClass(String bootstrapIndexClass) {
+    public TableBuilder setBootstrapIndexClass(String bootstrapIndexClass) {
       this.bootstrapIndexClass = bootstrapIndexClass;
       return this;
     }
 
-    public PropertyBuilder setBootstrapBasePath(String bootstrapBasePath) {
+    public TableBuilder setBootstrapBasePath(String bootstrapBasePath) {
       this.bootstrapBasePath = bootstrapBasePath;
       return this;
     }
 
-    public PropertyBuilder setBootstrapIndexEnable(Boolean bootstrapIndexEnable) {
+    public TableBuilder setBootstrapIndexEnable(Boolean bootstrapIndexEnable) {
       this.bootstrapIndexEnable = bootstrapIndexEnable;
       return this;
     }
 
-    public PropertyBuilder setPopulateMetaFields(boolean populateMetaFields) {
+    public TableBuilder setPopulateMetaFields(boolean populateMetaFields) {
       this.populateMetaFields = populateMetaFields;
       return this;
     }
 
-    public PropertyBuilder setKeyGeneratorClassProp(String keyGeneratorClassProp) {
+    public TableBuilder setKeyGeneratorClassProp(String keyGeneratorClassProp) {
       this.keyGeneratorClassProp = keyGeneratorClassProp;
       return this;
     }
 
-    public PropertyBuilder setKeyGeneratorType(String keyGeneratorType) {
+    public TableBuilder setKeyGeneratorType(String keyGeneratorType) {
       this.keyGeneratorType = keyGeneratorType;
       return this;
     }
 
-    public PropertyBuilder setHiveStylePartitioningEnable(Boolean hiveStylePartitioningEnable) {
+    public TableBuilder setHiveStylePartitioningEnable(Boolean hiveStylePartitioningEnable) {
       this.hiveStylePartitioningEnable = hiveStylePartitioningEnable;
       return this;
     }
 
-    public PropertyBuilder setUrlEncodePartitioning(Boolean urlEncodePartitioning) {
+    public TableBuilder setUrlEncodePartitioning(Boolean urlEncodePartitioning) {
       this.urlEncodePartitioning = urlEncodePartitioning;
       return this;
     }
 
-    public PropertyBuilder setCommitTimezone(HoodieTimelineTimeZone timelineTimeZone) {
+    public TableBuilder setCommitTimezone(HoodieTimelineTimeZone timelineTimeZone) {
       this.commitTimeZone = timelineTimeZone;
       return this;
     }
 
-    public PropertyBuilder setPartitionMetafileUseBaseFormat(Boolean useBaseFormat) {
+    public TableBuilder setPartitionMetafileUseBaseFormat(Boolean useBaseFormat) {
       this.partitionMetafileUseBaseFormat = useBaseFormat;
       return this;
     }
 
-    public PropertyBuilder setShouldDropPartitionColumns(Boolean shouldDropPartitionColumns) {
+    public TableBuilder setShouldDropPartitionColumns(Boolean shouldDropPartitionColumns) {
       this.shouldDropPartitionColumns = shouldDropPartitionColumns;
       return this;
     }
 
-    public PropertyBuilder setMetadataPartitions(String partitions) {
+    public TableBuilder setMetadataPartitions(String partitions) {
       this.metadataPartitions = partitions;
       return this;
     }
 
-    public PropertyBuilder setInflightMetadataPartitions(String partitions) {
+    public TableBuilder setInflightMetadataPartitions(String partitions) {
       this.inflightMetadataPartitions = partitions;
       return this;
     }
 
-    public PropertyBuilder setSecondaryIndexesMetadata(String secondaryIndexesMetadata) {
+    public TableBuilder setSecondaryIndexesMetadata(String secondaryIndexesMetadata) {
       this.secondaryIndexesMetadata = secondaryIndexesMetadata;
       return this;
     }
 
-    public PropertyBuilder setMultipleBaseFileFormatsEnabled(Boolean multipleBaseFileFormatsEnabled) {
+    public TableBuilder setMultipleBaseFileFormatsEnabled(Boolean multipleBaseFileFormatsEnabled) {
       this.multipleBaseFileFormatsEnabled = multipleBaseFileFormatsEnabled;
       return this;
     }
 
-    public PropertyBuilder setIndexDefinitionPath(String indexDefinitionPath) {
+    public TableBuilder setIndexDefinitionPath(String indexDefinitionPath) {
       this.indexDefinitionPath = indexDefinitionPath;
       return this;
     }
 
-    public PropertyBuilder set(Map<String, Object> props) {
+    public TableBuilder set(Map<String, Object> props) {
       for (ConfigProperty<String> configProperty : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
         if (containsConfigProperty(props, configProperty)) {
           String value = getStringWithAltKeys(props, configProperty);
@@ -1153,16 +1168,17 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
-    public PropertyBuilder fromMetaClient(HoodieTableMetaClient metaClient) {
+    public TableBuilder fromMetaClient(HoodieTableMetaClient metaClient) {
       return setTableType(metaClient.getTableType())
           .setTableName(metaClient.getTableConfig().getTableName())
+          .setTableVersion(metaClient.getTableConfig().getTableVersion())
           .setArchiveLogFolder(metaClient.getTableConfig().getArchivelogFolder())
           .setRecordMergeMode(metaClient.getTableConfig().getRecordMergeMode())
           .setPayloadClassName(metaClient.getTableConfig().getPayloadClass())
           .setRecordMergerStrategy(metaClient.getTableConfig().getRecordMergerStrategy());
     }
 
-    public PropertyBuilder fromProperties(Properties properties) {
+    public TableBuilder fromProperties(Properties properties) {
       HoodieConfig hoodieConfig = new HoodieConfig(properties);
 
       for (ConfigProperty<String> configProperty : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
@@ -1180,6 +1196,11 @@ public class HoodieTableMetaClient implements Serializable {
       if (hoodieConfig.contains(HoodieTableConfig.NAME)) {
         setTableName(hoodieConfig.getString(HoodieTableConfig.NAME));
       }
+
+      if (hoodieConfig.contains(VERSION)) {
+        setTableVersion(hoodieConfig.getString(VERSION));
+      }
+
       if (hoodieConfig.contains(HoodieTableConfig.TYPE)) {
         setTableType(hoodieConfig.getString(HoodieTableConfig.TYPE));
       }
@@ -1279,10 +1300,12 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
+    @VisibleForTesting
     public Properties build() {
       checkArgument(tableType != null, "tableType is null");
       checkArgument(tableName != null, "tableName is null");
 
+      // TODO(vc): This is where we need to make these table configs be version specific..,
       HoodieTableConfig tableConfig = new HoodieTableConfig();
 
       tableConfig.setAll(others);
@@ -1292,7 +1315,12 @@ public class HoodieTableMetaClient implements Serializable {
       }
       tableConfig.setValue(HoodieTableConfig.NAME, tableName);
       tableConfig.setValue(HoodieTableConfig.TYPE, tableType.name());
-      tableConfig.setValue(HoodieTableConfig.VERSION, String.valueOf(HoodieTableVersion.current().versionCode()));
+
+      if (null != tableVersion) {
+        tableConfig.setTableVersion(tableVersion);
+      } else {
+        tableConfig.setTableVersion(HoodieTableVersion.current());
+      }
 
       if (tableType == HoodieTableType.MERGE_ON_READ) {
         if (null != payloadClassName) {
@@ -1401,13 +1429,12 @@ public class HoodieTableMetaClient implements Serializable {
       return tableConfig.getProps();
     }
 
-    /**
-     * Init Table with the properties build by this builder.
-     *
-     * @param configuration The storage configuration.
-     * @param basePath      The base path for hoodie table.
-     */
     public HoodieTableMetaClient initTable(StorageConfiguration<?> configuration, String basePath)
+        throws IOException {
+      return HoodieTableMetaClient.initTableAndGetMetaClient(configuration, basePath, build());
+    }
+
+    public HoodieTableMetaClient initTable(StorageConfiguration<?> configuration, StoragePath basePath)
         throws IOException {
       return HoodieTableMetaClient.initTableAndGetMetaClient(configuration, basePath, build());
     }
@@ -1496,10 +1523,6 @@ public class HoodieTableMetaClient implements Serializable {
       stringBuilder.append(") should be consistent with the record merge mode ");
       stringBuilder.append(recordMergeMode);
       return stringBuilder.toString();
-    }
-
-    public HoodieTableMetaClient initTable(StorageConfiguration<?> configuration, StoragePath basePath) throws IOException {
-      return HoodieTableMetaClient.initTableAndGetMetaClient(configuration, basePath, build());
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -18,9 +18,11 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.exception.HoodieException;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Table's version that controls what version of writer/readers can actually read/write
@@ -28,39 +30,35 @@ import java.util.Arrays;
  */
 public enum HoodieTableVersion {
   // < 0.6.0 versions
-  ZERO(0, "0.3.0"),
+  ZERO(0, CollectionUtils.createImmutableList("0.3.0")),
   // 0.6.0 onwards
-  ONE(1, "0.6.0"),
+  ONE(1, CollectionUtils.createImmutableList("0.6.0")),
   // 0.9.0 onwards
-  TWO(2, "0.9.0"),
+  TWO(2, CollectionUtils.createImmutableList("0.9.0")),
   // 0.10.0 onwards
-  THREE(3, "0.10.0"),
+  THREE(3, CollectionUtils.createImmutableList("0.10.0")),
   // 0.11.0 onwards
-  FOUR(4, "0.11.0"),
+  FOUR(4, CollectionUtils.createImmutableList("0.11.0")),
   // 0.12.0 onwards
-  FIVE(5, "0.12.0"),
+  FIVE(5, CollectionUtils.createImmutableList("0.12.0", "0.13.0")),
   // 0.14.0 onwards
-  SIX(6, "0.14.0"),
+  SIX(6, CollectionUtils.createImmutableList("0.14.0")),
   // 0.16.0
-  SEVEN(7, "0.16.0"),
+  SEVEN(7, CollectionUtils.createImmutableList("0.16.0")),
   // 1.0
-  EIGHT(8, "1.0.0");
+  EIGHT(8, CollectionUtils.createImmutableList("1.0.0"));
   
   private final int versionCode;
 
-  private final String firstReleaseVersion;
+  private final List<String> releaseVersions;
 
-  HoodieTableVersion(int versionCode, String firstReleaseVersion) {
+  HoodieTableVersion(int versionCode, List<String> releaseVersions) {
     this.versionCode = versionCode;
-    this.firstReleaseVersion = firstReleaseVersion;
+    this.releaseVersions = releaseVersions;
   }
 
   public int versionCode() {
     return versionCode;
-  }
-
-  public String firstReleaseVersion() {
-    return firstReleaseVersion;
   }
 
   public static HoodieTableVersion current() {
@@ -71,6 +69,12 @@ public enum HoodieTableVersion {
     return Arrays.stream(HoodieTableVersion.values())
         .filter(v -> v.versionCode == versionCode).findAny()
         .orElseThrow(() -> new HoodieException("Unknown table versionCode:" + versionCode));
+  }
+
+  public static HoodieTableVersion fromReleaseVersion(String releaseVersion) {
+    return Arrays.stream(HoodieTableVersion.values())
+        .filter(v -> v.releaseVersions.contains(releaseVersion)).findAny()
+        .orElseThrow(() -> new HoodieException("Unknown table firstReleaseVersion:" + releaseVersion));
   }
 
   public boolean greaterThan(HoodieTableVersion other) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -28,32 +28,39 @@ import java.util.Arrays;
  */
 public enum HoodieTableVersion {
   // < 0.6.0 versions
-  ZERO(0),
+  ZERO(0, "0.3.0"),
   // 0.6.0 onwards
-  ONE(1),
+  ONE(1, "0.6.0"),
   // 0.9.0 onwards
-  TWO(2),
+  TWO(2, "0.9.0"),
   // 0.10.0 onwards
-  THREE(3),
+  THREE(3, "0.10.0"),
   // 0.11.0 onwards
-  FOUR(4),
+  FOUR(4, "0.11.0"),
   // 0.12.0 onwards
-  FIVE(5),
+  FIVE(5, "0.12.0"),
   // 0.14.0 onwards
-  SIX(6),
+  SIX(6, "0.14.0"),
   // 0.16.0
-  SEVEN(7),
-  // 1.0 beta
-  EIGHT(8);
+  SEVEN(7, "0.16.0"),
+  // 1.0
+  EIGHT(8, "1.0.0");
   
   private final int versionCode;
 
-  HoodieTableVersion(int versionCode) {
+  private final String firstReleaseVersion;
+
+  HoodieTableVersion(int versionCode, String firstReleaseVersion) {
     this.versionCode = versionCode;
+    this.firstReleaseVersion = firstReleaseVersion;
   }
 
   public int versionCode() {
     return versionCode;
+  }
+
+  public String firstReleaseVersion() {
+    return firstReleaseVersion;
   }
 
   public static HoodieTableVersion current() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -67,10 +67,10 @@ public enum HoodieTableVersion {
     return EIGHT;
   }
 
-  public static HoodieTableVersion versionFromCode(int versionCode) {
+  public static HoodieTableVersion fromVersionCode(int versionCode) {
     return Arrays.stream(HoodieTableVersion.values())
         .filter(v -> v.versionCode == versionCode).findAny()
-        .orElseThrow(() -> new HoodieException("Unknown versionCode:" + versionCode));
+        .orElseThrow(() -> new HoodieException("Unknown table versionCode:" + versionCode));
   }
 
   public boolean greaterThan(HoodieTableVersion other) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -311,7 +311,7 @@ public class TableSchemaResolver {
   }
 
   private Schema readSchemaFromLogFile(StoragePath path) throws IOException {
-    return readSchemaFromLogFile(metaClient.getRawHoodieStorage(), path);
+    return readSchemaFromLogFile(metaClient.getRawStorage(), path);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieTableConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieTableConfigUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class HoodieTableConfigUtils {
+
+  /**
+   * This function returns the partition fields joined by BaseKeyGenerator.FIELD_SEPARATOR. It will also
+   * include the key generator partition type with the field. The key generator partition type is used for
+   * Custom Key Generator.
+   */
+  public static Option<String> getPartitionFieldPropForKeyGenerator(HoodieConfig config) {
+    return Option.ofNullable(config.getString(HoodieTableConfig.PARTITION_FIELDS));
+  }
+
+  /**
+   * This function returns the partition fields joined by BaseKeyGenerator.FIELD_SEPARATOR. It will
+   * strip the partition key generator related info from the fields.
+   */
+  public static Option<String> getPartitionFieldProp(HoodieConfig config) {
+    if (getTableVersion(config).greaterThan(HoodieTableVersion.SEVEN)) {
+      // With table version eight, the table config org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS
+      // stores the corresponding partition type as well. This partition type is useful for CustomKeyGenerator
+      // and CustomAvroKeyGenerator.
+      return getPartitionFields(config).map(fields -> String.join(BaseKeyGenerator.FIELD_SEPARATOR, fields));
+    } else {
+      return Option.ofNullable(config.getString(HoodieTableConfig.PARTITION_FIELDS));
+    }
+  }
+
+  /**
+   * This function returns the partition fields only. This method strips the key generator related
+   * partition key types from the configured fields.
+   */
+  public static Option<String[]> getPartitionFields(HoodieConfig config) {
+    if (HoodieConfig.contains(HoodieTableConfig.PARTITION_FIELDS, config)) {
+      return Option.of(Arrays.stream(config.getString(HoodieTableConfig.PARTITION_FIELDS).split(","))
+          .filter(p -> !p.isEmpty())
+          .map(p -> getPartitionFieldWithoutKeyGenPartitionType(p, config))
+          .collect(Collectors.toList()).toArray(new String[] {}));
+    }
+    return Option.empty();
+  }
+
+  /**
+   * This function returns the partition fields only. The input partition field would contain partition
+   * type corresponding to the custom key generator if table version is eight and if custom key
+   * generator is configured. This function would strip the partition type and return the partition field.
+   */
+  public static String getPartitionFieldWithoutKeyGenPartitionType(String partitionField, HoodieConfig config) {
+    return getTableVersion(config).greaterThan(HoodieTableVersion.SEVEN)
+        ? partitionField.split(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX)[0]
+        : partitionField;
+  }
+  
+  /**
+   * This function returns the hoodie.table.version from hoodie.properties file.
+   */
+  public static HoodieTableVersion getTableVersion(HoodieConfig config) {
+    return HoodieConfig.contains(HoodieTableConfig.VERSION, config)
+        ? HoodieTableVersion.fromVersionCode(config.getInt(HoodieTableConfig.VERSION))
+        : HoodieTableConfig.VERSION.defaultValue();
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -181,8 +181,8 @@ public class HoodieTestUtils {
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
                                            Properties properties, String databaseName)
       throws IOException {
-    HoodieTableMetaClient.PropertyBuilder builder =
-        HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.TableBuilder builder =
+        HoodieTableMetaClient.newTableBuilder()
             .setDatabaseName(databaseName)
             .setTableName(RAW_TRIPS_TEST_NAME)
             .setTableType(tableType)
@@ -198,9 +198,8 @@ public class HoodieTestUtils {
       builder.setPartitionFields("some_nonexistent_field");
     }
 
-    Properties processedProperties = builder.fromProperties(properties).build();
-
-    return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, processedProperties);
+    return builder.fromProperties(properties)
+        .initTable(storageConf.newInstance(), basePath);
   }
 
   public static HoodieTableMetaClient init(String basePath, HoodieTableType tableType, String bootstrapBasePath, HoodieFileFormat baseFileFormat, String keyGenerator) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.HoodieWriteStat.RuntimeStats;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieIOException;
@@ -129,6 +130,12 @@ public class HoodieTestUtils {
 
   public static HoodieTableMetaClient init(String basePath, HoodieFileFormat baseFileFormat) throws IOException {
     return init(getDefaultStorageConf(), basePath, HoodieTableType.COPY_ON_WRITE, baseFileFormat);
+  }
+
+  public static HoodieTableMetaClient init(String basePath, HoodieTableType tableType, HoodieTableVersion version) throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(version.versionCode()));
+    return init(getDefaultStorageConf(), basePath, tableType, properties);
   }
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath) throws IOException {

--- a/hudi-examples/hudi-examples-java/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
+++ b/hudi-examples/hudi-examples-java/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
@@ -82,7 +82,7 @@ public class HoodieJavaWriteClientExample {
     Path path = new Path(tablePath);
     FileSystem fs = HadoopFSUtils.getFs(tablePath, storageConf);
     if (!fs.exists(path)) {
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .setTableType(tableType)
         .setTableName(tableName)
           .setPayloadClassName(HoodieAvroPayload.class.getName())

--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
@@ -86,7 +86,7 @@ public class HoodieWriteClientExample {
       Path path = new Path(tablePath);
       FileSystem fs = HadoopFSUtils.getFs(tablePath, jsc.hadoopConfiguration());
       if (!fs.exists(path)) {
-        HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
             .setTableType(tableType)
             .setTableName(tableName)
             .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -397,6 +397,13 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(WriteOperationType.UPSERT.value())
       .withDescription("The write operation, that this write should do");
 
+  @AdvancedConfig
+  public static final ConfigOption<Integer> WRITE_TABLE_VERSION = ConfigOptions
+      .key(HoodieWriteConfig.WRITE_TABLE_VERSION.key())
+      .intType()
+      .defaultValue(HoodieWriteConfig.WRITE_TABLE_VERSION.defaultValue())
+      .withDescription("Table version produced by this writer.");
+
   /**
    * Flag to indicate whether to drop duplicates before insert/upsert.
    * By default false to gain extra performance.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
@@ -116,6 +117,9 @@ public class FlinkStreamerConfig extends Configuration {
   @Parameter(names = {"--source-ordering-field"}, description = "Field within source record to decide how"
       + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record.")
   public String sourceOrderingField = "ts";
+
+  @Parameter(names = {"--write-table-version"}, description = "Version of table written")
+  public Integer writeTableVersion = HoodieTableVersion.current().versionCode();
 
   @Parameter(names = {"--payload-class"}, description = "Subclass of HoodieRecordPayload, that works off "
       + "a GenericRecord. Implement your own, if you want to do something other than overwriting existing value.")
@@ -422,6 +426,7 @@ public class FlinkStreamerConfig extends Configuration {
     conf.setBoolean(FlinkOptions.INSERT_CLUSTER, config.insertCluster);
     conf.setString(FlinkOptions.OPERATION, config.operation.value());
     conf.setString(FlinkOptions.PRECOMBINE_FIELD, config.sourceOrderingField);
+    conf.setInteger(FlinkOptions.WRITE_TABLE_VERSION, config.writeTableVersion);
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, config.payloadClassName);
     conf.setString(FlinkOptions.RECORD_MERGER_IMPLS, config.recordMergerImpls);
     conf.setString(FlinkOptions.RECORD_MERGER_STRATEGY, config.recordMergerStrategy);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -718,7 +718,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
           HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setBasePath(location)
               .setConf(HadoopFSUtils.getStorageConfWithCopy(hiveConf)).build();
           //Init table with new name
-          HoodieTableMetaClient.withPropertyBuilder().fromProperties(metaClient.getTableConfig().getProps())
+          HoodieTableMetaClient.newTableBuilder().fromProperties(metaClient.getTableConfig().getProps())
               .setTableName(newTableName)
               .initTable(HadoopFSUtils.getStorageConfWithCopy(hiveConf), location);
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkTables.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkTables.java
@@ -20,6 +20,7 @@ package org.apache.hudi.util;
 
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.table.HoodieFlinkTable;
@@ -36,6 +37,12 @@ public class FlinkTables {
   private FlinkTables() {
   }
 
+  private static HoodieFlinkTable<?> createTableInternal(HoodieWriteConfig writeConfig, HoodieEngineContext context) {
+    HoodieFlinkTable<?> table = HoodieFlinkTable.create(writeConfig, context);
+    CommonClientUtils.validateTableVersion(table.getMetaClient().getTableConfig(), writeConfig);
+    return table;
+  }
+
   /**
    * Creates the hoodie flink table.
    *
@@ -46,7 +53,7 @@ public class FlinkTables {
         HadoopFSUtils.getStorageConf(getHadoopConf(conf)),
         new FlinkTaskContextSupplier(runtimeContext));
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, true);
-    return HoodieFlinkTable.create(writeConfig, context);
+    return createTableInternal(writeConfig, context);
   }
 
   /**
@@ -61,7 +68,7 @@ public class FlinkTables {
     HoodieFlinkEngineContext context = new HoodieFlinkEngineContext(
         HadoopFSUtils.getStorageConfWithCopy(hadoopConf),
         new FlinkTaskContextSupplier(runtimeContext));
-    return HoodieFlinkTable.create(writeConfig, context);
+    return createTableInternal(writeConfig, context);
   }
 
   /**
@@ -71,6 +78,6 @@ public class FlinkTables {
    */
   public static HoodieFlinkTable<?> createTable(Configuration conf) {
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, true, false);
-    return HoodieFlinkTable.create(writeConfig, HoodieFlinkEngineContext.DEFAULT);
+    return createTableInternal(writeConfig, HoodieFlinkEngineContext.DEFAULT);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -160,6 +160,8 @@ public class FlinkWriteClients {
             .withEngineType(EngineType.FLINK)
             .withPath(conf.getString(FlinkOptions.PATH))
             .combineInput(conf.getBoolean(FlinkOptions.PRE_COMBINE), true)
+            // TODO(vc): if unspecified, would this pick up the default.
+            .withWriteTableVersion(conf.getInteger(FlinkOptions.WRITE_TABLE_VERSION))
             .withMergeAllowDuplicateOnInserts(OptionsResolver.insertClustering(conf))
             .withClusteringConfig(
                 HoodieClusteringConfig.newBuilder()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -160,7 +160,6 @@ public class FlinkWriteClients {
             .withEngineType(EngineType.FLINK)
             .withPath(conf.getString(FlinkOptions.PATH))
             .combineInput(conf.getBoolean(FlinkOptions.PRE_COMBINE), true)
-            // TODO(vc): if unspecified, would this pick up the default.
             .withWriteTableVersion(conf.getInteger(FlinkOptions.WRITE_TABLE_VERSION))
             .withMergeAllowDuplicateOnInserts(OptionsResolver.insertClustering(conf))
             .withClusteringConfig(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -249,7 +249,7 @@ public class StreamerUtil {
       org.apache.hadoop.conf.Configuration hadoopConf) throws IOException {
     final String basePath = conf.getString(FlinkOptions.PATH);
     if (!tableExists(basePath, hadoopConf)) {
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
           .setTableCreateSchema(conf.getString(FlinkOptions.SOURCE_AVRO_SCHEMA))
           .setTableType(conf.getString(FlinkOptions.TABLE_TYPE))
           .setTableName(conf.getString(FlinkOptions.TABLE_NAME))

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -253,6 +253,7 @@ public class StreamerUtil {
           .setTableCreateSchema(conf.getString(FlinkOptions.SOURCE_AVRO_SCHEMA))
           .setTableType(conf.getString(FlinkOptions.TABLE_TYPE))
           .setTableName(conf.getString(FlinkOptions.TABLE_NAME))
+          .setTableVersion(conf.getInteger(FlinkOptions.WRITE_TABLE_VERSION))
           .setDatabaseName(conf.getString(FlinkOptions.DATABASE_NAME))
           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD, null))
           .setPayloadClassName(conf.getString(FlinkOptions.PAYLOAD_CLASS_NAME))

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -78,7 +78,7 @@ public class TestHoodieBigQuerySyncClient {
   @BeforeAll
   static void setupOnce() throws Exception {
     basePath = tempDir.toString();
-    metaClient = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TEST_TABLE)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -78,7 +78,7 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     HoodieWrapperFileSystem fs =
         new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
     HoodieStorage storage = new HoodieHadoopStorage(fs);
-    metaClient.setHoodieStorage(storage);
+    metaClient.setStorage(storage);
   }
 
   // Test the scenario that fs keeps retrying until it fails.
@@ -92,7 +92,7 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     HoodieWrapperFileSystem fs =
         new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
     HoodieStorage storage = new HoodieHadoopStorage(fs);
-    metaClient.setHoodieStorage(storage);
+    metaClient.setStorage(storage);
     List<String> folders =
         Arrays.asList("2016/04/15", ".hoodie/.temp/2/2016/04/15");
     folders.forEach(f -> assertThrows(RuntimeException.class, () -> metaClient.getStorage()

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -37,6 +39,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -44,11 +47,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_CHECKSUM;
 import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -235,5 +240,44 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
     assertArrayEquals(Arrays.stream(partitionFields.split(BaseKeyGenerator.FIELD_SEPARATOR)).toArray(), HoodieTableConfig.getPartitionFieldsForKeyGenerator(config).get().toArray());
     assertArrayEquals(new String[] {"p1", "p2"}, HoodieTableConfig.getPartitionFields(config).get());
     assertEquals("p1", HoodieTableConfig.getPartitionFieldWithoutKeyGenPartitionType(partitionFields.split(",")[0], config));
+  }
+
+  @Test
+  public void testValidateConfigVersion() {
+    assertTrue(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.EIGHT));
+    assertTrue(HoodieTableConfig.validateConfigVersion(ConfigProperty.key("").noDefaultValue().withDocumentation(""),
+        HoodieTableVersion.SIX));
+    assertFalse(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.SIX));
+  }
+
+  @Test
+  public void testDropInvalidConfigs() {
+    // test invalid configs are dropped
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTableConfig.VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
+    config.setValue(HoodieTableConfig.INITIAL_VERSION, String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
+    config.setValue(RECORD_MERGE_MODE, RECORD_MERGE_MODE.defaultValue());
+
+    HoodieTableConfig.dropInvalidConfigs(config);
+    assertTrue(config.contains(HoodieTableConfig.VERSION));
+    assertFalse(config.contains(HoodieTableConfig.INITIAL_VERSION));
+    assertFalse(config.contains(RECORD_MERGE_MODE));
+
+    // test valid ones are not dropped
+    config = new HoodieConfig();
+    config.setValue(HoodieTableConfig.VERSION, String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
+    config.setValue(RECORD_MERGE_MODE, RECORD_MERGE_MODE.defaultValue());
+    HoodieTableConfig.dropInvalidConfigs(config);
+    assertTrue(config.contains(RECORD_MERGE_MODE));
+  }
+
+  @Test
+  public void testDefinedTableConfigs() {
+    List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
+    assertEquals(37, configProperties.size());
+    configProperties.forEach(c -> {
+      assertNotNull(c);
+      assertFalse(c.doc().isEmpty());
+    });
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -186,7 +186,7 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
                                        Option<String> payloadType,
                                        Option<String> recordMergerStrategy,
                                        RecordMergeMode expectedRecordMergeMode) {
-    HoodieTableMetaClient.PropertyBuilder builder = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.TableBuilder builder = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ.name())
         .setTableName("table_name");
     if (payloadClassName.isPresent()) {
@@ -235,7 +235,7 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
                                                   Option<String> recordMergerStrategy,
                                                   RecordMergeMode recordMergeMode,
                                                   String expectedErrorMessage) {
-    HoodieTableMetaClient.PropertyBuilder builder = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.TableBuilder builder = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ.name())
         .setTableName("table_name")
         .setRecordMergeMode(recordMergeMode);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -30,7 +30,9 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.StoragePath;
 
+import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID;
@@ -81,7 +84,7 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void checkSerDe() {
+  public void testSerDe() {
     // check if this object is serialized and de-serialized, we are able to read from the file system
     HoodieTableMetaClient deserializedMetaClient =
         HoodieTestUtils.serializeDeserialize(metaClient, HoodieTableMetaClient.class);
@@ -99,7 +102,7 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void checkCommitTimeline() {
+  public void testCommitTimeline() {
     HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
     HoodieTimeline activeCommitTimeline = activeTimeline.getCommitAndReplaceTimeline();
     assertTrue(activeCommitTimeline.empty(), "Should be empty commit timeline");
@@ -257,7 +260,6 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
   public void testEquals() throws IOException {
     HoodieTableMetaClient metaClient1 = HoodieTestUtils.init(tempDir.toAbsolutePath().toString(), getTableType());
     HoodieTableMetaClient metaClient2 = HoodieTestUtils.init(tempDir.toAbsolutePath().toString(), getTableType());
-    assertEquals(metaClient1, metaClient1);
     assertEquals(metaClient1, metaClient2);
     assertNotEquals(metaClient1, null);
     assertNotEquals(metaClient1, new Object());
@@ -269,5 +271,106 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     HoodieTableMetaClient metaClient2 = HoodieTestUtils.init(tempDir.toAbsolutePath().toString(), getTableType());
     assertEquals(metaClient1.toString(), metaClient2.toString());
     assertNotEquals(metaClient1.toString(), new Object().toString());
+  }
+
+  @Test
+  public void testTableVersion() throws IOException {
+    final String basePath = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t1";
+    HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+        .setTableType(HoodieTableType.MERGE_ON_READ.name())
+        .setTableName("table-version-test")
+        .setTableVersion(HoodieTableVersion.SIX.versionCode())
+        .initTable(this.metaClient.getStorageConf(), basePath);
+
+    assertEquals(HoodieTableVersion.SIX, metaClient1.getTableConfig().getTableVersion());
+    assertEquals(HoodieTableVersion.SIX, metaClient1.getTableConfig().getTableInitialVersion());
+
+    HoodieTableMetaClient metaClient2 = HoodieTableMetaClient.builder()
+        .setConf(this.metaClient.getStorageConf())
+        .setBasePath(basePath)
+        .build();
+    assertEquals(HoodieTableVersion.SIX, metaClient2.getTableConfig().getTableInitialVersion());
+    assertEquals(HoodieTableVersion.SIX, metaClient2.getTableConfig().getTableVersion());
+  }
+
+  @Test
+  public void testGenerateFromAnotherMetaClient() throws IOException {
+    final String basePath1 = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t2A";
+    final String basePath2 = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t2B";
+
+    HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+        .setTableType(HoodieTableType.MERGE_ON_READ.name())
+        .setTableName("table-version-test")
+        .setTableVersion(HoodieTableVersion.SIX.versionCode())
+        .initTable(this.metaClient.getStorageConf(), basePath1);
+
+    HoodieTableMetaClient metaClient2 = HoodieTableMetaClient.newTableBuilder()
+        .fromMetaClient(metaClient1)
+        .initTable(this.metaClient.getStorageConf(), basePath2);
+
+    assertEquals(metaClient1.getTableConfig().getTableType(), metaClient2.getTableConfig().getTableType());
+    assertEquals(metaClient1.getTableConfig().getTableVersion(), metaClient2.getTableConfig().getTableVersion());
+    assertEquals(metaClient1.getTableConfig().getTableName(), metaClient2.getTableConfig().getTableName());
+  }
+
+  @Test
+  public void testTableBuilderRequiresTableNameAndType() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      HoodieTableMetaClient.builder()
+          .setConf(this.metaClient.getStorageConf())
+          .build();
+    });
+    assertThrows(IllegalArgumentException.class, () -> {
+      HoodieTableMetaClient.newTableBuilder()
+          .setTableName("test-table")
+          .initTable(this.metaClient.getStorageConf(), tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "failing2");
+    });
+    assertThrows(IllegalArgumentException.class, () -> {
+      HoodieTableMetaClient.newTableBuilder()
+          .setTableType(HoodieTableType.COPY_ON_WRITE.name())
+          .initTable(this.metaClient.getStorageConf(), tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "failing3");
+    });
+  }
+
+  @Test
+  public void testCreateMetaClientFromProperties() throws IOException {
+    final String basePath = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t5";
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+    props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+
+    HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+        .fromProperties(props)
+        .initTable(this.metaClient.getStorageConf(),basePath);
+
+    HoodieTableMetaClient metaClient2 = HoodieTableMetaClient.builder()
+        .setConf(this.metaClient.getStorageConf())
+        .setBasePath(basePath)
+        .build();
+
+    // test table name and type and precombine field also match
+    assertEquals(metaClient1.getTableConfig().getTableName(), metaClient2.getTableConfig().getTableName());
+    assertEquals(metaClient1.getTableConfig().getTableType(), metaClient2.getTableConfig().getTableType());
+    assertEquals(metaClient1.getTableConfig().getPreCombineField(), metaClient2.getTableConfig().getPreCombineField());
+    // default table version should be current version
+    assertEquals(HoodieTableVersion.current(), metaClient2.getTableConfig().getTableVersion());
+  }
+
+  @Test
+  public void testCreateLayoutInStorage() throws IOException {
+    final String basePath = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t6";
+    HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+        .setTableType(HoodieTableType.COPY_ON_WRITE.name())
+        .setTableName("table-layout-test")
+        .initTable(this.metaClient.getStorageConf(), basePath);
+
+    // test the folder structure
+    this.metaClient.getRawStorage().exists(new StoragePath(basePath, HoodieTableMetaClient.AUXILIARYFOLDER_NAME));
+    this.metaClient.getRawStorage().exists(new StoragePath(basePath, HoodieTableMetaClient.METAFOLDER_NAME));
+    this.metaClient.getRawStorage().exists(new StoragePath(basePath, HoodieTableMetaClient.TEMPFOLDER_NAME));
+    this.metaClient.getRawStorage().exists(new StoragePath(basePath, HoodieTableConfig.ARCHIVELOG_FOLDER.defaultValue()));
+    this.metaClient.getRawStorage().exists(new StoragePath(basePath, HoodieTableMetaClient.METAFOLDER_NAME
+        + Path.SEPARATOR + "hoodie.properties"));
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -275,21 +275,18 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
 
   @Test
   public void testTableVersion() throws IOException {
-    final String basePath = tempDir.toAbsolutePath().toString() + Path.SEPARATOR + "t1";
+    final String basePath = tempDir.toAbsolutePath() + Path.SEPARATOR + "t1";
     HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ.name())
         .setTableName("table-version-test")
         .setTableVersion(HoodieTableVersion.SIX.versionCode())
         .initTable(this.metaClient.getStorageConf(), basePath);
-
     assertEquals(HoodieTableVersion.SIX, metaClient1.getTableConfig().getTableVersion());
-    assertEquals(HoodieTableVersion.SIX, metaClient1.getTableConfig().getTableInitialVersion());
 
     HoodieTableMetaClient metaClient2 = HoodieTableMetaClient.builder()
         .setConf(this.metaClient.getStorageConf())
         .setBasePath(basePath)
         .build();
-    assertEquals(HoodieTableVersion.SIX, metaClient2.getTableConfig().getTableInitialVersion());
     assertEquals(HoodieTableVersion.SIX, metaClient2.getTableConfig().getTableVersion());
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -138,7 +138,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
         "Check the instants stream");
 
     // Backwards compatibility testing for reading compaction plans
-    metaClient = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .fromMetaClient(metaClient)
         .setTimelineLayoutVersion(VERSION_0)
         .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -773,11 +773,11 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
       HoodieStorage storage = metaClient.getStorage();
       FileSystem fs = (FileSystem) storage.getFileSystem();
       HoodieWrapperFileSystem newFs = new HoodieWrapperFileSystem(fs, new NoOpConsistencyGuard());
-      metaClient.setHoodieStorage(new HoodieHadoopStorage(newFs));
+      metaClient.setStorage(new HoodieHadoopStorage(newFs));
       try {
         fun.accept(metaClient);
       } finally {
-        metaClient.setHoodieStorage(storage);
+        metaClient.setStorage(storage);
       }
       return;
     }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -169,7 +169,7 @@ public class HoodieTestTable implements AutoCloseable {
                             HoodieTableMetaClient metaClient, Option<HoodieEngineContext> context) {
     ValidationUtils.checkArgument(Objects.equals(basePath, metaClient.getBasePath().toString()));
     ValidationUtils.checkArgument(Objects.equals(
-        storage.getFileSystem(), metaClient.getRawHoodieStorage().getFileSystem()));
+        storage.getFileSystem(), metaClient.getRawStorage().getFileSystem()));
     this.basePath = basePath;
     this.storage = storage;
     this.fs = (FileSystem) storage.getFileSystem();
@@ -180,7 +180,7 @@ public class HoodieTestTable implements AutoCloseable {
 
   public static HoodieTestTable of(HoodieTableMetaClient metaClient) {
     testTableState = HoodieTestTableState.of();
-    return new HoodieTestTable(metaClient.getBasePath().toString(), metaClient.getRawHoodieStorage(), metaClient);
+    return new HoodieTestTable(metaClient.getBasePath().toString(), metaClient.getRawStorage(), metaClient);
   }
 
   public void setNonPartitioned() {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestInputPathHandler.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestInputPathHandler.java
@@ -163,8 +163,9 @@ public class TestInputPathHandler {
     properties.setProperty(HoodieTableConfig.TYPE.key(), tableType.name());
     properties.setProperty(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieAvroPayload.class.getName());
     properties.setProperty(HoodieTableConfig.RECORD_MERGER_STRATEGY.key(), HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID);
-    return HoodieTableMetaClient.initTableAndGetMetaClient(
-        HadoopFSUtils.getStorageConfWithCopy(hadoopConf), basePath, properties);
+    return HoodieTableMetaClient.newTableBuilder()
+        .fromProperties(properties)
+        .initTable(HadoopFSUtils.getStorageConfWithCopy(hadoopConf), basePath);
   }
 
   static List<Path> generatePartitions(DistributedFileSystem dfs, String basePath)

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteJob.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteJob.java
@@ -121,7 +121,7 @@ public class HoodieTestSuiteJob {
         (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
 
     if (!fs.exists(new Path(cfg.targetBasePath))) {
-      metaClient = HoodieTableMetaClient.withPropertyBuilder()
+      metaClient = HoodieTableMetaClient.newTableBuilder()
           .setTableType(cfg.tableType)
           .setTableName(cfg.targetTableName)
           .setRecordKeyFields(this.props.getString(DataSourceWriteOptions.RECORDKEY_FIELD().key()))

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
@@ -100,6 +100,7 @@ public class KafkaConnectTransactionServices implements ConnectTransactionServic
           .setPayloadClassName(HoodieAvroPayload.class.getName())
           .setRecordKeyFields(recordKeyFields)
           .setPartitionFields(partitionColumns)
+          .setTableVersion(writeConfig.getWriteVersion())
           .setKeyGeneratorClassProp(writeConfig.getKeyGeneratorClass())
           .fromProperties(connectConfigs.getProps())
           .initTable(storageConf.newInstance(), tableBasePath));

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
@@ -94,7 +94,7 @@ public class KafkaConnectTransactionServices implements ConnectTransactionServic
       LOG.info(String.format("Setting record key %s and partition fields %s for table %s",
           recordKeyFields, partitionColumns, tableBasePath + tableName));
 
-      tableMetaClient = Option.of(HoodieTableMetaClient.withPropertyBuilder()
+      tableMetaClient = Option.of(HoodieTableMetaClient.newTableBuilder()
           .setTableType(HoodieTableType.COPY_ON_WRITE.name())
           .setTableName(tableName)
           .setPayloadClassName(HoodieAvroPayload.class.getName())

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/writers/TestKafkaConnectTransactionServices.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/writers/TestKafkaConnectTransactionServices.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.writers;
+
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.connect.writers.KafkaConnectConfigs;
+import org.apache.hudi.connect.writers.KafkaConnectTransactionServices;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestKafkaConnectTransactionServices {
+
+  @TempDir
+  Path path;
+
+  @Test
+  public void testTableCreation() {
+    Properties props = new Properties();
+    props.put("hoodie.table.name", "test");
+    props.put("hoodie.base.path", path);
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+    props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "key");
+    props.put("hoodie.table.version", "6");
+    KafkaConnectConfigs configs = KafkaConnectConfigs.newBuilder()
+        .withProperties(props)
+        .build();
+    new KafkaConnectTransactionServices(configs);
+
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(path.toFile().getPath());
+    assertEquals(HoodieTableVersion.SIX, metaClient.getTableConfig().getTableVersion());
+    assertEquals(HoodieTableType.COPY_ON_WRITE, metaClient.getTableConfig().getTableType());
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
@@ -70,7 +70,7 @@ public class DataSourceInternalWriterHelper {
 
     this.metaClient = HoodieTableMetaClient.builder()
         .setConf(storageConf.newInstance()).setBasePath(writeConfig.getBasePath()).build();
-    this.metaClient.validateTableProperties(writeConfig.getProps());
+    this.writeClient.validateAgainstTableProperties(this.metaClient.getTableConfig(), writeConfig);
     this.writeClient.preWrite(instantTime, WriteOperationType.BULK_INSERT, metaClient);
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -48,7 +48,7 @@ import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, T
 import org.apache.hudi.common.util.ConfigUtils.getAllConfigKeys
 import org.apache.hudi.common.util.{CommitUtils, StringUtils, Option => HOption}
 import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME}
-import org.apache.hudi.config.HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY
+import org.apache.hudi.config.HoodieWriteConfig.{SPARK_SQL_MERGE_INTO_PREPPED_KEY, WRITE_TABLE_VERSION}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieInternalConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.{HoodieException, HoodieRecordCreationException, HoodieWriteConflictException}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -750,6 +750,7 @@ class HoodieSparkSqlWriterInternal {
           .setTableType(HoodieTableType.valueOf(tableType))
           .setTableName(tableName)
           .setRecordKeyFields(recordKeyFields)
+          .setTableVersion(hoodieConfig.getIntOrDefault(WRITE_TABLE_VERSION))
           .setArchiveLogFolder(archiveLogFolder)
           .setPayloadClassName(payloadClass)
           .setPreCombineField(hoodieConfig.getStringOrDefault(PRECOMBINE_FIELD, null))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -301,7 +301,7 @@ class HoodieSparkSqlWriterInternal {
           if (StringUtils.nonEmpty(hoodieConfig.getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME)))
             hoodieConfig.getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME)
           else KeyGeneratorType.getKeyGeneratorClassName(hoodieConfig)
-        HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
           .setTableType(tableType)
           .setDatabaseName(databaseName)
           .setTableName(tblName)
@@ -746,7 +746,7 @@ class HoodieSparkSqlWriterInternal {
           String.valueOf(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue())
         ))
 
-        HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
           .setTableType(HoodieTableType.valueOf(tableType))
           .setTableName(tableName)
           .setRecordKeyFields(recordKeyFields)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -205,7 +205,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         "The database names from this hoodie path and this catalog table is not same.")
       val recordName = AvroSchemaUtils.getAvroRecordQualifiedName(table.identifier.table)
       // just persist hoodie.table.create.schema
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
         .setDatabaseName(catalogDatabaseName)
         .setTableCreateSchema(SchemaConverters.toAvroType(dataSchema, recordName = recordName).toString())
@@ -221,7 +221,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         table.partitionColumnNames.mkString(",")
       }
 
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
         .setDatabaseName(catalogDatabaseName)
         .setTableName(table.identifier.table)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableRenameCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableRenameCommand.scala
@@ -38,7 +38,7 @@ case class AlterHoodieTableRenameCommand(
       val hoodieCatalogTable = HoodieCatalogTable(sparkSession, oldName)
 
       // Init table with new name.
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .fromProperties(hoodieCatalogTable.tableConfig.getProps)
         .setTableName(newName.table)
         .initTable(

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/TruncateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/TruncateHoodieTableCommand.scala
@@ -72,7 +72,7 @@ case class TruncateHoodieTableCommand(
       FSUtils.deleteDir(engineContext, storage, targetPath, sparkSession.sparkContext.defaultParallelism)
 
       // ReInit hoodie.properties
-      val metaClient = HoodieTableMetaClient.withPropertyBuilder()
+      val metaClient = HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
         .initTable(
           HadoopFSUtils.getStorageConf(sparkSession.sessionState.newHadoopConf),

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -234,7 +234,7 @@ public class BootstrapExecutorUtils implements Serializable {
     Map<String, Object> timestampKeyGeneratorConfigs =
         extractConfigsRelatedToTimestampBasedKeyGenerator(keyGenClassAndParColsForKeyGenerator.getLeft(), props);
 
-    HoodieTableMetaClient.PropertyBuilder builder = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.TableBuilder builder = HoodieTableMetaClient.newTableBuilder()
         .fromProperties(props)
         .setTableType(cfg.tableType)
         .setDatabaseName(cfg.database)

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -239,6 +239,7 @@ public class BootstrapExecutorUtils implements Serializable {
         .setTableType(cfg.tableType)
         .setDatabaseName(cfg.database)
         .setTableName(cfg.tableName)
+        .setTableVersion(bootstrapConfig.getWriteVersion())
         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
         .setPreCombineField(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
         .setPopulateMetaFields(props.getBoolean(

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
@@ -67,7 +67,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import scala.Tuple2;
 
@@ -155,12 +154,10 @@ public class HDFSParquetImporterUtils implements Serializable {
 
       if (!fs.exists(new Path(this.targetPath))) {
         // Initialize target hoodie table.
-        Properties properties = HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
             .setTableName(this.tableName)
             .setTableType(this.tableType)
-            .build();
-        HoodieTableMetaClient.initTableAndGetMetaClient(
-            HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), this.targetPath, properties);
+            .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), this.targetPath);
       }
 
       // Get schema.

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
@@ -24,6 +24,7 @@ import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
@@ -91,7 +92,10 @@ public class TestDataSkippingWithMORColstats extends HoodieSparkClientTestBase {
     Properties props = new Properties();
     props.putAll(options);
     try {
-      metaClient = HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath.toString(), props);
+      metaClient = HoodieTableMetaClient.newTableBuilder()
+          .fromProperties(props)
+          .setTableType(HoodieTableType.MERGE_ON_READ.name())
+          .initTable(storageConf.newInstance(), basePath.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -157,11 +157,12 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
   @Test
   def testPartitionSchemaWithoutKeyGenerator(): Unit = {
     val metaClient = HoodieTestUtils.init(
-      storageConf, basePath, HoodieTableType.COPY_ON_WRITE, HoodieTableMetaClient.withPropertyBuilder()
+      storageConf, basePath, HoodieTableType.COPY_ON_WRITE, HoodieTableMetaClient.newTableBuilder()
         .fromMetaClient(this.metaClient)
         .setRecordKeyFields("_row_key")
         .setPartitionFields("partition_path")
-        .setTableName("hoodie_test").build())
+        .setTableName("hoodie_test")
+        .build())
     val props = Map(
       "hoodie.insert.shuffle.parallelism" -> "4",
       "hoodie.upsert.shuffle.parallelism" -> "4",

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -573,7 +573,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
     // when metadata is enabled, directly instantiating write client using DataSourceUtils.createHoodieClient
     // will hit a code which tries to instantiate meta client for data table. if table does not exist, it fails.
     // hence doing an explicit instantiation here.
-    val tableMetaClientBuilder = HoodieTableMetaClient.withPropertyBuilder()
+    val tableMetaClientBuilder = HoodieTableMetaClient.newTableBuilder()
       .setTableType(tableType)
       .setTableName(hoodieFooTableName)
       .setRecordKeyFields(fooTableParams(DataSourceWriteOptions.RECORDKEY_FIELD.key))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestMultipleTableVersionWriting.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestMultipleTableVersionWriting.scala
@@ -1,0 +1,76 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.exception.HoodieNotSupportedException
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.scalatest.Assertions.assertThrows
+
+import java.util.Properties
+
+class TestMultipleTableVersionWriting extends HoodieSparkWriterTestBase {
+
+  @Test
+  def testTableVersionAndWriteVersionMatching(): Unit = {
+    val basePath = s"${tempBasePath}/tbl_1";
+    val df = spark.range(1).selectExpr("1 as id", "1 as name", "1 as partition")
+
+    df.write.format("hudi")
+      .option(HoodieWriteConfig.TBL_NAME.key, "tbl_1")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val metaClient = HoodieTestUtils.createMetaClient(basePath);
+    assertEquals(HoodieTableVersion.current().versionCode(),
+      metaClient.getTableConfig.getTableVersion.versionCode())
+
+    assertThrows[HoodieNotSupportedException] {
+      df.write.format("hudi")
+        .option(HoodieWriteConfig.TBL_NAME.key, "tbl_1")
+        .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key, HoodieTableVersion.SIX.versionCode())
+        .mode(SaveMode.Append)
+        .save(basePath)
+    }
+  }
+
+  @Test
+  def testThrowsExceptionForIncompatibleTableVersion(): Unit = {
+    val basePath = s"${tempBasePath}/tbl_2";
+    val props = new Properties()
+    props.put("hoodie.table.name", "tbl_2")
+    props.put("hoodie.table.version", HoodieTableVersion.SIX.versionCode.toString)
+    HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE, props);
+
+    val df = spark.range(1).selectExpr("1 as id", "1 as name", "1 as partition")
+    assertThrows[HoodieNotSupportedException] {
+      df.write.format("hudi")
+        .option(HoodieWriteConfig.TBL_NAME.key, "tbl_2")
+        .mode(SaveMode.Append)
+        .save(basePath)
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestMultipleTableVersionWriting.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestMultipleTableVersionWriting.scala
@@ -21,16 +21,14 @@
 package org.apache.hudi
 
 import org.apache.hudi.common.model.HoodieTableType
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+import org.apache.hudi.common.table.HoodieTableVersion
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.exception.HoodieNotSupportedException
+import org.apache.hudi.exception.{HoodieException, HoodieNotSupportedException}
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.scalatest.Assertions.assertThrows
-
-import java.util.Properties
 
 class TestMultipleTableVersionWriting extends HoodieSparkWriterTestBase {
 
@@ -50,8 +48,9 @@ class TestMultipleTableVersionWriting extends HoodieSparkWriterTestBase {
       metaClient.getTableConfig.getTableVersion.versionCode())
 
     // should error out when writing with lower write version.
-    assertThrows[HoodieNotSupportedException] {
+    assertThrows[HoodieException] {
       df.write.format("hudi")
+        .option(HoodieWriteConfig.AUTO_UPGRADE_VERSION.key(), "false")
         .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key, HoodieTableVersion.SIX.versionCode())
         .mode(SaveMode.Append)
         .save(basePath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -44,7 +44,7 @@ class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
     HoodieTableType.values().foreach { tableType =>
       withTempDir { inputDir =>
         val tablePath = s"${inputDir.getCanonicalPath}/test_stream_${tableType.name()}"
-        HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
           .setTableType(tableType)
           .setTableName(s"test_stream_${tableType.name()}")
           .setPayloadClassName(DataSourceWriteOptions.PAYLOAD_CLASS_NAME.defaultValue)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -60,7 +60,7 @@ class TestStreamingSource extends StreamTest {
   test("test cow stream source") {
     withTempDir { inputDir =>
       val tablePath = s"${inputDir.getCanonicalPath}/test_cow_stream"
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
@@ -113,7 +113,7 @@ class TestStreamingSource extends StreamTest {
   test("test mor stream source") {
     withTempDir { inputDir =>
       val tablePath = s"${inputDir.getCanonicalPath}/test_mor_stream"
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .setTableType(MERGE_ON_READ)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
@@ -160,7 +160,7 @@ class TestStreamingSource extends StreamTest {
   test("Test cow from latest offset") {
     withTempDir { inputDir =>
       val tablePath = s"${inputDir.getCanonicalPath}/test_cow_stream"
-      HoodieTableMetaClient.withPropertyBuilder()
+      HoodieTableMetaClient.newTableBuilder()
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
@@ -193,7 +193,7 @@ class TestStreamingSource extends StreamTest {
   test("Test cow from specified offset") {
     withTempDir { inputDir =>
       val tablePath = s"${inputDir.getCanonicalPath}/test_cow_stream"
-      val metaClient = HoodieTableMetaClient.withPropertyBuilder()
+      val metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
@@ -230,7 +230,7 @@ class TestStreamingSource extends StreamTest {
   test("test mor stream source with compaction") {
     withTempDir { inputDir =>
       val tablePath = s"${inputDir.getCanonicalPath}/test_mor_stream"
-      val metaClient = HoodieTableMetaClient.withPropertyBuilder()
+      val metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(MERGE_ON_READ)
         .setTableName(getTableName(tablePath))
         .setPayloadClassName(DataSourceWriteOptions.PAYLOAD_CLASS_NAME.defaultValue)

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.sync.datahub;
 
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.sync.datahub.config.DataHubSyncConfig;
@@ -71,8 +72,10 @@ public class TestDataHubSyncClient {
     Properties props = new Properties();
     props.put("hoodie.table.name", "some_table");
     tableBasePath = Paths.get(tmpDir.toString(), "some_table").toString();
-    HoodieTableMetaClient.initTableAndGetMetaClient(
-        HadoopFSUtils.getStorageConf(new Configuration()), tableBasePath, props);
+    HoodieTableMetaClient.newTableBuilder()
+        .fromProperties(props)
+        .setTableType(HoodieTableType.MERGE_ON_READ.name())
+        .initTable(HadoopFSUtils.getStorageConf(new Configuration()), tableBasePath);
   }
 
   @BeforeEach

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveSyncFunctionalTestHarness.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveSyncFunctionalTestHarness.java
@@ -108,7 +108,7 @@ public class HiveSyncFunctionalTestHarness {
   }
 
   public HoodieHiveSyncClient hiveClient(HiveSyncConfig hiveSyncConfig) throws IOException {
-    HoodieTableMetaClient metaClient = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(hiveSyncConfig.getString(META_SYNC_TABLE_NAME))
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestCluster.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestCluster.java
@@ -161,7 +161,7 @@ public class HiveTestCluster implements BeforeAllCallback, AfterAllCallback, Bef
     String tablePathStr = tablePath(dbName, tableName);
     Path path = new Path(tablePathStr);
     FileIOUtils.deleteDirectory(new File(path.toString()));
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(tableName)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -185,7 +185,7 @@ public class HiveTestUtil {
 
   public static void clear() throws IOException, HiveException, MetaException {
     fileSystem.delete(new Path(basePath), true);
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)
@@ -281,7 +281,7 @@ public class HiveTestUtil {
     if (fileSystem.exists(path)) {
       fileSystem.delete(path, true);
     }
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(tableName)
         .setPayloadClass(HoodieAvroPayload.class)
@@ -381,7 +381,7 @@ public class HiveTestUtil {
       throws IOException, URISyntaxException {
     Path path = new Path(basePath);
     FileIOUtils.deleteDirectory(new File(basePath));
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)
@@ -418,7 +418,7 @@ public class HiveTestUtil {
       throws IOException, URISyntaxException, InterruptedException {
     Path path = new Path(basePath);
     FileIOUtils.deleteDirectory(new File(basePath));
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
@@ -60,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import scala.Tuple2;
 
@@ -139,12 +138,10 @@ public class HDFSParquetImporter implements Serializable {
 
       if (!fs.exists(new Path(cfg.targetPath))) {
         // Initialize target hoodie table.
-        Properties properties = HoodieTableMetaClient.withPropertyBuilder()
+        HoodieTableMetaClient.newTableBuilder()
             .setTableName(cfg.tableName)
             .setTableType(cfg.tableType)
-            .build();
-        HoodieTableMetaClient.initTableAndGetMetaClient(
-            HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), cfg.targetPath, properties);
+            .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), cfg.targetPath);
       }
 
       // Get schema.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
@@ -141,6 +142,7 @@ public class HDFSParquetImporter implements Serializable {
         HoodieTableMetaClient.newTableBuilder()
             .setTableName(cfg.tableName)
             .setTableType(cfg.tableType)
+            .setTableVersion(cfg.tableVersion)
             .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), cfg.targetPath);
       }
 
@@ -264,6 +266,8 @@ public class HDFSParquetImporter implements Serializable {
     public String tableName = null;
     @Parameter(names = {"--table-type", "-tt"}, description = "Table type", required = true)
     public String tableType = null;
+    @Parameter(names = {"--table-version", "-tv"}, description = "Table version")
+    public int tableVersion = HoodieTableVersion.current().versionCode();
     @Parameter(names = {"--row-key-field", "-rk"}, description = "Row key field name", required = true)
     public String rowKey = null;
     @Parameter(names = {"--partition-key-field", "-pk"}, description = "Partition key field name", required = true)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -261,6 +261,7 @@ public class HoodieClusteringJob {
 
       if (cfg.retryLastFailedClusteringJob) {
         HoodieSparkTable<HoodieRecordPayload> table = HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
+        client.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), client.getConfig());
         Option<HoodieInstant> lastClusterOpt = table.getActiveTimeline().getLastPendingClusterInstant();
 
         if (lastClusterOpt.isPresent()) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
@@ -323,6 +323,7 @@ public class HoodieDropPartitionsTool implements Serializable {
   public void dryRun() {
     try (SparkRDDWriteClient<HoodieRecordPayload> client =  UtilHelpers.createHoodieClient(jsc, cfg.basePath, "", cfg.parallelism, Option.empty(), props)) {
       HoodieSparkTable<HoodieRecordPayload> table = HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
+      client.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), client.getConfig());
       List<String> parts = Arrays.asList(cfg.partitions.split(","));
       Map<String, List<String>> partitionToReplaceFileIds = jsc.parallelize(parts, parts.size()).distinct()
           .mapToPair(partitionPath -> new Tuple2<>(partitionPath, table.getSliceView().getLatestFileSlices(partitionPath).map(fg -> fg.getFileId()).distinct().collect(Collectors.toList())))

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -59,6 +59,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_METAFILE_
 import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_TIMEZONE;
 import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_NAME;
+import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
 import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
@@ -211,6 +212,7 @@ public class BootstrapExecutor implements Serializable {
         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
         .setPreCombineField(props.getString(
             PRECOMBINE_FIELD_NAME.key(), PRECOMBINE_FIELD_NAME.defaultValue()))
+        .setTableVersion(props.getInteger(WRITE_TABLE_VERSION.key(), WRITE_TABLE_VERSION.defaultValue()))
         .setPopulateMetaFields(props.getBoolean(
             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
         .setArchiveLogFolder(props.getString(

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -204,7 +204,7 @@ public class BootstrapExecutor implements Serializable {
       throw new IllegalArgumentException("Bootstrap source base path and Hudi table base path must be different");
     }
 
-    HoodieTableMetaClient.PropertyBuilder builder = HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.TableBuilder builder = HoodieTableMetaClient.newTableBuilder()
         .fromProperties(props)
         .setTableType(cfg.tableType)
         .setTableName(cfg.targetTableName)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -93,7 +93,7 @@ public class SparkSampleWritesUtils {
   private static Pair<Boolean, String> doSampleWrites(JavaSparkContext jsc, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieWriteConfig writeConfig, String instantTime)
       throws IOException {
     final String sampleWritesBasePath = getSampleWritesBasePath(jsc, writeConfig, instantTime);
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(String.format("%s_samples_%s", writeConfig.getTableName(), instantTime))
         .setCDCEnabled(false)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -398,7 +398,7 @@ public class StreamSync implements Serializable, Closeable {
     this.commitsTimelineOpt = Option.empty();
     this.allCommitsTimelineOpt = Option.empty();
     String partitionColumns = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props);
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(cfg.tableType)
         .setTableName(cfg.targetTableName)
         .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -405,6 +405,8 @@ public class StreamSync implements Serializable, Closeable {
         .setPayloadClassName(cfg.payloadClassName)
         .setBaseFileFormat(cfg.baseFileFormat)
         .setPartitionFields(partitionColumns)
+        .setTableVersion(props.getInteger(HoodieWriteConfig.WRITE_TABLE_VERSION.key(),
+            HoodieWriteConfig.WRITE_TABLE_VERSION.defaultValue()))
         .setRecordKeyFields(props.getProperty(DataSourceWriteOptions.RECORDKEY_FIELD().key()))
         .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
             HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -99,6 +99,7 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.sources.TestParquetDFSSourceEmptyBatch;
 import org.apache.hudi.utilities.streamer.HoodieStreamer;
 import org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy;
+import org.apache.hudi.utilities.streamer.StreamSync;
 import org.apache.hudi.utilities.testutils.JdbcTestUtils;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 import org.apache.hudi.utilities.testutils.sources.DistributedTestDataSource;
@@ -2618,7 +2619,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     TypedProperties properties = new TypedProperties();
     properties.setProperty("hoodie.datasource.write.recordkey.field", "key");
     properties.setProperty("hoodie.datasource.write.partitionpath.field", "pp");
-    TestStreamSync testDeltaSync = new TestStreamSync(cfg, sparkSession, null, properties,
+    DummyStreamSync testDeltaSync = new DummyStreamSync(cfg, sparkSession, null, properties,
         jsc, fs, jsc.hadoopConfiguration(), null);
 
     properties.put(HoodieTableConfig.NAME.key(), "sample_tbl");
@@ -2960,11 +2961,11 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     return baseFileStream.map(HoodieBaseFile::getFileId).collect(Collectors.toSet());
   }
 
-  class TestStreamSync extends DeltaSync {
+  static class DummyStreamSync extends StreamSync {
 
-    public TestStreamSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
-                          JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                          Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+    public DummyStreamSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
+                           JavaSparkContext jssc, FileSystem fs, Configuration conf,
+                           Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
       super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
     }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
@@ -91,7 +91,7 @@ public class TestHoodieSnapshotExporter extends SparkClientFunctionalTestHarness
     targetPath = Paths.get(basePath(), "target").toString();
     storage = HoodieStorageUtils.getStorage(basePath(), HadoopFSUtils.getStorageConf(jsc().hadoopConfiguration()));
 
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(TABLE_NAME)
         .setPayloadClass(HoodieAvroPayload.class)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
@@ -58,14 +58,12 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     Properties props = getPropertiesForKeyGen(true);
     HoodieWriteConfig config = getWriteConfig(tableBasePath);
     props.putAll(config.getProps());
-    Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
+        .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath);
 
-    metaClient = HoodieTableMetaClient.initTableAndGetMetaClient(
-        HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath, metaClientProps);
     client = new SparkRDDWriteClient(context, config);
 
     writeData(false, client.createNewInstantTime(), 100, true);
@@ -97,14 +95,11 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     Properties props = getPropertiesForKeyGen(true);
     HoodieWriteConfig config = getWriteConfig(tableBasePath);
     props.putAll(config.getProps());
-    Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
-
-    metaClient = HoodieTableMetaClient.initTableAndGetMetaClient(
-        HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath, metaClientProps);
+        .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath);
     client = new SparkRDDWriteClient(context, config);
 
     writeData(false, client.createNewInstantTime(), 100, true);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
@@ -73,14 +73,12 @@ public class TestHoodieCompactorJob extends HoodieOfflineJobTestBase {
         .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).withIndexType(HoodieIndex.IndexType.BUCKET).withBucketNum("1").build())
         .build();
     props.putAll(config.getProps());
-    Properties metaClientProps = HoodieTableMetaClient.withPropertyBuilder()
+    metaClient = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
+        .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath);
 
-    metaClient =  HoodieTableMetaClient.initTableAndGetMetaClient(
-        HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), tableBasePath, metaClientProps);
     client = new SparkRDDWriteClient(context, config);
 
     writeData(true, client.createNewInstantTime(), 100, true);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -106,13 +106,12 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
   @Override
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
-    props = HoodieTableMetaClient.withPropertyBuilder()
+    return HoodieTableMetaClient.newTableBuilder()
         .setTableName(RAW_TRIPS_TEST_NAME)
         .setTableType(tableType)
         .setPayloadClass(HoodieAvroPayload.class)
         .fromProperties(props)
-        .build();
-    return HoodieTableMetaClient.initTableAndGetMetaClient(storageConf.newInstance(), basePath, props);
+        .initTable(storageConf.newInstance(), basePath);
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -309,7 +309,7 @@ public class UtilitiesTestBase {
     // Create Dummy hive sync config
     HiveSyncConfig hiveSyncConfig = getHiveSyncConfig(tempWriteablePath, "dummy");
     hiveSyncConfig.setHadoopConf(hiveTestService.getHiveConf());
-    HoodieTableMetaClient.withPropertyBuilder()
+    HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(hiveSyncConfig.getString(META_SYNC_TABLE_NAME))
         .initTable(storage.getConf().newInstance(), hiveSyncConfig.getString(META_SYNC_BASE_PATH));


### PR DESCRIPTION
### Change Logs

- Add new write config `hoodie.write.table.version` to specify the table version to be created and produced by the writer.
- Add new write config `hoodie.write.auto.upgrade` to control whether or not writer can auto-upgrade a table when attempting to write to a table with lower version. 
- Wiring in the table version in all write paths and validate that write and table versions match, on all write operations and tooling. 
-  Only table versions 6,8 are supported as valid value for hoodie.write.table.version
- Handle rollback done in startCommit* methods and as part of upgrade, w.r.t table version mismatches
- Code cleanups on HoodieBaseClient's children around createTable, adhoc creation of HoodieTable, without creating writeClient, handle case-by-case, renaming few methods that are out of convention, cleanup HoodieTableMetaClient static helper methods. Finally, also streamline creation of meta client and table initialization across the tests
 
### Impact

none 

### Risk level (write none, low medium or high below)

low

### Documentation Update
Configs have docs added for auto generation.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
