### PR TITLE
[HUDI-8248] Fixing Log Record reader to include rollback blocks with timestamps > maxInstant times 

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -241,7 +241,7 @@ public class HoodieIndexUtils {
       HoodieData<Pair<String, String>> partitionLocations, HoodieWriteConfig config, HoodieTable hoodieTable) {
     final Option<String> instantTime = hoodieTable
         .getMetaClient()
-        .getCommitsTimeline()
+        .getActiveTimeline() // we need to include all actions and completed
         .filterCompletedInstants()
         .lastInstant()
         .map(HoodieInstant::getTimestamp);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -252,7 +252,7 @@ public abstract class AbstractHoodieLogRecordReader {
         HoodieLogBlock logBlock = logFormatReaderWrapper.next();
         final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
         totalLogBlocks.incrementAndGet();
-        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType())) {
+        if (logBlock.isDataOrDeleteBlock()) {
           if (HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
             // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
             continue;
@@ -438,7 +438,7 @@ public abstract class AbstractHoodieLogRecordReader {
           totalCorruptBlocks.incrementAndGet();
           continue;
         }
-        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType())
+        if (logBlock.isDataOrDeleteBlock()
             && HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
           // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
           continue;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -438,8 +438,8 @@ public abstract class AbstractHoodieLogRecordReader {
           totalCorruptBlocks.incrementAndGet();
           continue;
         }
-        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType()) &&
-            HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
+        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType())
+            && HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
           // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
           continue;
         }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -252,13 +252,11 @@ public abstract class AbstractHoodieLogRecordReader {
         HoodieLogBlock logBlock = logFormatReaderWrapper.next();
         final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
         totalLogBlocks.incrementAndGet();
-        if (logBlock.getBlockType() != CORRUPT_BLOCK
-            && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
-        )) {
-          // hit a block with instant time greater than should be processed, stop processing further
-          break;
-        }
-        if (logBlock.getBlockType() != CORRUPT_BLOCK && logBlock.getBlockType() != COMMAND_BLOCK) {
+        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType())) {
+          if (HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
+            // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
+            continue;
+          }
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
             // filter the log block by instant range
             continue;
@@ -440,10 +438,10 @@ public abstract class AbstractHoodieLogRecordReader {
           totalCorruptBlocks.incrementAndGet();
           continue;
         }
-        if (!HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME),
-            HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime)) {
-          // hit a block with instant time greater than should be processed, stop processing further
-          break;
+        if (HoodieLogBlock.HoodieLogBlockType.isDataOrDeleteBlock(logBlock.getBlockType()) &&
+            HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
+          // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
+          continue;
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -261,13 +261,11 @@ public abstract class BaseHoodieLogRecordReader<T> {
           blockSeqNo = Integer.parseInt(parts[1]);
         }
         totalLogBlocks.incrementAndGet();
-        if (logBlock.getBlockType() != CORRUPT_BLOCK
-            && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
-        )) {
-          // hit a block with instant time greater than should be processed, stop processing further
-          continue;
-        }
-        if (logBlock.getBlockType() != CORRUPT_BLOCK && logBlock.getBlockType() != COMMAND_BLOCK) {
+        if (logBlock.isDataOrDeleteBlock()) {
+          if (HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
+            // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
+            continue;
+          }
           if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
               || inflightInstantsTimeline.containsInstant(instantTime)) {
             // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
@@ -594,10 +592,10 @@ public abstract class BaseHoodieLogRecordReader<T> {
           totalCorruptBlocks.incrementAndGet();
           continue;
         }
-        if (!HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME),
-            HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime)) {
-          // hit a block with instant time greater than should be processed, stop processing further
-          break;
+        if (logBlock.isDataOrDeleteBlock()
+            && HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.GREATER_THAN, this.latestInstantTime)) {
+          // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
+          continue;
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
           if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -177,6 +177,14 @@ public abstract class HoodieLogBlock {
     public static HoodieLogBlockType fromId(String id) {
       return ID_TO_ENUM_MAP.get(id);
     }
+
+    /**
+     * @param logBlockType log block type to be inspected.
+     * @returns true if the log block type refers to data or delete block. false otherwise.
+     */
+    public static boolean isDataOrDeleteBlock(HoodieLogBlockType logBlockType) {
+      return logBlockType != HoodieLogBlockType.COMMAND_BLOCK && logBlockType != HoodieLogBlockType.CORRUPT_BLOCK;
+    }
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -98,6 +98,10 @@ public abstract class HoodieLogBlock {
 
   public abstract HoodieLogBlockType getBlockType();
 
+  public boolean isDataOrDeleteBlock() {
+    return getBlockType().isDataOrDeleteBlock();
+  }
+
   public long getLogBlockLength() {
     throw new HoodieException("No implementation was provided");
   }
@@ -179,11 +183,10 @@ public abstract class HoodieLogBlock {
     }
 
     /**
-     * @param logBlockType log block type to be inspected.
      * @returns true if the log block type refers to data or delete block. false otherwise.
      */
-    public static boolean isDataOrDeleteBlock(HoodieLogBlockType logBlockType) {
-      return logBlockType != HoodieLogBlockType.COMMAND_BLOCK && logBlockType != HoodieLogBlockType.CORRUPT_BLOCK;
+    public boolean isDataOrDeleteBlock() {
+      return this != HoodieLogBlockType.COMMAND_BLOCK && this != HoodieLogBlockType.CORRUPT_BLOCK;
     }
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -687,184 +687,23 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
                                                   boolean enableOptimizedLogBlocksScan)
       throws IOException, URISyntaxException, InterruptedException {
 
-    Schema schema = HoodieAvroUtils.addMetadataFields(getSimpleSchema());
-    SchemaTestUtil testUtil = new SchemaTestUtil();
-    appendAndValidate(schema, testUtil, diskMapType, isCompressionEnabled, enableOptimizedLogBlocksScan,
-        "100");
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testLogRecordReaderWithMaxInstantTimeConfigured(boolean enableOptimizedLogScan) throws IOException, URISyntaxException, InterruptedException {
-    Schema schema = HoodieAvroUtils.addMetadataFields(getSimpleSchema());
-    SchemaTestUtil testUtil = new SchemaTestUtil();
-
-    Pair<List<IndexedRecord>, Set<HoodieLogFile>> firstBatch = appendAndValidate(schema, testUtil, ExternalSpillableMap.DiskMapType.BITCASK, false, enableOptimizedLogScan,
-        "100");
-
-    // trigger another batch of writes for next commit
-    Pair<List<IndexedRecord>, Set<HoodieLogFile>> secondBatch = appendAndValidate(schema, testUtil, ExternalSpillableMap.DiskMapType.BITCASK, false, enableOptimizedLogScan,
-        "200", firstBatch.getKey(), firstBatch.getValue());
-
-    List<IndexedRecord> firstAndSecondBatch = new ArrayList<>(firstBatch.getKey());
-    firstAndSecondBatch.addAll(secondBatch.getKey());
-
-    // set max commit time as 200 and validate only first batch of records are returned
-    List<HoodieLogFile> allLogFiles = getSortedLogFilesList(Arrays.asList(firstBatch.getValue(), secondBatch.getValue()));
-
-    // expect records only from first batch when max commit time is set to 100.
-    readAndValidate(schema, "100", allLogFiles, firstBatch.getKey());
-
-    // add another batch.
-    Pair<List<IndexedRecord>, Set<HoodieLogFile>> thirdBatch = appendAndValidate(schema, testUtil, ExternalSpillableMap.DiskMapType.BITCASK, false, enableOptimizedLogScan,
-        "300", firstAndSecondBatch, new HashSet<>(allLogFiles));
-
-    allLogFiles = getSortedLogFilesList(Arrays.asList(firstBatch.getValue(), secondBatch.getValue(), thirdBatch.getValue()));
-
-    // set max commit time as 100 and validate only first batch of records are returned
-    readAndValidate(schema, "100", allLogFiles, firstBatch.getKey());
-    readAndValidate(schema, "200", allLogFiles, firstAndSecondBatch);
-    List<IndexedRecord> allBatches = new ArrayList<>(firstAndSecondBatch);
-    allBatches.addAll(thirdBatch.getKey());
-    readAndValidate(schema, "300", allLogFiles, allBatches);
-
-    // add rollback to commit 200
-    addRollbackBlock("400", "200");
-
-    // lets not remove commit 200 from timeline. but still due to presence of rollback block, 2nd batch should be ignored.
-    List<IndexedRecord> firstAndThirdBatch = new ArrayList<>(firstBatch.getKey());
-    firstAndThirdBatch.addAll(thirdBatch.getKey());
-    readAndValidate(schema, "300", allLogFiles, firstAndThirdBatch);
-
-    // if we set maxCommitTime as 200 (which is rolled back), expected records are just from batch1
-    readAndValidate(schema, "200", allLogFiles, firstBatch.getKey());
-
-    // lets repeat the same after removing the commit from timeline.
-    FileCreateUtils.deleteDeltaCommit(basePath, "200", storage);
-    readAndValidate(schema, "300", allLogFiles, firstAndThirdBatch);
-    // if we set maxCommitTime as 200 (which is rolled back commit), expected records are just from batch1
-    readAndValidate(schema, "200", allLogFiles, firstBatch.getKey());
-
-    // let's test rollback issue from HUDI-8248
-    // lets add commit 400 (batch4). add a rollback block with commit time 500 which rollsback 400. again, add log files with commit time 400 (batch5)
-    // when we read all log files w/ max commit time as 400, batch4 needs to be ignored and only batch5 should be read.
-    // trigger another batch of writes for next commit
-    Pair<List<IndexedRecord>, Set<HoodieLogFile>> fourthBatch = appendAndValidate(schema, testUtil, ExternalSpillableMap.DiskMapType.BITCASK, false, enableOptimizedLogScan,
-        "400", firstAndThirdBatch, new HashSet<>(allLogFiles));
-
-    // lets delete commit 400 from timeline to simulate crash.
-    FileCreateUtils.deleteDeltaCommit(basePath, "400", storage);
-
-    // set max commit time as 400 and validate only first and 3rd batch is read. 1st batch is rolled back completely. 4th batch is partially failed commit.
-    allLogFiles = getSortedLogFilesList(Arrays.asList(firstBatch.getValue(), thirdBatch.getValue(), fourthBatch.getValue()));
-    readAndValidate(schema, "400", allLogFiles, firstAndThirdBatch);
-
-    // lets add the rollback block
-    addRollbackBlock("500", "400");
-    // lets redo the read test
-    readAndValidate(schema, "400", allLogFiles, firstAndThirdBatch);
-
-    // and lets re-add new log files w/ commit time 400.
-    Pair<List<IndexedRecord>, Set<HoodieLogFile>> fifthBatch = appendAndValidate(schema, testUtil, ExternalSpillableMap.DiskMapType.BITCASK, false, enableOptimizedLogScan,
-        "400", firstBatch.getKey(), firstBatch.getValue());
-
-    // lets redo the read test. this time, first batch, 3rd batch and fifth batch should be expected.
-    allLogFiles = getSortedLogFilesList(Arrays.asList(firstBatch.getValue(), thirdBatch.getValue(),  fourthBatch.getValue(), fifthBatch.getValue()));
-    List<IndexedRecord> firstThirdFifthBatch = new ArrayList<>(firstAndThirdBatch);
-    firstThirdFifthBatch.addAll(fifthBatch.getKey());
-    readAndValidate(schema, "400", allLogFiles, firstThirdFifthBatch);
-
-    // even setting very high value for max commit time should not matter.
-    readAndValidate(schema, "600", allLogFiles, firstThirdFifthBatch);
-  }
-
-  private void addRollbackBlock(String rollbackCommitTime, String commitToRollback) throws IOException, InterruptedException {
-    Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withFileExtension(HoodieLogFile.DELTA_EXTENSION)
-            .withSizeThreshold(1024).withFileId("test-fileid1").withDeltaCommit("100").withStorage(storage).build();
-    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
-
-    // Rollback the 1st block i.e. a data block.
-    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, rollbackCommitTime);
-    header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, commitToRollback);
-    header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
-        String.valueOf(HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_BLOCK.ordinal()));
-    HoodieCommandBlock commandBlock = new HoodieCommandBlock(header);
-    writer.appendBlock(commandBlock);
-    writer.close();
-  }
-
-  private List<HoodieLogFile> getSortedLogFilesList(List<Set<HoodieLogFile>> logFilesSets) {
-    Set<HoodieLogFile> allLogFiles = new HashSet<>();
-    logFilesSets.forEach(logfileSet -> allLogFiles.addAll(logfileSet));
-    List<HoodieLogFile> allLogFilesList = new ArrayList<>(allLogFiles);
-    Collections.sort(allLogFilesList, new HoodieLogFile.LogFileComparator());
-    return allLogFilesList;
-  }
-
-  private void readAndValidate(Schema schema, String maxCommitTime, List<HoodieLogFile> logFiles, List<IndexedRecord> expectedRecords) throws IOException {
-    try (HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
-        .withStorage(storage).withBasePath(basePath)
-        .withLogFilePaths(
-            logFiles.stream()
-                .map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
-        .withReaderSchema(schema)
-        .withLatestInstantTime(maxCommitTime)
-        .withMaxMemorySizeInBytes(10240L)
-        .withReverseReader(false)
-        .withBufferSize(BUFFER_SIZE)
-        .withSpillableMapBasePath(spillableBasePath)
-        .withDiskMapType(ExternalSpillableMap.DiskMapType.BITCASK)
-        .withBitCaskDiskMapCompressionEnabled(false)
-        .withOptimizedLogBlocksScan(false)
-        .build()) {
-
-      List<IndexedRecord> scannedRecords = new ArrayList<>();
-      for (HoodieRecord record : scanner) {
-        scannedRecords.add((IndexedRecord)
-            ((HoodieAvroRecord) record).getData().getInsertValue(schema).get());
-      }
-
-      assertEquals(sort(expectedRecords), sort(scannedRecords),
-          "Scanner records count should be the same as appended records");
-    }
-  }
-
-  private Pair<List<IndexedRecord>, Set<HoodieLogFile>> appendAndValidate(Schema schema, SchemaTestUtil testUtil, ExternalSpillableMap.DiskMapType diskMapType,
-                                 boolean isCompressionEnabled,
-                                 boolean enableOptimizedLogBlocksScan,
-                                 String commitTime) throws IOException, URISyntaxException, InterruptedException {
-    return appendAndValidate(schema, testUtil, diskMapType, isCompressionEnabled, enableOptimizedLogBlocksScan, commitTime,
-        Collections.emptyList(), Collections.emptySet());
-  }
-
-  private Pair<List<IndexedRecord>, Set<HoodieLogFile>> appendAndValidate(Schema schema, SchemaTestUtil testUtil, ExternalSpillableMap.DiskMapType diskMapType,
-                                                                            boolean isCompressionEnabled,
-                                                                            boolean enableOptimizedLogBlocksScan,
-                                                                            String commitTime,
-                                                                            List<IndexedRecord> prevGenRecords, Set<HoodieLogFile> prevLogFiles) throws IOException,
-        URISyntaxException, InterruptedException {
-
     // Generate 4 delta-log files w/ random records
+    Schema schema = HoodieAvroUtils.addMetadataFields(getSimpleSchema());
+    SchemaTestUtil testUtil = new SchemaTestUtil();
     List<IndexedRecord> genRecords = testUtil.generateHoodieTestRecords(0, 400);
-    Set<HoodieLogFile> logFiles = writeLogFiles(partitionPath, schema, genRecords, 4, commitTime);
 
-    Set<HoodieLogFile> allLogFiles = new HashSet<>();
-    allLogFiles.addAll(logFiles);
-    allLogFiles.addAll(prevLogFiles);
-    List<HoodieLogFile> allLogFilesList = new ArrayList<>(allLogFiles);
-    Collections.sort(allLogFilesList, new HoodieLogFile.LogFileComparator());
+    Set<HoodieLogFile> logFiles = writeLogFiles(partitionPath, schema, genRecords, 4);
 
-    FileCreateUtils.createDeltaCommit(basePath, commitTime, storage);
+    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
     // scan all log blocks (across multiple log files)
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(
-            allLogFilesList.stream()
+            logFiles.stream()
                 .map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
         .withReaderSchema(schema)
-        .withLatestInstantTime(commitTime)
+        .withLatestInstantTime("100")
         .withMaxMemorySizeInBytes(10240L)
         .withReverseReader(false)
         .withBufferSize(BUFFER_SIZE)
@@ -880,13 +719,9 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
           ((HoodieAvroRecord) record).getData().getInsertValue(schema).get());
     }
 
-    List<IndexedRecord> allGenRecords = new ArrayList<>(genRecords);
-    allGenRecords.addAll(prevGenRecords);
-
-    assertEquals(sort(allGenRecords), sort(scannedRecords),
+    assertEquals(sort(genRecords), sort(scannedRecords),
         "Scanner records count should be the same as appended records");
     scanner.close();
-    return Pair.of(genRecords, logFiles);
   }
 
   @ParameterizedTest
@@ -2995,15 +2830,16 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
                                                   List<IndexedRecord> records,
                                                   int numFiles)
       throws IOException, InterruptedException {
-    return writeLogFiles(partitionPath, schema, records, numFiles, "100");
+    return writeLogFiles(partitionPath, schema, records, numFiles, false);
   }
 
   private static Set<HoodieLogFile> writeLogFiles(StoragePath partitionPath,
                                                   Schema schema,
                                                   List<IndexedRecord> records,
                                                   int numFiles,
-                                                  String commitTime)
+                                                  boolean enableBlockSequenceNumbers)
       throws IOException, InterruptedException {
+    int blockSeqNo = 0;
     Writer writer =
         HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
@@ -3015,7 +2851,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
           (FSDataOutputStream) storage.append(writer.getLogFile().getPath()));
     }
     Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
