### PR TITLE
[HUDI-6910] Fix schema evolution in the filegroup reader for parquet log blocks

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -118,7 +118,7 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   public ClosableIterator<UnsafeRow> getUnsafeRowIterator(StructType requestedSchema) throws IOException {
-    SparkBasicSchemaEvolution evolution = new SparkBasicSchemaEvolution(getStructSchema(), requestedSchema);
+    SparkBasicSchemaEvolution evolution = new SparkBasicSchemaEvolution(getStructSchema(), requestedSchema, SQLConf.get().sessionLocalTimeZone());
     String readSchemaJson = evolution.getRequestSchema().json();
     storage.getConf().set(ParquetReadSupport.PARQUET_READ_SCHEMA, readSchemaJson);
     storage.getConf().set(ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA(), readSchemaJson);

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -25,6 +25,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.read.HoodiePositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
+import org.apache.hudi.common.table.read.HoodiePositionBasedSchemaHandler
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader}
@@ -38,7 +39,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.HoodieInternalRowUtils
 import org.apache.spark.sql.avro.HoodieAvroDeserializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{JoinedRow, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, SparkParquetReader}
 import org.apache.spark.sql.hudi.SparkAdapter
@@ -87,17 +88,15 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
     }
     val structType = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
     if (FSUtils.isLogFile(filePath)) {
-      val projection = HoodieInternalRowUtils.getCachedUnsafeProjection(structType, structType)
-      new CloseableMappingIterator[InternalRow, UnsafeRow](
+      val dataSchemaWithMergeCol = if (hasRowIndexField) {
+        HoodiePositionBasedSchemaHandler.addPositionalMergeCol(dataSchema)
+      } else {
+        dataSchema
+      }
+      new CloseableMappingIterator[InternalRow, InternalRow](
         new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
-          .asInstanceOf[HoodieSparkParquetReader].getInternalRowIterator(dataSchema, requiredSchema),
-        new java.util.function.Function[InternalRow, UnsafeRow] {
-          override def apply(data: InternalRow): UnsafeRow = {
-            // NOTE: We have to do [[UnsafeProjection]] of incoming [[InternalRow]] to convert
-            //       it to [[UnsafeRow]] holding just raw bytes
-            projection.apply(data)
-          }
-        }).asInstanceOf[ClosableIterator[InternalRow]]
+          .asInstanceOf[HoodieSparkParquetReader].getInternalRowIterator(dataSchema, dataSchemaWithMergeCol),
+        projectRecord(dataSchemaWithMergeCol, requiredSchema))
     } else {
       // partition value is empty because the spark parquet reader will append the partition columns to
       // each row if they are given. That is the only usage of the partition values in the reader.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkBasicSchemaEvolution.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkBasicSchemaEvolution.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.types.StructType
  * Intended to be used just with HoodieSparkParquetReader to avoid any java/scala issues
  */
 class SparkBasicSchemaEvolution(fileSchema: StructType,
-                                requiredSchema: StructType) {
+                                requiredSchema: StructType,
+                                sessionLocalTimeZone: String) {
 
   val (implicitTypeChangeInfo, sparkRequestSchema) = HoodieParquetFileFormatHelper.buildImplicitSchemaChangeInfo(fileSchema, requiredSchema)
 
@@ -44,7 +45,7 @@ class SparkBasicSchemaEvolution(fileSchema: StructType,
 
   def generateUnsafeProjection(): UnsafeProjection = {
     val schemaUtils: HoodieSchemaUtils = sparkAdapter.getSchemaUtils
-    HoodieParquetFileFormatHelper.generateUnsafeProjection(schemaUtils.toAttributes(requiredSchema), Option.empty,
+    HoodieParquetFileFormatHelper.generateUnsafeProjection(schemaUtils.toAttributes(requiredSchema), Some(sessionLocalTimeZone),
       implicitTypeChangeInfo, requiredSchema, new StructType(), schemaUtils)
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkBasicSchemaEvolution.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkBasicSchemaEvolution.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.hudi.SparkAdapterSupport.sparkAdapter
+
+import org.apache.spark.sql.HoodieSchemaUtils
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.types.StructType
+
+
+/**
+ * Intended to be used just with HoodieSparkParquetReader to avoid any java/scala issues
+ */
+class SparkBasicSchemaEvolution(fileSchema: StructType,
+                                requiredSchema: StructType) {
+
+  val (implicitTypeChangeInfo, sparkRequestSchema) = HoodieParquetFileFormatHelper.buildImplicitSchemaChangeInfo(fileSchema, requiredSchema)
+
+  def getRequestSchema: StructType = {
+    if (implicitTypeChangeInfo.isEmpty) {
+      requiredSchema
+    } else {
+      sparkRequestSchema
+    }
+  }
+
+  def generateUnsafeProjection(): UnsafeProjection = {
+    val schemaUtils: HoodieSchemaUtils = sparkAdapter.getSchemaUtils
+    HoodieParquetFileFormatHelper.generateUnsafeProjection(schemaUtils.toAttributes(requiredSchema), Option.empty,
+      implicitTypeChangeInfo, requiredSchema, new StructType(), schemaUtils)
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedSchemaHandler.java
@@ -89,7 +89,7 @@ public class HoodiePositionBasedSchemaHandler<T> extends HoodieFileGroupReaderSc
     return dataAndMetaCols;
   }
 
-  private static Schema addPositionalMergeCol(Schema input) {
+  public static Schema addPositionalMergeCol(Schema input) {
     return appendFieldsToSchemaDedupNested(input, Collections.singletonList(getPositionalMergeField()));
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedSchemaHandler.java
@@ -89,7 +89,7 @@ public class HoodiePositionBasedSchemaHandler<T> extends HoodieFileGroupReaderSc
     return dataAndMetaCols;
   }
 
-  public static Schema addPositionalMergeCol(Schema input) {
+  private static Schema addPositionalMergeCol(Schema input) {
     return appendFieldsToSchemaDedupNested(input, Collections.singletonList(getPositionalMergeField()));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -25,6 +25,7 @@ import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -96,6 +97,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
   protected Boolean multiLogFiles;
   protected Boolean useSchemaProvider;
   protected Boolean hasTransformer;
+  protected Boolean useParquetLogBlock;
   protected String sourceSchemaFile;
   protected String targetSchemaFile;
   protected boolean useKafkaSource;
@@ -116,6 +118,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     useSchemaProvider = false;
     hasTransformer = false;
     withErrorTable = false;
+    useParquetLogBlock = false;
     sourceSchemaFile = "";
     targetSchemaFile = "";
     topicName = "topic" + testNum;
@@ -156,6 +159,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     extraProps.setProperty("hoodie.datasource.write.table.type", tableType);
     extraProps.setProperty("hoodie.datasource.write.row.writer.enable", rowWriterEnable.toString());
     extraProps.setProperty(DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS().key(), Boolean.toString(nullForDeletedCols));
+    extraProps.setProperty(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), useParquetLogBlock ? "parquet" : "avro");
 
     //we set to 0 so that we create new base files on insert instead of adding inserts to existing filegroups via small file handling
     extraProps.setProperty("hoodie.parquet.small.file.limit", "0");

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionQuick.java
@@ -61,33 +61,35 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
     boolean fullTest = false;
     Stream.Builder<Arguments> b = Stream.builder();
     if (fullTest) {
-      //only testing row-writer enabled for now
       for (Boolean rowWriterEnable : new Boolean[] {false, true}) {
         for (Boolean nullForDeletedCols : new Boolean[] {false, true}) {
           for (Boolean useKafkaSource : new Boolean[] {false, true}) {
             for (Boolean addFilegroups : new Boolean[] {false, true}) {
               for (Boolean multiLogFiles : new Boolean[] {false, true}) {
-                for (Boolean shouldCluster : new Boolean[] {false, true}) {
-                  for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
-                    if (!multiLogFiles || tableType.equals("MERGE_ON_READ")) {
-                      b.add(Arguments.of(tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
+                for (Boolean useParquetLogFile : new Boolean[] {false, true}) {
+                  for (Boolean shouldCluster : new Boolean[] {false, true}) {
+                    for (String tableType : new String[] {"COPY_ON_WRITE", "MERGE_ON_READ"}) {
+                      if ((!multiLogFiles && !useParquetLogFile) || tableType.equals("MERGE_ON_READ")) {
+                        b.add(Arguments.of(tableType, shouldCluster, false, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols, useParquetLogFile));
+                      }
                     }
                   }
+                  b.add(Arguments.of("MERGE_ON_READ", false, true, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols, useParquetLogFile));
                 }
-                b.add(Arguments.of("MERGE_ON_READ", false, true, rowWriterEnable, addFilegroups, multiLogFiles, useKafkaSource, nullForDeletedCols));
               }
             }
           }
         }
       }
     } else {
-      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, false));
-      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, true));
-      b.add(Arguments.of("COPY_ON_WRITE", true, false, false, false, false, true, true));
-      b.add(Arguments.of("MERGE_ON_READ", true, false, false, true, true, true, true));
-      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true));
-      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true));
-      b.add(Arguments.of("MERGE_ON_READ", false, false, true, true, true, false, true));
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, false, false));
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, true, false, false, true, true, false));
+      b.add(Arguments.of("COPY_ON_WRITE", true, false, false, false, false, true, true, false));
+      b.add(Arguments.of("MERGE_ON_READ", true, false, false, true, true, true, true, false));
+      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true, false));
+      b.add(Arguments.of("MERGE_ON_READ", false, true, true, true, true, true, true, false));
+      b.add(Arguments.of("MERGE_ON_READ", false, false, true, true, true, false, true, false));
+      b.add(Arguments.of("MERGE_ON_READ", false, false, false, true, true, false, true, true));
     }
     return b.build();
   }
