### PR TITLE
[HUDI-8365] Reduce serialization overhead of HoodieTable

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -104,7 +104,7 @@ public abstract class HoodieFlinkTable<T>
       HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy) {
     if (config.isMetadataTableEnabled() || getMetaClient().getTableConfig().isMetadataTableAvailable()) {
       return Option.of(FlinkHoodieBackedTableMetadataWriter.create(
-          context.getStorageConf(), config, failedWritesCleaningPolicy, context,
+          getContext().getStorageConf(), config, failedWritesCleaningPolicy, getContext(),
           Option.of(triggeringInstantTimestamp)));
     } else {
       return Option.empty();

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaTable.java
@@ -87,7 +87,7 @@ public abstract class HoodieJavaTable<T>
       // metadata table bootstrapping. Bootstrapping process could fail and checking the table
       // existence after the creation is needed.
       final HoodieTableMetadataWriter metadataWriter = JavaHoodieBackedTableMetadataWriter.create(
-          context.getStorageConf(), config, failedWritesCleaningPolicy, context,
+          getContext().getStorageConf(), config, failedWritesCleaningPolicy, getContext(),
           Option.of(triggeringInstantTimestamp));
       // even with metadata enabled, some index could have been disabled
       // delete metadata partitions corresponding to such indexes

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
@@ -108,7 +108,7 @@ public abstract class HoodieSparkTable<T>
       // metadata table bootstrapping. Bootstrapping process could fail and checking the table
       // existence after the creation is needed.
       HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(
-          context.getStorageConf(), config, failedWritesCleaningPolicy, context,
+          getContext().getStorageConf(), config, failedWritesCleaningPolicy, getContext(),
           Option.of(triggeringInstantTimestamp));
       try {
         if (isMetadataTableExists || metaClient.getStorage().exists(

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -23,10 +23,10 @@ import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
-
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import com.esotericsoftware.kryo.{Kryo, Serializer}
+import org.apache.hudi.table.{HoodieSparkCopyOnWriteTable, HoodieSparkMergeOnReadTable}
 import org.apache.spark.serializer.KryoRegistrator
 
 /**
@@ -59,6 +59,8 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
 
     kryo.register(classOf[HoodieSparkRecord])
     kryo.register(classOf[HoodieInternalRow])
+    kryo.register(classOf[HoodieSparkCopyOnWriteTable[_]])
+    kryo.register(classOf[HoodieSparkMergeOnReadTable[_]])
 
     // NOTE: This entry is used for [[SerializableConfiguration]] before since
     //       Hadoop's configuration is not a serializable object by itself, and hence

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
@@ -19,6 +19,10 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.common.HoodieJsonPayload;
+import org.apache.hudi.common.config.HoodieMetaserverConfig;
+import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
+import org.apache.hudi.common.fs.ConsistencyGuardConfig;
+import org.apache.hudi.common.fs.FileSystemRetryConfig;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
@@ -26,6 +30,7 @@ import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecordDelegate;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordLocation;
@@ -35,11 +40,16 @@ import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.RewriteAvroPayload;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.storage.StoragePath;
 
 import com.esotericsoftware.kryo.Kryo;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * NOTE: PLEASE READ CAREFULLY BEFORE CHANGING
@@ -85,7 +95,18 @@ public class HoodieCommonKryoRegistrar {
 
         HoodieRecordLocation.class,
         HoodieRecordGlobalLocation.class,
-        HoodieRecordDelegate.class
+        HoodieRecordDelegate.class,
+        HoodieInstant.class,
+        HoodieActiveTimeline.class,
+        HoodieTableConfig.class,
+        ConsistencyGuardConfig.class,
+        FileSystemRetryConfig.class,
+        HoodieMetaserverConfig.class,
+        HoodieTimeGeneratorConfig.class,
+        Option.class,
+        HoodieIndexMetadata.class,
+        HashMap.class,
+        StoragePath.class
     })
         .forEachOrdered(kryo::register);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
@@ -41,6 +41,7 @@ import org.apache.hudi.common.model.RewriteAvroPayload;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
@@ -106,7 +107,8 @@ public class HoodieCommonKryoRegistrar {
         Option.class,
         HoodieIndexMetadata.class,
         HashMap.class,
-        StoragePath.class
+        StoragePath.class,
+        HoodieTableMetaClient.class
     })
         .forEachOrdered(kryo::register);
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
@@ -19,13 +19,11 @@
 package org.apache.hudi.io.storage.row;
 
 import org.apache.hudi.client.WriteStatus;
-import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
@@ -185,24 +183,6 @@ public class TestHoodieRowCreateHandle extends HoodieSparkClientTestHarness {
     Dataset<Row> result = sqlContext.read().parquet(basePath + "/" + partitionPath);
     // passing only first batch of inputRows since after first batch global error would have been thrown
     assertRows(inputRows, result, instantTime, fileNames, true);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testInstantiationFailure(boolean enableMetadataTable) {
-    // init config and table
-    HoodieWriteConfig cfg = SparkDatasetTestUtils.getConfigBuilder(basePath, timelineServicePort)
-        .withPath("/dummypath/abc/")
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadataTable).build())
-        .build();
-
-    try {
-      HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
-      new HoodieRowCreateHandle(table, cfg, " def", UUID.randomUUID().toString(), "001", RANDOM.nextInt(100000), RANDOM.nextLong(), RANDOM.nextLong(), SparkDatasetTestUtils.STRUCT_TYPE);
-      fail("Should have thrown exception");
-    } catch (TableNotFoundException e) {
-      // expected throw failure
-    }
   }
 
   private WriteStatus writeAndGetWriteStatus(Dataset<Row> inputRows, HoodieRowCreateHandle handle)


### PR DESCRIPTION
### Change Logs

- Lazily initialize the `HoodieTableMetadata`, `HoodieIndex`, and `HoodieStorageLayout` objects within the `HoodieTable` and avoid serializing it as part of the `HoodieTable`
- Register classes referenced within `HoodieTable` and the `HoodieTableMetaClient` with Kryo

### Impact

Reduces serialization overhead of Spark tasks that reference `HoodieTable` 

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