-    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, commitTime);
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, "100");
     header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
 
     Set<HoodieLogFile> logFiles = new HashSet<>();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -161,8 +161,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
     final String p3 = "p3";
     List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, p1, 0, payloadClass);
     List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0.subList(0, 4), p2, 5, payloadClass);
-    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
 
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
       // 1st batch: inserts
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
       client.startCommitWithTime(commitTimeAtEpoch0);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -25,6 +25,9 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.TimeGenerator;
+import org.apache.hudi.common.table.timeline.TimeGenerators;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodiePayloadConfig;
@@ -154,6 +157,7 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
   public void testRollbacksWithPartitionUpdate(HoodieTableType tableType, IndexType indexType, boolean isUpsert) throws IOException {
     final Class<?> payloadClass = DefaultHoodieRecordPayload.class;
     HoodieWriteConfig writeConfig = getWriteConfig(payloadClass, indexType);
+    TimeGenerator timeGenerator = TimeGenerators.getTimeGenerator(writeConfig.getTimeGeneratorConfig(), storageConf());
     HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
     final int totalRecords = 8;
     final String p1 = "p1";
@@ -164,12 +168,12 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
       // 1st batch: inserts
-      String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
+      String commitTimeAtEpoch0 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
       client.startCommitWithTime(commitTimeAtEpoch0);
       assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 2), commitTimeAtEpoch0).collect());
 
       // 2nd batch: update 4 records from p1 to p2
