### PR TITLE
[HUDI-7928] Remove shared HFile reader in HoodieNativeAvroHFileReader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 public class HoodieReaderConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> USE_NATIVE_HFILE_READER = ConfigProperty
       .key("_hoodie.hfile.use.native.reader")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("When enabled, the native HFile reader is used to read HFiles.  This is an internal config.");

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -71,12 +71,14 @@ import static org.apache.hudi.io.hfile.HFileUtils.isPrefixOfKey;
  */
 public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieNativeAvroHFileReader.class);
+  // Keys of the meta info that should be preloaded on demand from the HFile
   private static final Set<String> PRELOADED_META_INFO_KEYS = new HashSet<>(
       Arrays.asList(KEY_MIN_RECORD, KEY_MAX_RECORD, SCHEMA_KEY));
 
   private final HoodieStorage storage;
   private final Option<StoragePath> path;
   private final Option<byte[]> bytesContent;
+  // In-memory cache for meta info
   private final Map<String, byte[]> metaInfoMap;
   private final Lazy<Schema> schema;
   private boolean isMetaInfoLoaded = false;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -49,9 +49,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -66,29 +70,30 @@ import static org.apache.hudi.io.hfile.HFileUtils.isPrefixOfKey;
  */
 public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieNativeAvroHFileReader.class);
+  private static final Set<String> PRELOADED_META_INFO_KEYS = new HashSet<>(
+      Arrays.asList(KEY_MIN_RECORD, KEY_MAX_RECORD, SCHEMA_KEY));
 
   private final HoodieStorage storage;
   private final Option<StoragePath> path;
   private final Option<byte[]> bytesContent;
-  private Option<HFileReader> sharedHFileReader;
+  private final Map<String, byte[]> metaInfoMap;
   private final Lazy<Schema> schema;
+  private long numKeyValueEntries = -1L;
 
   public HoodieNativeAvroHFileReader(HoodieStorage storage, StoragePath path, Option<Schema> schemaOption) {
     this.storage = storage;
     this.path = Option.of(path);
     this.bytesContent = Option.empty();
-    this.sharedHFileReader = Option.empty();
-    this.schema = schemaOption.map(Lazy::eagerly)
-        .orElseGet(() -> Lazy.lazily(() -> fetchSchema(getSharedHFileReader())));
+    this.metaInfoMap = new HashMap<>();
+    this.schema = schemaOption.map(Lazy::eagerly).orElseGet(() -> Lazy.lazily(this::fetchSchema));
   }
 
   public HoodieNativeAvroHFileReader(HoodieStorage storage, byte[] content, Option<Schema> schemaOption) {
     this.storage = storage;
     this.path = Option.empty();
     this.bytesContent = Option.of(content);
-    this.sharedHFileReader = Option.empty();
-    this.schema = schemaOption.map(Lazy::eagerly)
-        .orElseGet(() -> Lazy.lazily(() -> fetchSchema(getSharedHFileReader())));
+    this.metaInfoMap = new HashMap<>();
+    this.schema = schemaOption.map(Lazy::eagerly).orElseGet(() -> Lazy.lazily(this::fetchSchema));
   }
 
   @Override
@@ -106,11 +111,10 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   @Override
   public String[] readMinMaxRecordKeys() {
-    HFileReader reader = getSharedHFileReader();
     try {
       return new String[] {
-          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MIN_RECORD)).get()),
-          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_MAX_RECORD)).get())};
+          fromUTF8Bytes(getHFileMetaInfoFromCache(KEY_MIN_RECORD)),
+          fromUTF8Bytes(getHFileMetaInfoFromCache(KEY_MAX_RECORD))};
     } catch (IOException e) {
       throw new HoodieIOException("Cannot read min and max record keys from HFile.", e);
     }
@@ -118,8 +122,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   @Override
   public BloomFilter readBloomFilter() {
-    try {
-      HFileReader reader = getSharedHFileReader();
+    try (HFileReader reader = newHFileReader()) {
       ByteBuffer byteBuffer = reader.getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK).get();
       return BloomFilterFactory.fromByteBuffer(byteBuffer,
           fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(KEY_BLOOM_FILTER_TYPE_CODE)).get()));
