### PR TITLE
[HUDI-8098] With custom keygen, only read timestamp partition columns from the file

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/CustomAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/CustomAvroKeyGenerator.java
@@ -106,6 +106,18 @@ public class CustomAvroKeyGenerator extends BaseKeyGenerator {
     }
   }
 
+  public static List<String> getTimestampFields(List<String> partitionPathFields) {
+    if (partitionPathFields.size() == 1 && partitionPathFields.get(0).isEmpty()) {
+      return Collections.emptyList(); // Corresponds to no partition case
+    } else {
+      return partitionPathFields.stream()
+          .map(CustomAvroKeyGenerator::getPartitionFieldAndKeyType)
+          .filter(fieldAndKeyType -> fieldAndKeyType.getRight().equals(PartitionKeyType.TIMESTAMP))
+          .map(Pair::getLeft)
+          .collect(Collectors.toList());
+    }
+  }
+
   public static Pair<String, PartitionKeyType> getPartitionFieldAndKeyType(String field) {
     String[] fieldWithType = field.split(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX);
     if (fieldWithType.length != 2) {


### PR DESCRIPTION
### Change Logs

Before, we were reading all columns from the file when using custom keygen. Now, we only read the timestamp columns.

### Impact

Better read performance

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
