### PR TITLE
[HUDI-8306] Fix the bug where the Flink table config hoodie.populate.meta.fields is not effective

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -271,7 +271,7 @@ public class SparkMain {
       HoodieWriteConfig config = client.getConfig();
       HoodieEngineContext context = client.getEngineContext();
       HoodieSparkTable table = HoodieSparkTable.create(config, context);
-      client.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), config);
+      SparkRDDWriteClient.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), config);
       WriteMarkersFactory.get(config.getMarkersType(), table, instantTime)
           .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism());
       return 0;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -33,7 +33,6 @@ import org.apache.hudi.client.heartbeat.HeartbeatUtils;
 import org.apache.hudi.client.utils.TransactionUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.config.HoodieCommonConfig;
-import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.ActionType;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -306,9 +306,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
         metadataValues.setCommitTime(instantTime);
         metadataValues.setCommitSeqno(seqId);
       }
-    }
-    if (config.allowOperationMetadataField()) {
-      metadataValues.setOperation(hoodieRecord.getOperation().getName());
+
+      if (config.allowOperationMetadataField()) {
+        metadataValues.setOperation(hoodieRecord.getOperation().getName());
+      }
     }
 
     return metadataValues;
@@ -452,7 +453,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
     try {
       header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
-      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, config.populateMetaFields() ? writeSchemaWithMetaFields.toString() : writeSchema.toString());
       List<HoodieLogBlock> blocks = new ArrayList<>(2);
       if (recordList.size() > 0) {
         String keyField = config.populateMetaFields()

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+
+public class TestBaseHoodieWriteClient {
+  private HoodieStorage storage;
+  private StoragePath metaPath;
+
+  @TempDir
+  private Path tempDir;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    StorageConfiguration<Configuration> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    storageConf.set("fs.defaultFS", "file:///");
+    storageConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+    this.storage = HoodieStorageUtils.getStorage(tempDir.toString(), storageConf);
+    this.metaPath = new StoragePath(tempDir + "/.hoodie");
+  }
+
+  @Test
+  public void testValidateAgainstTableProperties() throws IOException {
+    // Init table config
+    Properties properties = new Properties();
+    properties.put(HoodieTableConfig.TYPE.key(), HoodieTableType.COPY_ON_WRITE.toString());
+    properties.put(HoodieTableConfig.VERSION.key(), 6);
+    properties.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), false);
+    HoodieTestUtils.init(this.storage.getConf().newInstance(), this.tempDir.toString(), HoodieTableType.MERGE_ON_READ, properties);
+
+    HoodieTableConfig tableConfig = new HoodieTableConfig(this.storage, this.metaPath,
+        HoodieTableConfig.PAYLOAD_CLASS_NAME.defaultValue(), HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID);
+
+    // Test version conflicts
+    HoodieWriteConfig versionConflictConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withWriteTableVersion(8)
+        .build();
+    Assertions.assertThrowsExactly(HoodieNotSupportedException.class,
+        () -> BaseHoodieWriteClient.validateAgainstTableProperties(tableConfig, versionConflictConfig),
+        "Table version (6) and Writer version (8) do not match.");
+
+    // Test hoodie.populate.meta.fields conflicts
+    HoodieWriteConfig metaFieldsConflictConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withWriteTableVersion(6)
+        .withPopulateMetaFields(true)
+        .build();
+    Assertions.assertThrowsExactly(HoodieException.class,
+        () -> BaseHoodieWriteClient.validateAgainstTableProperties(tableConfig, metaFieldsConflictConfig),
+        "hoodie.populate.meta.fields already disabled for the table. Can't be re-enabled back");
+
+    // Test record key fields conflicts
+    HoodieWriteConfig recordKeyConflictConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withWriteTableVersion(6)
+        .withPopulateMetaFields(false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withRecordKeyField("a,b").build())
+        .build();
+    Assertions.assertThrowsExactly(HoodieException.class,
+        () -> BaseHoodieWriteClient.validateAgainstTableProperties(tableConfig, recordKeyConflictConfig),
+        "When meta fields are not populated, the number of record key fields must be exactly one");
+
+    // Test hoodie.allow.operation.metadata.field conflicts
+    HoodieWriteConfig operationMetaFieldConflictConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withWriteTableVersion(6)
+        .withPopulateMetaFields(false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withRecordKeyField("a").build())
+        .withAllowOperationMetadataField(true)
+        .build();
+    Assertions.assertThrowsExactly(HoodieException.class,
+        () -> BaseHoodieWriteClient.validateAgainstTableProperties(tableConfig, operationMetaFieldConflictConfig),
+        "Operation metadata fields are allowed, but populateMetaFields is not enabled. "
+        + "Please ensure that populateMetaFields is set to true in the configuration.");
+
+    // Test hoodie.index.bucket.engine conflicts
+    HoodieWriteConfig bucketIndexEngineTypeConflictConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withWriteTableVersion(6)
+        .withPopulateMetaFields(false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .withRecordKeyField("a")
+            .withIndexType(HoodieIndex.IndexType.BUCKET)
+            .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING)
+            .build())
+        .withAllowOperationMetadataField(true)
+        .build();
+    Assertions.assertThrowsExactly(HoodieException.class,
+        () -> BaseHoodieWriteClient.validateAgainstTableProperties(tableConfig, bucketIndexEngineTypeConflictConfig),
+        "Consistent hashing bucket index does not work with COW table. Use simple bucket index or an MOR table.");
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -254,7 +254,7 @@ public class HoodieTableConfig extends HoodieConfig {
       .key("hoodie.populate.meta.fields")
       .defaultValue(true)
       .withDocumentation("When enabled, populates all meta fields. When disabled, no meta fields are populated "
-          + "and incremental queries will not be functional. This is only meant to be used for append only/immutable data for batch processing");
+          + "and incremental queries will not be functional. In the disabled state, the number of record key fields must be equal to one.");
 
   public static final ConfigProperty<String> KEY_GENERATOR_CLASS_NAME = ConfigProperty
       .key("hoodie.table.keygenerator.class")

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -655,7 +655,9 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     boolean allowFullScan = allowFullScanOverride.orElseGet(() -> isFullScanAllowedForPartition(partitionName));
 
     // Load the schema
