### PR TITLE
[HUDI-8402] Fix for CVE-2023-39410 and CVE-2020-13956

### DIFF
--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -182,6 +182,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
     </dependency>
 
     <dependency>

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -182,7 +182,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
     <aws.sdk.httpclient.version>4.5.13</aws.sdk.httpclient.version>
     <aws.sdk.httpcore.version>4.4.13</aws.sdk.httpcore.version>
     <http.version>4.4.1</http.version>
+    <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
     <spark.version>${spark3.version}</spark.version>
     <spark2.version>2.4.4</spark2.version>
     <spark3.version>3.5.1</spark3.version>
@@ -1195,7 +1196,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>${http.version}</version>
+        <version>${httpcomponents.httpclient.version}</version>
       </dependency>
 
       <!-- Hadoop -->

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                (hudi.spark.common.modules.*) -->
     <hudi.spark.common.modules.1>hudi-spark3-common</hudi.spark.common.modules.1>
     <hudi.spark.common.modules.2>hudi-spark3.2plus-common</hudi.spark.common.modules.2>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.11.3</avro.version>
     <bijection-avro.version>0.9.7</bijection-avro.version>
     <caffeine.version>2.9.1</caffeine.version>
     <commons.io.version>2.11.0</commons.io.version>


### PR DESCRIPTION
Upgrade httpclient version to 4.5.13
Upgrade avro version to 1.11.3

**Reference PR**  - https://github.com/apache/hudi/pull/11964

### Change Logs

This issue will address the below CVE from hudi-presto-bundle:0.14.0 jar
https://nvd.nist.gov/vuln/detail/CVE-2023-39410
https://nvd.nist.gov/vuln/detail/CVE-2020-13956

### Impact

No user facing impacts

### Risk level (write none, low medium or high below)

Included the new changes in presto and we haven't seen any regression issues

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
