### PR TITLE
[HUDI-8331] Remove excessive table validity check

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -162,7 +162,6 @@ public class HoodieTableMetaClient implements Serializable {
     this.storage = storage;
     this.basePath = new StoragePath(basePath);
     this.metaPath = new StoragePath(basePath, METAFOLDER_NAME);
-    TableNotFoundException.checkTableValidity(this.storage, this.basePath, metaPath);
     this.tableConfig = new HoodieTableConfig(this.storage, metaPath, payloadClassName, recordMergerStrategy);
     this.indexMetadataOpt = getIndexMetadata();
     this.tableType = tableConfig.getTableType();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -53,7 +53,6 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.HoodieStorage;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -25,8 +25,8 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.RecordPayloadType;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
@@ -581,7 +581,7 @@ public class ConfigUtils {
       throw new IllegalArgumentException(
           "hoodie.properties file seems invalid. Please check for left over `.updated` files if any, manually copy it to hoodie.properties and retry");
     } else {
-      throw new HoodieIOException("Could not load Hoodie properties from " + cfgPath);
+      throw new TableNotFoundException("Could not load Hoodie properties from " + cfgPath);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.RecordPayloadType;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.storage.HoodieStorage;
@@ -580,8 +581,10 @@ public class ConfigUtils {
     if (found) {
       throw new IllegalArgumentException(
           "hoodie.properties file seems invalid. Please check for left over `.updated` files if any, manually copy it to hoodie.properties and retry");
+    } else if (!storage.exists(metaPath)) {
+      throw new TableNotFoundException(metaPath.toString());
     } else {
-      throw new TableNotFoundException("Could not load Hoodie properties from " + cfgPath);
+      throw new HoodieIOException("Could not load Hoodie properties from " + cfgPath);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/exception/TableNotFoundException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/TableNotFoundException.java
@@ -43,20 +43,4 @@ public class TableNotFoundException extends HoodieException {
   private static String getErrorMessage(String basePath) {
     return "Hoodie table not found in path " + basePath;
   }
-
-  public static void checkTableValidity(HoodieStorage storage, StoragePath basePathDir, StoragePath metaPathDir) {
-    // Check if the base and meta paths are found
-    try {
-      // Since metaPath is within the basePath, it is enough to check the metaPath exists
-      StoragePathInfo pathInfo = storage.getPathInfo(metaPathDir);
-      if (!pathInfo.isDirectory()) {
-        throw new TableNotFoundException(metaPathDir.toString());
-      }
-    } catch (FileNotFoundException | IllegalArgumentException e) {
-      // if the base path is file:///, then we have a IllegalArgumentException
-      throw new TableNotFoundException(metaPathDir.toString(), e);
-    } catch (IOException e) {
-      throw new HoodieIOException("Could not check if " + basePathDir + " is a valid table", e);
-    }
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/exception/TableNotFoundException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/TableNotFoundException.java
@@ -18,13 +18,6 @@
 
 package org.apache.hudi.exception;
 
-import org.apache.hudi.storage.HoodieStorage;
-import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StoragePathInfo;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
 /**
  * <p>
  * Exception thrown to indicate that a hoodie table was not found on the path provided.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -80,7 +80,6 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
 
     StoragePath metaPath =
         new StoragePath(dataBasePath, HoodieTableMetaClient.METAFOLDER_NAME);
-    TableNotFoundException.checkTableValidity(storage, this.dataBasePath, metaPath);
     HoodieTableConfig tableConfig = new HoodieTableConfig(storage, metaPath, null, null);
     this.hiveStylePartitioningEnabled =
         Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -33,7 +33,6 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieMetadataException;
-import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.expression.BindVisitor;
 import org.apache.hudi.expression.Expression;
 import org.apache.hudi.expression.PartialBindVisitor;


### PR DESCRIPTION
### Change Logs

Remove `TableNotFoundException#checkTableValidity` and its usages.

This method is excessive because Hudi should just fail later on if this path is not valid/does not exist. This check is also problematic because it adds excessive FS calls, which can be very expensive when interacting with object stores like S3.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