-      String commitTimeAtEpoch5 = getCommitTimeAtUTC(0);
+      String commitTimeAtEpoch5 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
       client.startCommitWithTime(commitTimeAtEpoch5);
       if (isUpsert) {
         assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch5).collect());
@@ -187,7 +191,7 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
       // re-ingest same batch
-      String commitTimeAtEpoch10 = getCommitTimeAtUTC(0);
+      String commitTimeAtEpoch10 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
       client.startCommitWithTime(commitTimeAtEpoch10);
       if (isUpsert) {
         assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch10).collect());
@@ -204,7 +208,7 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       // update 4 of them from p2 to p3.
       // delete test:
       // update 4 of them to p3. these are treated as new inserts since they are deleted. no changes should be seen wrt p2.
-      String commitTimeAtEpoch15 = getCommitTimeAtUTC(0);
+      String commitTimeAtEpoch15 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
       List<HoodieRecord> updatesAtEpoch15 = getUpdates(updatesAtEpoch5, p3, 15, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch15);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch15, 2), commitTimeAtEpoch15).collect());
@@ -213,7 +217,7 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p3, 15);
 
       // lets move 2 of them back to p1
-      String commitTimeAtEpoch20 = getCommitTimeAtUTC(0);
+      String commitTimeAtEpoch20 = HoodieActiveTimeline.createNewInstantTime(false, timeGenerator);
       List<HoodieRecord> updatesAtEpoch20 = getUpdates(updatesAtEpoch5.subList(0, 2), p1, 20, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch20);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch20, 1), commitTimeAtEpoch20).collect());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodiePayloadConfig;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -25,10 +25,13 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex.IndexType;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.spark.SparkConf;
