### PR TITLE
[HUDI-8273] Fix read optimized query for bootstrap tables

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
@@ -55,11 +55,17 @@ public class FileSlice implements Serializable {
   private final TreeSet<HoodieLogFile> logFiles;
 
   public FileSlice(FileSlice fileSlice) {
+    this(fileSlice, true);
+  }
+
+  private FileSlice(FileSlice fileSlice, boolean includeLogFiles) {
     this.baseInstantTime = fileSlice.baseInstantTime;
     this.baseFile = fileSlice.baseFile != null ? new HoodieBaseFile(fileSlice.baseFile) : null;
     this.fileGroupId = fileSlice.fileGroupId;
     this.logFiles = new TreeSet<>(HoodieLogFile.getReverseLogFileComparator());
-    fileSlice.logFiles.forEach(lf -> this.logFiles.add(new HoodieLogFile(lf)));
+    if (includeLogFiles) {
+      fileSlice.logFiles.forEach(lf -> this.logFiles.add(new HoodieLogFile(lf)));
+    }
   }
 
   public FileSlice(String partitionPath, String baseInstantTime, String fileId) {
@@ -88,6 +94,22 @@ public class FileSlice implements Serializable {
 
   public void addLogFile(HoodieLogFile logFile) {
     this.logFiles.add(logFile);
+  }
+
+  public FileSlice withLogFiles(boolean includeLogFiles) {
+    if (includeLogFiles) {
+      return this;
+    } else {
+      return new FileSlice(this, false);
+    }
+  }
+
+  public boolean hasBootstrapBase() {
+    return getBaseFile().isPresent() && getBaseFile().get().getBootstrapBaseFile().isPresent();
+  }
+
+  public boolean hasLogFiles() {
+    return !logFiles.isEmpty();
   }
 
   public Stream<HoodieLogFile> getLogFiles() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
@@ -97,7 +97,7 @@ public class FileSlice implements Serializable {
   }
 
   public FileSlice withLogFiles(boolean includeLogFiles) {
-    if (includeLogFiles) {
+    if (includeLogFiles || !hasLogFiles()) {
       return this;
     } else {
       return new FileSlice(this, false);

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -452,15 +452,14 @@ public class ITTestHoodieDemo extends ITTestBase {
 
   private void testSparkSQLAfterSecondBatch() throws Exception {
     Pair<String, String> stdOutErrPair = executeSparkSQLCommand(SPARKSQL_BATCH2_COMMANDS, true);
-    // TODO(HUDI-8273): fix RO queries on bootstrapped MOR tables
     assertStdOutContains(stdOutErrPair,
-        "+------+-------------------+\n|GOOG  |2018-08-31 10:59:00|\n+------+-------------------+", 5);
+        "+------+-------------------+\n|GOOG  |2018-08-31 10:59:00|\n+------+-------------------+", 4);
 
     assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 09:59:00|6330  |1230.5   |1230.02 |", 6);
-    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:59:00|9021  |1227.1993|1227.215|", 5);
+    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:59:00|9021  |1227.1993|1227.215|", 4);
     assertStdOutContains(stdOutErrPair,
-        "+------+-------------------+\n|GOOG  |2018-08-31 10:29:00|\n+------+-------------------+", 1);
-    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:29:00|3391  |1230.1899|1230.085|", 1);
+        "+------+-------------------+\n|GOOG  |2018-08-31 10:29:00|\n+------+-------------------+", 2);
+    assertStdOutContains(stdOutErrPair, "|GOOG  |2018-08-31 10:29:00|3391  |1230.1899|1230.085|", 2);
   }
 
   private void testIncrementalHiveQuery(String minCommitTimeScript, String incrementalCommandsFile,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -363,7 +363,7 @@ class HoodieCopyOnWriteIncrementalHadoopFsRelationFactory(override val sqlContex
     preCombineFieldOpt.map(Seq(_)).getOrElse(Seq()) ++ partitionColumnsToRead
 
   override val fileIndex = new HoodieIncrementalFileIndex(
-    sparkSession, metaClient, schemaSpec, options, FileStatusCache.getOrCreate(sparkSession), false, isBootstrap)
+    sparkSession, metaClient, schemaSpec, options, FileStatusCache.getOrCreate(sparkSession), false, true)
 
   override def buildFileFormat(): FileFormat = {
     if (metaClient.getTableConfig.isMultipleBaseFileFormatsEnabled && !isBootstrap) {
@@ -402,7 +402,7 @@ class HoodieCopyOnWriteCDCHadoopFsRelationFactory(override val sqlContext: SQLCo
                                                   isBootstrap: Boolean)
   extends HoodieCopyOnWriteIncrementalHadoopFsRelationFactory(sqlContext, metaClient, options, schemaSpec, isBootstrap) {
   override val fileIndex = new HoodieCDCFileIndex(
-    sparkSession, metaClient, schemaSpec, options, FileStatusCache.getOrCreate(sparkSession), false, isBootstrap)
+    sparkSession, metaClient, schemaSpec, options, FileStatusCache.getOrCreate(sparkSession), false, true)
 
   override def buildDataSchema(): StructType = fileIndex.cdcRelation.schema
 


### PR DESCRIPTION
### Change Logs

redo of https://github.com/apache/hudi/pull/12056

If a filegroup had both bootstrap base file, and log files, it would pass the log files to the fg reader.

Additionally, data skipping does not consider log files if includelogfiles is false

Additionally, we set shouldEmbedFIleSlices to true for all indexes used by the fg reader read path so that timestamp filter conversion occurs if needed.

### Impact

Read optimized query correct for bootstrap mor

data skipping is better

fixes bugs around partition pruning for timestamp keygen

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
