### PR TITLE
[HUDI-8175] Fix LongWritable cannot be cast to TimestampWritable for MOR table with timestamp column and schema evolution enabled

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -94,6 +94,10 @@ public abstract class AbstractRealtimeRecordReader {
       }
       this.usesCustomPayload = usesCustomPayload(metaClient);
       LOG.info("usesCustomPayload ==> " + this.usesCustomPayload);
+
+      // get timestamp columns
+      supportTimestamp = HoodieColumnProjectionUtils.supportTimestamp(jobConf);
+
       schemaEvolutionContext = new SchemaEvolutionContext(split, job, Option.of(metaClient));
       if (schemaEvolutionContext.internalSchemaOption.isPresent()) {
         schemaEvolutionContext.doEvolutionForRealtimeInputFormat(this);
@@ -164,9 +168,6 @@ public abstract class AbstractRealtimeRecordReader {
     readerSchema = HoodieRealtimeRecordReaderUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields);
     LOG.info(String.format("About to read compacted logs %s for base split %s, projecting cols %s",
         split.getDeltaLogPaths(), split.getPath(), projectionFields));
-
-    // get timestamp columns
-    supportTimestamp = HoodieColumnProjectionUtils.supportTimestamp(jobConf);
   }
 
   public Schema constructHiveOrderedSchema(Schema writerSchema, Map<String, Field> schemaFieldsMap, String hiveColumnString) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHiveTableSchemaEvolution.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHiveTableSchemaEvolution.java
@@ -26,6 +26,7 @@ import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -40,6 +41,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -87,6 +89,53 @@ public class TestHiveTableSchemaEvolution {
         .getOrCreate();
 
     spark.sparkContext().setLogLevel("ERROR");
+  }
+
+  @Test
+  public void testHiveReadTimestampColumnAsTimestampWritable() throws Exception {
+    if (HoodieSparkUtils.gteqSpark3_3()) {
+      String tableName = "hudi_test" + new Date().getTime();
+      String path = new Path(basePath.toAbsolutePath().toString()).toUri().toString();
+
+      spark.sql("set hoodie.schema.on.read.enable=true");
+
+      spark.sql(String.format("create table %s (col0 int, col1 float, col2 string, col3 timestamp) using hudi "
+              + "tblproperties (type='mor', primaryKey='col0', preCombineField='col1', "
+              + "hoodie.compaction.payload.class='org.apache.hudi.common.model.OverwriteWithLatestAvroPayload') location '%s'",
+          tableName, path));
+      spark.sql(String.format("insert into %s values(1, 1.1, 'text', timestamp('2021-12-25 12:01:01'))", tableName));
+      spark.sql(String.format("update %s set col2 = 'text2' where col0 = 1", tableName));
+      spark.sql(String.format("alter table %s rename column col2 to col2_new", tableName));
+
+      JobConf jobConf = new JobConf();
+      jobConf.set(HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key(), "true");
+      jobConf.set(ColumnProjectionUtils.READ_ALL_COLUMNS, "false");
+      jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "col1,col2_new,col3");
+      jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "6,7,8");
+      jobConf.set(serdeConstants.LIST_COLUMNS, "_hoodie_commit_time,_hoodie_commit_seqno,"
+          + "_hoodie_record_key,_hoodie_partition_path,_hoodie_file_name,col0,col1,col2_new,col3");
+      jobConf.set(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string,string,int,float,string,timestamp,string");
+      FileInputFormat.setInputPaths(jobConf, path);
+
+      HoodieParquetInputFormat inputFormat = new HoodieParquetRealtimeInputFormat();
+      inputFormat.setConf(jobConf);
+
+      InputSplit[] splits = inputFormat.getSplits(jobConf, 1);
+      int expectedSplits = 1;
+      assertEquals(expectedSplits, splits.length);
+
+      RecordReader<NullWritable, ArrayWritable> recordReader = inputFormat.getRecordReader(splits[0], jobConf, null);
+      List<List<Writable>> records = getWritableList(recordReader);
+      assertEquals(1, records.size());
+      List<Writable> record1 = records.get(0);
+      // _hoodie_record_key,_hoodie_commit_time,_hoodie_partition_path, col1, col2, col3
+      assertEquals(6, record1.size());
+
+      Writable c3 = record1.get(5);
+      assertTrue(c3 instanceof TimestampWritable);
+
+      recordReader.close();
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
For hudi MOR table with timestamp column In some cases we get exception:
org.apache.hadoop.io.LongWritable cannot be cast to org.apache.hadoop.hive.serde2.io.TimestampWritable*

This happens because timestamp long value in log file converted to LongWritable but must be converted to TimestampWritable.

Reason: field AbstractRealtimeRecordReader.supportTimestamp not initialized if Schema evolution context contain internal schema.

This example reproduce problem (tested on spark3.3, hive 3.1):
spark-sql>
set hoodie.schema.on.read.enable=true;
create table hudi_test1 (col0 int, col1 float, col2 string, col3 timestamp)
using hudi
tblproperties (
    type='mor',
    primaryKey='col0',
    preCombineField='col1',
    'hoodie.compaction.payload.class'='org.apache.hudi.common.model.OverwriteWithLatestAvroPayload');

insert into hudi_test1 values(1, 1.1, 'text', timestamp('2021-12-25 12:01:01'));
update hudi_test1 set col2 = 'text2' where col0 = 1;
alter table hudi_test1 rename column col2 to col2_new;

hive>
set hoodie.schema.on.read.enable=true;
select * from hudi_test1;
Failed with exception java.io.IOException:java.lang.ClassCastException: org.apache.hadoop.io.LongWritable cannot be cast to org.apache.hadoop.hive.serde2.io.TimestampWritableV2

### Change Logs

Logic of initialization of  supportTimestamp property moved to right place.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
