### PR TITLE
[MINOR] Remove shaded of codahale metrics in flink bundle.

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -194,10 +194,6 @@
                   <shadedPattern>${flink.bundle.shade.prefix}com.beust.jcommander.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.codahale.metrics.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}com.codahale.metrics.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.commons.codec.</pattern>
                   <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.codec.</shadedPattern>
                 </relocation>


### PR DESCRIPTION

### Change Logs

Remove shaded of codahale metrics in flink bundle for hudi-0.14.2
backport from [https://github.com/apache/hudi/pull/10723](url)

### Impact
Remove shaded of codahale metrics in flink bundle，and then we can register write metrics to flink correctly.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NONE
### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
