### PR TITLE
[HUDI-8126] Support proto messages for spark kryo serializer excluding DynamicMessages

### DIFF
--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -93,6 +93,12 @@
       <artifactId>parquet-avro</artifactId>
     </dependency>
 
+    <!-- Used for adding kryo serializers for protobuf -->
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-protobuf</artifactId>
+    </dependency>
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -18,11 +18,6 @@
 
 package org.apache.spark
 
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.serializers.JavaSerializer
-import com.esotericsoftware.kryo.{Kryo, Serializer}
-import com.google.protobuf.Message
-import com.twitter.chill.protobuf.ProtobufSerializer
 import org.apache.hudi.client.model.HoodieInternalRow
 import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar
@@ -30,6 +25,12 @@ import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.io.HoodieKeyLookupResult
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 import org.apache.hudi.table.{HoodieSparkCopyOnWriteTable, HoodieSparkMergeOnReadTable}
+
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.serializers.JavaSerializer
+import com.google.protobuf.Message
+import com.twitter.chill.protobuf.ProtobufSerializer
 import org.apache.spark.serializer.KryoRegistrator
 
 /**

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -18,15 +18,17 @@
 
 package org.apache.spark
 
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.serializers.JavaSerializer
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.google.protobuf.Message
+import com.twitter.chill.protobuf.ProtobufSerializer
 import org.apache.hudi.client.model.HoodieInternalRow
 import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.serializers.JavaSerializer
-import com.esotericsoftware.kryo.{Kryo, Serializer}
 import org.apache.hudi.io.HoodieKeyLookupResult
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 import org.apache.hudi.table.{HoodieSparkCopyOnWriteTable, HoodieSparkMergeOnReadTable}
 import org.apache.spark.serializer.KryoRegistrator
 
@@ -70,6 +72,8 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
     //       We cannot remove this entry; otherwise the ordering is changed.
     //       So we replace it with [[HadoopStorageConfiguration]] for Spark.
     kryo.register(classOf[HadoopStorageConfiguration], new JavaSerializer())
+    // NOTE: Protobuf objects are not serializable by default using kryo, need to register them explicitly.
+    kryo.addDefaultSerializer(classOf[Message], new ProtobufSerializer())
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ProtoKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ProtoKafkaSource.java
@@ -101,6 +101,13 @@ public class ProtoKafkaSource extends KafkaSource<JavaRDD<Message>> {
     }
   }
 
+  @Override
+  protected boolean allowSourcePersist() {
+    // Persisting proto messages where protobuf class is unknown, is expensive because of the overhead.
+    // Eg: Persisting DynamicMessage using kryo requires attaching descriptor info for each message.
+    return persistRdd && deserializerName.equals(ByteArrayDeserializer.class.getName());
+  }
+
   private static class ProtoDeserializer implements Serializable {
     private final String className;
     private transient Class protoClass;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
@@ -71,7 +71,7 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
 
   private final SourceType sourceType;
   private final StorageLevel storageLevel;
-  private final boolean persistRdd;
+  protected final boolean persistRdd;
   private Either<Dataset<Row>, JavaRDD<?>> cachedSourceRdd = null;
 
   protected Source(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
@@ -196,7 +196,7 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
 
   private synchronized void persist(T data) {
     boolean isSparkRdd = data.getClass().isAssignableFrom(Dataset.class) || data.getClass().isAssignableFrom(JavaRDD.class);
-    if (persistRdd && isSparkRdd) {
+    if (allowSourcePersist() && isSparkRdd) {
       if (data.getClass().isAssignableFrom(Dataset.class)) {
         Dataset<Row> df = (Dataset<Row>) data;
         cachedSourceRdd = Either.left(df);
@@ -207,6 +207,10 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
         javaRDD.persist(storageLevel);
       }
     }
+  }
+
+  protected boolean allowSourcePersist() {
+    return persistRdd;
   }
 
   @Override

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -118,6 +118,7 @@
                   <include>com.beust:jcommander</include>
                   <include>com.twitter:bijection-avro_${scala.binary.version}</include>
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
+                  <include>com.twitter:chill-protobuf</include>
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>com.twitter:parquet-avro</include>
                   <include>com.twitter.common:objectsize</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -101,6 +101,7 @@
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>com.twitter:bijection-avro_${scala.binary.version}</include>
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
+                  <include>com.twitter:chill-protobuf</include>
 
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -126,6 +126,7 @@
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.twitter:bijection-avro_${scala.binary.version}</include>
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
+                  <include>com.twitter:chill-protobuf</include>
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
                   <include>io.confluent:common-config</include>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -114,6 +114,7 @@
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.twitter:bijection-avro_${scala.binary.version}</include>
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
+                  <include>com.twitter:chill-protobuf</include>
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
                   <include>io.confluent:common-config</include>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
     <presto.bundle.bootstrap.shade.prefix>org.apache.hudi.</presto.bundle.bootstrap.shade.prefix>
     <trino.bundle.bootstrap.scope>compile</trino.bundle.bootstrap.scope>
     <trino.bundle.bootstrap.shade.prefix>org.apache.hudi.</trino.bundle.bootstrap.shade.prefix>
+    <twitter.chill.version>0.10.0</twitter.chill.version>
     <shadeSources>true</shadeSources>
     <zk-curator.version>2.7.1</zk-curator.version>
     <disruptor.version>3.4.2</disruptor.version>
@@ -1752,6 +1753,13 @@
         <artifactId>kryo</artifactId>
         <version>4.0.0</version>
         <scope>test</scope>
+      </dependency>
+
+      <!-- Used for adding kryo serializers for protobuf -->
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-protobuf</artifactId>
+        <version>${twitter.chill.version}</version>
       </dependency>
 
       <!-- Other Utils -->


### PR DESCRIPTION
### Change Logs

NOTE: Stacked on top of https://github.com/apache/hudi/pull/11844
Persisting a proto RDD<Message> is failing because KyroSerializer in Spark doesn't have handling for proto messages and failing with errors like this.

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 0.0 failed 1 times, most recent failure: Lost task 1.0 in stage 0.0 (TID 1) (vinish-ka-mbp executor driver): com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException
Serialization trace:
dependencies (com.google.protobuf.Descriptors$DescriptorPool)
pool (com.google.protobuf.Descriptors$FileDescriptor)
file (com.google.protobuf.Descriptors$FieldDescriptor)
fields (com.google.protobuf.Descriptors$Descriptor)
containingType (com.google.protobuf.Descriptors$Descriptor)
descriptor (com.google.protobuf.MapEntry$Metadata)
metadata (com.google.protobuf.MapEntry)
defaultEntry (com.google.protobuf.MapField$ImmutableMessageConverter)
converter (com.google.protobuf.MapField)
mapMessage_ (org.apache.hudi.utilities.test.proto.Sample)
```

Spark already uses the [scala kryo serializers](https://github.com/onehouseinc/spark-internal/blob/master/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala#L199) provided by https://github.com/twitter/chill, this PR includes the proto one as well.

DynamicMessage doesn't have `parseFrom(byte[]..)` method available in compiled proto messages, and we it's expensive to handle this serialization so we will be ignoring to persist the sourceRDD for such cases.

### Impact

No impact on existing functionality, improving `HoodieSparkKryoRegistrar` to handle proto messages as well.

### Risk level (write none, low medium or high below)

Medium. 

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed