### PR TITLE
[HUDI-8276] Add support for File path regex for Hoodie Incr Source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -94,7 +94,7 @@ public class CloudSourceConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Only selects objects in the bucket whose relative path matches this regex. "
           + "For example: When hoodie.streamer.source.cloud.data.select.relpath.prefix is set to /path/prefix, and the hoodie.streamer.source.cloud.data.select.relative.path.regex"
-          + " is regex/files[0-9]+,only files located in the /path/prefix/regex directory that match the pattern (e.g., file1, file2, etc.) will be ingested.\n"
+          + " is regex/files[0-9]+, only files located in the /path/prefix/regex directory that match the pattern (e.g., file1, file2, etc.) will be ingested.\n"
           + "If hoodie.streamer.source.cloud.data.select.relpath.prefix is not set, the ingestion process will look for files matching /regex/files[0-9]+ in the source bucket.");
 
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_PREFIX = ConfigProperty

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -92,7 +92,7 @@ public class CloudSourceConfig extends HoodieConfig {
       .noDefaultValue()
       .markAdvanced()
       .sinceVersion("1.0.0")
-      .withDocumentation("Only selects objects in the bucket whose relative path matches this regex"
+      .withDocumentation("Only selects objects in the bucket whose relative path matches this regex. "
           + "For example: When hoodie.streamer.source.cloud.data.select.relpath.prefix is set to /path/prefix, and the hoodie.streamer.source.cloud.data.select.relative.path.regex"
           + " is regex/files[0-9]+,only files located in the /path/prefix/regex directory that match the pattern (e.g., file1, file2, etc.) will be ingested.\n"
           + "If hoodie.streamer.source.cloud.data.select.relpath.prefix is not set, the ingestion process will look for files matching /regex/files[0-9]+ in the source bucket.");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -87,6 +87,13 @@ public class CloudSourceConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Only selects objects in the bucket whose relative path starts with this prefix");
 
+  public static final ConfigProperty<String> SELECT_RELATIVE_PATH_REGEX = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.select.path.regex")
+      .noDefaultValue()
+      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.path.regex")
+      .markAdvanced()
+      .withDocumentation("Only selects objects in the bucket whose relative path matches this regex");
+
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_PREFIX = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.ignore.relpath.prefix")
       .noDefaultValue()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -88,11 +88,14 @@ public class CloudSourceConfig extends HoodieConfig {
       .withDocumentation("Only selects objects in the bucket whose relative path starts with this prefix");
 
   public static final ConfigProperty<String> SELECT_RELATIVE_PATH_REGEX = ConfigProperty
-      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.select.path.regex")
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.select.relative.path.regex")
       .noDefaultValue()
-      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.relative.path.regex")
       .markAdvanced()
-      .withDocumentation("Only selects objects in the bucket whose relative path matches this regex");
+      .sinceVersion("1.0.0")
+      .withDocumentation("Only selects objects in the bucket whose relative path matches this regex"
+          + "For example: When hoodie.streamer.source.cloud.data.select.relpath.prefix is set to /path/prefix, and the hoodie.streamer.source.cloud.data.select.relative.path.regex"
+          + " is regex/files[0-9]+,only files located in the /path/prefix/regex directory that match the pattern (e.g., file1, file2, etc.) will be ingested.\n"
+          + "If hoodie.streamer.source.cloud.data.select.relpath.prefix is not set, the ingestion process will look for files matching /regex/files[0-9]+ in the root directory.");
 
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_PREFIX = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.ignore.relpath.prefix")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -95,7 +95,7 @@ public class CloudSourceConfig extends HoodieConfig {
       .withDocumentation("Only selects objects in the bucket whose relative path matches this regex"
           + "For example: When hoodie.streamer.source.cloud.data.select.relpath.prefix is set to /path/prefix, and the hoodie.streamer.source.cloud.data.select.relative.path.regex"
           + " is regex/files[0-9]+,only files located in the /path/prefix/regex directory that match the pattern (e.g., file1, file2, etc.) will be ingested.\n"
-          + "If hoodie.streamer.source.cloud.data.select.relpath.prefix is not set, the ingestion process will look for files matching /regex/files[0-9]+ in the root directory.");
+          + "If hoodie.streamer.source.cloud.data.select.relpath.prefix is not set, the ingestion process will look for files matching /regex/files[0-9]+ in the source bucket.");
 
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_PREFIX = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.ignore.relpath.prefix")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -90,7 +90,7 @@ public class CloudSourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> SELECT_RELATIVE_PATH_REGEX = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.select.path.regex")
       .noDefaultValue()
-      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.path.regex")
+      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.relative.path.regex")
       .markAdvanced()
       .withDocumentation("Only selects objects in the bucket whose relative path matches this regex");
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -218,9 +218,8 @@ public class CloudObjectsSelectorCommon {
 
       // Update path if regex is present
       if (!regex.isEmpty()) {
-        String updatedPathRegex = prefix.endsWith(StoragePath.SEPARATOR) || prefix.isEmpty() ?
-            prefix + regex :
-            prefix + StoragePath.SEPARATOR + regex;
+        String updatedPathRegex = prefix.isEmpty() || prefix.endsWith(StoragePath.SEPARATOR)
+            ? prefix + regex : prefix + StoragePath.SEPARATOR + regex;
         filter.append(SPACE_DELIMTER).append(String.format("and %s rlike '%s'", objectKey, updatedPathRegex));
       } else if (!prefix.isEmpty()) {
         // Build the condition based on whether regex or prefix is present

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -227,7 +227,6 @@ public class CloudObjectsSelectorCommon {
         filter.append(SPACE_DELIMTER).append(String.format("and %s like '%s%%'", objectKey, prefix));
       }
     }
-
     if (ignoreRelativePathPrefix.isPresent()) {
       filter.append(SPACE_DELIMTER).append(String.format("and %s not like '%s%%'", objectKey, ignoreRelativePathPrefix.get()));
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -100,6 +100,7 @@ public class CloudObjectsSelectorCommon {
   public static final String GCS_OBJECT_KEY = "name";
   public static final String GCS_OBJECT_SIZE = "size";
   private static final String SPACE_DELIMTER = " ";
+  private static final String PATH_DELIMITER = "/";
   private static final String GCS_PREFIX = "gs://";
 
   private final TypedProperties properties;
@@ -157,7 +158,7 @@ public class CloudObjectsSelectorCommon {
     final Configuration configuration = storageConf.unwrapCopy();
 
     String bucket = row.getString(0);
-    String filePath = storageUrlSchemePrefix + bucket + "/" + row.getString(1);
+    String filePath = storageUrlSchemePrefix + bucket + PATH_DELIMITER + row.getString(1);
 
     try {
       String filePathUrl = URLDecoder.decode(filePath, StandardCharsets.UTF_8.name());
@@ -224,7 +225,7 @@ public class CloudObjectsSelectorCommon {
       String prefix = selectRelativePathPrefix.orElse("");
       String regex = selectRelativePathRegex.get();
 
-      String updatedPathRegex = prefix.isEmpty() || prefix.endsWith("/") ? prefix + regex : prefix + "/" + regex;
+      String updatedPathRegex = prefix.isEmpty() || prefix.endsWith(PATH_DELIMITER) ? prefix + regex : prefix + PATH_DELIMITER + regex;
 
       filter.append(SPACE_DELIMTER).append(String.format("and %s rlike '%s'", objectKey, updatedPathRegex));
     }
@@ -336,7 +337,7 @@ public class CloudObjectsSelectorCommon {
       for (String partitionKey : partitionKeysToAdd) {
         String partitionPathPattern = String.format("%s=", partitionKey);
         LOG.info(String.format("Adding column %s to dataset", partitionKey));
-        dataset = dataset.withColumn(partitionKey, split(split(input_file_name(), partitionPathPattern).getItem(1), "/").getItem(0));
+        dataset = dataset.withColumn(partitionKey, split(split(input_file_name(), partitionPathPattern).getItem(1), PATH_DELIMITER).getItem(0));
       }
     }
     dataset = coalesceOrRepartition(dataset, numPartitions);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -75,6 +75,7 @@ import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE
 import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE_PATH_SUBSTR;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.PATH_BASED_PARTITION_FIELDS;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.SELECT_RELATIVE_PATH_PREFIX;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.SELECT_RELATIVE_PATH_REGEX;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.SPARK_DATASOURCE_READER_COMMA_SEPARATED_PATH_FORMAT;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_FS_PREFIX;
 import static org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig.S3_IGNORE_KEY_PREFIX;
@@ -193,6 +194,7 @@ public class CloudObjectsSelectorCommon {
     Option<String> selectRelativePathPrefix = getPropVal(props, SELECT_RELATIVE_PATH_PREFIX);
     Option<String> ignoreRelativePathPrefix = getPropVal(props, IGNORE_RELATIVE_PATH_PREFIX);
     Option<String> ignoreRelativePathSubStr = getPropVal(props, IGNORE_RELATIVE_PATH_SUBSTR);
+    Option<String> selectRelativePathRegex = getPropVal(props, SELECT_RELATIVE_PATH_REGEX);
 
     String objectKey;
     String objectSizeKey;
@@ -217,6 +219,14 @@ public class CloudObjectsSelectorCommon {
     }
     if (ignoreRelativePathSubStr.isPresent()) {
       filter.append(SPACE_DELIMTER).append(String.format("and %s not like '%%%s%%'", objectKey, ignoreRelativePathSubStr.get()));
+    }
+    if (selectRelativePathRegex.isPresent()) {
+      String prefix = selectRelativePathPrefix.orElse("");
+      String regex = selectRelativePathRegex.get();
+
+      String updatedPathRegex = prefix.isEmpty() || prefix.endsWith("/") ? prefix + regex : prefix + "/" + regex;
+
+      filter.append(SPACE_DELIMTER).append(String.format("and %s rlike '%s'", objectKey, updatedPathRegex));
     }
 
     // Match files with a given extension, or use the fileFormat as the default.

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -448,7 +448,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
 
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
     typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to/skip");
-    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.path.regex", "path/to/file[0-9]+");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relative.path.regex", "path/to/file[0-9]+");
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("1#path/to/file3.json"), 50L, "3#path/to/file4.json", typedProperties);
 
@@ -487,7 +487,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     when(mockCloudObjectsSelectorCommon.loadAsDataset(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(schemaProvider), Mockito.anyInt())).thenReturn(Option.empty());
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
     typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to/skip");
-    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.path.regex", "path/to/file[0-9]+");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relative.path.regex", "path/to/file[0-9]+");
 
     List<Long> bytesPerPartition = Arrays.asList(10L, 20L, -1L, 1000L * 1000L * 1000L);
 
@@ -498,7 +498,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50000L, exptected1, typedProperties);
     //2. incremental query, as commit is present in timeline
     typedProperties.setProperty("hoodie.streamer.source.s3incr.key.prefix", "path/to/");
-    typedProperties.setProperty("hoodie.deltastreamer.source.cloud.data.select.path.regex", "file[0-9]+");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relative.path.regex", "file[0-9]+");
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(10L, sourcePartitions, bytesPerPartition.get(1)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(exptected1), 10L, exptected2, typedProperties);
     //3. snapshot query with source limit less than first commit size

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -486,7 +486,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     setMockQueryRunner(inputDs, Option.of(snapshotCheckPoint));
     when(mockCloudObjectsSelectorCommon.loadAsDataset(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(schemaProvider), Mockito.anyInt())).thenReturn(Option.empty());
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
-    typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to/skip");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.ignore.relpath.prefix", "path/to/skip");
     typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relative.path.regex", "path/to/file[0-9]+");
 
     List<Long> bytesPerPartition = Arrays.asList(10L, 20L, -1L, 1000L * 1000L * 1000L);
@@ -497,15 +497,17 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(50000L, sourcePartitions, bytesPerPartition.get(0)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50000L, exptected1, typedProperties);
     //2. incremental query, as commit is present in timeline
-    typedProperties.setProperty("hoodie.streamer.source.s3incr.key.prefix", "path/to/");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relpath.prefix", "path/to/");
     typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relative.path.regex", "file[0-9]+");
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(10L, sourcePartitions, bytesPerPartition.get(1)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(exptected1), 10L, exptected2, typedProperties);
     //3. snapshot query with source limit less than first commit size
-    typedProperties.setProperty("hoodie.streamer.source.s3incr.key.prefix", "path/to");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.relpath.prefix", "path/to");
+    typedProperties.remove("hoodie.streamer.source.cloud.data.select.relative.path.regex");
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(50L, sourcePartitions, bytesPerPartition.get(2)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50L, exptected3, typedProperties);
-    typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.ignore.relpath.prefix", "path/to");
+    typedProperties.remove("hoodie.streamer.source.cloud.data.select.relpath.prefix");
     //4. As snapshotQuery will return 1 -> same would be return as nextCheckpoint (dataset is empty due to ignore prefix).
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(50L, sourcePartitions, bytesPerPartition.get(3)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50L, exptected4, typedProperties);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -431,6 +431,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     filePathSizeAndCommitTime.add(Triple.of("path/to/file2.json", 150L, "1"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/skip1.json", 50L, "2"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/skip2.json", 150L, "2"));
+    filePathSizeAndCommitTime.add(Triple.of("path/to/file_no_match1.json", 150L, "2"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file5.json", 150L, "3"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file4.json", 150L, "3"));
 
@@ -447,6 +448,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
 
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
     typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to/skip");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.path.regex", "path/to/file[0-9]+");
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of("1#path/to/file3.json"), 50L, "3#path/to/file4.json", typedProperties);
 
