### PR TITLE
[HUDI-5128] Use HoodieStorage in DFSPathSelector

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/helpers/DFSTestSuitePathSelector.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/helpers/DFSTestSuitePathSelector.java
@@ -24,20 +24,17 @@ import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.integ.testsuite.HoodieTestSuiteJob;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.utilities.config.DFSPathSelectorConfig;
 import org.apache.hudi.utilities.sources.helpers.DFSPathSelector;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,13 +67,13 @@ public class DFSTestSuitePathSelector extends DFSPathSelector {
       }
 
       // obtain all eligible files for the batch
-      List<FileStatus> eligibleFiles = new ArrayList<>();
-      FileStatus[] fileStatuses = fs.globStatus(
-          new Path(getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH), "*"));
+      List<StoragePathInfo> eligibleFiles = new ArrayList<>();
+      List<StoragePathInfo> pathInfos = storage.globEntries(
+          new StoragePath(getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH), "*"));
       // Say input data is as follow input/1, input/2, input/5 since 3,4 was rolled back and 5 is new generated data
       // checkpoint from the latest commit metadata will be 2 since 3,4 has been rolled back. We need to set the
       // next batch id correctly as 5 instead of 3
-      Option<String> correctBatchIdDueToRollback = Option.fromJavaOptional(Arrays.stream(fileStatuses)
+      Option<String> correctBatchIdDueToRollback = Option.fromJavaOptional(pathInfos.stream()
           .map(f -> f.getPath().toString().split("/")[f.getPath().toString().split("/").length - 1])
           .filter(bid1 -> Integer.parseInt(bid1) > lastBatchId)
           .min((bid1, bid2) -> Integer.min(Integer.parseInt(bid1), Integer.parseInt(bid2))));
@@ -85,16 +82,14 @@ public class DFSTestSuitePathSelector extends DFSPathSelector {
       }
       log.info("Using DFSTestSuitePathSelector, checkpoint: " + lastCheckpointStr + " sourceLimit: " + sourceLimit
           + " lastBatchId: " + lastBatchId + " nextBatchId: " + nextBatchId);
-      for (FileStatus fileStatus : fileStatuses) {
-        if (!fileStatus.isDirectory() || IGNORE_FILEPREFIX_LIST.stream()
-            .anyMatch(pfx -> fileStatus.getPath().getName().startsWith(pfx))) {
+      for (StoragePathInfo pathInfo : pathInfos) {
+        if (!pathInfo.isDirectory() || IGNORE_FILEPREFIX_LIST.stream()
+            .anyMatch(pfx -> pathInfo.getPath().getName().startsWith(pfx))) {
           continue;
-        } else if (Integer.parseInt(fileStatus.getPath().getName()) > lastBatchId && Integer.parseInt(fileStatus.getPath()
+        } else if (Integer.parseInt(pathInfo.getPath().getName()) > lastBatchId && Integer.parseInt(pathInfo.getPath()
             .getName()) <= nextBatchId) {
-          RemoteIterator<LocatedFileStatus> files = fs.listFiles(fileStatus.getPath(), true);
-          while (files.hasNext()) {
-            eligibleFiles.add(files.next());
-          }
+          List<StoragePathInfo> files = storage.listFiles(pathInfo.getPath());
+          eligibleFiles.addAll(files);
         }
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
@@ -165,8 +165,8 @@ public class DFSPathSelector implements Serializable {
   }
 
   protected List<StoragePathInfo> listEligibleFiles(HoodieStorage storage,
-                                               StoragePath path,
-                                               long lastCheckpointTime) throws IOException {
+                                                    StoragePath path,
+                                                    long lastCheckpointTime) throws IOException {
     return listEligibleFiles(storage, path, lastCheckpointTime, new HashSet<>());
   }
 
@@ -174,9 +174,9 @@ public class DFSPathSelector implements Serializable {
    * List files recursively, filter out illegible files/directories while doing so.
    */
   protected List<StoragePathInfo> listEligibleFiles(HoodieStorage storage,
-                                               StoragePath path,
-                                               long lastCheckpointTime,
-                                               Set<StoragePathInfo> visited) throws IOException {
+                                                    StoragePath path,
+                                                    long lastCheckpointTime,
+                                                    Set<StoragePathInfo> visited) throws IOException {
     // skip files/dirs whose names start with (_, ., etc)
     List<StoragePathInfo> pathInfos = storage.listDirectEntries(path, file ->
         IGNORE_FILEPREFIX_LIST.stream().noneMatch(pfx -> file.getName().startsWith(pfx)));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DatePartitionPathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DatePartitionPathSelector.java
@@ -24,13 +24,14 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.utilities.config.DatePartitionPathSelectorConfig;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,25 +132,27 @@ public class DatePartitionPathSelector extends DFSPathSelector {
             + currentDate);
     long lastCheckpointTime = lastCheckpointStr.map(Long::parseLong).orElse(Long.MIN_VALUE);
     HoodieSparkEngineContext context = new HoodieSparkEngineContext(sparkContext);
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(fs.getConf());
+    HadoopStorageConfiguration storageConf = (HadoopStorageConfiguration) storage.getConf();
     List<String> prunedPartitionPaths = pruneDatePartitionPaths(
-        context, fs, getStringWithAltKeys(props, ROOT_INPUT_PATH), currentDate);
+        context, storage, getStringWithAltKeys(props, ROOT_INPUT_PATH), currentDate);
 
-    List<FileStatus> eligibleFiles = context.flatMap(prunedPartitionPaths,
+    List<StoragePathInfo> eligibleFiles = context.flatMap(prunedPartitionPaths,
         path -> {
-          FileSystem fs = new Path(path).getFileSystem(storageConf.unwrap());
-          return listEligibleFiles(fs, new Path(path), lastCheckpointTime).stream();
+          StoragePath storagePath = new StoragePath(path);
+          HoodieStorage storage = HoodieStorageUtils.getStorage(storagePath, storageConf);
+          return listEligibleFiles(storage, storagePath, lastCheckpointTime).stream();
         }, partitionsListParallelism);
     // sort them by modification time ascending.
-    List<FileStatus> sortedEligibleFiles = eligibleFiles.stream()
-        .sorted(Comparator.comparingLong(FileStatus::getModificationTime)).collect(Collectors.toList());
+    List<StoragePathInfo> sortedEligibleFiles = eligibleFiles.stream()
+        .sorted(Comparator.comparingLong(StoragePathInfo::getModificationTime))
+        .collect(Collectors.toList());
 
     // Filter based on checkpoint & input size, if needed
     long currentBytes = 0;
     long newCheckpointTime = lastCheckpointTime;
-    List<FileStatus> filteredFiles = new ArrayList<>();
-    for (FileStatus f : sortedEligibleFiles) {
-      if (currentBytes + f.getLen() >= sourceLimit && f.getModificationTime() > newCheckpointTime) {
+    List<StoragePathInfo> filteredFiles = new ArrayList<>();
+    for (StoragePathInfo f : sortedEligibleFiles) {
+      if (currentBytes + f.getLength() >= sourceLimit && f.getModificationTime() > newCheckpointTime) {
         // we have enough data, we are done
         // Also, we've read up to a file with a newer modification time
         // so that some files with the same modification time won't be skipped in next read
@@ -157,7 +160,7 @@ public class DatePartitionPathSelector extends DFSPathSelector {
       }
 
       newCheckpointTime = f.getModificationTime();
-      currentBytes += f.getLen();
+      currentBytes += f.getLength();
       filteredFiles.add(f);
     }
 
@@ -176,24 +179,27 @@ public class DatePartitionPathSelector extends DFSPathSelector {
    * Prunes date level partitions to last few days configured by 'NUM_PREV_DAYS_TO_LIST' from
    * 'CURRENT_DATE'. Parallelizes listing by leveraging HoodieSparkEngineContext's methods.
    */
-  public List<String> pruneDatePartitionPaths(HoodieSparkEngineContext context, FileSystem fs, String rootPath, LocalDate currentDate) {
+  public List<String> pruneDatePartitionPaths(HoodieSparkEngineContext context,
+                                              HoodieStorage storage,
+                                              String rootPath,
+                                              LocalDate currentDate) {
     List<String> partitionPaths = new ArrayList<>();
     // get all partition paths before date partition level
     partitionPaths.add(rootPath);
     if (datePartitionDepth <= 0) {
       return partitionPaths;
     }
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(fs.getConf());
+    HadoopStorageConfiguration storageConf = (HadoopStorageConfiguration) storage.getConf();
     for (int i = 0; i < datePartitionDepth; i++) {
       partitionPaths = context.flatMap(partitionPaths, path -> {
-        Path subDir = new Path(path);
-        FileSystem fileSystem = subDir.getFileSystem(storageConf.unwrap());
+        StoragePath subDir = new StoragePath(path);
+        HoodieStorage hoodieStorage = HoodieStorageUtils.getStorage(subDir, storageConf);
         // skip files/dirs whose names start with (_, ., etc)
-        FileStatus[] statuses = fileSystem.listStatus(subDir,
+        List<StoragePathInfo> pathInfos = hoodieStorage.listDirectEntries(subDir,
             file -> IGNORE_FILEPREFIX_LIST.stream().noneMatch(pfx -> file.getName().startsWith(pfx)));
         List<String> res = new ArrayList<>();
-        for (FileStatus status : statuses) {
-          res.add(status.getPath().toString());
+        for (StoragePathInfo pathInfo : pathInfos) {
+          res.add(pathInfo.getPath().toString());
         }
         return res.stream();
       }, partitionsListParallelism);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
@@ -23,11 +23,10 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestDFSPathSelectorCommonMethods extends HoodieSparkClientTestHarness {
 
   TypedProperties props;
-  Path inputPath;
+  StoragePath inputPath;
 
   @BeforeEach
   void setUp() {
@@ -57,7 +56,7 @@ public class TestDFSPathSelectorCommonMethods extends HoodieSparkClientTestHarne
     props = new TypedProperties();
     props.setProperty(ROOT_INPUT_PATH.key(), basePath);
     props.setProperty(PARTITIONS_LIST_PARALLELISM.key(), "1");
-    inputPath = new Path(basePath);
+    inputPath = new StoragePath(basePath);
   }
 
   @AfterEach
@@ -73,8 +72,7 @@ public class TestDFSPathSelectorCommonMethods extends HoodieSparkClientTestHarne
     createBaseFile(basePath, "p1", "000", ".foo2", 1);
     createBaseFile(basePath, "p1", "000", "_foo3", 1);
 
-    List<FileStatus> eligibleFiles = selector.listEligibleFiles(
-        (FileSystem) storage.getFileSystem(), inputPath, 0);
+    List<StoragePathInfo> eligibleFiles = selector.listEligibleFiles(storage, inputPath, 0);
     assertEquals(1, eligibleFiles.size());
     assertTrue(eligibleFiles.get(0).getPath().getName().startsWith("foo1"));
   }
@@ -87,8 +85,7 @@ public class TestDFSPathSelectorCommonMethods extends HoodieSparkClientTestHarne
     createBaseFile(basePath, "p1", "000", "foo2", 0);
     createBaseFile(basePath, "p1", "000", "foo3", 0);
 
-    List<FileStatus> eligibleFiles = selector.listEligibleFiles(
-        (FileSystem) storage.getFileSystem(), inputPath, 0);
+    List<StoragePathInfo> eligibleFiles = selector.listEligibleFiles(storage, inputPath, 0);
     assertEquals(1, eligibleFiles.size());
     assertTrue(eligibleFiles.get(0).getPath().getName().startsWith("foo1"));
   }
@@ -101,8 +98,7 @@ public class TestDFSPathSelectorCommonMethods extends HoodieSparkClientTestHarne
     createBaseFile(basePath, "p1", "000", "foo2", 1);
     createBaseFile(basePath, "p1", "000", "foo3", 1);
 
-    List<FileStatus> eligibleFiles = selector.listEligibleFiles(
-        (FileSystem) storage.getFileSystem(), inputPath, Long.MAX_VALUE);
+    List<StoragePathInfo> eligibleFiles = selector.listEligibleFiles(storage, inputPath, Long.MAX_VALUE);
     assertEquals(0, eligibleFiles.size());
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDatePartitionPathSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDatePartitionPathSelector.java
@@ -24,7 +24,6 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -217,7 +216,7 @@ public class TestDatePartitionPathSelector extends HoodieSparkClientTestHarness 
     createDatePartitionsWithFiles(leafDirs, isHiveStylePartition, dateFormat);
 
     List<String> paths = pathSelector.pruneDatePartitionPaths(
-        context, (FileSystem) storage.getFileSystem(), root.toString(), LocalDate.parse(currentDate));
+        context, storage, root.toString(), LocalDate.parse(currentDate));
     assertEquals(expectedNumFiles, paths.size());
   }
 }


### PR DESCRIPTION
Replace filesystem and related classes with HoodieStorage around DFSPathSelector. This refactoring helps centralize the FS usages

### Change Logs

FileSystem -> HoodieStorage
Path -> StoragePath
FileStatus -> StoragePathInfo

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