@@ -190,18 +193,19 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   @Override
   public void close() {
-    try {
-      if (sharedHFileReader.isPresent()) {
-        sharedHFileReader.get().close();
-      }
-    } catch (IOException e) {
-      throw new HoodieIOException("Error closing the HFile reader", e);
-    }
+    metaInfoMap.clear();
   }
 
   @Override
   public long getTotalRecords() {
-    return getSharedHFileReader().getNumKeyValueEntries();
+    if (numKeyValueEntries < 0) {
+      try {
+        loadAllMetaInfoIntoCache();
+      } catch (IOException e) {
+        throw new HoodieIOException("Cannot get the number of entries from HFile", e);
+      }
+    }
+    return numKeyValueEntries;
   }
 
   @Override
@@ -224,10 +228,10 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
         iterator, data -> unsafeCast(new HoodieAvroIndexedRecord(data)));
   }
 
-  private static Schema fetchSchema(HFileReader reader) {
+  private Schema fetchSchema() {
     try {
       return new Schema.Parser().parse(
-          fromUTF8Bytes(reader.getMetaInfo(new UTF8StringKey(SCHEMA_KEY)).get()));
+          fromUTF8Bytes(getHFileMetaInfoFromCache(SCHEMA_KEY)));
     } catch (IOException e) {
       throw new HoodieIOException("Unable to read schema from HFile", e);
     }
@@ -244,14 +248,32 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
         readerSchema);
   }
 
-  private synchronized HFileReader getSharedHFileReader() {
-    try {
-      if (!sharedHFileReader.isPresent()) {
-        sharedHFileReader = Option.of(newHFileReader());
+  private byte[] getHFileMetaInfoFromCache(String key) throws IOException {
+    if (!PRELOADED_META_INFO_KEYS.contains(key)) {
+      throw new IllegalStateException("HoodieNativeAvroHFileReader#getHFileMetaInfoFromCache"
+          + " should only be called on supported meta info keys; this key is not supported: "
+          + key);
+    }
+    byte[] bytes = metaInfoMap.get(key);
+    if (bytes != null) {
+      return bytes;
+    }
+    loadAllMetaInfoIntoCache();
+    return metaInfoMap.get(key);
+  }
+
+  private synchronized void loadAllMetaInfoIntoCache() throws IOException {
+    // Load all meta info that are small into cache
+    try (HFileReader reader = newHFileReader()) {
+      this.numKeyValueEntries = reader.getNumKeyValueEntries();
+      for (String metaInfoKey : PRELOADED_META_INFO_KEYS) {
+        Option<byte[]> metaInfo = reader.getMetaInfo(new UTF8StringKey(metaInfoKey));
+        if (metaInfo.isPresent()) {
+          metaInfoMap.put(metaInfoKey, metaInfo.get());
+        }
       }
-      return sharedHFileReader.get();
-    } catch (IOException e) {
-      throw new HoodieIOException("Unable to construct HFile reader", e);
+    } catch (Exception e) {
+      throw new IOException("Unable to construct HFile reader", e);
     }
   }
 


### PR DESCRIPTION
### Change Logs

The shared HFile reader in `HoodieNativeAvroHFileReader` uses non-trivial amount of memory (see the screenshots below) and is kept open for reading meta info from the HFile.  This PR adds the changes to avoid keeping the reference to the shared HFile reader by removing the shared HFile reader and caching the meta info by loading the information once, so the memory usage is reduced.

This PR also enables the native HFile reader (`_hoodie.hfile.use.native.reader`) by default again.  It was turned off by default before in #11488 due to OOM in CI.

Screenshots of memory usage of `HoodieNativeAvroHFileReader`:
<img width="1868" alt="Screenshot 2024-06-21 at 17 53 07" src="https://github.com/user-attachments/assets/38f249c6-a467-471b-9bd9-5d3afa46d1bc">
<img width="1752" alt="Screenshot 2024-09-12 at 08 18 25" src="https://github.com/user-attachments/assets/8a9ad95f-5e5c-466f-8274-cca8f063ba75">

### Impact

Reduces memory usage.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
