### PR TITLE
[HUDI-6910] Support schema evolution for both Avro and Spark records

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -21,12 +21,15 @@ package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.DefaultSparkRecordMerger;
 import org.apache.hudi.HoodieSparkUtils;
+import org.apache.hudi.OverwriteWithLatestSparkRecordMerger;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieAvroRecordMerger;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -74,6 +77,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.hudi.config.HoodieWriteConfig.RECORD_MERGER_IMPLS;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -191,6 +195,12 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
       extraProps.setProperty(HoodieErrorTableConfig.ERROR_TABLE_WRITE_CLASS.key(), TestErrorTable.class.getName());
       extraProps.setProperty("hoodie.base.path", tableBasePath);
     }
+
+    // Schema evolution
+    extraProps.setProperty(RECORD_MERGER_IMPLS.key(),
+        HoodieAvroRecordMerger.class.getCanonicalName()
+            + "," + DefaultSparkRecordMerger.class.getName()
+            + "," + OverwriteWithLatestSparkRecordMerger.class.getSimpleName());
 
     List<String> transformerClassNames = new ArrayList<>();
     Collections.addAll(transformerClassNames, transformerClasses);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -108,6 +108,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   protected boolean withErrorTable;
   protected boolean useTransformer;
   protected boolean userProvidedSchema;
+  protected boolean isSparkRecord;
 
   @BeforeAll
   public static void initKafka() {
@@ -143,18 +144,14 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
 
   protected HoodieStreamer deltaStreamer;
 
-  protected HoodieDeltaStreamer.Config getDeltaStreamerConfig() throws IOException {
-    return getDeltaStreamerConfig(true);
+  protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(TypedProperties extraProps) throws IOException {
+    return getDeltaStreamerConfig(true, extraProps);
   }
 
-  protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(boolean nullForDeletedCols) throws IOException {
+  protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(boolean nullForDeletedCols, TypedProperties extraProps) throws IOException {
     String[] transformerClasses = useTransformer ? new String[] {TestHoodieDeltaStreamer.TestIdentityTransformer.class.getName()}
         : new String[0];
-    return getDeltaStreamerConfig(transformerClasses, nullForDeletedCols);
-  }
-
-  protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(String[] transformerClasses, boolean nullForDeletedCols) throws IOException {
-    return getDeltaStreamerConfig(transformerClasses, nullForDeletedCols, new TypedProperties());
+    return getDeltaStreamerConfig(transformerClasses, nullForDeletedCols, extraProps);
   }
 
   protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(String[] transformerClasses, boolean nullForDeletedCols,
@@ -197,13 +194,6 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
       extraProps.setProperty(HoodieErrorTableConfig.ERROR_TABLE_WRITE_CLASS.key(), TestErrorTable.class.getName());
       extraProps.setProperty("hoodie.base.path", tableBasePath);
     }
-
-    // Schema evolution
-    extraProps.setProperty(RECORD_MERGER_IMPLS.key(),
-        HoodieAvroRecordMerger.class.getCanonicalName()
-            + "," + DefaultSparkRecordMerger.class.getName()
-            + "," + OverwriteWithLatestSparkRecordMerger.class.getSimpleName());
-    extraProps.setProperty(LOG_FILE_FORMAT.key(), HoodieFileFormat.PARQUET.name());
 
     List<String> transformerClassNames = new ArrayList<>();
     Collections.addAll(transformerClassNames, transformerClasses);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -30,6 +30,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieAvroRecordMerger;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -77,6 +78,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.LOG_FILE_FORMAT;
 import static org.apache.hudi.config.HoodieWriteConfig.RECORD_MERGER_IMPLS;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME;
@@ -201,6 +203,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
         HoodieAvroRecordMerger.class.getCanonicalName()
             + "," + DefaultSparkRecordMerger.class.getName()
             + "," + OverwriteWithLatestSparkRecordMerger.class.getSimpleName());
+    extraProps.setProperty(LOG_FILE_FORMAT.key(), HoodieFileFormat.PARQUET.name());
 
     List<String> transformerClassNames = new ArrayList<>();
     Collections.addAll(transformerClassNames, transformerClasses);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -21,16 +21,12 @@ package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DataSourceWriteOptions;
-import org.apache.hudi.DefaultSparkRecordMerger;
 import org.apache.hudi.HoodieSparkUtils;
-import org.apache.hudi.OverwriteWithLatestSparkRecordMerger;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
-import org.apache.hudi.common.model.HoodieAvroRecordMerger;
-import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -78,8 +74,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.hudi.common.table.HoodieTableConfig.LOG_FILE_FORMAT;
-import static org.apache.hudi.config.HoodieWriteConfig.RECORD_MERGER_IMPLS;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
@@ -141,8 +141,6 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
     return new HoodieDeltaStreamer(getDeltaStreamerConfig(extraProps), jsc);
   }
 
-
-
   /**
    * Main testing logic for non-type promotion tests
    */
@@ -238,15 +236,9 @@ public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieD
           for (Boolean shouldCluster : new Boolean[]{false, true}) {
             for (String tableType : new String[]{"COPY_ON_WRITE", "MERGE_ON_READ"}) {
               for (Boolean isSparkRecord : new Boolean[]{false, true}) {
-                if (!multiLogFiles || tableType.equals("MERGE_ON_READ")) {
+                if ((!multiLogFiles || tableType.equals("MERGE_ON_READ")) && (!rowWriterEnable || !isSparkRecord)) {
                   b.add(Arguments.of(
-                      tableType,
-                      shouldCluster,
-                      false,
-                      rowWriterEnable,
-                      addFilegroups,
-                      multiLogFiles,
-                      isSparkRecord));
+                      tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, isSparkRecord));
                 }
               }
             }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionExtensive.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -51,11 +50,9 @@ import static org.apache.hudi.common.table.HoodieTableConfig.LOG_FILE_FORMAT;
 import static org.apache.hudi.config.HoodieWriteConfig.RECORD_MERGER_IMPLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 /**
  * Takes hours to run. Use to debug schema evolution. Don't enable for ci
  */
-@Disabled
 public class TestHoodieDeltaStreamerSchemaEvolutionExtensive extends TestHoodieDeltaStreamerSchemaEvolutionBase {
 
   protected void testBase(String updateFile, String updateColumn, String condition, int count) throws Exception {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -163,7 +163,9 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
     PARQUET_SOURCE_ROOT = basePath + "parquetFilesDfs" + ++testNum;
     tableName = "test_parquet_table" + testNum;
     tableBasePath = basePath + tableName;
-    this.deltaStreamer = new HoodieDeltaStreamer(getDeltaStreamerConfig(allowNullForDeletedCols), jsc);
+    TypedProperties extraProps = new TypedProperties();
+    this.deltaStreamer = new HoodieDeltaStreamer(
+        getDeltaStreamerConfig(allowNullForDeletedCols, extraProps), jsc);
 
     //first write
     String datapath = String.class.getResource("/data/schema-evolution/startTestEverything.json").getPath();


### PR DESCRIPTION
### Change Logs

We want to test if the schedule evolution has been done correctly for both Avro and Spark records.

### Impact

Better support for schema evolution.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
