### PR TITLE
[HUDI-8234] Fix and enable testPartitionStatsWithMultiWriter

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
@@ -133,7 +133,6 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
   protected SparkSession sparkSession;
   protected SQLContext sqlContext;
   protected ExecutorService executorService;
-  protected HoodieTableMetaClient metaClient;
   protected SparkRDDWriteClient writeClient;
   protected SparkRDDReadClient readClient;
   protected HoodieTableFileSystemView tableView;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -202,7 +202,7 @@ class PartitionStatsIndexTestBase extends HoodieSparkClientTestBase {
   /**
    * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
    */
-  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = {
+  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = synchronized {
     val prevDfOpt = mergedDfList.lastOption
     if (prevDfOpt.isEmpty) {
       mergedDfList = mergedDfList :+ latestBatchDf

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -35,6 +35,7 @@ import org.apache.hudi.metadata.HoodieBackedTableMetadata
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.util.JavaConversions
+
 import org.apache.spark.sql.functions.{col, not}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach}
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Collectors
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.matching.Regex

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -199,7 +199,6 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
 
     assertTrue(f1.value.get.get || f2.value.get.get)
     executor.shutdownNow()
-    Thread.sleep(2000L)
     validateDataAndPartitionStats()
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -177,7 +177,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       override def apply(): Boolean = {
         try {
           doWriteAndValidateDataAndPartitionStats(hudiOpts,
-            operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+            operation = DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL,
             saveMode = SaveMode.Append,
             validate = false)
           true

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.{Disabled, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -157,7 +157,6 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
    */
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
-  @Disabled("HUDI-8234")
   def testPartitionStatsWithMultiWriter(tableType: HoodieTableType): Unit = {
     val hudiOpts = commonOpts ++ Map(
       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -199,6 +199,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
 
     assertTrue(f1.value.get.get || f2.value.get.get)
     executor.shutdownNow()
+    Thread.sleep(2000L)
     validateDataAndPartitionStats()
   }
 


### PR DESCRIPTION
### Change Logs

There are two issues with the test:

1. Originally we use `insert` operation for concurrent writes. Since most of the time, these two writes have conflicts, only one write could succeed and another one fails. In such case, there are no test failures, and it is not very meaningful for the purpose of the test.
2. When we use `bulk_insert` operation, two concurrent writes could both succeed; but there is a test failure. The failure is caused by the race condition between two concurrent updates on the latestSnapshot. After adding the `synchronized` keyword, the problem is resolved. 

### Impact

More coverage.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
