### PR TITLE
[HUDI-8362] Fix DebeziumSource to always returning dataframe with schema

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -115,21 +115,15 @@ public abstract class DebeziumSource extends RowSource {
     long totalNewMsgs = CheckpointUtils.totalNewMessages(offsetRanges);
     LOG.info("About to read " + totalNewMsgs + " from Kafka for topic :" + offsetGen.getTopicName());
 
-    if (totalNewMsgs == 0) {
-      // If there are no new messages, use empty dataframe with no schema. This is because the schema from schema registry can only be considered
-      // up to date if a change event has occurred.
-      return Pair.of(Option.of(sparkSession.emptyDataFrame()), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
-    } else {
-      try {
-        String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(getStringWithAltKeys(props, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
-        Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
-        LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
-        LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));
-        return Pair.of(Option.of(dataset), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
-      } catch (Exception e) {
-        LOG.error("Fatal error reading and parsing incoming debezium event", e);
-        throw new HoodieReadFromSourceException("Fatal error reading and parsing incoming debezium event", e);
-      }
+    try {
+      String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(getStringWithAltKeys(props, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
+      Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
+      LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
+      LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));
+      return Pair.of(Option.of(dataset), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
+    } catch (Exception e) {
+      LOG.error("Fatal error reading and parsing incoming debezium event", e);
+      throw new HoodieReadFromSourceException("Fatal error reading and parsing incoming debezium event", e);
     }
   }
 


### PR DESCRIPTION
### Change Logs

Change DebeziumSource.java to always returning Spark DataFrame with schema even the data is absent.

### Impact

This will allow HudiStreamer to fetch data from Debezium Postgres source and apply SqlQueryBasedTransformer without any error (https://github.com/apache/hudi/issues/11468)

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
