### PR TITLE
[HUDI-8183] Throw exception if record key field does not exist

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -158,7 +158,7 @@ public class KeyGenUtils {
       try {
         recordKeyValue = HoodieAvroUtils.getNestedFieldValAsString(record, recordKeyField, false, consistentLogicalTimestampEnabled);
       } catch (HoodieException e) {
-        throw new HoodieKeyException("Recordkey field '" + recordKeyField + "' does not exist in the input record");
+        throw new HoodieKeyException("Record key field '" + recordKeyField + "' does not exist in the input record");
       }
       if (recordKeyValue == null) {
         recordKey.append(recordKeyField).append(DEFAULT_COMPOSITE_KEY_FILED_VALUE).append(NULL_RECORDKEY_PLACEHOLDER);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -731,7 +731,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
     }
 
     try {
-      inputDF1.write.format("org.apache.hudi")
+      inputDF1.write.format("hudi")
         .option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "fake_field_name")
         .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
         .mode(SaveMode.Overwrite)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -754,7 +754,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
 
     try {
       inputDF1.write.format("org.apache.hudi")
-        .option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "tip_history.fake_field_name")
+        .option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "tip_history.non_existent_field")
         .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
         .mode(SaveMode.Overwrite)
         .save(basePath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -725,7 +725,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
         .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
         .mode(SaveMode.Overwrite)
         .save(basePath)
-      fail("should fail when fake field is provided for recordkey")
+      fail("should fail when the specified record key field does not exist")
     } catch {
       case e: Exception => assertTrue(containsErrorMessage(e, "Recordkey field 'fake_field_name' does not exist in the input record"))
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -727,7 +727,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
         .save(basePath)
       fail("should fail when the specified record key field does not exist")
     } catch {
-      case e: Exception => assertTrue(containsErrorMessage(e, "Recordkey field 'fake_field_name' does not exist in the input record"))
+      case e: Exception => assertTrue(containsErrorMessage(e, "Record key field 'non_existent_field' does not exist in the input record"))
     }
 
     try {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -721,7 +721,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
 
     try {
       inputDF1.write.format("org.apache.hudi")
-        .option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "_row_key,fake_field_name")
+        .option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "_row_key,non_existent_field")
         .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
         .mode(SaveMode.Overwrite)
         .save(basePath)


### PR DESCRIPTION
### Change Logs

If the recordkey field doesn't exist at all, throw an exception

### Impact

Currently happens silently so user won't know until they query the record

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
