### PR TITLE
[HUDI-8191] Fix MockStateInitializationContext#getKeyedStateStore to use non-KeyedStateStore

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
@@ -150,7 +150,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
     // checkpoint the coordinator first
     this.coordinator.checkpointCoordinator(checkpointId, new CompletableFuture<>());
     writeFunction.snapshotState(new MockFunctionSnapshotContext(checkpointId));
-    stateInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
+    stateInitializationContext.checkpointBegin(checkpointId);
   }
 
   public void endInput() {
@@ -158,7 +158,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   }
 
   public void checkpointComplete(long checkpointId) {
-    stateInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
+    stateInitializationContext.checkpointSuccess(checkpointId);
     coordinator.notifyCheckpointComplete(checkpointId);
     if (asyncCompaction) {
       try {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
@@ -76,6 +76,6 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
     this.coordinator.checkpointCoordinator(checkpointId, new CompletableFuture<>());
     writeFunction.snapshotState(functionSnapshotContext);
     assignFunction.snapshotState(functionSnapshotContext);
-    stateInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
+    stateInitializationContext.checkpointBegin(checkpointId);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
@@ -126,7 +126,7 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.coordinator.checkpointCoordinator(checkpointId, new CompletableFuture<>());
 
     writeFunction.snapshotState(new MockFunctionSnapshotContext(checkpointId));
-    stateInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
+    stateInitializationContext.checkpointBegin(checkpointId);
   }
 
   @Override
@@ -135,7 +135,7 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void checkpointComplete(long checkpointId) {
-    stateInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
+    stateInitializationContext.checkpointSuccess(checkpointId);
     coordinator.notifyCheckpointComplete(checkpointId);
     if (asyncClustering) {
       try {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockKeyedStateStore.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockKeyedStateStore.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.hudi.sink.utils.keyedstate.MockKeyContext;
+import org.apache.hudi.sink.utils.keyedstate.MockKeyedListState;
+import org.apache.hudi.sink.utils.keyedstate.MockKeyedMapState;
+import org.apache.hudi.sink.utils.keyedstate.MockKeyedValueState;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * This class simulates a keyed state store for testing purposes.
+ * It provides methods to manage different types of state (ValueState, ListState, MapState)
+ * and supports checkpointing and rollback functionalities.
+ */
+@SuppressWarnings("rawtypes")
+public class MockKeyedStateStore implements KeyedStateStore {
+  private final MockKeyContext keyContext;
+
+  private Map<String, MockKeyedValueState> keyedValueStateMap;
+  private Map<String, MockKeyedListState> keyedListStateMap;
+  private Map<String, MockKeyedMapState> keyedMapStateMap;
+
+  private final Map<Long, Map<String, MockKeyedValueState>> historyValueStateMap;
+  private final Map<Long, Map<String, MockKeyedListState>> historyListStateMap;
+  private final Map<Long, Map<String, MockKeyedMapState>> historyMapStateMap;
+
+  private Map<String, MockKeyedValueState> lastSuccessValueStateMap;
+  private Map<String, MockKeyedListState> lastSuccessListStateMap;
+  private Map<String, MockKeyedMapState> lastSuccessMapStateMap;
+
+  public MockKeyedStateStore() {
+    this.keyContext = new MockKeyContext();
+
+    this.keyedValueStateMap = new HashMap<>();
+    this.keyedListStateMap = new HashMap<>();
+    this.keyedMapStateMap = new HashMap<>();
+
+    this.historyValueStateMap = new HashMap<>();
+    this.historyListStateMap = new HashMap<>();
+    this.historyMapStateMap = new HashMap<>();
+
+    this.lastSuccessValueStateMap = new HashMap<>();
+    this.lastSuccessListStateMap = new HashMap<>();
+    this.lastSuccessMapStateMap = new HashMap<>();
+  }
+
+  @Override
+  public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
+    String name = stateProperties.getName();
+    keyedValueStateMap.putIfAbsent(name, new MockKeyedValueState<T>(keyContext));
+    return keyedValueStateMap.get(name);
+  }
+
+  @Override
+  public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
+    String name = stateProperties.getName();
+    keyedListStateMap.putIfAbsent(name, new MockKeyedListState<T>(keyContext));
+    return keyedListStateMap.get(name);
+  }
+
+  @Override
+  public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
+    throw new UnsupportedOperationException("getReducingState is not supported yet");
+  }
+
+  @Override
+  public <I, A, O> AggregatingState<I, O> getAggregatingState(AggregatingStateDescriptor<I, A, O> stateProperties) {
+    throw new UnsupportedOperationException("getAggregatingState is not supported yet");
+  }
+
+  @Override
+  public <K, V> MapState<K, V> getMapState(MapStateDescriptor<K, V> stateProperties) {
+    String name = stateProperties.getName();
+    keyedMapStateMap.putIfAbsent(name, new MockKeyedMapState(keyContext));
+    return keyedMapStateMap.get(name);
+  }
+
+  public void setCurrentKey(Object currentKey) {
+    Objects.requireNonNull(currentKey, "currentKey is null");
+    keyContext.setCurrentKey(currentKey);
+  }
+
+  public void checkpointBegin(long checkpointId) throws Exception {
+    historyValueStateMap.put(checkpointId, copyKeyedValueStates(keyedValueStateMap));
+
+    historyListStateMap.put(checkpointId, copyKeyedListStates(keyedListStateMap));
+
+    historyMapStateMap.put(checkpointId, copyKeyedMapStates(keyedMapStateMap));
+  }
+
+  public void checkpointSuccess(long checkpointId) {
+    lastSuccessValueStateMap = historyValueStateMap.get(checkpointId);
+    lastSuccessListStateMap = historyListStateMap.get(checkpointId);
+    lastSuccessMapStateMap = historyMapStateMap.get(checkpointId);
+  }
+
+  public void rollBackToLastSuccessCheckpoint() {
+    this.keyedValueStateMap = copyKeyedValueStates(lastSuccessValueStateMap);
+    this.keyedListStateMap = copyKeyedListStates(lastSuccessListStateMap);
+    this.keyedMapStateMap = copyKeyedMapStates(lastSuccessMapStateMap);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, MockKeyedValueState> copyKeyedValueStates(Map<String, MockKeyedValueState> keyedValueStateMap) {
+    return Collections.unmodifiableMap(keyedValueStateMap.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, entry -> (MockKeyedValueState) entry.getValue().clone())));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, MockKeyedListState> copyKeyedListStates(Map<String, MockKeyedListState> keyedListStateMap) {
+    return Collections.unmodifiableMap(keyedListStateMap.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, entry -> (MockKeyedListState) entry.getValue().clone())));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, MockKeyedMapState> copyKeyedMapStates(Map<String, MockKeyedMapState> keyedMapStateMap) {
+    return Collections.unmodifiableMap(keyedMapStateMap.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, entry -> (MockKeyedMapState) entry.getValue().clone())));
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockOperatorStateStore.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockOperatorStateStore.java
@@ -17,19 +17,11 @@
 
 package org.apache.hudi.sink.utils;
 
-import org.apache.flink.api.common.state.AggregatingState;
-import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.state.BroadcastState;
-import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
-import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
-import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils;
 
 import java.util.Collections;
@@ -41,79 +33,48 @@ import java.util.Set;
  * An {@link OperatorStateStore} for testing purpose.
  */
 @SuppressWarnings("rawtypes")
-public class MockOperatorStateStore implements KeyedStateStore, OperatorStateStore {
+public class MockOperatorStateStore implements OperatorStateStore {
+  private Map<String, TestUtils.MockListState> listStateMap;
 
   private final Map<Long, Map<String, TestUtils.MockListState>> historyStateMap;
-
-  private Map<String, TestUtils.MockListState> currentStateMap;
   private Map<String, TestUtils.MockListState> lastSuccessStateMap;
 
-  private MapState mapState;
-  private Map<String, ValueState> valueStateMap;
-
   public MockOperatorStateStore() {
+    this.listStateMap = new HashMap<>();
     this.historyStateMap = new HashMap<>();
-
-    this.currentStateMap = new HashMap<>();
     this.lastSuccessStateMap = new HashMap<>();
-
-    this.mapState = new MockMapState<>();
-    this.valueStateMap = new HashMap<>();
   }
 
   @Override
   public <K, V> BroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) throws Exception {
-    return null;
-  }
-
-  @Override
-  public <T> ValueState<T> getState(ValueStateDescriptor<T> valueStateDescriptor) {
-    String name = valueStateDescriptor.getName();
-    valueStateMap.putIfAbsent(name, new MockValueState());
-    return valueStateMap.get(name);
+    throw new UnsupportedOperationException("getBroadcastState is not supported yet");
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) {
+  public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
     String name = stateDescriptor.getName();
-    currentStateMap.putIfAbsent(name, new TestUtils.MockListState());
-    return currentStateMap.get(name);
-  }
-
-  @Override
-  public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> reducingStateDescriptor) {
-    return null;
-  }
-
-  @Override
-  public <I, A, O> AggregatingState<I, O> getAggregatingState(AggregatingStateDescriptor<I, A, O> aggregatingStateDescriptor) {
-    return null;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <K, V> MapState<K, V> getMapState(MapStateDescriptor<K, V> mapStateDescriptor) {
-    return this.mapState;
+    listStateMap.putIfAbsent(name, new TestUtils.MockListState());
+    return listStateMap.get(name);
   }
 
   @Override
   public <S> ListState<S> getUnionListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("getUnionListState is not supported yet");
   }
 
   @Override
   public Set<String> getRegisteredStateNames() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("getRegisteredStateNames is not supported yet");
   }
 
   @Override
   public Set<String> getRegisteredBroadcastStateNames() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("getRegisteredBroadcastStateNames is not supported yet");
   }
 
   public void checkpointBegin(long checkpointId) {
-    Map<String, TestUtils.MockListState> copiedStates = Collections.unmodifiableMap(copyStates(currentStateMap));
+    Map<String, TestUtils.MockListState> copiedStates = Collections.unmodifiableMap(copyStates(listStateMap));
     historyStateMap.put(checkpointId, copiedStates);
   }
 
