### PR TITLE
[HUDI-8185] Handle Avro GenericData byte array comparison

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/ConvertingGenericData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/ConvertingGenericData.java
@@ -25,6 +25,7 @@ import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -139,6 +140,15 @@ public class ConvertingGenericData extends GenericData {
       default:
         return false;
     }
+  }
+
+  @Override
+  public int compare(Object o1, Object o2, Schema s) {
+    // Handle byte[] by wrapping first in ByteBuffer because byte array is not comparable
+    if (s.getType() == Schema.Type.BYTES && o1 instanceof byte[] && o2 instanceof byte[]) {
+      return super.compare(ByteBuffer.wrap((byte[]) o1), ByteBuffer.wrap((byte[]) o2), s);
+    }
+    return super.compare(o1, o2, s);
   }
 }
 

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -581,6 +581,50 @@ public class TestHoodieAvroUtils {
     }
   }
 
+  @Test
+  public void testConvertingGenericDataCompare() {
+    Schema schema = new Schema.Parser().parse(SCHEMA_WITH_AVRO_TYPES);
+    // create two records with same values
+    GenericRecord record1 = new GenericData.Record(schema);
+    record1.put("booleanField", true);
+    record1.put("intField", 698);
+    record1.put("longField", 192485030493L);
+    record1.put("floatField", 18.125f);
+    record1.put("doubleField", 94385932.342104);
+    record1.put("bytesField", new byte[] {1, 20, 0, 60, 2, 108});
+    record1.put("stringField", "abcdefghijk");
+    record1.put("decimalField", getUTF8Bytes("9213032.4966"));
+    record1.put("timeMillisField", 57996136);
+    record1.put("timeMicrosField", 57996136930L);
+    record1.put("timestampMillisField", 1690828731156L);
+    record1.put("timestampMicrosField", 1690828731156982L);
+    record1.put("localTimestampMillisField", 1690828731156L);
+    record1.put("localTimestampMicrosField", 1690828731156982L);
+
+    GenericRecord record2 = new GenericData.Record(schema);
+    record2.put("booleanField", true);
+    record2.put("intField", 698);
+    record2.put("longField", 192485030493L);
+    record2.put("floatField", 18.125f);
+    record2.put("doubleField", 94385932.342104);
+    record2.put("bytesField", new byte[] {1, 20, 0, 60, 2, 108});
+    record2.put("stringField", "abcdefghijk");
+    record2.put("decimalField", getUTF8Bytes("9213032.4966"));
+    record2.put("timeMillisField", 57996136);
+    record2.put("timeMicrosField", 57996136930L);
+    record2.put("timestampMillisField", 1690828731156L);
+    record2.put("timestampMicrosField", 1690828731156982L);
+    record2.put("localTimestampMillisField", 1690828731156L);
+    record2.put("localTimestampMicrosField", 1690828731156982L);
+
+    // get schema of each field in SCHEMA_WITH_AVRO_TYPES
+    List<Schema> fieldSchemas = schema.getFields().stream().map(Schema.Field::schema).collect(Collectors.toList());
+    // compare each field in SCHEMA_WITH_AVRO_TYPES
+    for (int i = 0; i < fieldSchemas.size(); i++) {
+      assertEquals(0, ConvertingGenericData.INSTANCE.compare(record1.get(i), record2.get(i), fieldSchemas.get(i)));
+    }
+  }
+
   public static Stream<Arguments> javaValueParams() {
     Object[][] data =
         new Object[][] {


### PR DESCRIPTION
### Change Logs

While building colstats for `bytes` field, we noticed that the comparison throws below exception:
```
java.lang.ClassCastException: [B cannot be cast to java.lang.Comparable

	at org.apache.avro.generic.GenericData.compare(GenericData.java:1263)
	at org.apache.avro.generic.GenericData.compare(GenericData.java:1148)
...
```
Byte arrays are not inherently comparable. So, we first need to wrap in `ByteBuffer`. This PR fixes the issue and adds a simple comparison test.

### Impact

Fix byte array comparison (colstats is one use case).

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
