### PR TITLE
[HUDI-8178] Fix CI failures for partition-stats enablement

### DIFF
--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -584,7 +584,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     doWriteOperation(testTable, metaClient.createNewInstantTime());
     HoodieTableMetadata tableMetadata = metadata(writeConfig, context);
     // verify that compaction of metadata table does not kick in.
-    assertFalse(tableMetadata.getLatestCompactionTime().isPresent());
+    assertTrue(tableMetadata.getLatestCompactionTime().isPresent());
 
     // write some commits to trigger the MDT compaction
     doWriteOperation(testTable, metaClient.createNewInstantTime(), INSERT);
@@ -1723,7 +1723,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     // Ensure all commits were synced to the Metadata Table
     HoodieTableMetaClient metadataMetaClient = createMetaClientForMetadataTable();
-    assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 5);
+    assertEquals(6, metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants());
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "0000002")));
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "0000003")));
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "0000004")));
@@ -1775,7 +1775,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       LOG.warn("total commits in metadata table " + metadataMetaClient.getActiveTimeline().getCommitsTimeline().countInstants());
 
       // 6 commits and 2 cleaner commits.
-      assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 8);
+      assertEquals(9, metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants());
       assertTrue(metadataMetaClient.getActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants().countInstants() <= 1);
       // Validation
       validateMetadata(writeClient);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -243,6 +243,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadata)
+            .withMetadataIndexPartitionStats(false)
             .withMaxNumDeltaCommitsBeforeCompaction(maxDeltaCommitsMetadataTable).build())
         .withWriteConcurrencyMode(writeConcurrencyMode)
         .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(InProcessLockProvider.class)
@@ -1645,6 +1646,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true)
+            .withMetadataIndexPartitionStats(false)
             .withMaxNumDeltaCommitsBeforeCompaction(8)
             .build())
         .forTable("test-trip-table").build();

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -339,7 +339,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("1.0.0")
       .withDocumentation("Enable aggregating stats for each column at the storage partition level.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -196,8 +196,8 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
                     } else if (!path.getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
                       return Pair.of(Option.empty(), Option.of(path));
                     }
-                  } else if (path.getName()
-                      .startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)) {
+                  } else if (path.getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)
+                      || MetadataPartitionType.isValidPartitionFilePath(path.getName())) {
                     String partitionName =
                         FSUtils.getRelativePartitionPath(dataBasePath,
                             path.getParent());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -212,7 +212,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
                 || (Boolean) fullBoundExpr.eval(
                 extractPartitionValues(partitionFields, relativePartitionPath,
                     urlEncodePartitioningEnabled)))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toSet()));
 
         Expression partialBoundExpr;
         // If partitionPaths is nonEmpty, we're already at the last path level, and all paths

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2196,7 +2196,7 @@ public class HoodieTableMetadataUtil {
         .build();
   }
 
-  public static Comparable castAndCompare(Comparable newVal, Comparable<?> prevVal, boolean isMin) {
+  public static Comparable castAndCompare(Comparable newVal, Comparable prevVal, boolean isMin) {
     if (newVal == null) {
       return prevVal;
     } else if (prevVal == null) {
@@ -2207,10 +2207,7 @@ public class HoodieTableMetadataUtil {
     // Same type.
     if (newVal.getClass() == prevVal.getClass()) {
       picked = newVal.compareTo(prevVal) < 0 ? newVal : prevVal;
-    }
-
-    // Different types.
-    if (newVal instanceof Number && prevVal instanceof Number) {
+    } else if (newVal instanceof Number && prevVal instanceof Number) {
       picked = Double.compare(((Number) newVal).doubleValue(), ((Number) prevVal).doubleValue()) < 0 ? newVal : prevVal;
     } else {
       picked = newVal.toString().compareTo(prevVal.toString()) < 0 ? newVal : prevVal;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -297,8 +297,8 @@ public enum MetadataPartitionType {
           String.format("Valid %s record expected for type: %s", SCHEMA_FIELD_ID_COLUMN_STATS, MetadataPartitionType.COLUMN_STATS.getRecordType()));
     } else {
       payload.columnStatMetadata = HoodieMetadataColumnStats.newBuilder(METADATA_COLUMN_STATS_BUILDER_STUB.get())
-          .setFileName((String) columnStatsRecord.get(COLUMN_STATS_FIELD_FILE_NAME))
-          .setColumnName((String) columnStatsRecord.get(COLUMN_STATS_FIELD_COLUMN_NAME))
+          .setFileName(columnStatsRecord.get(COLUMN_STATS_FIELD_FILE_NAME).toString())
+          .setColumnName(columnStatsRecord.get(COLUMN_STATS_FIELD_COLUMN_NAME).toString())
           // AVRO-2377 1.9.2 Modified the type of org.apache.avro.Schema#FIELD_RESERVED to Collections.unmodifiableSet.
           // This causes Kryo to fail when deserializing a GenericRecord, See HUDI-5484.
           // We should avoid using GenericRecord and convert GenericRecord into a serializable type.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -434,6 +434,16 @@ public enum MetadataPartitionType {
     throw new IllegalArgumentException("No MetadataPartitionType for partition path: " + partitionPath);
   }
 
+  public static boolean isValidPartitionFilePath(String partitionFilePath) {
+    partitionFilePath = partitionFilePath.startsWith(".") ? partitionFilePath.substring(1) : partitionFilePath;
+    for (MetadataPartitionType partitionType : getValidValues()) {
+      if (partitionFilePath.startsWith(partitionType.fileIdPrefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override
   public String toString() {
     return "Metadata partition {"

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -65,19 +65,19 @@ public class TestMetadataPartitionType {
       case FUNCTIONAL_INDEX:
       case SECONDARY_INDEX:
         metadataConfigBuilder.enable(true);
-        expectedEnabledPartitions = 1;
+        expectedEnabledPartitions = 2;
         break;
       case COLUMN_STATS:
         metadataConfigBuilder.enable(true).withMetadataIndexColumnStats(true);
-        expectedEnabledPartitions = 2;
+        expectedEnabledPartitions = 3;
         break;
       case BLOOM_FILTERS:
         metadataConfigBuilder.enable(true).withMetadataIndexBloomFilter(true);
-        expectedEnabledPartitions = 2;
+        expectedEnabledPartitions = 3;
         break;
       case RECORD_INDEX:
         metadataConfigBuilder.enable(true).withEnableRecordIndex(true);
-        expectedEnabledPartitions = 2;
+        expectedEnabledPartitions = 3;
         break;
       case PARTITION_STATS:
         metadataConfigBuilder.enable(true).withMetadataIndexPartitionStats(true).withColumnStatsIndexForColumns("partitionCol");
@@ -91,7 +91,7 @@ public class TestMetadataPartitionType {
 
     // Verify partition type is enabled due to config
     if (partitionType == MetadataPartitionType.FUNCTIONAL_INDEX || partitionType == MetadataPartitionType.SECONDARY_INDEX) {
-      assertEquals(1, enabledPartitions.size(), "FUNCTIONAL_INDEX or SECONDARY_INDEX should be enabled by SQL, only FILES is enabled in this case.");
+      assertEquals(2, enabledPartitions.size(), "FUNCTIONAL_INDEX or SECONDARY_INDEX should be enabled by SQL, only FILES is enabled in this case.");
       assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES));
     } else {
       assertEquals(expectedEnabledPartitions, enabledPartitions.size());
@@ -114,7 +114,7 @@ public class TestMetadataPartitionType {
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify RECORD_INDEX and FILES is enabled due to availability
-    assertEquals(2, enabledPartitions.size(), "RECORD_INDEX and FILES should be available");
+    assertEquals(3, enabledPartitions.size(), "RECORD_INDEX, FILES, and PARTITION_STATS should be available; ");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.RECORD_INDEX), "RECORD_INDEX should be enabled by availability");
   }
@@ -153,7 +153,7 @@ public class TestMetadataPartitionType {
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify FUNCTIONAL_INDEX and FILES is enabled due to availability
-    assertEquals(2, enabledPartitions.size(), "FUNCTIONAL_INDEX and FILES should be available");
+    assertEquals(3, enabledPartitions.size(), "FUNCTIONAL_INDEX, FILES and PARTITION_STATS should be available");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.FUNCTIONAL_INDEX), "FUNCTIONAL_INDEX should be enabled by availability");
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -447,7 +447,7 @@ public class ParquetUtils extends FileFormatUtils {
       synchronized (primitiveType.stringifier()) {
         // Date logical type is implemented as a signed INT32
         // REF: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
-        return java.sql.Date.valueOf(
+        return java.time.LocalDate.parse(
             primitiveType.stringifier().stringify((Integer) val)
         );
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -89,7 +89,7 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     // not supported GreaterThan query
     val reckey = latestSnapshotDf.collect().map(row => row.getAs(colName).toString).sorted
     dataFilter = GreaterThan(attribute(colName), Literal(reckey(0)))
-    assertTrue(fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size >= 3)
+    assertTrue(fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size >= 2)
 
     // not supported OR query
     dataFilter = Or(EqualTo(attribute(colName), Literal(reckey(0))), GreaterThanOrEqual(attribute("timestamp"), Literal(0)))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -87,7 +87,7 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     assertEquals(0, fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size)
 
     // not supported GreaterThan query
-    val reckey = latestSnapshotDf.limit(2).collect().map(row => row.getAs(colName).toString)
+    val reckey = latestSnapshotDf.collect().map(row => row.getAs(colName).toString).sorted
     dataFilter = GreaterThan(attribute(colName), Literal(reckey(0)))
     assertTrue(fileIndex.listFiles(Seq.empty, Seq(dataFilter)).flatMap(s => s.files).size >= 3)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
@@ -586,7 +586,8 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
                |  hoodie.datasource.write.recordkey.field = 'id',
                |  hoodie.metadata.record.index.enable = 'true',
                |  hoodie.metadata.index.column.stats.enable = 'true',
-               |  hoodie.metadata.index.column.stats.column.list = 'price'
+               |  hoodie.metadata.index.column.stats.column.list = 'price',
+               |  hoodie.metadata.index.partition.stats.enable = 'true'
                |)
                |location '${tmp.getCanonicalPath}/$tableName'
                |""".stripMargin
@@ -628,7 +629,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           val result7DF = spark.sql(
             s"select type, key, ColumnStatsMetadata from hudi_metadata('$identifier') where type=${MetadataPartitionType.PARTITION_STATS.getRecordType}"
           )
-          assert(result7DF.count() == 0)
+          assert(result7DF.count() == 3)
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
@@ -56,14 +56,14 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(4) {
+      assertResult(5) {
         commits.length
       }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(3) {
+      assertResult(2) {
         archivedCommits.length
       }
     }
@@ -106,14 +106,14 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(4) {
+      assertResult(5) {
         commits.length
       }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits_metadata(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(3) {
+      assertResult(2) {
         archivedCommits.length
       }
     }


### PR DESCRIPTION
### Change Logs

Enable partition stats index by default, and fix test failures caused.

Root causes include:
1. Test setup.
2. UTF8 to String casting.
3. Date to LocalDate casting.
4. `.partition.metadata` is missing within partition-stats folder.
5. Different types of partition stats due to schema evolution.

### Impact

Partition stats is available genreally.

### Risk level (write none, low medium or high below)

High.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
