### PR TITLE
[HUDI-8186] Fix empty meta sync class issue

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -1037,6 +1037,11 @@ public class StreamSync implements Serializable, Closeable {
 
       Map<String, HoodieException> failedMetaSyncs = new HashMap<>();
       for (String impl : syncClientToolClasses) {
+        if (impl.trim().isEmpty()) {
+          LOG.warn("Cannot run MetaSync with empty class name");
+          continue;
+        }
+
         Timer.Context syncContext = metrics.getMetaSyncTimerContext();
         Option<HoodieMetaSyncException> metaSyncException = Option.empty();
         try {


### PR DESCRIPTION
### Change Logs

When MetaSync class name is empty, the java reflection would throw error.

### Impact

Reduced errors.

### Risk level (write none, low medium or high below)

No.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
