### PR TITLE
[HUDI-8363] Support to provide custom spark app name for HoodieStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -434,6 +434,11 @@ public class HoodieStreamer implements Serializable {
         + " committed checkpoint, and rely on other configs to pick the starting offsets).")
     public String ignoreCheckpoint = null;
 
+    @Parameter(names = {"--spark-app-name"},
+            description = "spark app name to use while creating spark context, " +
+                    "if not defined then defaults to streamer-{cfg.targetTableName}.")
+    public String sparkAppName = "";
+
     public boolean isAsyncCompactionEnabled() {
       return continuousMode && !forceDisableCompaction
           && HoodieTableType.MERGE_ON_READ.equals(HoodieTableType.valueOf(tableType));
@@ -593,10 +598,17 @@ public class HoodieStreamer implements Serializable {
     final Config cfg = getConfig(args);
     Map<String, String> additionalSparkConfigs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
     JavaSparkContext jssc = null;
+    String sparkAppName;
+    if (!StringUtils.isNullOrEmpty(cfg.sparkAppName)) {
+      sparkAppName = cfg.sparkAppName;
+    }
+    else {
+      sparkAppName = "streamer-" + cfg.targetTableName;
+    }
     if (StringUtils.isNullOrEmpty(cfg.sparkMaster)) {
-      jssc = UtilHelpers.buildSparkContext("streamer-" + cfg.targetTableName, additionalSparkConfigs);
+      jssc = UtilHelpers.buildSparkContext(sparkAppName, additionalSparkConfigs);
     } else {
-      jssc = UtilHelpers.buildSparkContext("streamer-" + cfg.targetTableName, cfg.sparkMaster, additionalSparkConfigs);
+      jssc = UtilHelpers.buildSparkContext(sparkAppName, cfg.sparkMaster, additionalSparkConfigs);
     }
     if (cfg.enableHiveSync) {
       LOG.warn("--enable-hive-sync will be deprecated in a future release; please use --enable-sync instead for Hive syncing");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -435,8 +435,8 @@ public class HoodieStreamer implements Serializable {
     public String ignoreCheckpoint = null;
 
     @Parameter(names = {"--spark-app-name"},
-            description = "spark app name to use while creating spark context, " +
-                    "if not defined then defaults to streamer-{cfg.targetTableName}.")
+            description = "spark app name to use while creating spark context." +
+                    " If not defined then defaults to streamer-{cfg.targetTableName}.")
     public String sparkAppName = "";
 
     public boolean isAsyncCompactionEnabled() {
@@ -601,8 +601,7 @@ public class HoodieStreamer implements Serializable {
     String sparkAppName;
     if (!StringUtils.isNullOrEmpty(cfg.sparkAppName)) {
       sparkAppName = cfg.sparkAppName;
-    }
-    else {
+    } else {
       sparkAppName = "streamer-" + cfg.targetTableName;
     }
     if (StringUtils.isNullOrEmpty(cfg.sparkMaster)) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -435,8 +435,8 @@ public class HoodieStreamer implements Serializable {
     public String ignoreCheckpoint = null;
 
     @Parameter(names = {"--spark-app-name"},
-            description = "spark app name to use while creating spark context." +
-                    " If not defined then defaults to streamer-{cfg.targetTableName}.")
+            description = "spark app name to use while creating spark context."
+                    + " If not defined then defaults to streamer-{cfg.targetTableName}.")
     public String sparkAppName = "";
 
     public boolean isAsyncCompactionEnabled() {


### PR DESCRIPTION
### Change Logs
Currently for HoodieStreamer, spark app name is created using `streamer-<target-table-name>`

2 Different databases can have same tables & using the current spark app name convention, 2 tables with same name will end up having same spark app name.
The proposed idea to resolve this by adding a new config `--spark-app-name`.

This will make sure that existing things stays as is while providing user with a config to override spark app name

### Impact
NA

### Risk level (write none, low medium or high below)
NA

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none". : none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