@@ -43,6 +46,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
@@ -76,6 +80,13 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
         Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
         Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM),
         Arguments.of(MERGE_ON_READ, RECORD_INDEX)
+    );
+  }
+
+  private static Stream<Arguments> getTableTypeAndIndexTypeUpdateOrDelete() {
+    return Stream.of(
+        Arguments.of(MERGE_ON_READ, RECORD_INDEX, true),
+        Arguments.of(MERGE_ON_READ, RECORD_INDEX, false)
     );
   }
 
@@ -132,6 +143,87 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       client.startCommitWithTime(commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
       readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
+    }
+  }
+
+  /**
+   * Tests getTableTypeAndIndexTypeUpdateOrDelete
+   * @throws IOException
+   */
+  @ParameterizedTest
+  @MethodSource("getTableTypeAndIndexTypeUpdateOrDelete")
+  public void testRollbacksWithPartitionUpdate(HoodieTableType tableType, IndexType indexType, boolean isUpsert) throws IOException {
+    final Class<?> payloadClass = DefaultHoodieRecordPayload.class;
+    HoodieWriteConfig writeConfig = getWriteConfig(payloadClass, indexType);
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
+    final int totalRecords = 8;
+    final String p1 = "p1";
+    final String p2 = "p2";
+    final String p3 = "p3";
+    List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, p1, 0, payloadClass);
+    List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0.subList(0, 4), p2, 5, payloadClass);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+
+      // 1st batch: inserts
+      String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
+      client.startCommitWithTime(commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 2), commitTimeAtEpoch0).collect());
+
+      // 2nd batch: update 4 records from p1 to p2
+      String commitTimeAtEpoch5 = getCommitTimeAtUTC(0);
+      client.startCommitWithTime(commitTimeAtEpoch5);
+      if (isUpsert) {
+        assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch5).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 5);
+      } else {
+        assertNoWriteErrors(client.delete(jsc().parallelize(updatesAtEpoch5.stream().map(hoodieRecord -> hoodieRecord.getKey()).collect(Collectors.toList()), 2), commitTimeAtEpoch5).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {}, p2, 0);
+      }
+      // simuate crash. delete latest completed dc.
+      String latestCompletedDeltaCommit = metaClient.reloadActiveTimeline().getCommitsAndCompactionTimeline().lastInstant().get().getFileName();
+      metaClient.getStorage().deleteFile(new StoragePath(metaClient.getBasePath() + "/.hoodie/" + latestCompletedDeltaCommit));
+    }
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      // re-ingest same batch
+      String commitTimeAtEpoch10 = getCommitTimeAtUTC(0);
+      client.startCommitWithTime(commitTimeAtEpoch10);
+      if (isUpsert) {
+        assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch10).collect());
+        // this also tests snapshot query. We had a bug where MOR snapshot was ignoring rollbacks while determining last instant while reading log records.
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 5);
+      } else {
+        assertNoWriteErrors(client.delete(jsc().parallelize(updatesAtEpoch5.stream().map(hoodieRecord -> hoodieRecord.getKey()).collect(Collectors.toList()), 2), commitTimeAtEpoch10).collect());
+        readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+        readTableAndValidate(metaClient, new int[] {}, p2, 0);
+      }
+
+      // upsert test
+      // update 4 of them from p2 to p3.
+      // delete test:
+      // update 4 of them to p3. these are treated as new inserts since they are deleted. no changes should be seen wrt p2.
+      String commitTimeAtEpoch15 = getCommitTimeAtUTC(0);
+      List<HoodieRecord> updatesAtEpoch15 = getUpdates(updatesAtEpoch5, p3, 15, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch15);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch15, 2), commitTimeAtEpoch15).collect());
+      // for the same bug pointed out earlier, (ignoring rollbacks while determining last instant while reading log records), this tests the HoodieMergedReadHandle.
+      readTableAndValidate(metaClient, new int[] {4, 5, 6, 7}, p1, 0);
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p3, 15);
+
+      // lets move 2 of them back to p1
+      String commitTimeAtEpoch20 = getCommitTimeAtUTC(0);
+      List<HoodieRecord> updatesAtEpoch20 = getUpdates(updatesAtEpoch5.subList(0, 2), p1, 20, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch20);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch20, 1), commitTimeAtEpoch20).collect());
+      // for the same bug pointed out earlier, (ignoring rollbacks while determining last instant while reading log records), this tests the HoodieMergedReadHandle.
+      Map<String, Long> expectedTsMap = new HashMap<>();
+      Arrays.stream(new int[] {0, 1}).forEach(entry -> expectedTsMap.put(String.valueOf(entry), 20L));
+      Arrays.stream(new int[] {4, 5, 6, 7}).forEach(entry -> expectedTsMap.put(String.valueOf(entry), 0L));
+      readTableAndValidate(metaClient, new int[] {0, 1, 4, 5, 6, 7}, p1, expectedTsMap);
+      readTableAndValidate(metaClient, new int[] {2, 3}, p3, 15);
     }
   }
 