-    Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+    Schema schema = metadataTableConfig.populateMetaFields()
+        ? HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema())
+        : HoodieMetadataRecord.getClassSchema();
     HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().fromProperties(metadataConfig.getProps()).build();
     HoodieMetadataLogRecordReader logRecordScanner = HoodieMetadataLogRecordReader.newBuilder(partitionName)
         .withStorage(metadataMetaClient.getStorage())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -497,6 +497,14 @@ public class FlinkOptions extends HoodieConfig {
           + "By default false (the names of partition folders are only partition values)");
 
   @AdvancedConfig
+  public static final ConfigOption<Boolean> POPULATE_META_FIELDS = ConfigOptions
+      .key(HoodieTableConfig.POPULATE_META_FIELDS.key())
+      .booleanType()
+      .defaultValue(true)
+      .withDescription("When enabled, populates all meta fields. When disabled, no meta fields are populated "
+          + "and incremental queries will not be functional. In the disabled state, the number of record key fields must be equal to one.");
+
+  @AdvancedConfig
   public static final ConfigOption<String> KEYGEN_CLASS_NAME = ConfigOptions
       .key(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key())
       .stringType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -255,11 +255,12 @@ public class StreamerUtil {
           .setTableName(conf.getString(FlinkOptions.TABLE_NAME))
           .setTableVersion(conf.getInteger(FlinkOptions.WRITE_TABLE_VERSION))
           .setDatabaseName(conf.getString(FlinkOptions.DATABASE_NAME))
-          .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD, null))
+          .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD))
           .setPayloadClassName(conf.getString(FlinkOptions.PAYLOAD_CLASS_NAME))
           .setPreCombineField(OptionsResolver.getPreCombineField(conf))
           .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD, null))