@@ -470,11 +472,14 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     List<Triple<String, Long, String>> filePathSizeAndCommitTime = new ArrayList<>();
     // Add file paths and sizes to the list
     filePathSizeAndCommitTime.add(Triple.of("path/to/file1.json", 50L, "1"));
+    filePathSizeAndCommitTime.add(Triple.of("path/to/file_no_match1.json", 50L, "1"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file2.json", 50L, "1"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/skip1.json", 50L, "2"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/skip2.json", 50L, "2"));
+    filePathSizeAndCommitTime.add(Triple.of("path/to/file_no_match2.json", 50L, "2"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file5.json", 50L, "3"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file4.json", 50L, "3"));
+    filePathSizeAndCommitTime.add(Triple.of("path/to/file_no_match3.json", 50L, "3"));
 
     Dataset<Row> inputDs = generateDataset(filePathSizeAndCommitTime);
 
@@ -482,6 +487,8 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     when(mockCloudObjectsSelectorCommon.loadAsDataset(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(schemaProvider), Mockito.anyInt())).thenReturn(Option.empty());
     TypedProperties typedProperties = setProps(READ_UPTO_LATEST_COMMIT);
     typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to/skip");
+    typedProperties.setProperty("hoodie.streamer.source.cloud.data.select.path.regex", "path/to/file[0-9]+");
+
     List<Long> bytesPerPartition = Arrays.asList(10L, 20L, -1L, 1000L * 1000L * 1000L);
 
     // If the computed number of partitions based on bytes is less than this value, it should use this value for num partitions.
@@ -490,9 +497,12 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(50000L, sourcePartitions, bytesPerPartition.get(0)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50000L, exptected1, typedProperties);
     //2. incremental query, as commit is present in timeline
+    typedProperties.setProperty("hoodie.streamer.source.s3incr.key.prefix", "path/to/");
+    typedProperties.setProperty("hoodie.deltastreamer.source.cloud.data.select.path.regex", "file[0-9]+");
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(10L, sourcePartitions, bytesPerPartition.get(1)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(exptected1), 10L, exptected2, typedProperties);
     //3. snapshot query with source limit less than first commit size
+    typedProperties.setProperty("hoodie.streamer.source.s3incr.key.prefix", "path/to");
     when(sourceProfileSupplier.getSourceProfile()).thenReturn(new TestSourceProfile(50L, sourcePartitions, bytesPerPartition.get(2)));
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.empty(), 50L, exptected3, typedProperties);
     typedProperties.setProperty("hoodie.streamer.source.s3incr.ignore.key.prefix", "path/to");


### PR DESCRIPTION
### Change Logs

Add support for regex-based path matching for Hoodie Incr source

### Impact

When users add file path pattern field in Hoodie Incr Sourc source config, we read only files matching this provided regular expression

### Risk level (write none, low medium or high below)

NA

### Documentation Update


- Added a new configuration to capture the file path pattern: hoodie.streamer.source.cloud.data.select.path.regex, with an alternative configuration hoodie.deltastreamer.source.cloud.data.select.path.regex.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
