### PR TITLE
[MINOR] Have BaseWriterCommitMessage implement Serializable

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/BaseWriterCommitMessage.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/BaseWriterCommitMessage.java
@@ -20,13 +20,14 @@ package org.apache.hudi.internal;
 
 import org.apache.hudi.client.WriteStatus;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * Base class for HoodieWriterCommitMessage used by Spark datasource v2.
  */
-public class BaseWriterCommitMessage {
+public class BaseWriterCommitMessage implements Serializable {
 
   private List<WriteStatus> writeStatuses;
 


### PR DESCRIPTION
### Change Logs

Have BaseWriterCommitMessage implement Serializable. Recently we are exploring using Hudi with JavaSerializer instead of Kryo and found this minor gap. It shouldn't impact existing Hudi code.

### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
