### PR TITLE
[MINOR] Disable Maven cache that generates large files in Github Java setup

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -222,7 +222,6 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Build Project
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
@@ -235,7 +234,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Quickstart Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
@@ -429,7 +427,6 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Build Project
         env:
           SCALA_PROFILE: 'scala-2.12'
@@ -526,7 +523,6 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Build Project
         env:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
@@ -590,7 +586,6 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
       - name: Build Project
         env:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}


### PR DESCRIPTION
### Change Logs

This PR disables maven cache in more jobs in Github action that contribute to large cache entries and files (see below), causing the integration tests to run out of disk space.

```
test-spark-java17-java-tests
Cache Size: ~861 MB (903308583 B)

test-flink (flink1.16)
Cache Size: ~762 MB (799024766 B)

validate-bundles (scala-2.13, flink1.19, spark3.5, spark3.5.1)
Cache Size: ~1153 MB (1209484010 B)

validate-bundles-java11 (scala-2.12, flink1.19, spark3.5, spark3.5.0)
Cache Size: ~1935 MB (2029325940 B)
```

### Impact

Improves Github CI stability

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
