### PR TITLE
[HUDI-8197] Get rid of set sqlconf in Filegroupreader parquet file format

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -87,7 +87,6 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tableState: HoodieTableState,
       supportBatchCalled = true
       supportBatchResult = !isMOR && !isIncremental && !isBootstrap && super.supportBatch(sparkSession, schema)
     }
-    sparkSession.conf.set(PARQUET_VECTORIZED_READER_ENABLED.key, supportBatchResult)
     supportBatchResult
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
@@ -881,6 +881,10 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
           readTable(tempRecordPath, useFileGroupReader)
         }
       }
+    } else {
+      withSQLConf("spark.sql.parquet.enableNestedColumnVectorizedReader" -> "true") {
+        readTable(tempRecordPath, useFileGroupReader)
+      }
     }
 
     withSQLConf("spark.sql.parquet.enableNestedColumnVectorizedReader" -> "false") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
@@ -875,7 +875,7 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
 
     // after implicit type change, read the table with vectorized read enabled
     //fg reader with mor does not support vectorized currently and will auto read by row
-    if (HoodieSparkUtils.gteqSpark3_3 && !useFileGroupReader) {
+    if (HoodieSparkUtils.gteqSpark3_3 && (isCow || !useFileGroupReader)) {
       assertThrows(classOf[SparkException]){
         withSQLConf("spark.sql.parquet.enableNestedColumnVectorizedReader" -> "true") {
           readTable(tempRecordPath, useFileGroupReader)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -25,7 +25,6 @@ import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
-import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -103,12 +102,6 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   protected boolean useTransformer;
   protected boolean userProvidedSchema;
 
-  protected Map<String, String> readOpts = new HashMap<String, String>() {
-    {
-      put(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false");
-    }
-  };
-
   @BeforeAll
   public static void initKafka() {
     defaultSchemaProviderClassName = TestSchemaProvider.class.getName();
@@ -125,6 +118,9 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     sourceSchemaFile = "";
     targetSchemaFile = "";
     topicName = "topic" + testNum;
+    if (HoodieSparkUtils.gteqSpark3_3()) {
+      sparkSession.conf().set("spark.sql.parquet.enableNestedColumnVectorizedReader", "false");
+    }
   }
 
   @AfterEach

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
@@ -170,7 +170,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
     }
     assertRecordCount(numRecords);
 
-    Dataset<Row> df = sparkSession.read().format("hudi").options(readOpts).load(tableBasePath);
+    Dataset<Row> df = sparkSession.read().format("hudi").load(tableBasePath);
     df.show(9,false);
     df.select(updateColumn).show(9);
     for (String condition : conditions.keySet()) {
@@ -442,7 +442,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
   protected String typePromoUpdates;
 
   protected void assertDataType(String colName, DataType expectedType) {
-    assertEquals(expectedType, sparkSession.read().format("hudi").options(readOpts).load(tableBasePath).select(colName).schema().fields()[0].dataType());
+    assertEquals(expectedType, sparkSession.read().format("hudi").load(tableBasePath).select(colName).schema().fields()[0].dataType());
   }
 
   protected void testTypePromotionBase(String colName, DataType startType, DataType updateType) throws Exception {
@@ -499,7 +499,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
       assertFileNumber(numFiles, false);
     }
     assertRecordCount(numRecords);
-    sparkSession.read().format("hudi").options(readOpts).load(tableBasePath).select(colName).show(9);
+    sparkSession.read().format("hudi").load(tableBasePath).select(colName).show(9);
     assertDataType(colName, endType);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -241,7 +241,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
     }
     assertRecordCount(numRecords);
 
-    df = sparkSession.read().format("hudi").options(readOpts).load(tableBasePath);
+    df = sparkSession.read().format("hudi").load(tableBasePath);
     df.show(100,false);
     df.cache();
     assertDataType(df, "tip_history", DataTypes.createArrayType(DataTypes.LongType));


### PR DESCRIPTION
### Change Logs

Get rid of set sqlconf because it has side effects
Also use fgreader for all the schema evolution ds tests

### Impact

prevent side effects of modifying sqlconf mid query

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
