### PR TITLE
[HUDI-7930] Update Flink 1.19 to support Array and Map of Rows

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -19,11 +19,13 @@
 package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.table.format.cow.vector.HeapArrayGroupColumnVector;
 import org.apache.hudi.table.format.cow.vector.HeapArrayVector;
 import org.apache.hudi.table.format.cow.vector.HeapDecimalVector;
 import org.apache.hudi.table.format.cow.vector.HeapMapColumnVector;
 import org.apache.hudi.table.format.cow.vector.HeapRowColumnVector;
 import org.apache.hudi.table.format.cow.vector.reader.ArrayColumnReader;
+import org.apache.hudi.table.format.cow.vector.reader.ArrayGroupReader;
 import org.apache.hudi.table.format.cow.vector.reader.EmptyColumnReader;
 import org.apache.hudi.table.format.cow.vector.reader.FixedLenBytesColumnReader;
 import org.apache.hudi.table.format.cow.vector.reader.Int64TimestampColumnReader;
@@ -62,6 +64,8 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -282,12 +286,23 @@ public class ParquetSplitReaderUtil {
         }
         return tv;
       case ARRAY:
-        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
-        if (value == null) {
-          arrayVector.fillWithNulls();
-          return arrayVector;
+        ArrayType arrayType = (ArrayType) type;
+        if (arrayType.getElementType().isAnyOf(LogicalTypeFamily.CONSTRUCTED)) {
+          HeapArrayGroupColumnVector arrayGroup = new HeapArrayGroupColumnVector(batchSize);
+          if (value == null) {
+            arrayGroup.fillWithNulls();
+            return arrayGroup;
+          } else {
+            throw new UnsupportedOperationException("Unsupported create array with default value.");
+          }
         } else {
-          throw new UnsupportedOperationException("Unsupported create array with default value.");
+          HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+          if (value == null) {
+            arrayVector.fillWithNulls();
+            return arrayVector;
+          } else {
+            throw new UnsupportedOperationException("Unsupported create array with default value.");
+          }
         }
       case MAP:
         HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
@@ -394,12 +409,23 @@ public class ParquetSplitReaderUtil {
             throw new AssertionError();
         }
       case ARRAY:
-        return new ArrayColumnReader(
-            descriptor,
-            pageReader,
-            utcTimestamp,
-            descriptor.getPrimitiveType(),
-            fieldType);
+        ArrayType arrayType = (ArrayType) fieldType;
+        if (arrayType.getElementType().isAnyOf(LogicalTypeFamily.CONSTRUCTED)) {
+          return new ArrayGroupReader(createColumnReader(
+              utcTimestamp,
+              arrayType.getElementType(),
+              physicalType.asGroupType().getType(0),
+              descriptors,
+              pages,
+              depth + 1));
+        } else {
+          return new ArrayColumnReader(
+              descriptor,
+              pageReader,
+              utcTimestamp,
+              descriptor.getPrimitiveType(),
+              fieldType);
+        }
       case MAP:
         MapType mapType = (MapType) fieldType;
         ArrayColumnReader keyReader =
@@ -409,14 +435,24 @@ public class ParquetSplitReaderUtil {
                 utcTimestamp,
                 descriptor.getPrimitiveType(),
                 new ArrayType(mapType.getKeyType()));
-        ArrayColumnReader valueReader =
-            new ArrayColumnReader(
-                descriptors.get(1),
-                pages.getPageReader(descriptors.get(1)),
-                utcTimestamp,
-                descriptors.get(1).getPrimitiveType(),
-                new ArrayType(mapType.getValueType()));
-        return new MapColumnReader(keyReader, valueReader, fieldType);
+        ColumnReader<WritableColumnVector> valueReader;
+        if (mapType.getValueType().isAnyOf(LogicalTypeFamily.CONSTRUCTED)) {
+          valueReader = new ArrayGroupReader(createColumnReader(
+              utcTimestamp,
+              mapType.getValueType(),
+              physicalType.asGroupType().getType(0).asGroupType().getType(1), // Get the value physical type
+              descriptors.subList(1, descriptors.size()), // remove the key descriptor
+              pages,
+              depth + 2)); // increase the depth by 2, because there's a key_value entry in the path
+        } else {
+          valueReader = new ArrayColumnReader(
+              descriptors.get(1),
+              pages.getPageReader(descriptors.get(1)),
+              utcTimestamp,
+              descriptors.get(1).getPrimitiveType(),
+              new ArrayType(mapType.getValueType()));
+        }
+        return new MapColumnReader(keyReader, valueReader);
       case ROW:
         RowType rowType = (RowType) fieldType;
         GroupType groupType = physicalType.asGroupType();
@@ -427,14 +463,32 @@ public class ParquetSplitReaderUtil {
           if (fieldIndex < 0) {
             fieldReaders.add(new EmptyColumnReader());
           } else {
-            fieldReaders.add(
-                createColumnReader(
-                    utcTimestamp,
-                    rowType.getTypeAt(i),
-                    groupType.getType(fieldIndex),
-                    descriptors,
-                    pages,
-                    depth + 1));
+            // Check for nested row in array with atomic field type.
+
+            // This is done to meet the Parquet field algorithm that pushes multiplicity and structures down to individual fields.
+            // In Parquet, an array of rows is stored as separate arrays for each field.
+
+            // Limitations: It won't work for multiple nested arrays and maps.
+            // The main problem is that the Flink classes and interface don't follow that pattern.
+            if (descriptors.get(fieldIndex).getMaxRepetitionLevel() > 0 && !rowType.getTypeAt(i).is(LogicalTypeRoot.ARRAY)) {
+              fieldReaders.add(
+                  createColumnReader(
+                      utcTimestamp,
+                      new ArrayType(rowType.getTypeAt(i).isNullable(), rowType.getTypeAt(i)),
+                      groupType.getType(fieldIndex),
+                      descriptors,
+                      pages,
+                      depth + 1));
+            } else {
+              fieldReaders.add(
+                  createColumnReader(
+                      utcTimestamp,
+                      rowType.getTypeAt(i),
+                      groupType.getType(fieldIndex),
+                      descriptors,
+                      pages,
+                      depth + 1));
+            }
           }
         }
         return new RowColumnReader(fieldReaders);
@@ -501,43 +555,65 @@ public class ParquetSplitReaderUtil {
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         checkArgument(primitiveType.getOriginalType() != OriginalType.TIME_MICROS,
-                getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
+            getOriginalTypeCheckFailureMessage(primitiveType.getOriginalType(), fieldType));
         return new HeapTimestampVector(batchSize);
       case DECIMAL:
         checkArgument(
             (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
                 || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
                 && primitiveType.getOriginalType() == OriginalType.DECIMAL,
-                getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
+            getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapDecimalVector(batchSize);
       case ARRAY:
         ArrayType arrayType = (ArrayType) fieldType;
-        return new HeapArrayVector(
-            batchSize,
-            createWritableColumnVector(
-                batchSize,
-                arrayType.getElementType(),
-                physicalType,
-                descriptors,
-                depth));
+        if (arrayType.getElementType().isAnyOf(LogicalTypeFamily.CONSTRUCTED)) {
+          return new HeapArrayGroupColumnVector(
+              batchSize,
+              createWritableColumnVector(
+                  batchSize,
+                  arrayType.getElementType(),
+                  physicalType.asGroupType().getType(0),
+                  descriptors,
+                  depth + 1));
+        } else {
+          return new HeapArrayVector(
+              batchSize,
+              createWritableColumnVector(
+                  batchSize,
+                  arrayType.getElementType(),
+                  physicalType,
+                  descriptors,
+                  depth));
+        }
       case MAP:
         MapType mapType = (MapType) fieldType;
         GroupType repeatedType = physicalType.asGroupType().getType(0).asGroupType();
         // the map column has three level paths.
-        return new HeapMapColumnVector(
+        WritableColumnVector keyColumnVector = createWritableColumnVector(
             batchSize,
-            createWritableColumnVector(
-                batchSize,
-                mapType.getKeyType(),
-                repeatedType.getType(0),
-                descriptors,
-                depth + 2),
-            createWritableColumnVector(
-                batchSize,
-                mapType.getValueType(),
-                repeatedType.getType(1),
-                descriptors,
-                depth + 2));
+            new ArrayType(mapType.getKeyType().isNullable(), mapType.getKeyType()),
+            repeatedType.getType(0),
+            descriptors,
+            depth + 2);
+        WritableColumnVector valueColumnVector;
+        if (mapType.getValueType().isAnyOf(LogicalTypeFamily.CONSTRUCTED)) {
+          valueColumnVector = new HeapArrayGroupColumnVector(
+              batchSize,
+              createWritableColumnVector(
+                  batchSize,
+                  mapType.getValueType(),
+                  repeatedType.getType(1).asGroupType(),
+                  descriptors,
+                  depth + 2));
+        } else {
+          valueColumnVector = createWritableColumnVector(
+              batchSize,
+              new ArrayType(mapType.getValueType().isNullable(), mapType.getValueType()),
+              repeatedType.getType(1),
+              descriptors,
+              depth + 2);
+        }
+        return new HeapMapColumnVector(batchSize, keyColumnVector, valueColumnVector);
       case ROW:
         RowType rowType = (RowType) fieldType;
         GroupType groupType = physicalType.asGroupType();
@@ -546,15 +622,44 @@ public class ParquetSplitReaderUtil {
           // schema evolution: read the file with a new extended field name.
           int fieldIndex = getFieldIndexInPhysicalType(rowType.getFields().get(i).getName(), groupType);
           if (fieldIndex < 0) {
-            columnVectors[i] = (WritableColumnVector) createVectorFromConstant(rowType.getTypeAt(i), null, batchSize);
+            // Check for nested row in array with atomic field type.
+
+            // This is done to meet the Parquet field algorithm that pushes multiplicity and structures down to individual fields.
+            // In Parquet, an array of rows is stored as separate arrays for each field.
+
+            // Limitations: It won't work for multiple nested arrays and maps.
+            // The main problem is that the Flink classes and interface don't follow that pattern.
+            if (groupType.getRepetition().equals(Type.Repetition.REPEATED) && !rowType.getTypeAt(i).is(LogicalTypeRoot.ARRAY)) {
+              columnVectors[i] = (WritableColumnVector) createVectorFromConstant(
+                  new ArrayType(rowType.getTypeAt(i).isNullable(), rowType.getTypeAt(i)), null, batchSize);
+            } else {
+              columnVectors[i] = (WritableColumnVector) createVectorFromConstant(rowType.getTypeAt(i), null, batchSize);
+            }
           } else {
-            columnVectors[i] =
-                createWritableColumnVector(
-                    batchSize,
-                    rowType.getTypeAt(i),
-                    groupType.getType(fieldIndex),
-                    descriptors,
-                    depth + 1);
+            // Check for nested row in array with atomic field type.
+
+            // This is done to meet the Parquet field algorithm that pushes multiplicity and structures down to individual fields.
+            // In Parquet, an array of rows is stored as separate arrays for each field.
+
+            // Limitations: It won't work for multiple nested arrays and maps.
+            // The main problem is that the Flink classes and interface don't follow that pattern.
+            if (descriptors.get(fieldIndex).getMaxRepetitionLevel() > 0 && !rowType.getTypeAt(i).is(LogicalTypeRoot.ARRAY)) {
+              columnVectors[i] =
+                  createWritableColumnVector(
+                      batchSize,
+                      new ArrayType(rowType.getTypeAt(i).isNullable(), rowType.getTypeAt(i)),
+                      groupType.getType(fieldIndex),
+                      descriptors,
+                      depth + 1);
+            } else {
+              columnVectors[i] =
+                  createWritableColumnVector(
+                      batchSize,
+                      rowType.getTypeAt(i),
+                      groupType.getType(fieldIndex),
+                      descriptors,
+                      depth + 1);
+            }
           }
         }
         return new HeapRowColumnVector(batchSize, columnVectors);
@@ -575,8 +680,9 @@ public class ParquetSplitReaderUtil {
 
   /**
    * Construct the error message when primitive type mismatches.
+   *
    * @param primitiveType Primitive type
-   * @param fieldType Logical field type
+   * @param fieldType     Logical field type
    * @return The error message
    */
   private static String getPrimitiveTypeCheckFailureMessage(PrimitiveType.PrimitiveTypeName primitiveType, LogicalType fieldType) {
@@ -585,8 +691,9 @@ public class ParquetSplitReaderUtil {
 
   /**
    * Construct the error message when original type mismatches.
+   *
    * @param originalType Original type
-   * @param fieldType Logical field type
+   * @param fieldType    Logical field type
    * @return The error message
    */
   private static String getOriginalTypeCheckFailureMessage(OriginalType originalType, LogicalType fieldType) {

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupArrayData.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupArrayData.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
+
+public class ColumnarGroupArrayData implements ArrayData {
+
+  WritableColumnVector vector;
+  int rowId;
+
+  public ColumnarGroupArrayData(WritableColumnVector vector, int rowId) {
+    this.vector = vector;
+    this.rowId = rowId;
+  }
+
+  @Override
+  public int size() {
+    if (vector == null) {
+      return 0;
+    }
+
+    if (vector instanceof HeapRowColumnVector) {
+      // assume all fields have the same size
+      if (((HeapRowColumnVector) vector).vectors == null || ((HeapRowColumnVector) vector).vectors.length == 0) {
+        return 0;
+      }
+      return ((HeapArrayVector) ((HeapRowColumnVector) vector).vectors[0]).getArray(rowId).size();
+    }
+    throw new UnsupportedOperationException(vector.getClass().getName() + " is not supported. Supported vector types: HeapRowColumnVector");
+  }
+
+  @Override
+  public boolean isNullAt(int index) {
+    if (vector == null) {
+      return true;
+    }
+
+    if (vector instanceof HeapRowColumnVector) {
+      return ((HeapRowColumnVector) vector).vectors == null;
+    }
+
+    throw new UnsupportedOperationException(vector.getClass().getName() + " is not supported. Supported vector types: HeapRowColumnVector");
+  }
+
+  @Override
+  public boolean getBoolean(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public byte getByte(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public short getShort(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public int getInt(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public long getLong(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public float getFloat(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public double getDouble(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public StringData getString(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public DecimalData getDecimal(int index, int precision, int scale) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public TimestampData getTimestamp(int index, int precision) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public <T> RawValueData<T> getRawValue(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public byte[] getBinary(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public ArrayData getArray(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public MapData getMap(int index) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public RowData getRow(int index, int numFields) {
+    return new ColumnarGroupRowData((HeapRowColumnVector) vector, rowId, index);
+  }
+
+  @Override
+  public boolean[] toBooleanArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public short[] toShortArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public int[] toIntArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public long[] toLongArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public float[] toFloatArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public double[] toDoubleArray() {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+}

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupMapData.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupMapData.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
+
+public class ColumnarGroupMapData implements MapData {
+
+  WritableColumnVector keyVector;
+  WritableColumnVector valueVector;
+  int rowId;
+
+  public ColumnarGroupMapData(WritableColumnVector keyVector, WritableColumnVector valueVector, int rowId) {
+    this.keyVector = keyVector;
+    this.valueVector = valueVector;
+    this.rowId = rowId;
+  }
+
+  @Override
+  public int size() {
+    if (keyVector == null) {
+      return 0;
+    }
+
+    if (keyVector instanceof HeapArrayVector) {
+      return ((HeapArrayVector) keyVector).getArray(rowId).size();
+    }
+    throw new UnsupportedOperationException(keyVector.getClass().getName() + " is not supported. Supported vector types: HeapArrayVector");
+  }
+
+  @Override
+  public ArrayData keyArray() {
+    return ((HeapArrayVector) keyVector).getArray(rowId);
+  }
+
+  @Override
+  public ArrayData valueArray() {
+    if (valueVector instanceof HeapArrayVector) {
+      return ((HeapArrayVector) valueVector).getArray(rowId);
+    } else if (valueVector instanceof HeapArrayGroupColumnVector) {
+      return ((HeapArrayGroupColumnVector) valueVector).getArray(rowId);
+    }
+    throw new UnsupportedOperationException(valueVector.getClass().getName() + " is not supported. Supported vector types: HeapArrayVector, HeapArrayGroupColumnVector");
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupRowData.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/ColumnarGroupRowData.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.RowKind;
+
+public class ColumnarGroupRowData implements RowData {
+
+  HeapRowColumnVector vector;
+  int rowId;
+  int index;
+
+  public ColumnarGroupRowData(HeapRowColumnVector vector, int rowId, int index) {
+    this.vector = vector;
+    this.rowId = rowId;
+    this.index = index;
+  }
+
+  @Override
+  public int getArity() {
+    return vector.vectors.length;
+  }
+
+  @Override
+  public RowKind getRowKind() {
+    return RowKind.INSERT;
+  }
+
+  @Override
+  public void setRowKind(RowKind rowKind) {
+    throw new UnsupportedOperationException("Not support the operation!");
+  }
+
+  @Override
+  public boolean isNullAt(int pos) {
+    return
+        vector.vectors[pos].isNullAt(rowId)
+            || ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).isNullAt(index);
+  }
+
+  @Override
+  public boolean getBoolean(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getBoolean(index);
+  }
+
+  @Override
+  public byte getByte(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getByte(index);
+  }
+
+  @Override
+  public short getShort(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getShort(index);
+  }
+
+  @Override
+  public int getInt(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getInt(index);
+  }
+
+  @Override
+  public long getLong(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getLong(index);
+  }
+
+  @Override
+  public float getFloat(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getFloat(index);
+  }
+
+  @Override
+  public double getDouble(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getDouble(index);
+  }
+
+  @Override
+  public StringData getString(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getString(index);
+  }
+
+  @Override
+  public DecimalData getDecimal(int pos, int i1, int i2) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getDecimal(index, i1, i2);
+  }
+
+  @Override
+  public TimestampData getTimestamp(int pos, int i1) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getTimestamp(index, i1);
+  }
+
+  @Override
+  public <T> RawValueData<T> getRawValue(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getRawValue(index);
+  }
+
+  @Override
+  public byte[] getBinary(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getBinary(index);
+  }
+
+  @Override
+  public ArrayData getArray(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getArray(index);
+  }
+
+  @Override
+  public MapData getMap(int pos) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getMap(index);
+  }
+
+  @Override
+  public RowData getRow(int pos, int numFields) {
+    return ((HeapArrayVector) (vector.vectors[pos])).getArray(rowId).getRow(index, numFields);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapArrayGroupColumnVector.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapArrayGroupColumnVector.java
@@ -18,36 +18,36 @@
 
 package org.apache.hudi.table.format.cow.vector;
 
-import org.apache.flink.table.data.MapData;
-import org.apache.flink.table.data.columnar.vector.MapColumnVector;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.columnar.vector.ArrayColumnVector;
 import org.apache.flink.table.data.columnar.vector.heap.AbstractHeapVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
 
 /**
- * This class represents a nullable heap map column vector.
+ * This class represents a nullable heap row column vector.
  */
-public class HeapMapColumnVector extends AbstractHeapVector
-    implements WritableColumnVector, MapColumnVector {
+public class HeapArrayGroupColumnVector extends AbstractHeapVector
+    implements WritableColumnVector, ArrayColumnVector {
 
-  private WritableColumnVector keys;
-  private WritableColumnVector values;
+  public WritableColumnVector vector;
 
-  public HeapMapColumnVector(int len, WritableColumnVector keys, WritableColumnVector values) {
+  public HeapArrayGroupColumnVector(int len) {
     super(len);
-    this.keys = keys;
-    this.values = values;
   }
 
-  public WritableColumnVector getKeys() {
-    return keys;
-  }
-
-  public WritableColumnVector getValues() {
-    return values;
+  public HeapArrayGroupColumnVector(int len, WritableColumnVector vector) {
+    super(len);
+    this.vector = vector;
   }
 
   @Override
-  public MapData getMap(int rowId) {
-    return new ColumnarGroupMapData(keys, values, rowId);
+  public ArrayData getArray(int rowId) {
+    return new ColumnarGroupArrayData(vector, rowId);
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    vector.reset();
   }
 }

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ArrayGroupReader.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ArrayGroupReader.java
@@ -16,38 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.table.format.cow.vector;
+package org.apache.hudi.table.format.cow.vector.reader;
 
-import org.apache.flink.table.data.MapData;
-import org.apache.flink.table.data.columnar.vector.MapColumnVector;
-import org.apache.flink.table.data.columnar.vector.heap.AbstractHeapVector;
+import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
+import org.apache.hudi.table.format.cow.vector.HeapArrayGroupColumnVector;
+
+import java.io.IOException;
 
 /**
- * This class represents a nullable heap map column vector.
+ * Array of a Group type (Array, Map, Row, etc.) {@link ColumnReader}.
  */
-public class HeapMapColumnVector extends AbstractHeapVector
-    implements WritableColumnVector, MapColumnVector {
+public class ArrayGroupReader implements ColumnReader<WritableColumnVector> {
 
-  private WritableColumnVector keys;
-  private WritableColumnVector values;
+  private final ColumnReader<WritableColumnVector> fieldReader;
 
-  public HeapMapColumnVector(int len, WritableColumnVector keys, WritableColumnVector values) {
-    super(len);
-    this.keys = keys;
-    this.values = values;
-  }
-
-  public WritableColumnVector getKeys() {
-    return keys;
-  }
-
-  public WritableColumnVector getValues() {
-    return values;
+  public ArrayGroupReader(ColumnReader<WritableColumnVector> fieldReader) {
+    this.fieldReader = fieldReader;
   }
 
   @Override
-  public MapData getMap(int rowId) {
-    return new ColumnarGroupMapData(keys, values, rowId);
+  public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
+    HeapArrayGroupColumnVector rowColumnVector = (HeapArrayGroupColumnVector) vector;
+
+    fieldReader.readToVector(readNumber, rowColumnVector.vector);
   }
 }


### PR DESCRIPTION
### Change Logs

Added support for Array of Rows and Maps with Row values in Flink 1.19. Only supports nesting 1 level deep. The Row cannot contain another Array or Map. 

The changes were copied from Flink `1.18.x` applied in [[HUDI-7930] Flink Support for Array of Row and Map of Row value](https://github.com/apache/hudi/pull/11727.)

### Impact

No change to the public API. 

### Risk level (write none, low medium or high below)

Low provided the unit tests.

### Documentation Update

As far as I could tell, this was not in the documentation. But it would be nice to note somewhere that as of this change, Arrays and Map values support basic types and Rows, but does not support additional Arrays or Maps within the Row.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed