### PR TITLE
[HUDI-8200] Adding support to configure view storage type with HoodieMetadataTableValidator

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -299,7 +299,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
     public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
 
-    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing. Supported values are MEMORY and SPILLABLE_DISK", required = false)
+    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
     public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--validate-record-index-count"},

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -299,7 +299,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing", required = false)
     public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
 
-    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing", required = false)
+    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing. Supported values are MEMORY and SPILLABLE_DISK", required = false)
     public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--validate-record-index-count"},

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -23,6 +23,7 @@ import org.apache.hudi.async.HoodieAsyncService;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
@@ -48,12 +49,16 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.table.view.SpillableMapBasedFileSystemView;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.FileFormatUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
@@ -290,6 +295,12 @@ public class HoodieMetadataTableValidator implements Serializable {
 
     @Parameter(names = {"--validate-bloom-filters"}, description = "Validate bloom filters of base files", required = false)
     public boolean validateBloomFilters = false;
+
+    @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing", required = false)
+    public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
+
+    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing", required = false)
+    public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--validate-record-index-count"},
         description = "Validate the number of entries in the record index, which should be equal "
@@ -528,9 +539,9 @@ public class HoodieMetadataTableValidator implements Serializable {
     }
 
     try (HoodieMetadataValidationContext metadataTableBasedContext =
-             new HoodieMetadataValidationContext(engineContext, props, metaClient, true);
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, true, cfg.viewStorageTypeForMetadata);
          HoodieMetadataValidationContext fsBasedContext =
-             new HoodieMetadataValidationContext(engineContext, props, metaClient, false)) {
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, false, cfg.viewStorageTypeForFSListing)) {
       Set<String> finalBaseFilesForCleaning = baseFilesForCleaning;
       List<Pair<Boolean, ? extends Exception>> result = new ArrayList<>(
           engineContext.parallelize(allPartitions, allPartitions.size()).map(partitionPath -> {
@@ -1395,8 +1406,9 @@ public class HoodieMetadataTableValidator implements Serializable {
 
     public HoodieMetadataValidationContext(
         HoodieEngineContext engineContext, Properties props, HoodieTableMetaClient metaClient,
-        boolean enableMetadataTable) {
-      this.props = props;
+        boolean enableMetadataTable, String viewStorageType) {
+      this.props = new Properties();
+      this.props.putAll(props);
       this.metaClient = metaClient;
       this.enableMetadataTable = enableMetadataTable;
       HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
@@ -1405,12 +1417,33 @@ public class HoodieMetadataTableValidator implements Serializable {
           .withMetadataIndexColumnStats(enableMetadataTable)
           .withEnableRecordIndex(enableMetadataTable)
           .build();
-      this.fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
-          metaClient, metadataConfig);
+      props.put(FileSystemViewStorageConfig.VIEW_TYPE.key(), viewStorageType);
+      FileSystemViewStorageConfig viewConf = FileSystemViewStorageConfig.newBuilder().fromProperties(props).build();
+      ValidationUtils.checkArgument(viewConf.getStorageType().name().equals(viewStorageType), "View storage type not reflected");
+      HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().fromProperties(props).build();
+      this.fileSystemView = getFileSystemView(engineContext,
+          metaClient, metadataConfig, viewConf, commonConfig);
       this.tableMetadata = HoodieTableMetadata.create(
           engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString());
       if (metaClient.getCommitsTimeline().filterCompletedInstants().countInstants() > 0) {
         this.allColumnNameList = getAllColumnNames();
+      }
+    }
+
+    private HoodieTableFileSystemView getFileSystemView(HoodieEngineContext context,
+                                                        HoodieTableMetaClient metaClient, HoodieMetadataConfig metadataConfig,
+                                                        FileSystemViewStorageConfig viewConf, HoodieCommonConfig commonConfig) {
+      HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+      switch (viewConf.getStorageType()) {
+        case SPILLABLE_DISK:
+          LOG.debug("Creating Spillable Disk based Table View");
+          return new SpillableMapBasedFileSystemView(metaClient, timeline, viewConf, commonConfig);
+        case MEMORY:
+          LOG.debug("Creating in-memory based Table View");
+          return FileSystemViewManager.createInMemoryFileSystemView(context,
+              metaClient, metadataConfig);
+        default:
+          throw new HoodieException("Unsupported storage type " + viewConf.getStorageType() + ", used with HoodieMetadataTableValidator");
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -296,7 +296,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--validate-bloom-filters"}, description = "Validate bloom filters of base files", required = false)
     public boolean validateBloomFilters = false;
 
-    @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing", required = false)
+    @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
     public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing. Supported values are MEMORY and SPILLABLE_DISK", required = false)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -296,12 +296,6 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--validate-bloom-filters"}, description = "Validate bloom filters of base files", required = false)
     public boolean validateBloomFilters = false;
 
-    @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
-    public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
-
-    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata table based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
-    public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
-
     @Parameter(names = {"--validate-record-index-count"},
         description = "Validate the number of entries in the record index, which should be equal "
             + "to the number of record keys in the latest snapshot of the table",
@@ -318,6 +312,18 @@ public class HoodieMetadataTableValidator implements Serializable {
         description = "Number of error samples to show for record index validation",
         required = false)
     public int numRecordIndexErrorSamples = 100;
+
+    @Parameter(names = {"--view-storage-type-fs-listing"},
+        description = "View storage type to use for File System based listing. "
+            + "Supported values are MEMORY (by default) and SPILLABLE_DISK.",
+        required = false)
+    public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
+
+    @Parameter(names = {"--view-storage-type-mdt"},
+        description = "View storage type to use for metadata table based listing. "
+            + "Supported values are MEMORY (by default) and SPILLABLE_DISK.",
+        required = false)
+    public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--min-validate-interval-seconds"},
         description = "the min validate interval of each validate when set --continuous, default is 10 minutes.")
@@ -367,6 +373,8 @@ public class HoodieMetadataTableValidator implements Serializable {
           + "   --validate-record-index-count " + validateRecordIndexCount + ", \n"
           + "   --validate-record-index-content " + validateRecordIndexContent + ", \n"
           + "   --num-record-index-error-samples " + numRecordIndexErrorSamples + ", \n"
+          + "   --view-storage-type-fs-listing " + viewStorageTypeForFSListing + ", \n"
+          + "   --view-storage-type-mdt " + viewStorageTypeForMetadata + ", \n"
           + "   --continuous " + continuous + ", \n"
           + "   --skip-data-files-for-cleaning " + skipDataFilesForCleaning + ", \n"
           + "   --ignore-failed " + ignoreFailed + ", \n"
@@ -400,6 +408,8 @@ public class HoodieMetadataTableValidator implements Serializable {
           && Objects.equals(validateBloomFilters, config.validateBloomFilters)
           && Objects.equals(validateRecordIndexCount, config.validateRecordIndexCount)
           && Objects.equals(validateRecordIndexContent, config.validateRecordIndexContent)
+          && Objects.equals(viewStorageTypeForFSListing, config.viewStorageTypeForFSListing)
+          && Objects.equals(viewStorageTypeForMetadata, config.viewStorageTypeForMetadata)
           && Objects.equals(numRecordIndexErrorSamples, config.numRecordIndexErrorSamples)
           && Objects.equals(minValidateIntervalSeconds, config.minValidateIntervalSeconds)
           && Objects.equals(parallelism, config.parallelism)
@@ -417,6 +427,7 @@ public class HoodieMetadataTableValidator implements Serializable {
       return Objects.hash(basePath, continuous, skipDataFilesForCleaning, validateLatestFileSlices,
           validateLatestBaseFiles, validateAllFileGroups, validateAllColumnStats, validateBloomFilters,
           validateRecordIndexCount, validateRecordIndexContent, numRecordIndexErrorSamples,
+          viewStorageTypeForFSListing, viewStorageTypeForMetadata,
           minValidateIntervalSeconds, parallelism, recordIndexParallelism, ignoreFailed,
           sparkMaster, sparkMemory, assumeDatePartitioning, propsFilePath, configs, help);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -299,7 +299,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--view-storage-type-fs-listing"}, description = "View storage type to use for File System based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
     public String viewStorageTypeForFSListing = FileSystemViewStorageType.MEMORY.name();
 
-    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
+    @Parameter(names = {"--view-storage-type-mdt"}, description = "View storage type to use for metadata table based listing. Supported values are MEMORY (by default) and SPILLABLE_DISK.", required = false)
     public String viewStorageTypeForMetadata = FileSystemViewStorageType.MEMORY.name();
 
     @Parameter(names = {"--validate-record-index-count"},


### PR DESCRIPTION
### Change Logs

- Adding support to configure view storage type with HoodieMetadataTableValidator. We are adding two new config params, named "view-storage-type-fs-listing" and "view-storage-type-mdt" to configure different view storage types for FileSystem listing and MDT based listing. Possible values are "MEMORY" and "SPILLABLE_DISK". 

### Impact

Adding support to configure view storage type with HoodieMetadataTableValidator. We are adding two new config params, named "view-storage-type-fs-listing" and "view-storage-type-mdt" to configure different view storage types for FileSystem listing and MDT based listing. Possible values are "MEMORY" and "SPILLABLE_DISK". 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
