### PR TITLE
[HUDI-8182]Cache internalSchema for hive read, avoid each split reloa…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
@@ -67,7 +67,8 @@ public class FileBasedInternalSchemaStorageManager extends AbstractInternalSchem
   public FileBasedInternalSchemaStorageManager(HoodieTableMetaClient metaClient) {
     this.baseSchemaPath = new StoragePath(metaClient.getMetaPath(), SCHEMA_NAME);
     this.storage = metaClient.getStorage();
-    this.metaClient = metaClient;
+    // the history schema files should be located into .hoodie/.schema folder.
+    this.metaClient = metaClient.getBasePath().getName().equalsIgnoreCase(SCHEMA_NAME) ? metaClient : null;
   }
 
   // make metaClient build lazy

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
@@ -67,8 +67,7 @@ public class FileBasedInternalSchemaStorageManager extends AbstractInternalSchem
   public FileBasedInternalSchemaStorageManager(HoodieTableMetaClient metaClient) {
     this.baseSchemaPath = new StoragePath(metaClient.getMetaPath(), SCHEMA_NAME);
     this.storage = metaClient.getStorage();
-    // the history schema files should be located into .hoodie/.schema folder.
-    this.metaClient = metaClient.getBasePath().getName().equalsIgnoreCase(SCHEMA_NAME) ? metaClient : null;
+    this.metaClient = metaClient;
   }
 
   // make metaClient build lazy

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -18,13 +18,24 @@
 
 package org.apache.hudi.hadoop.hive;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.TablePathUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.HoodieParquetInputFormatBase;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hadoop.realtime.HoodieCombineRealtimeRecordReader;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -96,7 +107,7 @@ import java.util.concurrent.Future;
  * CombineHiveInputFormat is a parameterized InputFormat which looks at the path name and determine the correct
  * InputFormat for that path name from mapredPlan.pathToPartitionInfo(). It can be used to read files with different
  * input format in the same map-reduce job.
- *
+ * <p>
  * NOTE : This class is implemented to work with Hive 2.x +
  */
 public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extends Writable>
@@ -108,6 +119,8 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
   // max number of threads we can use to check non-combinable paths
   private static final int MAX_CHECK_NONCOMBINABLE_THREAD_NUM = 50;
   private static final int DEFAULT_NUM_PATH_PER_THREAD = 100;
