### PR TITLE
Fix CVE-2023-39410 and CVE-2020-13956 from hudi-presto-bundle

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -210,6 +210,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <version>1.11.3</version>
       <scope>compile</scope>
     </dependency>
 
@@ -238,6 +239,13 @@
       <artifactId>protobuf-java</artifactId>
       <version>${proto.version}</version>
       <scope>${presto.bundle.bootstrap.scope}</scope>
+    </dependency>
+
+    <!--httpclient needs to be updated to 4.5.13 due to vulnerability in lower versions -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Upgrade httpclient  version to 4.5.13
Upgrade avro version to 1.11.3

### Change Logs
This issue will address the below CVE from hudi-presto-bundle:0.14.0 jar
https://nvd.nist.gov/vuln/detail/CVE-2023-39410
https://nvd.nist.gov/vuln/detail/CVE-2020-13956

### Impact

No user facing impacts

### Risk level (write none, low medium or high below)

Included the new changes in presto and we haven't seen any regression issues

### Documentation Update
None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
