### PR TITLE
[HUDI-8171] rename fg reader and supporting classes

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -22,7 +22,7 @@ package org.apache.hudi.common.engine;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
-import org.apache.hudi.common.table.read.HoodieFileGroupReaderSchemaHandler;
+import org.apache.hudi.common.table.read.FileSliceReaderSchemaHandler;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -42,11 +42,11 @@ import java.util.function.UnaryOperator;
 import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
 
 /**
- * An abstract reader context class for {@code HoodieFileGroupReader} to use, containing APIs for
+ * An abstract reader context class for {@code FileSliceReader} to use, containing APIs for
  * engine-specific implementation on reading data files, getting field values from a record,
  * transforming a record, etc.
  * <p>
- * For each query engine, this class should be extended and plugged into {@code HoodieFileGroupReader}
+ * For each query engine, this class should be extended and plugged into {@code FileSliceReader}
  * to realize the file group reading.
  *
  * @param <T> The type of engine-specific record representation, e.g.,{@code InternalRow} in Spark
@@ -54,7 +54,7 @@ import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIEL
  */
 public abstract class HoodieReaderContext<T> {
 
-  private HoodieFileGroupReaderSchemaHandler<T> schemaHandler = null;
+  private FileSliceReaderSchemaHandler<T> schemaHandler = null;
   private String tablePath = null;
   private String latestCommitTime = null;
   private HoodieRecordMerger recordMerger = null;
@@ -64,11 +64,11 @@ public abstract class HoodieReaderContext<T> {
   private Boolean shouldMergeUseRecordPosition = null;
 
   // Getter and Setter for schemaHandler
-  public HoodieFileGroupReaderSchemaHandler<T> getSchemaHandler() {
+  public FileSliceReaderSchemaHandler<T> getSchemaHandler() {
     return schemaHandler;
   }
 
-  public void setSchemaHandler(HoodieFileGroupReaderSchemaHandler<T> schemaHandler) {
+  public void setSchemaHandler(FileSliceReaderSchemaHandler<T> schemaHandler) {
     this.schemaHandler = schemaHandler;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -32,7 +32,7 @@ import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
-import org.apache.hudi.common.table.read.HoodieFileGroupRecordBuffer;
+import org.apache.hudi.common.table.read.FileSliceRecordBuffer;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -140,7 +140,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
   private final List<String> validBlockInstants = new ArrayList<>();
   // Use scanV2 method.
   private final boolean enableOptimizedLogBlocksScan;
-  protected HoodieFileGroupRecordBuffer<T> recordBuffer;
+  protected FileSliceRecordBuffer<T> recordBuffer;
 
   protected BaseHoodieLogRecordReader(HoodieReaderContext readerContext,
                                       HoodieStorage storage,
@@ -152,7 +152,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
                                       boolean enableOptimizedLogBlocksScan,
                                       HoodieRecordMerger recordMerger,
                                       RecordMergeMode recordMergeMode,
-                                      HoodieFileGroupRecordBuffer<T> recordBuffer) {
+                                      FileSliceRecordBuffer<T> recordBuffer) {
     this.readerContext = readerContext;
     this.readerSchema = readerContext.getSchemaHandler().getRequiredSchema();
     this.latestInstantTime = readerContext.getLatestCommitTime();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
@@ -25,7 +25,7 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
-import org.apache.hudi.common.table.read.HoodieFileGroupRecordBuffer;
+import org.apache.hudi.common.table.read.FileSliceRecordBuffer;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.HoodieTimer;
@@ -77,7 +77,7 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
                                       boolean enableOptimizedLogBlocksScan,
                                       HoodieRecordMerger recordMerger,
                                       RecordMergeMode recordMergeMode,
-                                      HoodieFileGroupRecordBuffer<T> recordBuffer) {
+                                      FileSliceRecordBuffer<T> recordBuffer) {
     super(readerContext, storage, logFilePaths, reverseReader, bufferSize, instantRange, withOperationField,
         forceFullScan, partitionName, keyFieldOverride, enableOptimizedLogBlocksScan, recordMerger, recordMergeMode, recordBuffer);
     this.scannedPrefixes = new HashSet<>();
@@ -232,7 +232,7 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
     private HoodieRecordMerger recordMerger = HoodiePreCombineAvroRecordMerger.INSTANCE;
     private RecordMergeMode recordMergeMode;
 
-    private HoodieFileGroupRecordBuffer<T> recordBuffer;
+    private FileSliceRecordBuffer<T> recordBuffer;
 
     @Override
     public Builder<T> withHoodieReaderContext(HoodieReaderContext<T> readerContext) {
@@ -312,7 +312,7 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
       return this;
     }
 
-    public Builder<T> withRecordBuffer(HoodieFileGroupRecordBuffer<T> recordBuffer) {
+    public Builder<T> withRecordBuffer(FileSliceRecordBuffer<T> recordBuffer) {
       this.recordBuffer = recordBuffer;
       return this;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileSliceReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileSliceReaderSchemaHandler.java
@@ -46,7 +46,7 @@ import static org.apache.hudi.avro.AvroSchemaUtils.findNestedField;
 /**
  * This class is responsible for handling the schema for the file group reader.
  */
-public class HoodieFileGroupReaderSchemaHandler<T> {
+public class FileSliceReaderSchemaHandler<T> {
 
   protected final Schema dataSchema;
 
@@ -71,11 +71,11 @@ public class HoodieFileGroupReaderSchemaHandler<T> {
 
   protected final boolean needsMORMerge;
 
-  public HoodieFileGroupReaderSchemaHandler(HoodieReaderContext<T> readerContext,
-                                            Schema dataSchema,
-                                            Schema requestedSchema,
-                                            Option<InternalSchema> internalSchemaOpt,
-                                            HoodieTableConfig hoodieTableConfig) {
+  public FileSliceReaderSchemaHandler(HoodieReaderContext<T> readerContext,
+                                      Schema dataSchema,
+                                      Schema requestedSchema,
+                                      Option<InternalSchema> internalSchemaOpt,
+                                      HoodieTableConfig hoodieTableConfig) {
     this.readerContext = readerContext;
     this.hasBootstrapBaseFile = readerContext.getHasBootstrapBaseFile();
     this.needsMORMerge = readerContext.getHasLogFiles();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileSliceRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileSliceRecordBuffer.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map;
 
-public interface HoodieFileGroupRecordBuffer<T> {
+public interface FileSliceRecordBuffer<T> {
   enum BufferType {
     // Merging based on record key.
     KEY_BASED_MERGE,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -61,9 +61,9 @@ import static org.apache.hudi.common.config.HoodieMemoryConfig.MAX_MEMORY_FOR_ME
 import static org.apache.hudi.common.config.HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH;
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_SCHEMA;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.INSTANT_TIME;
-import static org.apache.hudi.common.table.read.HoodieFileGroupReader.getRecordMergeMode;
+import static org.apache.hudi.common.table.read.FileSliceReader.getRecordMergeMode;
 
-public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T> {
+public abstract class HoodieBaseFileGroupRecordBuffer<T> implements FileSliceRecordBuffer<T> {
   protected final HoodieReaderContext<T> readerContext;
   protected final Schema readerSchema;
   protected final Option<String> partitionNameOverrideOpt;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PositionBasedSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PositionBasedSchemaHandler.java
@@ -37,14 +37,14 @@ import static org.apache.hudi.avro.AvroSchemaUtils.appendFieldsToSchemaDedupNest
 import static org.apache.hudi.common.table.read.HoodiePositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME;
 
 /**
- * This class is responsible for handling the schema for the file group reader that supports positional merge.
+ * This class is responsible for handling the schema for the file slice reader that supports positional merge.
  */
-public class HoodiePositionBasedSchemaHandler<T> extends HoodieFileGroupReaderSchemaHandler<T> {
-  public HoodiePositionBasedSchemaHandler(HoodieReaderContext<T> readerContext,
-                                          Schema dataSchema,
-                                          Schema requestedSchema,
-                                          Option<InternalSchema> internalSchemaOpt,
-                                          HoodieTableConfig hoodieTableConfig) {
+public class PositionBasedSchemaHandler<T> extends FileSliceReaderSchemaHandler<T> {
+  public PositionBasedSchemaHandler(HoodieReaderContext<T> readerContext,
+                                    Schema dataSchema,
+                                    Schema requestedSchema,
+                                    Option<InternalSchema> internalSchemaOpt,
+                                    HoodieTableConfig hoodieTableConfig) {
     super(readerContext, dataSchema, requestedSchema, internalSchemaOpt, hoodieTableConfig);
   }
 
@@ -58,7 +58,7 @@ public class HoodiePositionBasedSchemaHandler<T> extends HoodieFileGroupReaderSc
 
   @Override
   protected Option<InternalSchema> getInternalSchemaOpt(Option<InternalSchema> internalSchemaOpt) {
-    return internalSchemaOpt.map(HoodiePositionBasedSchemaHandler::addPositionalMergeCol);
+    return internalSchemaOpt.map(PositionBasedSchemaHandler::addPositionalMergeCol);
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
- * Tests {@link HoodieFileGroupReader} with different engines
+ * Tests {@link FileSliceReader} with different engines
  */
 public abstract class TestHoodieFileGroupReaderBase<T> {
   @TempDir
@@ -285,7 +285,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       props.setProperty(PARTITION_FIELDS.key(), metaClient.getTableConfig().getString(PARTITION_FIELDS));
     }
     assertEquals(containsBaseFile, fileSlice.getBaseFile().isPresent());
-    HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
+    FileSliceReader<T> fileGroupReader = new FileSliceReader<>(
         getHoodieReaderContext(tablePath, avroSchema, storageConf),
         metaClient.getStorage(),
         tablePath,

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -25,7 +25,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.read.FileSliceReader;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.storage.HoodieStorage;
@@ -34,7 +34,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 
 public class HoodieFileGroupReaderTestUtils {
-  public static HoodieFileGroupReader<IndexedRecord> createFileGroupReader(
+  public static FileSliceReader<IndexedRecord> createFileGroupReader(
       Option<FileSlice> fileSliceOpt,
       String basePath,
       String latestCommitTime,
@@ -97,7 +97,7 @@ public class HoodieFileGroupReaderTestUtils {
       return this;
     }
 
-    public HoodieFileGroupReader<IndexedRecord> build(
+    public FileSliceReader<IndexedRecord> build(
         String basePath,
         String latestCommitTime,
         Schema schema,
@@ -108,7 +108,7 @@ public class HoodieFileGroupReaderTestUtils {
       props.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(),  basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME);
       props.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
       props.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
-      return new HoodieFileGroupReader<>(
+      return new FileSliceReader<>(
           readerContext,
           storage,
           basePath,

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieTableType;
-import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.read.FileSliceReader;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -127,7 +127,7 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
             FILE_ID
         );
 
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader =
+    FileSliceReader<IndexedRecord> fileGroupReader =
         HoodieFileGroupReaderTestUtils.createFileGroupReader(
             fileSliceOpt,
             basePath,

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
-import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.read.FileSliceReader;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -75,7 +75,7 @@ import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getPartitionFi
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getTableBasePath;
 
 /**
- * {@link HoodieFileGroupReader} based implementation of Hive's {@link RecordReader} for {@link ArrayWritable}.
+ * {@link FileSliceReader} based implementation of Hive's {@link RecordReader} for {@link ArrayWritable}.
  */
 public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<NullWritable, ArrayWritable> {
 
@@ -90,7 +90,7 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
   }
 
   private final HiveHoodieReaderContext readerContext;
-  private final HoodieFileGroupReader<ArrayWritable> fileGroupReader;
+  private final FileSliceReader<ArrayWritable> fileGroupReader;
   private final ArrayWritable arrayWritable;
   private final NullWritable nullWritable = NullWritable.get();
   private final InputSplit inputSplit;
@@ -124,7 +124,7 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
       }
     });
     LOG.debug("Creating HoodieFileGroupReaderRecordReader with tableBasePath={}, latestCommitTime={}, fileSplit={}", tableBasePath, latestCommitTime, fileSplit.getPath());
-    this.fileGroupReader = new HoodieFileGroupReader<>(readerContext, metaClient.getStorage(), tableBasePath,
+    this.fileGroupReader = new FileSliceReader<>(readerContext, metaClient.getStorage(), tableBasePath,
         latestCommitTime, getFileSliceFromSplit(fileSplit, getFs(tableBasePath, jobConfCopy), tableBasePath),
         tableSchema, requestedSchema, Option.empty(), metaClient, props, fileSplit.getStart(),
         fileSplit.getLength(), false);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodiePositionBasedFileGroupRecordBuffer.java
@@ -34,7 +34,7 @@ import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.read.HoodiePositionBasedFileGroupRecordBuffer;
-import org.apache.hudi.common.table.read.HoodiePositionBasedSchemaHandler;
+import org.apache.hudi.common.table.read.PositionBasedSchemaHandler;
 import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderOnSpark;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -122,7 +122,7 @@ public class TestHoodiePositionBasedFileGroupRecordBuffer extends TestHoodieFile
         ctx.setRecordMerger(new OverwriteWithLatestSparkMerger());
         break;
     }
-    ctx.setSchemaHandler(new HoodiePositionBasedSchemaHandler<>(ctx, avroSchema, avroSchema,
+    ctx.setSchemaHandler(new PositionBasedSchemaHandler<>(ctx, avroSchema, avroSchema,
         Option.empty(), metaClient.getTableConfig()));
     TypedProperties props = new TypedProperties();
     props.put(HoodieCommonConfig.RECORD_MERGE_MODE.key(), mergeMode.name());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -43,7 +43,7 @@ import java.util
 import scala.collection.JavaConverters._
 
 /**
- * Tests {@link HoodieFileGroupReader} with {@link SparkFileFormatInternalRowReaderContext}
+ * Tests {@link FileSliceReader} with {@link SparkFileFormatInternalRowReaderContext}
  * on Spark
  */
 class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[InternalRow] with SparkAdapterSupport {


### PR DESCRIPTION
### Change Logs

FG reader is actually a fileslice reader. We plan to create a fg reader that wraps this and cdc reader.

### Impact

Class naming is more clear

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
