### PR TITLE
[HUDI-8386] Fix update for secondary index and corresponding validation in metadata table validator

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -929,14 +929,14 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       // Sort it here once so that we don't need to sort individually for base file and for each individual log files.
       Set<String> secondaryKeySet = new HashSet<>(secondaryKeys.size());
       List<String> sortedSecondaryKeys = new ArrayList<>(secondaryKeys);
-      Collections.sort(sortedSecondaryKeys);
       secondaryKeySet.addAll(sortedSecondaryKeys);
+      Collections.sort(sortedSecondaryKeys);
 
       logRecordScanner.getRecords().forEach(record -> {
         HoodieMetadataPayload payload = record.getData();
-        String recordKey = payload.getRecordKeyFromSecondaryIndex();
-        if (secondaryKeySet.contains(recordKey)) {
-          String secondaryKey = payload.getRecordKeyFromSecondaryIndex();
+        String secondaryKey = payload.key;
+        if (secondaryKeySet.contains(secondaryKey)) {
+          String recordKey = payload.getRecordKeyFromSecondaryIndex();
           logRecordsMap.computeIfAbsent(secondaryKey, k -> new HashMap<>()).put(recordKey, record);
         }
       });

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1099,12 +1099,17 @@ public class HoodieMetadataTableValidator implements Serializable {
     secondaryKeys = secondaryKeys.sortBy(x -> x, true, numPartitions);
     for (int i = 0; i < numPartitions; i++) {
       List<String> secKeys = secondaryKeys.collectPartitions(new int[] {i})[0];
-      Map<String, List<String>> mdtSecondaryKeyToRecordKeys = ((HoodieBackedTableMetadata) metadataContext.tableMetadata)
+      Map<String, Set<String>> mdtSecondaryKeyToRecordKeys = ((HoodieBackedTableMetadata) metadataContext.tableMetadata)
           .getSecondaryIndexRecords(secKeys, indexDefinition.getIndexName())
           .entrySet().stream()
-          .collect(Collectors.toMap(Map.Entry::getKey,
-              e -> e.getValue().stream().map(rec -> rec.getData().getRecordKeyFromSecondaryIndex()).collect(Collectors.toList())));
-      Map<String, List<String>> fsSecondaryKeyToRecordKeys = getFSSecondaryKeyToRecordKeys(engineContext, basePath, latestCompletedCommit, indexDefinition.getSourceFields().get(0), secKeys);
+          .collect(Collectors.toMap(
+              Map.Entry::getKey,
+              e -> e.getValue().stream()
+                  .map(rec -> rec.getData().isSecondaryIndexDeleted() ? null : rec.getData().getRecordKeyFromSecondaryIndex())
+                  .filter(Objects::nonNull)
+                  .collect(Collectors.toSet()))
+          );
+      Map<String, Set<String>> fsSecondaryKeyToRecordKeys = getFSSecondaryKeyToRecordKeys(engineContext, basePath, latestCompletedCommit, indexDefinition.getSourceFields().get(0), secKeys);
       if (!fsSecondaryKeyToRecordKeys.equals(mdtSecondaryKeyToRecordKeys)) {
         throw new HoodieValidationException(String.format("Secondary Index does not match : \nMDT secondary index: %s \nFS secondary index: %s",
             StringUtils.join(mdtSecondaryKeyToRecordKeys), StringUtils.join(fsSecondaryKeyToRecordKeys)));
@@ -1117,16 +1122,16 @@ public class HoodieMetadataTableValidator implements Serializable {
    * Queries data in the table and generates a mapping from secondary key to list of record keys with value
    * as secondary key. Here secondary key is the value of secondary key column or the secondaryField. Also the
    * function returns the secondary key mapping only for the input secondary keys.
-
-   * @param sparkEngineContext Spark Engine context
-   * @param basePath Table base path
+   *
+   * @param sparkEngineContext    Spark Engine context
+   * @param basePath              Table base path
    * @param latestCompletedCommit Latest completed commit in the table
-   * @param secondaryField The secondary key column used to determine the secondary keys
-   * @param secKeys Input secondary keys which will be filtered
+   * @param secondaryField        The secondary key column used to determine the secondary keys
+   * @param secKeys               Input secondary keys which will be filtered
    * @return Mapping of secondary keys to list of record keys with value as secondary key
    */
-  Map<String, List<String>> getFSSecondaryKeyToRecordKeys(HoodieSparkEngineContext sparkEngineContext, String basePath, String latestCompletedCommit,
-                                                          String secondaryField, List<String> secKeys) {
+  Map<String, Set<String>> getFSSecondaryKeyToRecordKeys(HoodieSparkEngineContext sparkEngineContext, String basePath, String latestCompletedCommit,
+                                                         String secondaryField, List<String> secKeys) {
     List<Tuple2<String, String>> recordAndSecondaryKeys = sparkEngineContext.getSqlContext().read().format("hudi")
         .option(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT().key(), latestCompletedCommit)
         .load(basePath)
@@ -1135,10 +1140,10 @@ public class HoodieMetadataTableValidator implements Serializable {
         .javaRDD()
         .map(row -> new Tuple2<>(row.getAs(RECORD_KEY_METADATA_FIELD).toString(), row.getAs(secondaryField).toString()))
         .collect();
-    Map<String, List<String>> secondaryKeyToRecordKeys = new HashMap<>();
+    Map<String, Set<String>> secondaryKeyToRecordKeys = new HashMap<>();
     for (Tuple2<String, String> recordAndSecondaryKey : recordAndSecondaryKeys) {
       secondaryKeyToRecordKeys.compute(recordAndSecondaryKey._2, (k, v) -> {
-        List<String> recKeys = v != null ? v : new ArrayList<>();
+        Set<String> recKeys = v != null ? v : new HashSet<>();
         recKeys.add(recordAndSecondaryKey._1);
         return recKeys;
       });


### PR DESCRIPTION
### Change Logs

The Jira adds update validation for secondary index in metadata table validator. It also makes a fix in update logic and checks for secondary key instead of record key. The earlier logic was leading to some records getting skipped.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
