### PR TITLE
[HUDI-8277] Update wait time in ITTestDataStreamWrite#execute to prevent unit test failures

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -329,7 +329,7 @@ public class ITTestDataStreamWrite extends TestLogger {
       JobClient client = execEnv.executeAsync(jobName);
       if (client.getJobStatus().get() != JobStatus.FAILED) {
         try {
-          TimeUnit.SECONDS.sleep(20); // wait long enough for the compaction to finish
+          TimeUnit.SECONDS.sleep(35); // wait long enough for the compaction to finish
           client.cancel();
         } catch (Throwable var1) {
           // ignored


### PR DESCRIPTION
### Change Logs

Increase the waiting time to allow Compaction to complete successfully and avoid unit test failures.
During my testing on a Mac Book, with a current wait time of 20 seconds, there is a 50% probability that Compaction will not complete, resulting in unit test failures.
Of course, the failure probability depends on the machine's performance. By increasing the wait time to 35 seconds, the success rate reaches 100%.

### Impact

Significantly reduce the failure rate of ITTestDataStreamWrite.
For example, a PR addressing the failures in ITTestDataStreamWrite can be found at: [PR 12025 Link](https://github.com/apache/hudi/pull/12025)

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
