### PR TITLE
[HUDI-8307] Reduce docker image size for docker demo and integration tests

### DIFF
--- a/docker/hoodie/hadoop/base/Dockerfile
+++ b/docker/hoodie/hadoop/base/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x \
     && mkdir -p /opt/hadoop-$HADOOP_VERSION/logs \
     && tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
     && rm /tmp/hadoop.tar.gz* \
+    && rm -r /opt/hadoop-$HADOOP_VERSION/share/doc \
     && ln -s /opt/hadoop-$HADOOP_VERSION/etc/hadoop /etc/hadoop \
     && cp /etc/hadoop/mapred-site.xml.template /etc/hadoop/mapred-site.xml \
     && mkdir /hadoop-data

--- a/docker/hoodie/hadoop/hive_base/Dockerfile
+++ b/docker/hoodie/hadoop/hive_base/Dockerfile
@@ -48,9 +48,6 @@ ADD conf/hive-log4j2.properties $HIVE_HOME/conf
 ADD conf/ivysettings.xml $HIVE_HOME/conf
 ADD conf/llap-daemon-log4j2.properties $HIVE_HOME/conf
 
-# Setup Hoodie Library jars
-ADD target/ /var/hoodie/ws/docker/hoodie/hadoop/hive_base/target/
-
 ENV HUDI_HADOOP_BUNDLE=/var/hoodie/ws/docker/hoodie/hadoop/hive_base/target/hoodie-hadoop-mr-bundle.jar
 ENV HUDI_HIVE_SYNC_BUNDLE=/var/hoodie/ws/docker/hoodie/hadoop/hive_base/target/hoodie-hive-sync-bundle.jar
 ENV HUDI_SPARK_BUNDLE=/var/hoodie/ws/docker/hoodie/hadoop/hive_base/target/hoodie-spark-bundle.jar

--- a/docker/hoodie/hadoop/pom.xml
+++ b/docker/hoodie/hadoop/pom.xml
@@ -46,7 +46,22 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hadoop-mr-bundle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hive-sync-bundle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-spark${sparkbundle.version}-bundle_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-utilities-bundle_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Change Logs

After #11994, the integration tests are unstable in Github CI due to larger docker image size and large disk usage causing no space on disk. This PR reduces the docker image size for docker demo and integration tests:
- Removes `hadoop-2.8.4/share/doc` which contains docs only in the image.  This occupies 423MB out of 679MB in the Hadoop installation.
```
root@adhoc-1:/opt/hadoop-2.8.4/share# du -d 1 -h .
257M	./hadoop
423M	./doc
679M	.
```
- Avoids storing Hudi bundle jars in the image which account for ~300MB.  Based on our docker demo guide and integration test flow, the bundle jars are always built based on the code base and dynamically referenced, so there is no point storing pre-built bundle jars.
```
target:
total 314188
drwxr-xr-x 3 root root        96 Oct  5 05:54 antrun
-rw-r--r-- 1 root root  43788437 Oct  5 05:24 hoodie-hadoop-mr-bundle.jar
-rw-r--r-- 1 root root  48410870 Oct  5 05:54 hoodie-hive-sync-bundle.jar
-rw-r--r-- 1 root root 109379641 Oct  5 05:54 hoodie-spark-bundle.jar
-rw-r--r-- 1 root root 120138084 Oct  5 05:54 hoodie-utilities.jar
drwxr-xr-x 3 root root        96 Oct  5 05:54 maven-shared-archive-resources
```
- Fixes `docker/hoodie/hadoop/pom.xml` so the bundle jars are ready before copying.

Docker image size comparison:
| Image | Before | After |
|----------|----------|----------|
| base | 382.4 MB | 350.01 MB | 
| datanode | 382.4 MB | 350.02 MB | 
| history | 382.4 MB | 350.02 MB | 
| hivebase | 889.93 MB | 572.12 MB | 
| sparkbase | 1.25 GB | 965.9 MB | 
| sparkadhoc | 1.41 GB | 1.1 GB | 
| sparkmaster | 1.25 GB | 965.9 MB | 
| sparkworker | 1.25 GB | 965.9 MB | 

All new images are pushed to the Docker Hub already:
- `apachehudi/hudi-hadoop_2.8.4-base`
- `apachehudi/hudi-hadoop_2.8.4-datanode`
- `apachehudi/hudi-hadoop_2.8.4-history`
- `apachehudi/hudi-hadoop_2.8.4-hive_2.3.3`
- `apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkbase_3.5.3`
- `apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_3.5.3`
- `apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkmaster_3.5.3`
- `apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkworker_3.5.3`

Images are tested with `bullseye` tag by #12062 before pushing to the `latest` tag.

### Impact

Reduces the docker image size and the size of files on disk occupied with the docker instance, making `integration-tests` in GH CI much more stable, avoiding no space on disk.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