+  public static final String INTERNAL_SCHEMA_CACHE_KEY_PREFIX = "hudi.hive.internal.schema.cache.key.prefix";
+  public static final String SCHEMA_CACHE_KEY_PREFIX = "hudi.hive.schema.cache.key.prefix";
 
   protected String getParquetInputFormatClassName() {
     return HoodieParquetInputFormat.class.getName();
@@ -375,6 +388,39 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
     // clear work from ThreadLocal after splits generated in case of thread is reused in pool.
     Utilities.clearWorkMapForConf(job);
 
+    // build internal schema for the query
+    if (result.size() > 0) {
+      ArrayList<String> uniqTablePaths = new ArrayList<>();
+      Arrays.stream(paths).forEach(path -> {
+        HoodieStorage storage = null;
+        try {
+          storage = new HoodieHadoopStorage(path.getFileSystem(job));
+          Option<StoragePath> tablePath = TablePathUtils.getTablePath(storage, HadoopFSUtils.convertToStoragePath(path));
+          if (tablePath.isPresent()) {
+            uniqTablePaths.add(tablePath.get().toUri().toString());
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      try {
+        for (String path : uniqTablePaths) {
+          HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setBasePath(path).setConf(new HadoopStorageConfiguration(job)).build();
+          TableSchemaResolver schemaUtil = new TableSchemaResolver(metaClient);
+          String avroSchema = schemaUtil.getTableAvroSchema().toString();
+          Option<InternalSchema> internalSchema = schemaUtil.getTableInternalSchemaFromCommitMetadata();
+          if (internalSchema.isPresent()) {
+            LOG.info("Set internal internalSchema and avro schema of path: " + path.toString());
+            job.set(SCHEMA_CACHE_KEY_PREFIX + "." + path, avroSchema);
+            job.set(INTERNAL_SCHEMA_CACHE_KEY_PREFIX + "." + path, SerDeHelper.toJson(internalSchema.get()));
+          }
+        }
+      } catch (Exception e) {
+        LOG.warn("Fail to set internal schema", e);
+      }
+    }
+
     LOG.info("Number of all splits " + result.size());
     perfLogger.PerfLogEnd(CLASS_NAME, PerfLogger.GET_SPLITS);
     return result.toArray(new InputSplit[result.size()]);
@@ -390,6 +436,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
   /**
    * HiveFileFormatUtils.getPartitionDescFromPathRecursively is no longer available since Hive 3.
    * This method is to make it compatible with both Hive 2 and Hive 3.
+   *
    * @param pathToPartitionInfo
    * @param dir
    * @param cacheMap
@@ -397,7 +444,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
    * @throws IOException
    */
   private static PartitionDesc getPartitionFromPath(Map<Path, PartitionDesc> pathToPartitionInfo, Path dir,
-      Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cacheMap)
+                                                    Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cacheMap)
       throws IOException {
     Method method;
     try {
@@ -594,7 +641,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
     }
 
     public CombineHiveInputSplit(JobConf job, CombineFileSplit inputSplitShim,
-        Map<Path, PartitionDesc> pathToPartitionInfo) throws IOException {
+                                 Map<Path, PartitionDesc> pathToPartitionInfo) throws IOException {
       this.inputSplitShim = inputSplitShim;
       this.pathToPartitionInfo = pathToPartitionInfo;
       if (job != null) {
@@ -766,7 +813,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
     private final String deserializerClassName;
 
     public CombinePathInputFormat(List<Operator<? extends OperatorDesc>> opList, String inputFormatClassName,
-        String deserializerClassName) {
+                                  String deserializerClassName) {
       this.opList = opList;
       this.inputFormatClassName = inputFormatClassName;
       this.deserializerClassName = deserializerClassName;
@@ -929,13 +976,13 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
         int counter = 0;
         for (int pos = 0; pos < splits.length; pos++) {
           if (counter == maxSize - 1 || pos == splits.length - 1) {
-            builder.addSplit((FileSplit)splits[pos]);
+            builder.addSplit((FileSplit) splits[pos]);
             combineFileSplits.add(builder.build(job));
             builder = new HoodieCombineRealtimeFileSplit.Builder();
             counter = 0;
           } else if (counter < maxSize) {
             counter++;
-            builder.addSplit((FileSplit)splits[pos]);
+            builder.addSplit((FileSplit) splits[pos]);
           }
         }
         return combineFileSplits.toArray(new CombineFileSplit[combineFileSplits.size()]);
@@ -962,7 +1009,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
 
     @Override
     public RecordReader getRecordReader(JobConf job, CombineFileSplit split, Reporter reporter,
-        Class<RecordReader<K, V>> rrClass) throws IOException {
+                                        Class<RecordReader<K, V>> rrClass) throws IOException {
       isRealTime = Boolean.valueOf(job.get("hudi.hive.realtime", "false"));
       if (isRealTime) {
         List<RecordReader> recordReaders = new LinkedList<>();

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
@@ -31,8 +31,12 @@ import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.hadoop.SchemaEvolutionContext;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.hudi.internal.schema.utils.SerDeHelper;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
@@ -108,6 +112,85 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
   public void tearDown() throws IOException {
     if (fs != null) {
       fs.delete(new Path(tempDir.toAbsolutePath().toString()), true);
+    }
+  }
+
+  @Test
+  public void testInternalSchemaCacheForMR() throws Exception {
+    // test for HUDI-8182
+    StorageConfiguration<Configuration> conf = HoodieTestUtils.getDefaultStorageConf();
+    Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
+    java.nio.file.Path path1 = tempDir.resolve("tblOne");
+    java.nio.file.Path path2 = tempDir.resolve("tblTwo");
+    HoodieTestUtils.init(conf, path1.toString(), HoodieTableType.MERGE_ON_READ);
+    HoodieTestUtils.init(conf, path2.toString(), HoodieTableType.MERGE_ON_READ);
+    String commitTime = "100";
+    final int numRecords = 10;
+    // Create 3 parquet files with 10 records each for partition 1
+    File partitionDirOne = InputFormatTestUtil.prepareParquetTable(path1, schema, 3, numRecords, commitTime);
+    HoodieCommitMetadata commitMetadataOne = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
+        schema.toString(), HoodieTimeline.COMMIT_ACTION);
+    // mock the latest schema to the commit metadata
+    InternalSchema internalSchema = AvroInternalSchemaConverter.convert(schema);
+    commitMetadataOne.addMetadata(SerDeHelper.LATEST_SCHEMA, SerDeHelper.toJson(internalSchema));
+    FileCreateUtils.createCommit(path1.toString(), commitTime, Option.of(commitMetadataOne));
+    // Create 3 parquet files with 10 records each for partition 2
+    File partitionDirTwo = InputFormatTestUtil.prepareParquetTable(path2, schema, 3, numRecords, commitTime);
+    HoodieCommitMetadata commitMetadataTwo = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
+        schema.toString(), HoodieTimeline.COMMIT_ACTION);
+    // Mock the latest schema to the commit metadata
+    commitMetadataTwo.addMetadata(SerDeHelper.LATEST_SCHEMA, SerDeHelper.toJson(internalSchema));
+    FileCreateUtils.createCommit(path2.toString(), commitTime, Option.of(commitMetadataTwo));
+
+    // Enable schema evolution
+    conf.set("hoodie.schema.on.read.enable", "true");
+
+    TableDesc tblDesc = Utilities.defaultTd;
+    // Set the input format
+    tblDesc.setInputFileFormatClass(HoodieParquetRealtimeInputFormat.class);
+    PartitionDesc partDesc = new PartitionDesc(tblDesc, null);
+    LinkedHashMap<Path, PartitionDesc> pt = new LinkedHashMap<>();
+    LinkedHashMap<Path, ArrayList<String>> tableAlias = new LinkedHashMap<>();
+    ArrayList<String> alias = new ArrayList<>();
+    // Add partition info one
+    alias.add(path1.toAbsolutePath().toString());
+    tableAlias.put(new Path(path1.toAbsolutePath().toString()), alias);
+    pt.put(new Path(path1.toAbsolutePath().toString()), partDesc);
+    // Add partition info two
+    alias.add(path2.toAbsolutePath().toString());
+    tableAlias.put(new Path(path2.toAbsolutePath().toString()), alias);
+    pt.put(new Path(path2.toAbsolutePath().toString()), partDesc);
+
+    MapredWork mrwork = new MapredWork();
+    mrwork.getMapWork().setPathToPartitionInfo(pt);
+    mrwork.getMapWork().setPathToAliases(tableAlias);
+    mrwork.getMapWork().setMapperCannotSpanPartns(true);
+    Path mapWorkPath = new Path(tempDir.toAbsolutePath().toString());
+    Utilities.setMapRedWork(conf.unwrap(), mrwork, mapWorkPath);
+    JobConf jobConf = new JobConf(conf.unwrap());
+    // Add the paths
+    FileInputFormat.setInputPaths(jobConf, partitionDirOne.getPath() + "," + partitionDirTwo.getPath());
+    jobConf.set(HAS_MAP_WORK, "true");
+    // The following config tells Hive to choose ExecMapper to read the MAP_WORK
+    jobConf.set(MAPRED_MAPPER_CLASS, ExecMapper.class.getName());
+    // set SPLIT_MAXSIZE larger  to create one split for 3 files groups
+    jobConf.set(org.apache.hadoop.mapreduce.lib.input.FileInputFormat.SPLIT_MAXSIZE, "128000000");
+
+    HoodieCombineHiveInputFormat combineHiveInputFormat = new HoodieCombineHiveInputFormat();
+    String tripsHiveColumnTypes = "double,string,string,string,double,double,double,double,double";
+    InputFormatTestUtil.setProjectFieldsForInputFormat(jobConf, schema, tripsHiveColumnTypes);
+    InputSplit[] splits = combineHiveInputFormat.getSplits(jobConf, 2);
+    // Check the internal schema and avro is the same as the original one
+    for (InputSplit split : splits) {
+      HoodieCombineRealtimeFileSplit inputSplitShim = (HoodieCombineRealtimeFileSplit) ((HoodieCombineRealtimeHiveSplit) split).getInputSplitShim();
+      List<FileSplit> fileSplits = inputSplitShim.getRealtimeFileSplits();
+      for (FileSplit fileSplit : fileSplits) {
+        SchemaEvolutionContext schemaEvolutionContext = new SchemaEvolutionContext(fileSplit, jobConf);
+        Option<InternalSchema> internalSchemaFromCache = schemaEvolutionContext.getInternalSchemaFromCache();
+        assertEquals(internalSchemaFromCache.get(), internalSchema);
+        Schema avroSchemaFromCache = schemaEvolutionContext.getAvroSchemaFromCache();
+        assertEquals(avroSchemaFromCache, schema);
+      }
     }
   }
 


### PR DESCRIPTION
…d active timeline.

### Change Logs
Addressing this issue: [11723](https://github.com/apache/hudi/issues/11723)
When using MR to read Hudi, use a global InternalSchema to avoid each reader listing the metadata directory to obtain the InternalSchema, which places a significant load on the HDFS NameNode.

### Impact

Reduced metadata listing frequency to alleviate pressure on the HDFS NameNode.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
