### PR TITLE
[MINOR] Disable Maven cache in Github Java setup for integration tests

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -639,7 +639,6 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Build Project
         env:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}


### PR DESCRIPTION
### Change Logs

Maven cache using Github Java setup from the `integration-test` job is big which causes no disk space or random CI failures.  This PR disables it to make Github CI jobs stable.

### Impact

Makes Github CI jobs stable.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
