### PR TITLE
Revert "[HUDI-8134] Prevent mac m1 activation of profile without specifying spark version (#11849)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2366,9 +2366,6 @@
           <family>mac</family>
           <arch>aarch64</arch>
         </os>
-        <property>
-          <name>spark2.4</name>
-        </property>
       </activation>
     </profile>
 


### PR DESCRIPTION
### Change Logs

This reverts commit 3cb1dba99cee96f5c67a2636f7ecf5927cf1d0f6. Certain GH actions related to spark tests with java 11, 17 due to class not found exception started failing (check last few master commits) after merging this commit. It may not be the root cause but just checking to mitigate and unblock PR merges.
```
Caused by: java.lang.ClassNotFoundException: org.apache.spark.internal.Logging$class
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 79 more
```

### Impact

Fix GH CI.

### Risk level (write none, low medium or high below)

Brings back the docker image issue which the commit originally fixed.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
