### PR TITLE
[HUDI-8180] make permissions more strict for scheduled workflow

### DIFF
--- a/.github/workflows/scheduled_workflow.yml
+++ b/.github/workflows/scheduled_workflow.yml
@@ -22,7 +22,11 @@ on:
     # Runs every 5 minutes
     - cron: '*/5 * * * *'
 
-permissions: write-all
+permissions:
+  statuses: write
+  pull-requests: write
+  issues: read
+  actions: write
 
 jobs:
   delete-all-caches:
@@ -41,7 +45,6 @@ jobs:
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              echo "the key to delete is: $cacheKey"
               gh actions-cache delete $cacheKey -R $REPO --confirm
           done
           echo "Done"


### PR DESCRIPTION
### Change Logs

make permissions more strict now that we know the delete cache workflow works.
According to https://github.com/actions/gh-actions-cache/issues/85 it is the write action permission that we need for delete cache 

ok, found proof in the documentation: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-github-actions-caches-for-a-repository-using-a-cache-key

### Impact

more security for the repo

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
