### PR TITLE
[HUDI-6909] Add logic to check operation metadata field for Spark Record

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -237,14 +237,24 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
   }
 
   @Override
-  public boolean isDelete(Schema recordSchema, Properties props) throws IOException {
+  public boolean isDelete(Schema recordSchema, Properties props) {
     if (null == data) {
       return true;
     }
-    if (recordSchema.getField(HoodieRecord.HOODIE_IS_DELETED_FIELD) == null) {
+
+    // Use metadata filed to decide.
+    Schema.Field operationField = recordSchema.getField(OPERATION_METADATA_FIELD);
+    if (operationField != null && "D".equals(data.get(operationField.pos(), StringType))) {
+      return true;
+    }
+
+    // Use data field to decide.
+    if (recordSchema.getField(HOODIE_IS_DELETED_FIELD) == null) {
       return false;
     }
-    Object deleteMarker = data.get(recordSchema.getField(HoodieRecord.HOODIE_IS_DELETED_FIELD).pos(), BooleanType);
+
+    Object deleteMarker = data.get(
+        recordSchema.getField(HOODIE_IS_DELETED_FIELD).pos(), BooleanType);
     return deleteMarker instanceof Boolean && (boolean) deleteMarker;
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -56,7 +56,6 @@ import scala.Function1;
 import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
 import static org.apache.spark.sql.HoodieInternalRowUtils.getCachedUnsafeProjection;
 import static org.apache.spark.sql.types.DataTypes.BooleanType;
-import static org.apache.spark.sql.types.DataTypes.ByteType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -56,6 +56,7 @@ import scala.Function1;
 import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
 import static org.apache.spark.sql.HoodieInternalRowUtils.getCachedUnsafeProjection;
 import static org.apache.spark.sql.types.DataTypes.BooleanType;
+import static org.apache.spark.sql.types.DataTypes.ByteType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
@@ -244,7 +245,8 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
 
     // Use metadata filed to decide.
     Schema.Field operationField = recordSchema.getField(OPERATION_METADATA_FIELD);
-    if (operationField != null && "D".equals(data.get(operationField.pos(), StringType))) {
+    if (null != operationField
+        && HoodieOperation.isDeleteRecord((Byte) data.get(operationField.pos(), ByteType))) {
       return true;
     }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -246,7 +246,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     // Use metadata filed to decide.
     Schema.Field operationField = recordSchema.getField(OPERATION_METADATA_FIELD);
     if (null != operationField
-        && HoodieOperation.isDeleteRecord((Byte) data.get(operationField.pos(), ByteType))) {
+        && HoodieOperation.isDeleteRecord((String) data.get(operationField.pos(), StringType))) {
       return true;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieOperation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieOperation.java
@@ -122,4 +122,8 @@ public enum HoodieOperation {
   public static boolean isDelete(HoodieOperation operation) {
     return operation == DELETE;
   }
+
+  public static boolean isDeleteRecord(Byte value) {
+    return isDelete(fromValue(value));
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieOperation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieOperation.java
@@ -123,7 +123,7 @@ public enum HoodieOperation {
     return operation == DELETE;
   }
 
-  public static boolean isDeleteRecord(Byte value) {
-    return isDelete(fromValue(value));
+  public static boolean isDeleteRecord(String name) {
+    return isDelete(fromName(name));
   }
 }


### PR DESCRIPTION
### Change Logs

When we check if the Spark record is a delete record, we add logic to check the `_hoodie_operation`.
If the field exists, and its value is "D", then we think this record is a delete record.

### Impact

Incorporate more logic to identify delete records.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
