### PR TITLE
[HUDI-8351] Fix and optimize secondary index update

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1097,6 +1097,13 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   }
 
   private void updateSecondaryIndexIfPresent(HoodieCommitMetadata commitMetadata, Map<String, HoodieData<HoodieRecord>> partitionToRecordMap, HoodieData<WriteStatus> writeStatus) {
+    // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
+    // because these operations do not change the secondary key - record key mapping.
+    if (commitMetadata.getOperationType() == WriteOperationType.COMPACT
+        || commitMetadata.getOperationType() == WriteOperationType.CLUSTER) {
+      return;
+    }
+
     dataMetaClient.getTableConfig().getMetadataPartitions()
         .stream()
         .filter(partition -> partition.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX))

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieMetadataIndexException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieMetadataIndexException.java
@@ -20,15 +20,15 @@
 package org.apache.hudi.exception;
 
 /**
- * Exception for Hudi functional index.
+ * Exception for Hudi index.
  */
-public class HoodieFunctionalIndexException extends HoodieException {
+public class HoodieMetadataIndexException extends HoodieException {
 
-  public HoodieFunctionalIndexException(String message) {
+  public HoodieMetadataIndexException(String message) {
     super(message);
   }
 
-  public HoodieFunctionalIndexException(String message, Throwable t) {
+  public HoodieMetadataIndexException(String message, Throwable t) {
     super(message, t);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1895,7 +1895,8 @@ public class HoodieTableMetadataUtil {
       } else {
         readerSchema = tableSchema;
       }
-      return createSecondaryIndexGenerator(metaClient, engineType, logFilePaths, readerSchema, partition, dataFilePath, indexDefinition);
+      return createSecondaryIndexGenerator(metaClient, engineType, logFilePaths, readerSchema, partition, dataFilePath, indexDefinition,
+          metaClient.getActiveTimeline().getCommitsTimeline().lastInstant().map(HoodieInstant::getTimestamp).orElse(""));
     });
   }
 
@@ -1930,7 +1931,8 @@ public class HoodieTableMetadataUtil {
       } else {
         readerSchema = tableSchema;
       }
-      return createSecondaryIndexGenerator(metaClient, engineType, logFilePaths, readerSchema, partition, dataFilePath, indexDefinition);
+      return createSecondaryIndexGenerator(metaClient, engineType, logFilePaths, readerSchema, partition, dataFilePath, indexDefinition,
+          metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::getTimestamp).orElse(""));
     });
   }
 
@@ -1938,7 +1940,8 @@ public class HoodieTableMetadataUtil {
                                                                               EngineType engineType, List<String> logFilePaths,
                                                                               Schema tableSchema, String partition,
                                                                               Option<StoragePath> dataFilePath,
-                                                                              HoodieIndexDefinition indexDefinition) throws Exception {
+                                                                              HoodieIndexDefinition indexDefinition,
+                                                                              String instantTime) throws Exception {
     final String basePath = metaClient.getBasePath().toString();
     final StorageConfiguration<?> storageConf = metaClient.getStorageConf();
 
@@ -1950,10 +1953,10 @@ public class HoodieTableMetadataUtil {
 
     HoodieMergedLogRecordScanner mergedLogRecordScanner = HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(metaClient.getStorage())
-        .withBasePath(basePath)
+        .withBasePath(metaClient.getBasePath())
         .withLogFilePaths(logFilePaths)
         .withReaderSchema(tableSchema)
-        .withLatestInstantTime(metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::getTimestamp).orElse(""))
+        .withLatestInstantTime(instantTime)
         .withReverseReader(false)
         .withMaxMemorySizeInBytes(storageConf.getLong(MAX_MEMORY_FOR_COMPACTION.key(), DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES))
         .withBufferSize(HoodieMetadataConfig.MAX_READER_BUFFER_SIZE_PROP.defaultValue())

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -30,7 +30,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.exception.HoodieFunctionalIndexException;
+import org.apache.hudi.exception.HoodieMetadataIndexException;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.action.index.functional.BaseHoodieIndexClient;
 
@@ -84,9 +84,13 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
   public void create(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options) {
     indexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX) ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + indexName : PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX + indexName;
     if (indexExists(metaClient, indexName)) {
-      throw new HoodieFunctionalIndexException("Index already exists: " + indexName);
+      throw new HoodieMetadataIndexException("Index already exists: " + indexName);
     }
     checkArgument(columns.size() == 1, "Only one column can be indexed for functional or secondary index.");
+
+    if (!isEligibleForIndexing(metaClient, indexType)) {
+      throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + indexName);
+    }
 
     if (!metaClient.getTableConfig().getIndexDefinitionPath().isPresent()
         || !metaClient.getIndexMetadata().isPresent()
@@ -107,7 +111,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
         // build index
         writeClient.index(indexInstantTime.get());
       } else {
-        throw new HoodieFunctionalIndexException("Scheduling of index action did not return any instant.");
+        throw new HoodieMetadataIndexException("Scheduling of index action did not return any instant.");
       }
     }
   }
@@ -118,7 +122,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
       if (ignoreIfNotExists) {
         return;
       } else {
-        throw new HoodieFunctionalIndexException("Index does not exist: " + indexName);
+        throw new HoodieMetadataIndexException("Index does not exist: " + indexName);
       }
     }
 
@@ -168,5 +172,14 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
 
     HoodieIndexingConfig.fromIndexDefinition(indexDefinition).getProps().forEach((key, value) -> writeConfig.put(key.toString(), value.toString()));
     return writeConfig;
+  }
+
+  private static boolean isEligibleForIndexing(HoodieTableMetaClient metaClient, String indexType) {
+    // for secondary index, record index is a must
+    if (indexType.equals(PARTITION_NAME_SECONDARY_INDEX)) {
+      return metaClient.getTableConfig().getMetadataPartitions().stream()
+          .anyMatch(partition -> partition.equals(MetadataPartitionType.RECORD_INDEX.getPartitionPath()));
+    }
+    return true;
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -52,8 +52,9 @@ case class CreateIndexCommand(table: CatalogTable,
     columns.map(c => columnsMap.put(c._1.mkString("."), c._2.asJava))
 
     if (options.contains("func") || indexType.equals("secondary_index")) {
+      val extraOpts = options ++ table.properties
       HoodieSparkIndexClient.getInstance(sparkSession).create(
-        metaClient, indexName, indexType, columnsMap, options.asJava)
+        metaClient, indexName, indexType, columnsMap, extraOpts.asJava)
     } else {
       SecondaryIndexManager.getInstance().create(
         metaClient, indexName, indexType, ignoreIfExists, columnsMap, options.asJava)


### PR DESCRIPTION
### Change Logs

Fixes HUDI-8349 and HUDI-8351

- Since RLI is required for secondary index, so do not create secondary index if RLI does not exist.
- Fix secondary index update by passing the right instant time in merged log record scanner. 
- Return early when WriteOperationType is COMPACT or CLUSTER.

### Impact

A bug fix and minor optimization for secondary index update.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