@@ -252,9 +344,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
         .select("_hoodie_record_key", "_hoodie_partition_path", "id", "pt", "ts")
         .cache();
     int expectedCount = expectedIds.length;
-    assertEquals(expectedCount, df.count());
-    assertEquals(expectedCount, df.filter(String.format("pt = '%s'", expectedPartition)).count());
-    Row[] allRows = (Row[]) df.collect();
+    Row[] allRows = (Row[]) df.filter(String.format("pt = '%s'", expectedPartition)).collect();
+    assertEquals(expectedCount, allRows.length);
     for (int i = 0; i < expectedCount; i++) {
       int expectedId = expectedIds[i];
       Row r = allRows[i];
@@ -289,6 +380,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
             .withGlobalBloomIndexUpdatePartitionPath(true)
             .withGlobalSimpleIndexUpdatePartitionPath(true)
             .withRecordIndexUpdatePartitionPath(true).build())
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withMaxNumDeltaCommitsBeforeCompaction(4).build())
         .withSchema(SCHEMA_STR)
         .withPayloadConfig(HoodiePayloadConfig.newBuilder()
             .fromProperties(getPayloadProps(payloadClass)).build())


### PR DESCRIPTION
### Change Logs

- Fix Log record reading with rollback blocks having higher timestamps compared to maxInstant configured.  