@@ -147,13 +149,15 @@ public class TestHoodieDeltaStreamerSchemaEvolutionQuick extends TestHoodieDelta
                           Boolean addFilegroups,
                           Boolean multiLogFiles,
                           Boolean useKafkaSource,
-                          Boolean allowNullForDeletedCols) throws Exception {
+                          Boolean allowNullForDeletedCols,
+                          Boolean useParquetLogBlock) throws Exception {
     this.tableType = tableType;
     this.shouldCluster = shouldCluster;
     this.shouldCompact = shouldCompact;
     this.rowWriterEnable = rowWriterEnable;
     this.addFilegroups = addFilegroups;
     this.multiLogFiles = multiLogFiles;
+    this.useParquetLogBlock = useParquetLogBlock;
     this.useKafkaSource = useKafkaSource;
     if (useKafkaSource) {
       this.useSchemaProvider = true;


### PR DESCRIPTION
### Change Logs

Reading will fail if a parquet log block for some schema evolutions.  Now we will return the records in the requested schema when reading log files. 

I modeled HoodieSparkParquetReader after HoodieAvroParquetReader and I reused some of the schema evolution utils that we use for reading base files in the fg reader.

### Impact

Allow reading uncompacted mor table with schema evolution.

(Also might fix most schema evolution issues when writing with spark records but has not been tested)

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
