### PR TITLE
[HUDI-8308] Optimize the performance when disabling hoodie.populate.meta.fields

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -454,7 +454,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
     try {
       header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
-      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, config.populateMetaFields() ? writeSchemaWithMetaFields.toString() : writeSchema.toString());
       List<HoodieLogBlock> blocks = new ArrayList<>(2);
       if (recordList.size() > 0) {
         String keyField = config.populateMetaFields()

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -655,7 +655,9 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     boolean allowFullScan = allowFullScanOverride.orElseGet(() -> isFullScanAllowedForPartition(partitionName));
 
     // Load the schema
-    Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+    Schema schema = metadataTableConfig.populateMetaFields()
+        ? HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema())
+        : HoodieMetadataRecord.getClassSchema();
     HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().fromProperties(metadataConfig.getProps()).build();
     HoodieMetadataLogRecordReader logRecordScanner = HoodieMetadataLogRecordReader.newBuilder(partitionName)
         .withStorage(metadataMetaClient.getStorage())


### PR DESCRIPTION
### Change Logs

Reduce unnecessary encoding and decoding overhead when disabling hoodie.populate.meta.fields.
Disable hoodie.populate.meta.fields PR: [#12060](https://github.com/apache/hudi/pull/12060)

### Impact

Improve write performance. The write speed with hoodie.populate.meta.fields=false is **42.9% faster** than with hoodie.populate.meta.fields=true.

Consume from the earliest position in Kafka until all messages are consumed (Kafka Lag = 0), and compare the time taken for both：
**1）populate meta fields** 
time taken: 21hours and 25mins
![image](https://github.com/user-attachments/assets/5df6ea02-34e8-440d-9608-5eb0ad117a12)

**2）no meta fields** 
time taken: 12hours and 14mins
![image](https://github.com/user-attachments/assets/0aad909f-18e0-47ea-949d-203c190eb4a9)

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
