### PR TITLE
[HUDI-8248] Fixing Log Record reader to include rollback blocks with timestamps > maxInstant times

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -240,7 +240,7 @@ public class HoodieIndexUtils {
       HoodieData<Pair<String, String>> partitionLocations, HoodieWriteConfig config, HoodieTable hoodieTable) {
     final Option<String> instantTime = hoodieTable
         .getMetaClient()
-        .getCommitsTimeline()
+        .getActiveTimeline() // we need to include all actions and completed
         .filterCompletedInstants()
         .lastInstant()
         .map(HoodieInstant::getTimestamp);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -254,11 +254,10 @@ public abstract class AbstractHoodieLogRecordReader {
         HoodieLogBlock logBlock = logFormatReaderWrapper.next();
         final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
         totalLogBlocks.incrementAndGet();
-        if (logBlock.getBlockType() != CORRUPT_BLOCK
-            && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
+        if (logBlock.isDataOrDeleteBlock() && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
         )) {
-          // hit a block with instant time greater than should be processed, stop processing further
-          break;
+          // hit a data block with instant time greater than should be processed, ignore processing the block
+          continue;
         }
         if (logBlock.getBlockType() != CORRUPT_BLOCK && logBlock.getBlockType() != COMMAND_BLOCK) {
           if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -95,6 +95,10 @@ public abstract class HoodieLogBlock {
 
   public abstract HoodieLogBlockType getBlockType();
 
+  public boolean isDataOrDeleteBlock() {
+    return getBlockType() != HoodieLogBlockType.COMMAND_BLOCK && getBlockType() != HoodieLogBlockType.CORRUPT_BLOCK;
+  }
+
   public long getLogBlockLength() {
     throw new HoodieException("No implementation was provided");
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -25,14 +25,19 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,6 +47,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
@@ -70,6 +76,19 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
         Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
         Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM),
         Arguments.of(MERGE_ON_READ, RECORD_INDEX)
+    );
+  }
+
+  private static Stream<Arguments> getTableTypeAndIndexTypeUpdateOrDelete() {
+    return Stream.of(
+        Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE, true),
+        Arguments.of(COPY_ON_WRITE, RECORD_INDEX, true),
+        Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE, false),
+        Arguments.of(COPY_ON_WRITE, RECORD_INDEX, false),
+        Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE, true),
+        Arguments.of(MERGE_ON_READ, RECORD_INDEX, true),
+        Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE, false),
+        Arguments.of(MERGE_ON_READ, RECORD_INDEX, false)
     );
   }
 
@@ -126,6 +145,92 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       client.startCommitWithTime(commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
       readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
+    }
+  }
+
+  /**
+   * Tests getTableTypeAndIndexTypeUpdateOrDelete
+   * @throws IOException
+   */
+  @ParameterizedTest
+  @MethodSource("getTableTypeAndIndexTypeUpdateOrDelete")
+  public void testRollbacksWithPartitionUpdate(HoodieTableType tableType, IndexType indexType, boolean isUpsert) throws IOException {
+    final Class<?> payloadClass = DefaultHoodieRecordPayload.class;
+    HoodieWriteConfig writeConfig = getWriteConfig(payloadClass, indexType);
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
+    List<HoodieRecord> updatesAtEpoch5 = null;
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      final int totalRecords = 8;
+      final String p1 = "p1";
+      final String p2 = "p2";
+
+      // 1st batch: inserts
+      String commitTimeAtEpoch0 = HoodieActiveTimeline.createNewInstantTime();
+      List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, p1, 0, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 2), commitTimeAtEpoch0).collect());
+
+      // 2nd batch: update 4 records from p1 to p2
+      String commitTimeAtEpoch5 = HoodieActiveTimeline.createNewInstantTime();
+      updatesAtEpoch5 = getUpdates(insertsAtEpoch0.subList(0, 4), p2, 5, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch5);
+      if (isUpsert) {
+        assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch5).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 5);
+      } else {
+        assertNoWriteErrors(client.delete(jsc().parallelize(updatesAtEpoch5.stream().map(hoodieRecord -> hoodieRecord.getKey()).collect(Collectors.toList()), 2), commitTimeAtEpoch5).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {}, p2, 0);
+      }
+      // simuate crash. delete latest completed dc.
+      String latestCompletedDeltaCommit = metaClient.reloadActiveTimeline().getCommitsAndCompactionTimeline().lastInstant().get().getFileName();
+      metaClient.getFs().delete(new Path(metaClient.getBasePathV2() + "/.hoodie/" + latestCompletedDeltaCommit));
+
+    }
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      final String p1 = "p1";
+      final String p2 = "p2";
+      final String p3 = "p3";
+
+      // re-ingest same batch
+      String commitTimeAtEpoch10 = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(commitTimeAtEpoch10);
+      if (isUpsert) {
+        assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch10).collect());
+        // this also tests snapshot query. We had a bug where MOR snapshot was ignoring rollbacks while determining last instant while reading log records.
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 5);
+      } else {
+        assertNoWriteErrors(client.delete(jsc().parallelize(updatesAtEpoch5.stream().map(hoodieRecord -> hoodieRecord.getKey()).collect(Collectors.toList()), 2), commitTimeAtEpoch10).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {}, p2, 0);
+      }
+
+      // upsert test
+      // update 4 of them from p2 to p3.
+      // delete test:
+      // update 4 of them to p3. these are treated as new inserts since they are deleted. no changes should be seen wrt p2.
+      String commitTimeAtEpoch15 = HoodieActiveTimeline.createNewInstantTime();
+      List<HoodieRecord> updatesAtEpoch15 = getUpdates(updatesAtEpoch5, p3, 15, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch15);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch15, 2), commitTimeAtEpoch15).collect());
+      // for the same bug pointed out earlier, (ignoring rollbacks while determining last instant while reading log records), this tests the HoodieMergedReadHandle.
+      readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p3, 15);
+
+      // lets move 2 of them back to p1
+      String commitTimeAtEpoch20 = HoodieActiveTimeline.createNewInstantTime();
+      List<HoodieRecord> updatesAtEpoch20 = getUpdates(updatesAtEpoch5.subList(0, 2), p1, 20, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch20);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch20, 1), commitTimeAtEpoch20).collect());
+      // for the same bug pointed out earlier, (ignoring rollbacks while determining last instant while reading log records), this tests the HoodieMergedReadHandle.
+      Map<String, Long> expectedTsMap = new HashMap<>();
+      Arrays.stream(new int[] {0, 1}).forEach(entry -> expectedTsMap.put(String.valueOf(entry), 20L));
+      Arrays.stream(new int[] {4, 5, 6, 7}).forEach(entry -> expectedTsMap.put(String.valueOf(entry), 0L));
+      readTableAndValidate(metaClient, new int[] {0, 1, 4, 5, 6, 7}, p1, expectedTsMap);
+      readTableAndValidate(metaClient, new int[] {2, 3}, p3, 15);
     }
   }
 
