### PR TITLE
[HUDI-6909] Use isDelete instead of isDeleted function for Spark merger

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
@@ -50,7 +50,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
 
     if (newer instanceof HoodieSparkRecord) {
       HoodieSparkRecord newSparkRecord = (HoodieSparkRecord) newer;
-      if (newSparkRecord.isDeleted()) {
+      if (newSparkRecord.isDelete(newSchema, props)) {
         // Delete record
         return Option.empty();
       }
@@ -63,7 +63,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
 
     if (older instanceof HoodieSparkRecord) {
       HoodieSparkRecord oldSparkRecord = (HoodieSparkRecord) older;
-      if (oldSparkRecord.isDeleted()) {
+      if (oldSparkRecord.isDelete(oldSchema, props)) {
         // use natural order for delete record
         return Option.of(Pair.of(newer, newSchema));
       }
@@ -87,7 +87,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
 
     if (newer instanceof HoodieSparkRecord) {
       HoodieSparkRecord newSparkRecord = (HoodieSparkRecord) newer;
-      if (newSparkRecord.isDeleted()) {
+      if (newSparkRecord.isDelete(newSchema, props)) {
         // Delete record
         return Option.empty();
       }
@@ -100,7 +100,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
 
     if (older instanceof HoodieSparkRecord) {
       HoodieSparkRecord oldSparkRecord = (HoodieSparkRecord) older;
-      if (oldSparkRecord.isDeleted()) {
+      if (oldSparkRecord.isDelete(oldSchema, props)) {
         // use natural order for delete record
         return Option.of(Pair.of(newer, newSchema));
       }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -87,10 +87,6 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
    */
   private final transient StructType schema;
 
-  /**
-   * Record is considered deleted if data is null.
-   */
-  private boolean isDeleted;
   public HoodieSparkRecord(UnsafeRow data) {
     this(data, null);
   }
@@ -101,7 +97,6 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     validateRow(data, schema);
     this.copy = false;
     this.schema = schema;
-    isDeleted = data == null;
   }
 
   public HoodieSparkRecord(HoodieKey key, UnsafeRow data, boolean copy) {
@@ -114,7 +109,6 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     validateRow(data, schema);
     this.copy = copy;
     this.schema = schema;
-    isDeleted = data == null;
   }
 
   private HoodieSparkRecord(HoodieKey key, InternalRow data, StructType schema, HoodieOperation operation, boolean copy) {
@@ -123,7 +117,6 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     validateRow(data, schema);
     this.copy = copy;
     this.schema = schema;
-    isDeleted = data == null;
   }
 
   public HoodieSparkRecord(
@@ -137,10 +130,6 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     super(key, data, operation, currentLocation, newLocation);
     this.copy = copy;
     this.schema = schema;
-  }
-
-  public boolean isDeleted() {
-    return isDeleted;
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -72,7 +72,7 @@ class TestDefaultSparkRecordMerger {
    * If the input records are not Spark record, it throws.
    */
   @Test
-  void testMergerWithArvroRecord() {
+  void testMergerWithAvroRecord() {
     try (HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(0L)) {
       List<HoodieRecord> records = dataGenerator.generateInserts("001", 2);
       DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
@@ -142,7 +142,7 @@ class TestDefaultSparkRecordMerger {
    * If the new record is a delete record, the merged record is empty.
    */
   @Test
-  void testMergerWithNewRecordIsDeleteRecord() throws IOException {
+  void testMergerWithNewRecordAsDelete() throws IOException {
     HoodieKey key = new HoodieKey(ANY_KEY, ANY_PARTITION);
     Row oldValue = getSpecificValue(key, "001", 1L, "file1", 1, "1");
     HoodieRecord<InternalRow> oldRecord =
@@ -163,7 +163,7 @@ class TestDefaultSparkRecordMerger {
    * If the old record is a delete record, the merged record is the new record.
    */
   @Test
-  void testMergerWithOldRecordIsDeleteRecord() throws IOException {
+  void testMergerWithOldRecordAsDelete() throws IOException {
     HoodieKey key = new HoodieKey(ANY_KEY, ANY_PARTITION);
     Row newValue = getSpecificValue(key, "001", 1L, "file1", 1, "1");
     HoodieRecord<InternalRow> oldRecord = new HoodieEmptyRecord<>(key, SPARK);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -85,7 +85,8 @@ class TestDefaultSparkRecordMerger {
   }
 
   /**
-   * New record has higher ordering value than old record.
+   * If the new record has higher ordering value than old record,
+   * then the merged record is the new one.
    */
   @Test
   void testMergerWithNewRecordAccepted() throws IOException {
@@ -111,7 +112,8 @@ class TestDefaultSparkRecordMerger {
   }
 
   /**
-   * The ordering value of old record smaller than or equal to that of new record,
+   * If the ordering value of the old record smaller than or equal to that of the new record,
+   * the merged record is the old record.
    */
   @Test
   void testMergerWithOldRecordAccepted() throws IOException {
@@ -137,7 +139,7 @@ class TestDefaultSparkRecordMerger {
   }
 
   /**
-   * If new record is a delete record, merged record is empty.
+   * If the new record is a delete record, the merged record is empty.
    */
   @Test
   void testMergerWithNewRecordIsDeleteRecord() throws IOException {
@@ -158,7 +160,7 @@ class TestDefaultSparkRecordMerger {
   }
 
   /**
-   * If old record is delete record, merged record is new record.
+   * If the old record is a delete record, the merged record is the new record.
    */
   @Test
   void testMergerWithOldRecordIsDeleteRecord() throws IOException {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.SPARK;
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDefaultSparkRecordMerger {
+  public static final String RECORD_KEY_FIELD_NAME = "record_key";
+  public static final String PARTITION_PATH_FIELD_NAME = "partition_path";
+
+  public static final StructType STRUCT_TYPE = new StructType(new StructField[] {
+      new StructField(HoodieRecord.COMMIT_TIME_METADATA_FIELD, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(HoodieRecord.RECORD_KEY_METADATA_FIELD, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(HoodieRecord.PARTITION_PATH_METADATA_FIELD, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(HoodieRecord.FILENAME_METADATA_FIELD, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(RECORD_KEY_FIELD_NAME, DataTypes.StringType, false, Metadata.empty()),
+      new StructField(PARTITION_PATH_FIELD_NAME, DataTypes.StringType, false, Metadata.empty()),
+      new StructField("int_column", DataTypes.IntegerType, false, Metadata.empty()),
+      new StructField("string_column", DataTypes.StringType, false, Metadata.empty())});
+
+  @Test
+  void testMergerWithArvroRecordType() {
+    try (HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(0L)) {
+      List<HoodieRecord> records = dataGenerator.generateInserts("001", 2);
+      DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+      TypedProperties props = new TypedProperties();
+      Schema recordSchema = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> merger.merge(records.get(0), recordSchema, records.get(1), recordSchema, props));
+    }
+  }
+
+  @Test
+  void testMergerWithNewRecordAccpeted() throws IOException {
+    HoodieKey key = new HoodieKey("any_key", "any_partition");
+    Row oldValue = getSpecificValue(key, "001", 1L, "file1", 1, "1");
+    Row newValue = getSpecificValue(key, "002", 2L, "file2", 2, "2");
+    HoodieRecord<InternalRow> oldRecord =
+        new HoodieSparkRecord(InternalRow.apply(oldValue.toSeq()), STRUCT_TYPE);
+    HoodieRecord<InternalRow> newRecord =
+        new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), STRUCT_TYPE);
+
+    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(PRECOMBINE_FIELD.key(), "randomInt");
+    Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+        STRUCT_TYPE, "name", "namespace");
+    Option<Pair<HoodieRecord, Schema>> r =
+        merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
+    assertEquals(
+        InternalRow.apply(newValue.toSeq()),
+        r.get().getLeft().getData());
+  }
+
+  @Test
+  void testMergerWithOldRecordAccepted() throws IOException {
+    HoodieKey key = new HoodieKey("any_key", "any_partition");
+    Row oldValue = getSpecificValue(key, "001", 1L, "file1", 1, "2");
+    Row newValue = getSpecificValue(key, "002", 2L, "file2", 2, "2");
+    HoodieRecord<InternalRow> oldRecord =
+        new HoodieSparkRecord(InternalRow.apply(oldValue.toSeq()), STRUCT_TYPE);
+    HoodieRecord<InternalRow> newRecord =
+        new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), STRUCT_TYPE);
+
+    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(PRECOMBINE_FIELD.key(), "randomInt");
+    Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+        STRUCT_TYPE, "name", "namespace");
+    Option<Pair<HoodieRecord, Schema>> r =
+        merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
+    assertEquals(
+        InternalRow.apply(oldValue.toSeq()),
+        r.get().getLeft().getData());
+  }
+
+  @Test
+  void testMergerWithNewRecordIsDeleteRecord() throws IOException {
+    HoodieKey key = new HoodieKey("any_key", "any_partition");
+    Row oldValue = getSpecificValue(key, "001", 1L, "file1", 1, "1");
+    HoodieRecord<InternalRow> oldRecord =
+        new HoodieSparkRecord(InternalRow.apply(oldValue.toSeq()), STRUCT_TYPE);
+    HoodieRecord<InternalRow> newRecord = new HoodieEmptyRecord<>(key, SPARK);
+
+    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(PRECOMBINE_FIELD.key(), "randomInt");
+    Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+        STRUCT_TYPE, "name", "namespace");
+    Option<Pair<HoodieRecord, Schema>> r =
+        merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
+    assertTrue(r.isEmpty());
+  }
+
+  @Test
+  void testMergerWithOldRecordIsDeleteRecord() throws IOException {
+    HoodieKey key = new HoodieKey("any_key", "any_partition");
+    Row newValue = getSpecificValue(key, "001", 1L, "file1", 1, "1");
+    HoodieRecord<InternalRow> oldRecord = new HoodieEmptyRecord<>(key, SPARK);
+    HoodieRecord<InternalRow> newRecord =
+        new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), STRUCT_TYPE);
+
+    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(PRECOMBINE_FIELD.key(), "randomInt");
+    Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+        STRUCT_TYPE, "name", "namespace");
+    Option<Pair<HoodieRecord, Schema>> r =
+        merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
+    assertEquals(
+        InternalRow.apply(newValue.toSeq()),
+        r.get().getLeft().getData());
+  }
+
+  static Row getSpecificValue(
+      HoodieKey key, String commitTime, long seqNo, String filePath, int intValue, String stringValue) {
+    Object[] values = new Object[9];
+    values[0] = commitTime;
+    values[1] = seqNo;
+    values[2] = key.getRecordKey();
+    values[3] = key.getPartitionPath();
+    values[4] = filePath;
+    values[5] = key.getRecordKey();
+    values[6] = key.getPartitionPath();
+    values[7] = intValue;
+    values[8] = stringValue;
+    return new GenericRow(values);
+  }
+}


### PR DESCRIPTION
### Change Logs

`isDeleted()` only checks if the data == null.

`isDelete()` returns true when 
   1. data == null; or 
   2. _hoodie_operation field exists and is "D"; or 
   3. data contains a specified delete field.

Therefore, remove `isDeleted()` and its underlying variable.

### Impact

Clean the logic of determining delete record for Spark.

### Risk level (write none, low medium or high below)

Medium.
Existing tests should be sufficient.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
