### PR TITLE
[HUDI-8378] Fix Avro schema deserializer failing with schema evolution

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -28,6 +28,7 @@ import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.AvroConvertor;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
+import org.apache.hudi.utilities.sources.helpers.KafkaSourceUtil;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
 import org.apache.hudi.utilities.streamer.StreamContext;
 
@@ -48,7 +49,6 @@ import static org.apache.hudi.common.util.ConfigUtils.DELTA_STREAMER_CONFIG_PREF
 import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.utilities.config.KafkaSourceConfig.KAFKA_AVRO_VALUE_DESERIALIZER_CLASS;
-import static org.apache.hudi.utilities.config.KafkaSourceConfig.KAFKA_VALUE_DESERIALIZER_SCHEMA;
 
 /**
  * Reads avro serialized Kafka data, based on the confluent schema-registry.
@@ -92,7 +92,7 @@ public class AvroKafkaSource extends KafkaSource<JavaRDD<GenericRecord>> {
     }
 
     if (deserializerClassName.equals(KafkaAvroSchemaDeserializer.class.getName())) {
-      configureSchemaDeserializer();
+      KafkaSourceUtil.configureSchemaDeserializer(schemaProvider, props);
     }
     offsetGen = new KafkaOffsetGen(props);
   }
@@ -100,7 +100,7 @@ public class AvroKafkaSource extends KafkaSource<JavaRDD<GenericRecord>> {
   @Override
   protected InputBatch<JavaRDD<GenericRecord>> readFromCheckpoint(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
     if (deserializerClassName.equals(KafkaAvroSchemaDeserializer.class.getName())) {
-      configureSchemaDeserializer();
+      KafkaSourceUtil.configureSchemaDeserializer(schemaProvider, props);
       offsetGen = new KafkaOffsetGen(props);
     }
     return super.readFromCheckpoint(lastCheckpoint, sourceLimit);
@@ -134,12 +134,5 @@ public class AvroKafkaSource extends KafkaSource<JavaRDD<GenericRecord>> {
     } else {
       return kafkaRDD.map(consumerRecord -> (GenericRecord) consumerRecord.value());
     }
-  }
-
-  private void configureSchemaDeserializer() {
-    if (schemaProvider == null) {
-      throw new HoodieReadFromSourceException("SchemaProvider has to be set to use KafkaAvroSchemaDeserializer");
-    }
-    props.put(KAFKA_VALUE_DESERIALIZER_SCHEMA.key(), schemaProvider.getSourceSchema().toString());
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.config.HoodieSchemaProviderConfig;
 import org.apache.hudi.utilities.config.KafkaSourceConfig;
+import org.apache.hudi.utilities.deser.KafkaAvroSchemaDeserializer;
 import org.apache.hudi.utilities.exception.HoodieReadFromSourceException;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
@@ -34,6 +35,7 @@ import org.apache.hudi.utilities.sources.RowSource;
 import org.apache.hudi.utilities.sources.helpers.AvroConvertor;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
+import org.apache.hudi.utilities.sources.helpers.KafkaSourceUtil;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -103,6 +105,10 @@ public abstract class DebeziumSource extends RowSource {
       schemaRegistryProvider = new SchemaRegistryProvider(props, sparkContext);
     } else {
       schemaRegistryProvider = (SchemaRegistryProvider) schemaProvider;
+    }
+
+    if (deserializerClassName.equals(KafkaAvroSchemaDeserializer.class.getName())) {
+      KafkaSourceUtil.configureSchemaDeserializer(schemaRegistryProvider, props);
     }
 
     offsetGen = new KafkaOffsetGen(props);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaSourceUtil.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaSourceUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.hash.HashID;
+import org.apache.hudi.utilities.exception.HoodieReadFromSourceException;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import com.google.crypto.tink.subtle.Base64;
+
+import java.util.Objects;
+
+import static org.apache.hudi.utilities.config.KafkaSourceConfig.KAFKA_VALUE_DESERIALIZER_SCHEMA;
+
+public class KafkaSourceUtil {
+
+  public static final String NATIVE_KAFKA_CONSUMER_GROUP_ID = "group.id";
+  public static final int GROUP_ID_MAX_BYTES_LENGTH = 255;
+
+  public static void configureSchemaDeserializer(SchemaProvider schemaProvider, TypedProperties props) {
+    if (schemaProvider == null || Objects.isNull(schemaProvider.getSourceSchema())) {
+      throw new HoodieReadFromSourceException("SchemaProvider has to be set to use KafkaAvroSchemaDeserializer");
+    }
+    props.put(KAFKA_VALUE_DESERIALIZER_SCHEMA.key(), schemaProvider.getSourceSchema().toString());
+    // assign consumer group id based on the schema, since if there's a change in the schema we ensure KafkaRDDIterator doesn't use cached Kafka Consumer
+    String groupId = props.getString(NATIVE_KAFKA_CONSUMER_GROUP_ID, "");
+    String schemaHash = Base64.encode(HashID.hash(schemaProvider.getSourceSchema().toString(), HashID.Size.BITS_128));
+    String updatedConsumerGroup = groupId.isEmpty() ? schemaHash
+        : StringUtils.concatenateWithThreshold(String.format("%s_", groupId), schemaHash, GROUP_ID_MAX_BYTES_LENGTH);
+    props.put(NATIVE_KAFKA_CONSUMER_GROUP_ID, updatedConsumerGroup);
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaSourceUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaSourceUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.hash.HashID;
+import org.apache.hudi.utilities.exception.HoodieReadFromSourceException;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import com.google.crypto.tink.subtle.Base64;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.apache.hudi.utilities.config.KafkaSourceConfig.KAFKA_VALUE_DESERIALIZER_SCHEMA;
+import static org.apache.hudi.utilities.sources.helpers.KafkaSourceUtil.GROUP_ID_MAX_BYTES_LENGTH;
+import static org.apache.hudi.utilities.sources.helpers.KafkaSourceUtil.NATIVE_KAFKA_CONSUMER_GROUP_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestKafkaSourceUtil {
+
+  @Mock
+  SchemaProvider schemaProvider;
+
+  @Test
+  void testConfigureSchemaDeserializer() {
+    TypedProperties props = new TypedProperties();
+    // should throw exception when schema provider is null.
+    assertThrows(HoodieReadFromSourceException.class, () -> KafkaSourceUtil.configureSchemaDeserializer(schemaProvider, props));
+
+    String avroSchemaJson =
+        "{\"type\":\"record\",\"name\":\"Person\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},"
+            + "{\"name\":\"age\",\"type\":\"int\"},{\"name\":\"email\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"isEmployed\",\"type\":\"boolean\"}]}";
+    Schema schema = new Schema.Parser().parse(avroSchemaJson);
+    when(schemaProvider.getSourceSchema()).thenReturn(schema);
+    KafkaSourceUtil.configureSchemaDeserializer(schemaProvider, props);
+    assertTrue(props.containsKey(NATIVE_KAFKA_CONSUMER_GROUP_ID));
+    assertTrue(props.getString(NATIVE_KAFKA_CONSUMER_GROUP_ID, "").length() <= GROUP_ID_MAX_BYTES_LENGTH);
+    assertEquals(props.getString(KAFKA_VALUE_DESERIALIZER_SCHEMA.key()), avroSchemaJson);
+    String schemaHash = Base64.encode(HashID.hash(avroSchemaJson, HashID.Size.BITS_128));
+    assertEquals(props.getString(NATIVE_KAFKA_CONSUMER_GROUP_ID, ""), schemaHash);
+  }
+}

--- a/hudi-utilities/src/test/resources/schema/evolved-test-with-default-value.avsc
+++ b/hudi-utilities/src/test/resources/schema/evolved-test-with-default-value.avsc
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "namespace": "example.avro",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {"name": "name", "type": "string"},
+    {"name": "favorite_number",  "type": "int"},
+    {
+      "name": "age",
+      "type": "int",
+      "default": 30
+    },
+    {"name": "favorite_color", "type": "string"},
+    {
+      "name": "email",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      "name": "phone",
+      "type": ["null", "string"],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
### Change Logs

Add consumer group id to kafka params based on the schema hash when KafkaAvroSchemaDeserializer is used to avoid kafka connector caching the KafkaConsumer causing issues with schema evolution.

### Impact

Kafka connector will create a new Kafka consumer whenever there's a change in the schema instead of using cached kafka consumer.

### Risk level (write none, low medium or high below)

NA

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