+          .setPopulateMetaFields(conf.getBoolean(FlinkOptions.POPULATE_META_FIELDS))
           .setKeyGeneratorClassProp(
               conf.getOptional(FlinkOptions.KEYGEN_CLASS_NAME).orElse(SimpleAvroKeyGenerator.class.getName()))
           .setHiveStylePartitioningEnable(conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING))

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -329,7 +329,7 @@ public class ITTestDataStreamWrite extends TestLogger {
       JobClient client = execEnv.executeAsync(jobName);
       if (client.getJobStatus().get() != JobStatus.FAILED) {
         try {
-          TimeUnit.SECONDS.sleep(20); // wait long enough for the compaction to finish
+          TimeUnit.SECONDS.sleep(35); // wait long enough for the compaction to finish
           client.cancel();
         } catch (Throwable var1) {
           // ignored

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieArchivedLogFile;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -31,6 +32,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
 import org.apache.hudi.common.table.log.AppendResult;
@@ -63,6 +65,7 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.CorruptedLogFileException;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
@@ -114,6 +117,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME;
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getJavaVersion;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.shouldUseExternalHdfs;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.useExternalHdfs;
@@ -2766,6 +2770,72 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("testArguments")
+  public void testNoMetaFields(ExternalSpillableMap.DiskMapType diskMapType,
+                               boolean isCompressionEnabled,
+                               boolean enableOptimizedLogBlocksScan
+  ) throws IOException, URISyntaxException, InterruptedException {
+    final String recordKeyField = "name";
+    final String instantTime = "100";
+
+    // Clear the meta directory to ensure a clean test environment
+    storage.deleteDirectory(new StoragePath(basePath, METAFOLDER_NAME));
+
+    // Initialize the Hoodie table and do not populate meta fields
+    Properties properties = new Properties();
+    properties.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), false);
+    properties.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), recordKeyField);
+    HoodieTestUtils.init(storage.getConf().newInstance(), basePath, HoodieTableType.MERGE_ON_READ, properties);
+
+    // Generate a list of test records
+    Schema schema = getSimpleSchema();
+    SchemaTestUtil testUtil = new SchemaTestUtil();
+    List<GenericRecord> genRecords = testUtil.generateHoodieTestRecords(0, 400, schema).stream().map(r -> {
+      try {
+        return (GenericRecord) ((HoodieAvroPayload) r.getData()).getInsertValue(schema).get();
+      } catch (IOException e) {
+        throw new HoodieException(e);
+      }
+    }).collect(Collectors.toList());
+
+    // Deduplicate test records based on the Record Key to facilitate determining whether they are consistent with the scanner results,
+    // as the scanner will merge (deduplicate) records
+    List<IndexedRecord> duplicatedRecords = genRecords.stream().collect(Collectors.toMap(
+        r -> r.get(recordKeyField).toString(), // Use the recordKeyField as the key
+        r -> r,
+        (r1, r2) -> r1
+    )).values().stream().collect(Collectors.toList());
+
+    Set<HoodieLogFile> logFiles = writeLogFiles(partitionPath, schema, duplicatedRecords, 4);
+    FileCreateUtils.createDeltaCommit(basePath, instantTime, storage);
+
+    // Scan all log blocks
+    HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
+        .withStorage(storage)
+        .withBasePath(basePath)
+        .withLogFilePaths(logFiles.stream().map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
+        .withReaderSchema(schema)
+        .withLatestInstantTime(instantTime)
+        .withMaxMemorySizeInBytes(10240L)
+        .withReverseReader(false)
+        .withBufferSize(BUFFER_SIZE)
+        .withSpillableMapBasePath(spillableBasePath)
+        .withDiskMapType(diskMapType)
+        .withBitCaskDiskMapCompressionEnabled(isCompressionEnabled)
+        .withOptimizedLogBlocksScan(enableOptimizedLogBlocksScan)
+        .build();
+
+    List<IndexedRecord> scannedRecords = new ArrayList<>();
+    for (HoodieRecord record : scanner) {
+      scannedRecords.add((IndexedRecord) ((HoodieAvroRecord) record).getData().getInsertValue(schema).get());
+    }
+
+    assertEquals(sort(duplicatedRecords, recordKeyField), sort(scannedRecords, recordKeyField),
+        "Scanner records count should be the same as test records");
+    scanner.close();
+  }
+
   public static HoodieDataBlock getDataBlock(HoodieLogBlockType dataBlockType, List<IndexedRecord> records,
                                               Map<HeaderMetadataType, String> header) {
     return getDataBlock(dataBlockType, records.stream().map(HoodieAvroIndexedRecord::new).collect(Collectors.toList()), header, new StoragePath("dummy_path"));
@@ -2875,8 +2945,12 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   }
 
   private static List<IndexedRecord> sort(List<IndexedRecord> records) {
+    return sort(records, HoodieRecord.RECORD_KEY_METADATA_FIELD);
+  }
+
+  private static List<IndexedRecord> sort(List<IndexedRecord> records, String sortField) {
     List<IndexedRecord> copy = new ArrayList<>(records);
-    copy.sort(Comparator.comparing(r -> ((GenericRecord) r).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString()));
+    copy.sort(Comparator.comparing(r -> ((GenericRecord) r).get(sortField).toString()));
     return copy;
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
@@ -70,7 +70,7 @@ public class DataSourceInternalWriterHelper {
 
     this.metaClient = HoodieTableMetaClient.builder()
         .setConf(storageConf.newInstance()).setBasePath(writeConfig.getBasePath()).build();
-    this.writeClient.validateAgainstTableProperties(this.metaClient.getTableConfig(), writeConfig);
+    SparkRDDWriteClient.validateAgainstTableProperties(this.metaClient.getTableConfig(), writeConfig);
     this.writeClient.preWrite(instantTime, WriteOperationType.BULK_INSERT, metaClient);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
@@ -323,7 +323,7 @@ public class HoodieDropPartitionsTool implements Serializable {
   public void dryRun() {
     try (SparkRDDWriteClient<HoodieRecordPayload> client =  UtilHelpers.createHoodieClient(jsc, cfg.basePath, "", cfg.parallelism, Option.empty(), props)) {
       HoodieSparkTable<HoodieRecordPayload> table = HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
-      client.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), client.getConfig());
+      SparkRDDWriteClient.validateAgainstTableProperties(table.getMetaClient().getTableConfig(), client.getConfig());
       List<String> parts = Arrays.asList(cfg.partitions.split(","));
       Map<String, List<String>> partitionToReplaceFileIds = jsc.parallelize(parts, parts.size()).distinct()
           .mapToPair(partitionPath -> new Tuple2<>(partitionPath, table.getSliceView().getLatestFileSlices(partitionPath).map(fg -> fg.getFileId()).distinct().collect(Collectors.toList())))


### PR DESCRIPTION
### Change Logs

When setting hoodie.populate.meta.fields = false in Flink Table, an error occurs when the reader (Scanner) reads the log file. This PR fixes the bug when hoodie.populate.meta.fields = false.
1）Fix the missing populate meta fields configuration in Flink Table Config.
2）Add a check to ensure that hoodie.populate.meta.fields = false can only be set under certain conditions.

### Impact

Disabling hoodie.populate.meta.fields helps reduce file size and decoding overhead.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