### Impact

LogRecordReader takes in a maxInstant time beyond which log blocks are ignored. But w/ rollbacks, there are chances it could lead to data consistency issues. 

Lets go through an illustration: 

Say, we have t1.dc, t2.dc and t2.dc crashed mid way.  
Current layout is, 
```
base file(t1), lf1(partially committed data w/ t2 as instant time)
```

Then we start t5.dc say. just when we start t5.dc, hudi detects pending commit and triggers a rollback. And this rollback will get an instant time of t6 (t6.rb). Note that rollback's commit time is greater than t5 or current ongoing delta commit. 
So, once rollback completes, this is the layout.
```
base file, lf1(from t2.dc partially failed), lf3 (rollback command block with t6). 
```

And once t5.dc completes, this is how the layout looks like 
```
base file, lf1(from t2.dc partially failed), lf3 (rollback command block with t6). lf4 (from t5) 
```

At this point in time, when we trigger snapshot read or try to trigger tagLocation w/ global index, maxInstant is set to last entry among commits timeline which is t5. So, while LogRecordReader while processing all log blocks, when it reaches lf3, it detects the timestamp of t6 > t5 (i.e max instant time) and bails out of for loop. So, in essence it may even read lf4 in above scenario. 

This patch attempts the fix the same. 

Fix: 
We only hold the constraint true for any data blocks and relax it for other block types. For eg, any data blocks > max instant time will be ignored. But all rollback blocks are taken into consideration. 


### Risk level (write none, low medium or high below)

medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
