### PR TITLE
[HUDI-8370] Removed excessive `DataBucket::preWrite`

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/ConsistentBucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/ConsistentBucketStreamWriteFunction.java
@@ -71,11 +71,10 @@ public class ConsistentBucketStreamWriteFunction<I> extends StreamWriteFunction<
   }
 
   @Override
-  protected List<WriteStatus> writeBucket(String instant, DataBucket bucket, List<HoodieRecord> records) {
+  protected List<WriteStatus> writeRecords(String instant, List<HoodieRecord> records) {
     updateStrategy.initialize(this.writeClient);
-    bucket.preWrite(records);
     Pair<List<Pair<List<HoodieRecord>, String>>, Set<HoodieFileGroupId>> recordListFgPair =
-        updateStrategy.handleUpdate(Collections.singletonList(Pair.of(records, instant)));
+        updateStrategy.handleUpdate(Collections.singletonList(Pair.of(deduplicateRecordsIfNeeded(records), instant)));
     return recordListFgPair.getKey().stream().flatMap(
         recordsInstantPair -> writeFunction.apply(recordsInstantPair.getLeft(), recordsInstantPair.getRight()).stream()
     ).collect(Collectors.toList());


### PR DESCRIPTION
### Change Logs

`DataBucket::preWrite` sets new current location, using `fileID` from `DataBucket`, only for first record in the bucket. But `fileID` is set only during `DataBucket` initialization, where we use passed first record. So, we actually don't need to call `preWrite`.

### Impact

No impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
