### PR TITLE
[MINOR] pass the avro exception for better information

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.internal.schema.HoodieSchemaException
 
 import org.apache.avro.Schema.Type
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.{JsonProperties, Schema}
+import org.apache.avro.{AvroRuntimeException, JsonProperties, Schema}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
@@ -149,6 +149,7 @@ object AvroConversionUtils {
       val avroSchema = schemaConverters.toAvroType(structType, nullable = false, structName, recordNamespace)
       getAvroSchemaWithDefaults(avroSchema, structType)
     } catch {
+      case a: AvroRuntimeException => throw new HoodieSchemaException(a.getMessage, a)
       case e: Exception => throw new HoodieSchemaException("Failed to convert struct type to avro schema: " + structType, e)
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
@@ -20,6 +20,7 @@ package org.apache.hudi
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
+import org.apache.hudi.internal.schema.HoodieSchemaException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, DataTypes, MapType, StringType, StructField, StructType}
@@ -444,5 +445,14 @@ class TestAvroConversionUtils extends FunSuite with Matchers {
 
   private def checkNull(left: Any, right: Any): Boolean = {
     (left == null && right != null) || (left == null && right != null)
+  }
+
+  test("convert struct type with duplicate column names") {
+    val struct = new StructType().add("id", DataTypes.LongType, true)
+      .add("name", DataTypes.StringType, true)
+      .add("name", DataTypes.StringType, true)
+    the[HoodieSchemaException] thrownBy {
+      AvroConversionUtils.convertStructTypeToAvroSchema(struct, "SchemaName", "SchemaNS")
+    } should have message "Duplicate field name in record SchemaNS.SchemaName: name type:UNION pos:2 and name type:UNION pos:1."
   }
 }


### PR DESCRIPTION
### Change Logs

In a few cases, Avro exception is pretty good. Highlighting the error message instead of suppressing it is more informational.

e.g.: In this `spark connect` example, there is a duplicate column error. But the error is visible on the driver. Not on the python client. This PR will bubble the error message proactively and improve the UX.


```python
from pyspark.sql.session import SparkSession

sp = (
    SparkSession.builder.appName("Hudi").remote("sc://0.0.0.0").getOrCreate()
)

df_1 = sp.createDataFrame([
    (1, "foo"), (2, "bar"), (3, "baz")
], ["id", "name"])

df_2 = sp.createDataFrame([
    (1, "foo"), (2, "bar"), (3, "baz")
], ["id", "name"])

df = df_1.join(df_2, on="id")

df.write.format("hudi").option(
    "hoodie.table.name", "hudi_table"
).mode("overwrite").save("/tmp/hudi")
```

**Error _with_ this patch** [more readable]
```
pyspark.errors.exceptions.connect.SparkConnectGrpcException: 
(org.apache.hudi.internal.schema.HoodieSchemaException) 
Duplicate field name in record hoodie.hudi_table.hudi_table_record: name type:UNION pos:2 and name type:UNION pos:1.
```

**Error _without_ this patch**
```
pyspark.errors.exceptions.connect.SparkConnectGrpcException: 
(org.apache.hudi.internal.schema.HoodieSchemaException) 
Failed to convert struct type to avro schema: StructType(StructField(id,LongType,true),StructField(name,StringType,true),StructField(name,StringType,true))

```


### Impact

NA

### Risk level (write none, low medium or high below)

none

### Documentation Update

na

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