@@ -121,12 +82,8 @@ public class MockOperatorStateStore implements KeyedStateStore, OperatorStateSto
     lastSuccessStateMap = historyStateMap.get(checkpointId);
   }
 
-  public boolean isRestored() {
-    return !this.currentStateMap.isEmpty();
-  }
-
   public void rollBackToLastSuccessCheckpoint() {
-    this.currentStateMap = copyStates(lastSuccessStateMap);
+    this.listStateMap = copyStates(lastSuccessStateMap);
   }
 
   @SuppressWarnings("unchecked")

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStateInitializationContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStateInitializationContext.java
@@ -17,7 +17,6 @@
 
 package org.apache.hudi.sink.utils;
 
-import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -25,20 +24,21 @@ import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 
 import java.util.OptionalLong;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * A {@link FunctionInitializationContext} for testing purpose.
  */
 public class MockStateInitializationContext implements StateInitializationContext {
 
   private final MockOperatorStateStore operatorStateStore;
+  private final MockKeyedStateStore keyedStateStore;
+  private long lastCheckpointId;
 
   public MockStateInitializationContext() {
     operatorStateStore = new MockOperatorStateStore();
-  }
-
-  @Override
-  public boolean isRestored() {
-    return operatorStateStore.isRestored();
+    keyedStateStore = new MockKeyedStateStore();
+    lastCheckpointId = -1;
   }
 
   @Override
@@ -47,8 +47,8 @@ public class MockStateInitializationContext implements StateInitializationContex
   }
 
   @Override