@@ -246,9 +351,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
         .select("_hoodie_record_key", "_hoodie_partition_path", "id", "pt", "ts")
         .cache();
     int expectedCount = expectedIds.length;
-    assertEquals(expectedCount, df.count());
     assertEquals(expectedCount, df.filter(String.format("pt = '%s'", expectedPartition)).count());
-    Row[] allRows = (Row[]) df.collect();
+    Row[] allRows = (Row[]) df.filter(String.format("pt = '%s'", expectedPartition)).collect();
     for (int i = 0; i < expectedCount; i++) {
       int expectedId = expectedIds[i];
       Row r = allRows[i];
@@ -283,6 +387,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
             .withGlobalBloomIndexUpdatePartitionPath(true)
             .withGlobalSimpleIndexUpdatePartitionPath(true)
             .withRecordIndexUpdatePartitionPath(true).build())
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withMaxNumDeltaCommitsBeforeCompaction(4).build())
         .withSchema(SCHEMA_STR)
         .withPayloadConfig(HoodiePayloadConfig.newBuilder()
             .fromProperties(getPayloadProps(payloadClass)).build())


### PR DESCRIPTION
### Change Logs

- Fix Log record reading with rollback blocks having higher timestamps compared to maxInstant configured. This fix is required only for 0.x branch. Since with 1.x, we would have ordered log files based on completion time within a file slice. 

### Impact

LogRecordReader takes in a maxInstant time beyond which log blocks are ignored. But w/ rollbacks, there are chances it could lead to data consistency issues. 

Lets go through an illustration: 

Say, we have t1.dc, t2.dc and t2.dc crashed mid way.  
Current layout is, 
```
base file(t1), lf1(partially committed data w/ t2 as instant time)
```

Then we start t5.dc say. just when we start t5.dc, hudi detects pending commit and triggers a rollback. And this rollback will get an instant time of t6 (t6.rb). Note that rollback's commit time is greater than t5 or current ongoing delta commit. 
So, once rollback completes, this is the layout.
```
base file, lf1(from t2.dc partially failed), lf3 (rollback command block with t6). 
```

And once t5.dc completes, this is how the layout looks like 
```
base file, lf1(from t2.dc partially failed), lf3 (rollback command block with t6). lf4 (from t5) 
```

At this point in time, when we trigger snapshot read or try to trigger tagLocation w/ global index, maxInstant is set to last entry among commits timeline which is t5. So, while LogRecordReader while processing all log blocks, when it reaches lf3, it detects the timestamp of t6 > t5 (i.e max instant time) and bails out of for loop. So, in essence it may even read lf4 in above scenario. 

This patch attempts the fix the same. 

Fix: 
We only hold the constraint true for any data blocks and relax it for other block types. For eg, any data blocks > max instant time will be ignored. But all rollback blocks are taken into consideration. 


### Risk level (write none, low medium or high below)

medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
