### PR TITLE
[HUDI-8271] Enable Hive incremental queries in integration tests

### DIFF
--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -131,8 +131,7 @@ public class ITTestHoodieDemo extends ITTestBase {
     // testPrestoAfterSecondBatch();
     // testTrinoAfterSecondBatch();
     testSparkSQLAfterSecondBatch();
-    // TODO(HUDI-8271): fix incremental queries in integration tests on Hive
-    // testIncrementalHiveQueryBeforeCompaction();
+    testIncrementalHiveQueryBeforeCompaction();
     testIncrementalSparkSQLQuery();
 
     // compaction
@@ -142,7 +141,7 @@ public class ITTestHoodieDemo extends ITTestBase {
     // testHiveAfterSecondBatchAfterCompaction();
     // testPrestoAfterSecondBatchAfterCompaction();
     // testTrinoAfterSecondBatchAfterCompaction();
-    // testIncrementalHiveQueryAfterCompaction();
+    testIncrementalHiveQueryAfterCompaction();
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR enables Hive incremental queries in integration tests.  The Hive incremental queries failed due to failures in snapshot queries before.  The Hive snapshot query issue will be addressed by HUDI-8275.

### Impact

Re-enables tests for test coverage

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