-  public KeyedStateStore getKeyedStateStore() {
-    return operatorStateStore;
+  public MockKeyedStateStore getKeyedStateStore() {
+    return keyedStateStore;
   }
 
   @Override
@@ -61,8 +61,31 @@ public class MockStateInitializationContext implements StateInitializationContex
     return null;
   }
 
+  /**
+   * Override function to avoid different implementations in different Flink versions.
+   * @return true if the state is restored from a checkpoint, false otherwise
+   */
+  @Override
+  public boolean isRestored() {
+    return getRestoredCheckpointId().isPresent();
+  }
+
   @Override
   public OptionalLong getRestoredCheckpointId() {
-    return OptionalLong.empty();
+    return this.lastCheckpointId >= 0 ? OptionalLong.of(this.lastCheckpointId) : OptionalLong.empty();
+  }
+
+  public void checkpointBegin(long checkpointId) throws Exception {
+    assertTrue(checkpointId >= 0, "Checkpoint ID must be non-negative, but was: " + checkpointId);
+    getOperatorStateStore().checkpointBegin(checkpointId);
+    getKeyedStateStore().checkpointBegin(checkpointId);
+    this.lastCheckpointId = checkpointId;
+  }
+
+  public void checkpointSuccess(long checkpointId) {
+    assertTrue(checkpointId >= 0, "Checkpoint ID must be non-negative, but was: " + checkpointId);
+    getOperatorStateStore().checkpointSuccess(checkpointId);
+    getKeyedStateStore().checkpointSuccess(checkpointId);
+    this.lastCheckpointId = checkpointId;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStreamingRuntimeContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStreamingRuntimeContext.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Mock {@link StreamingRuntimeContext} to use in tests.
@@ -100,7 +101,8 @@ public class MockStreamingRuntimeContext extends StreamingRuntimeContext {
 
     private transient TestProcessingTimeService testProcessingTimeService;
 
-    private transient MockOperatorStateStore mockOperatorStateStore;
+    private transient Object currentKey;
+    private final transient Map<Object, MockKeyedStateStore> mockKeyedStateStoreMap = new HashMap<>();
 
     @Override
     public ExecutionConfig getExecutionConfig() {
@@ -121,11 +123,13 @@ public class MockStreamingRuntimeContext extends StreamingRuntimeContext {
     }
 
     @Override
+    public void setCurrentKey(Object key) {
+      this.currentKey = key;
+    }
+
+    @Override
     public KeyedStateStore getKeyedStateStore() {
-      if (mockOperatorStateStore == null) {
-        mockOperatorStateStore = new MockOperatorStateStore();
-      }
-      return mockOperatorStateStore;
+      return currentKey != null ? mockKeyedStateStoreMap.computeIfAbsent(currentKey, k -> new MockKeyedStateStore()) : null;
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils.keyedstate;
+
+import org.apache.flink.streaming.api.operators.KeyContext;
+
+/**
+ * Key context for testing.
+ *
+ */
+public class MockKeyContext implements KeyContext {
+  private Object currentKey;
+
+  @Override
+  public void setCurrentKey(Object key) {
+    currentKey = key;
+  }
+
+  @Override
+  public Object getCurrentKey() {
+    return currentKey;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedListState.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedListState.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils.keyedstate;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Mock keyed list state for testing.
+ * @param <T> Type of state value
+ */
+public class MockKeyedListState<T> implements ListState<T>, Cloneable  {
+  private MockKeyContext keyContext;
+  private Map<Object, TestUtils.MockListState<T>> mockListStateMap;
+
+  public MockKeyedListState(MockKeyContext keyContext) {
+    Objects.requireNonNull(keyContext, "keyContext is null");
+    this.keyContext = keyContext;
+  }
+
+  @Override
+  public void update(List<T> values) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    TestUtils.MockListState<T> listState = mockListStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new TestUtils.MockListState<>());
+    listState.update(values);
+  }
+
+  @Override
+  public void addAll(List<T> values) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    TestUtils.MockListState<T> listState = mockListStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new TestUtils.MockListState<>());
+    listState.addAll(values);
+  }
+
+  @Override
+  public Iterable<T> get() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    TestUtils.MockListState<T> listState = mockListStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new TestUtils.MockListState<>());
+    return listState.get();
+  }
+
+  @Override
+  public void add(T value) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    TestUtils.MockListState<T> listState = mockListStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new TestUtils.MockListState<>());
+    listState.add(value);
+  }
+
+  @Override
+  public void clear() {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    TestUtils.MockListState<T> listState = mockListStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new TestUtils.MockListState<>());
+    listState.clear();
+  }
+
+  @Override
+  public Object clone() {
+    try {
+      MockKeyedListState<T> copy = (MockKeyedListState<T>) super.clone();
+
+      // deep copy keyContext
+      MockKeyContext newKeyContext = new MockKeyContext();
+      newKeyContext.setCurrentKey(keyContext.getCurrentKey());
+      copy.keyContext = newKeyContext;
+
+      // deep copy mockListStateMap
+      copy.mockListStateMap = mockListStateMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+        TestUtils.MockListState<T> oldListState = entry.getValue();
+        TestUtils.MockListState<T> newListState = new TestUtils.MockListState<T>();
+        newListState.addAll(oldListState.getBackingList());
+        return newListState;
+      }));
+      return copy;
+    } catch (CloneNotSupportedException ex) {
+      throw new RuntimeException(ex.getMessage());
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedMapState.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedMapState.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils.keyedstate;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.hudi.sink.utils.MockMapState;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Mock keyed map state for testing.
+ * @param <K> Type of state key
+ * @param <V> Type of state value
+ */
+public class MockKeyedMapState<K, V> implements MapState<K, V>, Cloneable {
+  private MockKeyContext keyContext;
+  private Map<Object, MockMapState<K, V>> mockMapStateMap;
+
+  public MockKeyedMapState(MockKeyContext keyContext) {
+    Objects.requireNonNull(keyContext, "keyContext is null");
+    this.keyContext = keyContext;
+  }
+
+  @Override
+  public V get(K key) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.get(key);
+  }
+
+  @Override
+  public void put(K key, V value) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    mapState.put(key, value);
+  }
+
+  @Override
+  public void putAll(Map<K, V> map) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    mapState.putAll(map);
+  }
+
+  @Override
+  public void remove(K key) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    mapState.remove(key);
+  }
+
+  @Override
+  public boolean contains(K key) throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.contains(key);
+  }
+
+  @Override
+  public Iterable<Map.Entry<K, V>> entries() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.entries();
+  }
+
+  @Override
+  public Iterable<K> keys() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.keys();
+  }
+
+  @Override
+  public Iterable<V> values() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.values();
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, V>> iterator() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.iterator();
+  }
+
+  @Override
+  public boolean isEmpty() throws Exception {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    return mapState.isEmpty();
+  }
+
+  @Override
+  public void clear() {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockMapState<K, V> mapState = mockMapStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockMapState<K, V>());
+    mapState.clear();
+  }
+
+  @Override
+  public Object clone() {
+    try {
+      MockKeyedMapState<K, V> copy = (MockKeyedMapState<K, V>) super.clone();
+
+      // deep copy keyContext
+      MockKeyContext newKeyContext = new MockKeyContext();
+      newKeyContext.setCurrentKey(keyContext.getCurrentKey());
+      copy.keyContext = newKeyContext;
+
+      // deep copy mockMapStateMap
+      copy.mockMapStateMap = mockMapStateMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+        MockMapState<K, V> oldMapState = entry.getValue();
+        MockMapState<K, V> newMapState = new MockMapState();
+        oldMapState.entries().forEach(v -> newMapState.put(v.getKey(), v.getValue()));
+        return newMapState;
+      }));
+      return copy;
+    } catch (CloneNotSupportedException ex) {
+      throw new RuntimeException(ex.getMessage());
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedValueState.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/keyedstate/MockKeyedValueState.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils.keyedstate;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.hudi.sink.utils.MockValueState;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Mock keyed list state for testing.
+ * @param <V> Type of state value
+ */
+public class MockKeyedValueState<V> implements ValueState<V>, Cloneable {
+  private MockKeyContext keyContext;
+  private Map<Object, MockValueState<V>> keyValueStateMap;
+
+  public MockKeyedValueState(MockKeyContext keyContext) {
+    Objects.requireNonNull(keyContext, "keyContext is null");
+    this.keyContext = keyContext;
+    this.keyValueStateMap = new HashMap<>();
+  }
+
+  @Override
+  public V value() throws IOException {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockValueState<V> valueState = keyValueStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockValueState<>());
+    return valueState.value();
+  }
+
+  @Override
+  public void update(V value) throws IOException {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    MockValueState<V> valueState = keyValueStateMap.computeIfAbsent(keyContext.getCurrentKey(), k -> new MockValueState<>());
+    valueState.update(value);
+  }
+
+  @Override
+  public void clear() {
+    Objects.requireNonNull(keyContext.getCurrentKey(), "currentKey is null");
+    keyValueStateMap.remove(keyContext.getCurrentKey());
+  }
+
+  @Override
+  public Object clone() {
+    try {
+      MockKeyedValueState<V> copy = (MockKeyedValueState<V>) super.clone();
+
+      // deep copy keyContext
+      MockKeyContext newKeyContext = new MockKeyContext();
+      newKeyContext.setCurrentKey(keyContext.getCurrentKey());
+      copy.keyContext = newKeyContext;
+
+      // deep copy keyValueStateMap
+      copy.keyValueStateMap = keyValueStateMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+        MockValueState<V> oldValueState = entry.getValue();
+        MockValueState<V> newValueState = new MockValueState<>();
+        newValueState.update(oldValueState.value());
+        return newValueState;
+      }));
+      return copy;
+    } catch (CloneNotSupportedException ex) {
+      throw new RuntimeException(ex.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

hudi-flink UnitTest uses MockOperatorStateStore as the storage behind the state of KeyedStream. Because MockOperatorStateStore does not consider the key, stateful KeyedStream operators such as BucketAssignFunction are invalid for some tests because MockOperatorStateStore considers all input records to be duplicates, even if the key is different.

We added support for KeyedStream operators with MockKeyedStateStore.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
