### PR TITLE
[HUDI-8272] Fix incremental queries in integration tests on Spark

### DIFF
--- a/docker/demo/sparksql-incremental.commands
+++ b/docker/demo/sparksql-incremental.commands
@@ -28,70 +28,40 @@ import org.apache.hadoop.fs.FileSystem;
 
 val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
 val beginInstantTime = HoodieDataSourceHelpers.listCommitsSince(fs, "/user/hive/warehouse/stock_ticks_cow", "00000").get(0)
-println("Begin instant time for incremental query: " + beginInstantTime)
-val hoodieIncQueryDF =  spark.read.format("org.apache.hudi").
+println("Begin instant time for COW incremental query: " + beginInstantTime)
+val hoodieIncQueryDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
                       option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), beginInstantTime).
                       load("/user/hive/warehouse/stock_ticks_cow");
+println("stock_ticks_cow incremental count: " + hoodieIncQueryDF.count)
 hoodieIncQueryDF.registerTempTable("stock_ticks_cow_incr")
 spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close  from stock_ticks_cow_incr where  symbol = 'GOOG'").show(100, false);
 
-spark.sql("select key, `_hoodie_partition_path` as datestr, symbol, ts, open, close from stock_ticks_cow_incr").
-    write.format("org.apache.hudi").
-    option("hoodie.insert.shuffle.parallelism", "2").
-    option("hoodie.upsert.shuffle.parallelism","2").
-    option(DataSourceWriteOptions.TABLE_TYPE.key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL).
-    option(DataSourceWriteOptions.OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL).
-    option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "key").
-    option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key(), "datestr").
-    option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "ts").
-    option(HoodieWriteConfig.TBL_NAME.key(), "stock_ticks_derived_mor").
-    option(HoodieSyncConfig.META_SYNC_TABLE_NAME.key(), "stock_ticks_derived_mor").
-    option(HoodieSyncConfig.META_SYNC_DATABASE_NAME.key(), "default").
-    option(HiveSyncConfigHolder.HIVE_URL.key(), "jdbc:hive2://hiveserver:10000").
-    option(HiveSyncConfigHolder.HIVE_USER.key(), "hive").
-    option(HiveSyncConfigHolder.HIVE_PASS.key(), "hive").
-    option(HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key(), "true").
-    option(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key(), "datestr").
-    option(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), classOf[MultiPartKeysValueExtractor].getCanonicalName).
-    option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), "true").
-    mode(SaveMode.Overwrite).
-    save("/user/hive/warehouse/stock_ticks_derived_mor");
-
-spark.sql("select count(*) from stock_ticks_derived_mor_ro").show(20, false)
-spark.sql("select count(*) from stock_ticks_derived_mor_rt").show(20, false)
-
-val hoodieIncQueryBsDF =  spark.read.format("org.apache.hudi").
+val hoodieIncQueryBsDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
                       option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "00000000000001").
                       load("/user/hive/warehouse/stock_ticks_cow_bs");
+println("stock_ticks_cow_bs incremental count: " + hoodieIncQueryBsDF.count)
 hoodieIncQueryBsDF.registerTempTable("stock_ticks_cow_bs_incr")
 spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close  from stock_ticks_cow_bs_incr where  symbol = 'GOOG'").show(100, false);
 
-spark.sql("select key, `_hoodie_partition_path` as datestr, symbol, ts, open, close from stock_ticks_cow_bs_incr").
-    write.format("org.apache.hudi").
-    option("hoodie.insert.shuffle.parallelism", "2").
-    option("hoodie.upsert.shuffle.parallelism","2").
-    option(DataSourceWriteOptions.TABLE_TYPE.key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL).
-    option(DataSourceWriteOptions.OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL).
-    option(DataSourceWriteOptions.RECORDKEY_FIELD.key(), "key").
-    option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key(), "datestr").
-    option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "ts").
-    option(HoodieWriteConfig.TBL_NAME.key(), "stock_ticks_derived_mor_bs").
-    option(HoodieSyncConfig.META_SYNC_TABLE_NAME.key(), "stock_ticks_derived_mor_bs").
-    option(HoodieSyncConfig.META_SYNC_DATABASE_NAME.key(), "default").
-    option(HiveSyncConfigHolder.HIVE_URL.key(), "jdbc:hive2://hiveserver:10000").
-    option(HiveSyncConfigHolder.HIVE_USER.key(), "hive").
-    option(HiveSyncConfigHolder.HIVE_PASS.key(), "hive").
-    option(HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key(), "true").
-    option(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key(), "datestr").
-    option(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), classOf[MultiPartKeysValueExtractor].getCanonicalName).
-    option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), "true").
-    mode(SaveMode.Overwrite).
-    save("/user/hive/warehouse/stock_ticks_derived_mor_bs");
+val morBeginInstantTime = HoodieDataSourceHelpers.listCommitsSince(fs, "/user/hive/warehouse/stock_ticks_mor", "00000").get(0)
+println("Begin instant time for MOR incremental query: " + morBeginInstantTime)
 
