### PR TITLE
[HUDI-8403] Fixed values extraction for bucketing and optimized `KeyGenUtils::extractRecordKeysByFields`

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -25,7 +25,6 @@ import org.apache.hudi.keygen.KeyGenUtils;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -61,13 +60,11 @@ public class BucketIdentifier implements Serializable {
   }
 
   protected static List<String> getHashKeys(String recordKey, String indexKeyFields) {
-    return !recordKey.contains(":") ? Collections.singletonList(recordKey) :
-        getHashKeysUsingIndexFields(recordKey, Arrays.asList(indexKeyFields.split(",")));
+    return getHashKeysUsingIndexFields(recordKey, Arrays.asList(indexKeyFields.split(",")));
   }
 
   protected static List<String> getHashKeys(String recordKey, List<String> indexKeyFields) {
-    return !recordKey.contains(":") ? Collections.singletonList(recordKey) :
-        getHashKeysUsingIndexFields(recordKey, indexKeyFields);
+    return getHashKeysUsingIndexFields(recordKey, indexKeyFields);
   }
 
   private static List<String> getHashKeysUsingIndexFields(String recordKey, List<String> indexKeyFields) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -153,7 +153,7 @@ public class KeyGenUtils {
       keyValueSep1 = recordKey.indexOf(DEFAULT_COLUMN_VALUE_SEPARATOR, processed);
       currentField = recordKey.substring(processed, keyValueSep1);
       keyValueSep2 = recordKey.indexOf(DEFAULT_COLUMN_VALUE_SEPARATOR, keyValueSep1 + 1);
-      if (fields.isEmpty() || fields.contains(currentField)) {
+      if (fields.isEmpty() || (fields.size() == 1 && fields.get(0).isEmpty()) || fields.contains(currentField)) {
         if (keyValueSep2 < 0) {
           // there is no next key value pair
           currentValue = recordKey.substring(keyValueSep1 + 1);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/bucket/TestBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/bucket/TestBucketIdentifier.java
@@ -107,9 +107,10 @@ public class TestBucketIdentifier {
     assertEquals(1, keys.size());
     assertEquals("abc", keys.get(0));
 
+    // we don't extract key values if they contain only ':', because it could be a timestamp, for instance, '2014-10-21 12:23'
     keys = identifier.getHashKeys(new HoodieKey("f1:abc", "partition"), "f1");
     assertEquals(1, keys.size());
-    assertEquals("abc", keys.get(0));
+    assertEquals("f1:abc", keys.get(0));
 
     keys = identifier.getHashKeys(new HoodieKey("f1:abc,f2:bcd", "partition"), "f2");
     assertEquals(1, keys.size());
@@ -121,9 +122,8 @@ public class TestBucketIdentifier {
     assertEquals("bcd", keys.get(1));
 
     keys = identifier.getHashKeys(new HoodieKey("f1:abc,f2:bcd,efg", "partition"), "f1,f2");
-    assertEquals(3, keys.size());
+    assertEquals(2, keys.size());
     assertEquals("abc", keys.get(0));
-    assertEquals("bcd", keys.get(1));
-    assertEquals("efg", keys.get(2));
+    assertEquals("bcd,efg", keys.get(1));
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/bucket/TestBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/bucket/TestBucketIdentifier.java
@@ -103,15 +103,12 @@ public class TestBucketIdentifier {
   @Test
   public void testGetHashKeys() {
     BucketIdentifier identifier = new BucketIdentifier();
+    // if for recordKey one column only is used, then there is no added column name before value
     List<String> keys = identifier.getHashKeys(new HoodieKey("abc", "partition"), "");
     assertEquals(1, keys.size());
     assertEquals("abc", keys.get(0));
 
-    // we don't extract key values if they contain only ':', because it could be a timestamp, for instance, '2014-10-21 12:23'
-    keys = identifier.getHashKeys(new HoodieKey("f1:abc", "partition"), "f1");
-    assertEquals(1, keys.size());
-    assertEquals("f1:abc", keys.get(0));
-
+    // complex keys, composite from key-value pairs
     keys = identifier.getHashKeys(new HoodieKey("f1:abc,f2:bcd", "partition"), "f2");
     assertEquals(1, keys.size());
     assertEquals("bcd", keys.get(0));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -113,9 +113,9 @@ public class TestKeyGenUtils {
 
   @Test
   public void testExtractRecordKeys() {
-    // we don't extract key values if they contain only ':', because it could be a timestamp, for instance, '2014-10-21 12:23'
-    String[] s1 = KeyGenUtils.extractRecordKeys("id:1");
-    Assertions.assertArrayEquals(new String[] {"id:1"}, s1);
+    // if for recordKey one column only is used, then there is no added column name before value
+    String[] s1 = KeyGenUtils.extractRecordKeys("2024-10-22 14:11:53.023");
+    Assertions.assertArrayEquals(new String[] {"2024-10-22 14:11:53.023"}, s1);
 
     // test complex key form: field1:val1,field2:val2,...
     String[] s2 = KeyGenUtils.extractRecordKeys("id:1,id:2");
@@ -152,7 +152,7 @@ public class TestKeyGenUtils {
 
     fields.addAll(Arrays.asList("id1", "id3", "id4"));
     // tough case with a lot of ',' and ':'
-    String[] s4 = KeyGenUtils.extractRecordKeysByFields("id1:1,,,id2:2024-10-22 14:11:53,id3:,,3,id4:::1:2::4::", fields);
-    Assertions.assertArrayEquals(new String[] {"1,,", "2024-10-22 14:11:53", ",,3", "::1:2::4::"}, s4);
+    String[] s4 = KeyGenUtils.extractRecordKeysByFields("id1:1,,,id2:2024-10-22 14:11:53.023,id3:,,3,id4:::1:2::4::", fields);
+    Assertions.assertArrayEquals(new String[] {"1,,", "2024-10-22 14:11:53.023", ",,3", "::1:2::4::"}, s4);
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -19,17 +19,16 @@
 package org.apache.hudi.keygen;
 
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieKeyException;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestKeyGenUtils {
 
@@ -126,9 +125,8 @@ public class TestKeyGenUtils {
     Assertions.assertArrayEquals(new String[] {"1", null, ""}, s3);
 
     // keys with ':' are not supported
-    String wrongKeyValues = "id:ab:cd,id2:ef";
-    Throwable ex = assertThrows(HoodieKeyException.class, () -> KeyGenUtils.extractRecordKeys(wrongKeyValues));
-    assertEquals("Couldn't extract values from complex key: '" + wrongKeyValues + "', probably due to used ':' character as key value", ex.getMessage());
+    String[] s4 = KeyGenUtils.extractRecordKeys("id:ab:cd,id2:ef");
+    Assertions.assertArrayEquals(new String[] {"ab:cd", "ef"}, s4);
 
     // test simple key form: val1
     String[] s5 = KeyGenUtils.extractRecordKeys("1");
@@ -151,5 +149,10 @@ public class TestKeyGenUtils {
 
     String[] s3 = KeyGenUtils.extractRecordKeysByFields("id1:1,1,1,id2:,2,2,,id3:3", fields);
     Assertions.assertArrayEquals(new String[] {",2,2,"}, s3);
+
+    fields.addAll(Arrays.asList("id1", "id3", "id4"));
+    // tough case with a lot of ',' and ':'
+    String[] s4 = KeyGenUtils.extractRecordKeysByFields("id1:1,,,id2:2024-10-22 14:11:53,id3:,,3,id4:::1:2::4::", fields);
+    Assertions.assertArrayEquals(new String[] {"1,,", "2024-10-22 14:11:53", ",,3", "::1:2::4::"}, s4);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/BuiltinKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/BuiltinKeyGenerator.java
@@ -51,7 +51,7 @@ import java.util.function.Supplier;
 import scala.Function1;
 
 import static org.apache.hudi.common.util.CollectionUtils.tail;
-import static org.apache.hudi.keygen.KeyGenUtils.DEFAULT_COMPOSITE_KEY_FILED_VALUE;
+import static org.apache.hudi.keygen.KeyGenUtils.DEFAULT_COLUMN_VALUE_SEPARATOR;
 import static org.apache.hudi.keygen.KeyGenUtils.DEFAULT_RECORD_KEY_PARTS_SEPARATOR;
 import static org.apache.hudi.keygen.KeyGenUtils.EMPTY_RECORDKEY_PLACEHOLDER;
 import static org.apache.hudi.keygen.KeyGenUtils.NULL_RECORDKEY_PLACEHOLDER;
@@ -70,8 +70,6 @@ import static org.apache.hudi.keygen.KeyGenUtils.NULL_RECORDKEY_PLACEHOLDER;
 public abstract class BuiltinKeyGenerator extends BaseKeyGenerator implements SparkKeyGeneratorInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(BuiltinKeyGenerator.class);
-
-  private static final String COMPOSITE_KEY_FIELD_VALUE_INFIX = ":";
 
   protected static final String FIELDS_SEP = ",";
 
@@ -220,7 +218,7 @@ public abstract class BuiltinKeyGenerator extends BaseKeyGenerator implements Sp
 
     PartitionPathFormatterBase.StringBuilder<S> sb = builderFactory.get();
     for (int i = 0; i < recordKeyParts.size(); ++i) {
-      sb.appendJava(fieldNames.get(i)).appendJava(DEFAULT_COMPOSITE_KEY_FILED_VALUE);
+      sb.appendJava(fieldNames.get(i)).appendJava(DEFAULT_COLUMN_VALUE_SEPARATOR);
       // NOTE: If record-key part has already been a string [[toString]] will be a no-op
       sb.append(emptyKeyPartHandler.apply(converter.apply(recordKeyParts.get(i))));
 
@@ -248,7 +246,7 @@ public abstract class BuiltinKeyGenerator extends BaseKeyGenerator implements Sp
 
       if (recordKeyParts.length > 1) {
         sb.appendJava(recordKeyFields.get(i));
-        sb.appendJava(COMPOSITE_KEY_FIELD_VALUE_INFIX);
+        sb.appendJava(DEFAULT_COLUMN_VALUE_SEPARATOR);
       }
       sb.append(convertedKeyPart);
       // This check is to validate that overall composite-key has at least one non-null, non-empty

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -448,8 +448,9 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .defaultValue("uuid")
       .withDescription("Record key field. Value to be used as the `recordKey` component of `HoodieKey`.\n"
-          + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
-          + "the dot notation eg: `a.b.c`");
+          + "Note that in the case of complex keys `:` character is not supported in key values. "
+          + "Actual value will be obtained by invoking .toString() on the field value. "
+          + "Nested fields can be specified using the dot notation eg: `a.b.c`");
 
   @AdvancedConfig
   public static final ConfigOption<String> INDEX_KEY_FIELD = ConfigOptions
@@ -457,8 +458,9 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .defaultValue("")
       .withDescription("Index key field. Value to be used as hashing to find the bucket ID. Should be a subset of or equal to the recordKey fields.\n"
-          + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
-          + "the dot notation eg: `a.b.c`");
+          + "Note that in the case of complex keys `:` character is not supported in key values. "
+          + "Actual value will be obtained by invoking .toString() on the field value. "
+          + "Nested fields can be specified using the dot notation eg: `a.b.c`");
 
   @AdvancedConfig
   public static final ConfigOption<String> BUCKET_INDEX_ENGINE_TYPE = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -448,9 +448,8 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .defaultValue("uuid")
       .withDescription("Record key field. Value to be used as the `recordKey` component of `HoodieKey`.\n"
-          + "Note that in the case of complex keys `:` character is not supported in key values. "
-          + "Actual value will be obtained by invoking .toString() on the field value. "
-          + "Nested fields can be specified using the dot notation eg: `a.b.c`");
+          + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
+          + "the dot notation eg: `a.b.c`");
 
   @AdvancedConfig
   public static final ConfigOption<String> INDEX_KEY_FIELD = ConfigOptions
@@ -458,9 +457,8 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .defaultValue("")
       .withDescription("Index key field. Value to be used as hashing to find the bucket ID. Should be a subset of or equal to the recordKey fields.\n"
-          + "Note that in the case of complex keys `:` character is not supported in key values. "
-          + "Actual value will be obtained by invoking .toString() on the field value. "
-          + "Nested fields can be specified using the dot notation eg: `a.b.c`");
+          + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
+          + "the dot notation eg: `a.b.c`");
 
   @AdvancedConfig
   public static final ConfigOption<String> BUCKET_INDEX_ENGINE_TYPE = ConfigOptions

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -1702,7 +1702,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | (6, 'a1,1', 10, 1000, "2021-01-05"),
                  | (7, 'a1,1', 10, 1000, "2021-01-05"),
                  | (8, 'a1,1', 10, 1000, "2021-01-05"),
-                 | (9, 'a3,3', 30, 3000, "2021-01-05")
+                 | (10, 'a3,3', 30, 3000, "2021-01-05")
                """.stripMargin)
 
             checkAnswer(s"select count(distinct _hoodie_file_name) from $tableName where dt = '2021-01-05'")(


### PR DESCRIPTION
### Change Logs

During optimization found out that current bucketing using timestamps is wrong. Described in the comment below:
https://github.com/apache/hudi/pull/12120#issuecomment-2428125344

`KeyGenUtils::extractRecordKeysByFields` is used in Flink stream processing with buckets. Optimization of this part is critical because it's called from `BucketStreamWriteFunction::processElement`, which means it's called for each record.

**Before changes**:
![09 - string](https://github.com/user-attachments/assets/2a14d49f-5702-401e-8e8f-14e82a65e5c0)

**After changes**:
![16 - optimized extract - 2](https://github.com/user-attachments/assets/0ae303ba-879b-4c89-84d5-80400fd08af9)

Also, fix for HUDI-5302 introduced complex behavior depending on combination and sequence of `,` and `:`.
Actually, a sequence of `,` is not supported. For instance, key `col1:val1,,,col2:val2` with hash fields `col2` will be processed in the following way:
- parsed key value pair: `col1:val1`, `:null`, `:null`, `col2:val2`,
- after filtering by hash fields: `:null`, `:null`, `col2:val2`,
- hash calculation using `null`, `null`, and `val2`.

This is wrong behavior, because `col1` in this case has value `val1,,`, and we should skip it due to set hash fields. And use for hash `val2` only.

In the comment below, I showed, that for timestamps used for bucketing it could lead to only one bucket for all data.

This MR fix this behavior, and propose full support of `,` and `:` in composite key values.

### Impact

Memory allocation optimized when buckets are used.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
