### PR TITLE
[HUDI-8213]  Exclude jackson-databind from hudi-spark-bundle to fix CVE-2017-17485

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -204,6 +204,7 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/services/javax.*</exclude>
+                    <exclude>META-INF/maven/com.fasterxml.jackson.core/jackson-databind/*</exclude>
                     <exclude>**/*.proto</exclude>
                     <exclude>hbase-webapps/**</exclude>
                     <!-- hbase-default.xml comes from hbase-common, hbase related classes used in hudi are in shaded


### PR DESCRIPTION

### Change Logs

We are seeing Critical level CVE CVE-2017-17485 in Hudi. And it is traced out from HTrace component(which uses jackson-databind version 2.4.0). So it is good to exclude  jackson-databind in packaging hudi-spark-bundle module.

![Uploading Screenshot 2024-09-18 at 6.29.04 PM.png…]()

### Impact

No performance change, but fixing CRITICAL CVE CVE-2017-17485.

### Risk level (write none, low medium or high below)

CRITICAL

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
