### PR TITLE
[HUDI-8328] fix fileId of INSERT with NBCC

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -34,7 +34,7 @@ public class BucketIdentifier implements Serializable {
   private static final Pattern BUCKET_NAME = Pattern.compile(".*_(\\d+)(?:\\..*)?$");
 
   // Ensure the same records keys from different writers are desired to be distributed into the same bucket
-  private static final String CONSTANT_FILE_ID_SUFFIX = "-0000-0000-0000-000000000000";
+  public static final String CONSTANT_FILE_ID_SUFFIX = "-0000-0000-0000-000000000000";
 
   public static int getBucketId(HoodieRecord record, String indexKeyFields, int numBuckets) {
     return getBucketId(record.getKey(), indexKeyFields, numBuckets);
@@ -110,7 +110,7 @@ public class BucketIdentifier implements Serializable {
     return FSUtils.createNewFileIdPfx().replaceFirst(".{8}", bucketId);
   }
 
-  private static String newBucketFileIdFixedSuffix(String bucketId) {
+  public static String newBucketFileIdFixedSuffix(String bucketId) {
     return bucketId + CONSTANT_FILE_ID_SUFFIX;
   }
 


### PR DESCRIPTION
### Change Logs

details at https://issues.apache.org/jira/browse/HUDI-8328

INSERT with NBCC always writes into log file instead of base file, and the fileId doesn't add file number prefix.

### Impact

low
### Risk level (write none, low medium or high below)

none
### Documentation Update

none
- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
