### PR TITLE
[HUDI-8238] Skip this log file instead of skipping all log files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -253,10 +253,13 @@ public abstract class AbstractHoodieLogRecordReader {
         final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
         totalLogBlocks.incrementAndGet();
         if (logBlock.getBlockType() != CORRUPT_BLOCK
-            && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
+            && !HoodieTimeline.compareTimestamps(instantTime, HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
         )) {
           // hit a block with instant time greater than should be processed, stop processing further
-          break;
+          // skip current log file
+          LOG.info("Skipping log file {} as it has instant time: {} greater than latest instant time: {}", logFile.getPath(), instantTime, latestInstantTime);
+          logFormatReaderWrapper.nextLogFile();
+          continue;
         }
         if (logBlock.getBlockType() != CORRUPT_BLOCK && logBlock.getBlockType() != COMMAND_BLOCK) {
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
@@ -440,10 +443,13 @@ public abstract class AbstractHoodieLogRecordReader {
           totalCorruptBlocks.incrementAndGet();
           continue;
         }
-        if (!HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME),
+        if (!HoodieTimeline.compareTimestamps(instantTime,
             HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime)) {
           // hit a block with instant time greater than should be processed, stop processing further
-          break;
+          // skip current log file
+          LOG.info("Skipping log file {} as it has instant time: {} greater than latest instant time: {}", logFile.getPath(), instantTime, latestInstantTime);
+          logFormatReaderWrapper.nextLogFile();
+          continue;
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {


### PR DESCRIPTION
1. Skip this log file instead of skipping all log files when scan a log file which is written later.
 close issue: https://github.com/apache/hudi/issues/11986
close jira: https://issues.apache.org/jira/browse/HUDI-8238
### Change Logs
Skip this log file instead of skipping all log files when scan a log file which is written later
_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