-spark.sql("show tables").show(20, false)
-spark.sql("select count(*) from stock_ticks_derived_mor_bs_ro").show(20, false)
-spark.sql("select count(*) from stock_ticks_derived_mor_bs_rt").show(20, false)
+val hoodieMorIncQueryDF =  spark.read.format("hudi").
+                      option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
+                      option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), morBeginInstantTime).
+                      load("/user/hive/warehouse/stock_ticks_mor");
+println("stock_ticks_mor incremental count: " + hoodieMorIncQueryDF.count)
+hoodieMorIncQueryDF.registerTempTable("stock_ticks_mor_incr")
+spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close from stock_ticks_mor_incr where symbol = 'GOOG'").show(100, false);
+
+val hoodieMorIncQueryBsDF =  spark.read.format("hudi").
+                      option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
+                      option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "00000000000001").
+                      load("/user/hive/warehouse/stock_ticks_mor_bs");
+println("stock_ticks_mor_bs incremental count: " + hoodieMorIncQueryBsDF.count)
+hoodieIncQueryBsDF.registerTempTable("stock_ticks_mor_bs_incr")
+spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close from stock_ticks_mor_bs_incr where symbol = 'GOOG'").show(100, false);
 
 System.exit(0);

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
@@ -113,8 +113,10 @@ public abstract class ITTestBase {
   static String getSparkShellCommand(String commandFile) {
     return new StringBuilder().append("spark-shell --jars ").append(HUDI_SPARK_BUNDLE)
         .append(" --master local[2] --driver-class-path ").append(HADOOP_CONF_DIR)
-        .append(
-            " --conf spark.sql.hive.convertMetastoreParquet=false --deploy-mode client  --driver-memory 1G --executor-memory 1G --num-executors 1 ")
+        .append(" --conf spark.serializer=org.apache.spark.serializer.KryoSerializer")
+        .append(" --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog")
+        .append(" --conf spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+        .append(" --deploy-mode client  --driver-memory 1G --executor-memory 1G --num-executors 1")
         .append(" -i ").append(commandFile).toString();
   }
 

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -131,13 +131,14 @@ public class ITTestHoodieDemo extends ITTestBase {
     // testPrestoAfterSecondBatch();
     // testTrinoAfterSecondBatch();
     testSparkSQLAfterSecondBatch();
-    // TODO(HUDI-8271, HUDI-8272): fix incremental queries in integration tests on Hive and Spark
+    // TODO(HUDI-8271): fix incremental queries in integration tests on Hive
     // testIncrementalHiveQueryBeforeCompaction();
-    // testIncrementalSparkSQLQuery();
+    testIncrementalSparkSQLQuery();
 
     // compaction
     scheduleAndRunCompaction();
 
+    testIncrementalSparkSQLQuery();
     // testHiveAfterSecondBatchAfterCompaction();
     // testPrestoAfterSecondBatchAfterCompaction();
     // testTrinoAfterSecondBatchAfterCompaction();
@@ -498,24 +499,11 @@ public class ITTestHoodieDemo extends ITTestBase {
 
   private void testIncrementalSparkSQLQuery() throws Exception {
     Pair<String, String> stdOutErrPair = executeSparkSQLCommand(SPARKSQL_INCREMENTAL_COMMANDS, true);
-    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:59:00|9021  |1227.1993|1227.215|", 2);
-    assertStdOutContains(stdOutErrPair, "|default  |stock_ticks_cow              |false      |\n"
-        + "|default  |stock_ticks_cow_bs           |false      |\n"
-        + "|default  |stock_ticks_derived_mor      |false      |\n"
-        + "|default  |stock_ticks_derived_mor_bs   |false      |\n"
-        + "|default  |stock_ticks_derived_mor_bs_ro|false      |\n"
-        + "|default  |stock_ticks_derived_mor_bs_rt|false      |\n"
-        + "|default  |stock_ticks_derived_mor_ro   |false      |\n"
-        + "|default  |stock_ticks_derived_mor_rt   |false      |\n"
-        + "|default  |stock_ticks_mor              |false      |\n"
-        + "|default  |stock_ticks_mor_bs           |false      |\n"
-        + "|default  |stock_ticks_mor_bs_ro        |false      |\n"
-        + "|default  |stock_ticks_mor_bs_rt        |false      |\n"
-        + "|default  |stock_ticks_mor_ro           |false      |\n"
-        + "|default  |stock_ticks_mor_rt           |false      |\n"
-        + "|         |stock_ticks_cow_bs_incr      |true       |\n"
-        + "|         |stock_ticks_cow_incr         |true       |");
-    assertStdOutContains(stdOutErrPair, "|count(1)|\n+--------+\n|99     |", 4);
+    assertStdOutContains(stdOutErrPair, "stock_ticks_cow incremental count: 99", 1);
+    assertStdOutContains(stdOutErrPair, "stock_ticks_cow_bs incremental count: 99", 1);
+    assertStdOutContains(stdOutErrPair, "stock_ticks_mor incremental count: 99", 1);
+    assertStdOutContains(stdOutErrPair, "stock_ticks_mor_bs incremental count: 99", 1);
+    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:59:00|9021  |1227.1993|1227.215|", 4);
   }
 
   private void scheduleAndRunCompaction() throws Exception {


### PR DESCRIPTION
### Change Logs

This PR fixes incremental queries in integration tests on Spark:
- Adds missing Spark configs for running queries on Hudi tables in `spark-shell`
- Simplifies and enhances incremental query validation on Spark in the docker demo test
- Adds Spark incremental query validation after compaction

### Impact

Adds back incremental query validation in integration tests using docker demo.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
