### PR TITLE
[HUDI-8354] WIP: Have cloud event source use QueryContext

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -287,6 +287,19 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieTimeline findInstantsAfterByCompletionTime(String completionTime, int numCommits) {
+    return new HoodieDefaultTimeline(getInstantsOrderedByCompletionTime()
+        .filter(s -> compareTimestamps(s.getCompletionTime(), GREATER_THAN, completionTime))
+        .limit(numCommits), details);
+  }
+
+  @Override
+  public HoodieTimeline findInstantsAfterByCompletionTime(String completionTime) {
+    return new HoodieDefaultTimeline(getInstantsOrderedByCompletionTime()
+        .filter(s -> compareTimestamps(s.getCompletionTime(), GREATER_THAN, completionTime)), details);
+  }
+
+  @Override
   public HoodieDefaultTimeline findInstantsAfterOrEquals(String commitTime, int numCommits) {
     return new HoodieDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.getTimestamp(), GREATER_THAN_OR_EQUALS, commitTime))
@@ -297,6 +310,19 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
     return new HoodieDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.getTimestamp(), GREATER_THAN_OR_EQUALS, commitTime)), details);
+  }
+
+  @Override
+  public HoodieDefaultTimeline findInstantsAfterOrEqualsByCompletionTime(String completionTime, int numCommits) {
+    return new HoodieDefaultTimeline(getInstantsOrderedByCompletionTime()
+        .filter(s -> compareTimestamps(s.getCompletionTime(), GREATER_THAN_OR_EQUALS, completionTime))
+        .limit(numCommits), details);
+  }
+
+  @Override
+  public HoodieDefaultTimeline findInstantsAfterOrEqualsByCompletionTime(String completionTime) {
+    return new HoodieDefaultTimeline(getInstantsOrderedByCompletionTime()
+        .filter(s -> compareTimestamps(s.getCompletionTime(), GREATER_THAN_OR_EQUALS, completionTime)), details);
   }
 
   @Override
@@ -311,6 +337,13 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     return Option.fromJavaOptional(instants.stream()
         .filter(instant -> compareTimestamps(instant.getTimestamp(), LESSER_THAN, instantTime))
         .max(Comparator.comparing(HoodieInstant::getTimestamp)));
+  }
+
+  @Override
+  public Option<HoodieInstant> findInstantBeforeByCompletionTime(String completionTime) {
+    return Option.fromJavaOptional(getInstantsOrderedByCompletionTime()
+        .filter(instant -> compareTimestamps(instant.getCompletionTime(), LESSER_THAN, completionTime))
+        .max(Comparator.comparing(HoodieInstant::getCompletionTime)));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -261,6 +261,16 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline findInstantsAfterOrEquals(String commitTime);
 
   /**
+   * Create a new Timeline with all the instants completed after specified completion time.
+   */
+  HoodieTimeline findInstantsAfterOrEqualsByCompletionTime(String completionTime, int numCommits);
+
+  /**
+   * Create a new Timeline with all the instants completed after specified completion time.
+   */
+  HoodieTimeline findInstantsAfterOrEqualsByCompletionTime(String completionTime);
+
+  /**
    * Create a new Timeline with instants after startTs and before or on endTs.
    */
   HoodieTimeline findInstantsInRange(String startTs, String endTs);
@@ -292,6 +302,16 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline findInstantsAfter(String instantTime);
 
   /**
+   * Create a new Timeline with all the instants completed after specified completion time.
+   */
+  HoodieTimeline findInstantsAfterByCompletionTime(String completionTime);
+
+  /**
+   * Create a new Timeline with all the instants completed after specified completion time.
+   */
+  HoodieTimeline findInstantsAfterByCompletionTime(String completionTime, int numCommits);
+
+  /**
    * Create a new Timeline with all instants before specified time.
    */
   HoodieTimeline findInstantsBefore(String instantTime);
@@ -300,6 +320,11 @@ public interface HoodieTimeline extends Serializable {
    * Finds the instant before specified time.
    */
   Option<HoodieInstant> findInstantBefore(String instantTime);
+
+  /**
+   * Find the last completed instant before specified completion time
+   */
+  Option<HoodieInstant> findInstantBeforeByCompletionTime(String completionTime);
 
   /**
    * Create new timeline with all instants before or equals specified time.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -19,17 +19,16 @@
 package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
+import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer;
+import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.CloudDataFetcher;
 import org.apache.hudi.utilities.sources.helpers.CloudObjectIncrCheckpoint;
-import org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon;
+import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy;
-import org.apache.hudi.utilities.sources.helpers.QueryInfo;
 import org.apache.hudi.utilities.sources.helpers.QueryRunner;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
 import org.apache.hudi.utilities.streamer.StreamContext;
@@ -52,8 +51,6 @@ import static org.apache.hudi.utilities.config.CloudSourceConfig.ENABLE_EXISTS_C
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.HOODIE_SRC_BASE_PATH;
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.NUM_INSTANTS_PER_FETCH;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon.Type.GCS;
-import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.generateQueryInfo;
-import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getMissingCheckpointStrategy;
 
 /**
@@ -165,22 +162,23 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
   @Override
   public Pair<Option<Dataset<Row>>, String> fetchNextBatch(Option<String> lastCheckpoint, long sourceLimit) {
     CloudObjectIncrCheckpoint cloudObjectIncrCheckpoint = CloudObjectIncrCheckpoint.fromString(lastCheckpoint);
-    HollowCommitHandling handlingMode = getHollowCommitHandleMode(props);
 
-    QueryInfo queryInfo = generateQueryInfo(
+    IncrementalQueryAnalyzer analyzer =
+        IncrSourceHelper.generateQueryInfo(
         sparkContext, srcPath, numInstantsPerFetch,
         Option.of(cloudObjectIncrCheckpoint.getCommit()),
-        missingCheckpointStrategy, handlingMode, HoodieRecord.COMMIT_TIME_METADATA_FIELD,
-        CloudObjectsSelectorCommon.GCS_OBJECT_KEY,
-        CloudObjectsSelectorCommon.GCS_OBJECT_SIZE, true,
+        missingCheckpointStrategy,  true,
         Option.ofNullable(cloudObjectIncrCheckpoint.getKey()));
-    LOG.info("Querying GCS with:" + cloudObjectIncrCheckpoint + " and queryInfo:" + queryInfo);
+    QueryContext queryContext = analyzer.analyze();
+    LOG.info("Querying GCS with:" + cloudObjectIncrCheckpoint + " and queryInfo:" + analyzer);
 
-    if (isNullOrEmpty(cloudObjectIncrCheckpoint.getKey()) && queryInfo.areStartAndEndInstantsEqual()) {
-      LOG.info("Source of file names is empty. Returning empty result and endInstant: "
-          + queryInfo.getStartInstant());
-      return Pair.of(Option.empty(), queryInfo.getStartInstant());
+    if (isNullOrEmpty(cloudObjectIncrCheckpoint.getKey()) && queryContext.isEmpty()) {
+      LOG.info("Source of file names is empty. Returning empty result and lastCheckpoint: "
+          + lastCheckpoint.orElse(null));
+      return Pair.of(Option.empty(), lastCheckpoint.orElse(null));
     }
-    return cloudDataFetcher.fetchPartitionedSource(GCS, cloudObjectIncrCheckpoint, this.sourceProfileSupplier, queryRunner.run(queryInfo, snapshotLoadQuerySplitter), this.schemaProvider, sourceLimit);
+    return cloudDataFetcher.fetchPartitionedSource(
+        GCS, cloudObjectIncrCheckpoint, this.sourceProfileSupplier,
+        queryRunner.run(queryContext, snapshotLoadQuerySplitter), this.schemaProvider, sourceLimit);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -178,8 +178,9 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
       return Pair.of(Option.empty(), lastCheckpoint.orElse(null));
     }
     boolean shouldFullScan =
-        missingCheckpointStrategy == MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT
-            && queryContext.getActiveTimeline().isBeforeTimelineStartsByCompletionTime(analyzer.getStartCompletionTime().get());
+        queryContext.getInstantRange().isEmpty()
+            || (missingCheckpointStrategy == MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT
+            && queryContext.getActiveTimeline().isBeforeTimelineStartsByCompletionTime(analyzer.getStartCompletionTime().get()));
     return cloudDataFetcher.fetchPartitionedSource(
         GCS, cloudObjectIncrCheckpoint, this.sourceProfileSupplier,
         queryRunner.run(queryContext, snapshotLoadQuerySplitter, shouldFullScan), this.schemaProvider, sourceLimit);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -170,7 +170,7 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
         missingCheckpointStrategy,  true,
         Option.ofNullable(cloudObjectIncrCheckpoint.getKey()));
     QueryContext queryContext = analyzer.analyze();
-    LOG.info("Querying GCS with:" + cloudObjectIncrCheckpoint + " and queryInfo:" + analyzer);
+    LOG.info("Querying GCS with:" + cloudObjectIncrCheckpoint + " and queryContext:" + queryContext);
 
     if (isNullOrEmpty(cloudObjectIncrCheckpoint.getKey()) && queryContext.isEmpty()) {
       LOG.info("Source of file names is empty. Returning empty result and lastCheckpoint: "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -227,11 +227,11 @@ public class HoodieIncrSource extends RowSource {
         Option<SnapshotLoadQuerySplitter.CheckpointWithPredicates> newCheckpointAndPredicate =
             snapshotLoadQuerySplitter.get().getNextCheckpointWithPredicates(snapshot, queryContext);
         if (newCheckpointAndPredicate.isPresent()) {
-          endCompletionTime = newCheckpointAndPredicate.get().endCompletionTime;
-          predicate = Option.of(newCheckpointAndPredicate.get().predicateFilter);
+          endCompletionTime = newCheckpointAndPredicate.get().getEndCompletionTime();
+          predicate = Option.of(newCheckpointAndPredicate.get().getPredicateFilter());
           instantTimeList = queryContext.getInstants().stream()
               .filter(instant -> HoodieTimeline.compareTimestamps(
-                  instant.getCompletionTime(), HoodieTimeline.LESSER_THAN_OR_EQUALS, newCheckpointAndPredicate.get().endCompletionTime))
+                  instant.getCompletionTime(), HoodieTimeline.LESSER_THAN_OR_EQUALS, newCheckpointAndPredicate.get().getEndCompletionTime()))
               .map(HoodieInstant::getTimestamp)
               .collect(Collectors.toList());
         } else {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -122,8 +122,9 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
       return Pair.of(Option.empty(), lastCheckpoint.orElse(null));
     }
     boolean shouldFullScan =
-        missingCheckpointStrategy == MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT
-            && queryContext.getActiveTimeline().isBeforeTimelineStartsByCompletionTime(analyzer.getStartCompletionTime().get());
+        queryContext.getInstantRange().isEmpty()
+            || (missingCheckpointStrategy == MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT
+            && queryContext.getActiveTimeline().isBeforeTimelineStartsByCompletionTime(analyzer.getStartCompletionTime().get()));
     return cloudDataFetcher.fetchPartitionedSource(
         S3, cloudObjectIncrCheckpoint, this.sourceProfileSupplier,
         queryRunner.run(queryContext, snapshotLoadQuerySplitter, shouldFullScan), this.schemaProvider, sourceLimit);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
@@ -24,8 +24,6 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
-import org.apache.hudi.utilities.sources.helpers.QueryInfo;
-import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -56,8 +54,8 @@ public abstract class SnapshotLoadQuerySplitter {
    * Checkpoint returned for the SnapshotLoadQuerySplitter.
    */
   public static class CheckpointWithPredicates {
-    String endCompletionTime;
-    String predicateFilter;
+    private String endCompletionTime;
+    private String predicateFilter;
 
     public CheckpointWithPredicates(String endCompletionTime, String predicateFilter) {
       this.endCompletionTime = endCompletionTime;
@@ -90,21 +88,6 @@ public abstract class SnapshotLoadQuerySplitter {
    * @return The next checkpoint with predicates for partitionPath etc. to optimise snapshot query.
    */
   public abstract Option<CheckpointWithPredicates> getNextCheckpointWithPredicates(Dataset<Row> df, QueryContext queryContext);
-
-  /**
-   * Retrieves the next checkpoint based on query information and a SourceProfileSupplier.
-   *
-   * @param df The dataset to process.
-   * @param queryInfo The query information object.
-   * @param sourceProfileSupplier An Option of a SourceProfileSupplier to use in load splitting implementation
-   * @return Updated query information with the next checkpoint, in case of empty checkpoint,
-   * returning endPoint same as queryInfo.getEndInstant().
-   */
-  @Deprecated
-  public QueryInfo getNextCheckpoint(Dataset<Row> df, QueryInfo queryInfo, Option<SourceProfileSupplier> sourceProfileSupplier) {
-    // TODO(HUDI-8354): fix related usage in the event incremental source
-    throw new UnsupportedOperationException("getNextCheckpoint is no longer supported with instant time.");
-  }
 
   public static Option<SnapshotLoadQuerySplitter> getInstance(TypedProperties props) {
     return props.getNonEmptyStringOpt(SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME, null)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
@@ -550,5 +551,55 @@ public class CloudObjectsSelectorCommon {
   public enum Type {
     S3,
     GCS
+  }
+
+  public enum CloudDataColumnInfo {
+    S3(
+        CloudObjectsSelectorCommon.S3_OBJECT_KEY,
+        CloudObjectsSelectorCommon.S3_OBJECT_SIZE
+    ),
+    GCS(
+        CloudObjectsSelectorCommon.GCS_OBJECT_KEY,
+        CloudObjectsSelectorCommon.GCS_OBJECT_SIZE
+    );
+
+    // both S3 and GCS use COMMIT_TIME_METADATA_FIELD as order column
+    private final String orderColumn = HoodieRecord.COMMIT_TIME_METADATA_FIELD;
+    private final String keyColumn;
+    private final String limitColumn;
+    private final List<String> orderByColumns;
+
+    CloudDataColumnInfo(String keyColumn, String limitColumn) {
+      this.keyColumn = keyColumn;
+      this.limitColumn = limitColumn;
+      orderByColumns = Arrays.asList(orderColumn, keyColumn);
+    }
+
+    public String getOrderColumn() {
+      return orderColumn;
+    }
+
+    public String getKeyColumn() {
+      return keyColumn;
+    }
+
+    public String getLimitColumn() {
+      return limitColumn;
+    }
+
+    public List<String> getOrderByColumns() {
+      return orderByColumns;
+    }
+
+    public static CloudDataColumnInfo getCloudDataColumnInfo(CloudObjectsSelectorCommon.Type type) {
+      switch (type) {
+        case S3:
+          return S3;
+        case GCS:
+          return GCS;
+        default:
+          throw new IllegalArgumentException("Unsupported cloud data column type: " + type);
+      }
+    }
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hudi.DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT;
-import static org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.START_COMMIT_EARLIEST;
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -319,7 +319,8 @@ public class IncrSourceHelper {
     }
     LOG.info("Processed batch size: " + row.get(row.fieldIndex(CUMULATIVE_COLUMN_NAME)) + " bytes");
     sourceData.unpersist();
-    // TODO: row.getString(0) is the commit time, not the completion time
+    // TODO: row.getString(0) is the commit time, not the completion time, need queryContext (filtered by snapshotLoadSplitter)
+    //  here to map commit time to completion time again
     return Pair.of(new CloudObjectIncrCheckpoint(row.getString(0), row.getString(1)), Option.of(collectedRows));
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL;
 import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL;
 
+// TODO remove this class
 /**
  * This class is used to prepare query information for s3 and gcs incr source.
  * Some of the information in this class is used for batching based on sourceLimit.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -72,7 +72,7 @@ public class QueryRunner {
       QueryContext queryContext,
       Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption,
       boolean shouldFullScan) {
-    if (queryContext.getInstantRange().isEmpty() || shouldFullScan) {
+    if (shouldFullScan) {
       return runSnapshotQuery(queryContext, snapshotLoadQuerySplitterOption);
     } else {
       return runIncrementalQuery(queryContext);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -68,9 +68,11 @@ public class QueryRunner {
    * @param queryContext all meta info about the query to be executed.
    * @return the output of the query as Dataset < Row >.
    */
-  public Pair<String, Dataset<Row>> run(QueryContext queryContext, Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption) {
-    // no need to check if it's incremental
-    if (queryContext.getInstantRange().isEmpty()) {
+  public Pair<String, Dataset<Row>> run(
+      QueryContext queryContext,
+      Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption,
+      boolean shouldFullScan) {
+    if (queryContext.getInstantRange().isEmpty() || shouldFullScan) {
       return runSnapshotQuery(queryContext, snapshotLoadQuerySplitterOption);
     } else {
       return runIncrementalQuery(queryContext);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -21,9 +21,11 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.config.HoodieIncrSourceConfig;
 import org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter;
 
@@ -37,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ConfigUtils.checkRequiredConfigProperties;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
@@ -62,16 +65,15 @@ public class QueryRunner {
   /**
    * This is used to execute queries for cloud stores incremental pipelines.
    * Regular Hudi incremental queries does not take this flow.
-   * @param queryInfo all meta info about the query to be executed.
+   * @param queryContext all meta info about the query to be executed.
    * @return the output of the query as Dataset < Row >.
    */
-  public Pair<QueryInfo, Dataset<Row>> run(QueryInfo queryInfo, Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption) {
-    if (queryInfo.isIncremental()) {
-      return runIncrementalQuery(queryInfo);
-    } else if (queryInfo.isSnapshot()) {
-      return runSnapshotQuery(queryInfo, snapshotLoadQuerySplitterOption);
+  public Pair<String, Dataset<Row>> run(QueryContext queryContext, Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption) {
+    // no need to check if it's incremental
+    if (queryContext.getInstantRange().isEmpty()) {
+      return runSnapshotQuery(queryContext, snapshotLoadQuerySplitterOption);
     } else {
-      throw new HoodieException("Unknown query type " + queryInfo.getQueryType());
+      return runIncrementalQuery(queryContext);
     }
   }
 
@@ -83,35 +85,51 @@ public class QueryRunner {
     return dataset;
   }
 
-  public Pair<QueryInfo, Dataset<Row>> runIncrementalQuery(QueryInfo queryInfo) {
+  public Pair<String, Dataset<Row>> runIncrementalQuery(QueryContext queryContext) {
     LOG.info("Running incremental query");
-    return Pair.of(queryInfo, sparkSession.read().format("org.apache.hudi")
-        .option(DataSourceReadOptions.QUERY_TYPE().key(), queryInfo.getQueryType())
-        .option(DataSourceReadOptions.START_COMMIT().key(), queryInfo.getStartInstant())
-        .option(DataSourceReadOptions.END_COMMIT().key(), queryInfo.getEndInstant())
+    String inclusiveStartCompletionTime = queryContext.getInstants().stream()
+        .min(HoodieInstant.COMPLETION_TIME_COMPARATOR)
+        .map(HoodieInstant::getCompletionTime)
+        .get();
+
+    return Pair.of(queryContext.getMaxCompletionTime(), sparkSession.read().format("org.apache.hudi")
+        .option(DataSourceReadOptions.QUERY_TYPE().key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL())
+        .option(DataSourceReadOptions.START_COMMIT().key(), inclusiveStartCompletionTime)
+        .option(DataSourceReadOptions.END_COMMIT().key(), queryContext.getMaxCompletionTime())
         .option(DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN().key(),
             props.getString(DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN().key(),
                 DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN().defaultValue()))
         .load(sourcePath));
   }
 
-  public Pair<QueryInfo, Dataset<Row>> runSnapshotQuery(QueryInfo queryInfo, Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitterOption) {
+  public Pair<String, Dataset<Row>> runSnapshotQuery(QueryContext queryContext, Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter) {
     LOG.info("Running snapshot query");
-    Dataset<Row> snapshot = sparkSession.read().format("org.apache.hudi")
-        .option(DataSourceReadOptions.QUERY_TYPE().key(), queryInfo.getQueryType()).load(sourcePath);
-    QueryInfo snapshotQueryInfo = snapshotLoadQuerySplitterOption
-        .map(snapshotLoadQuerySplitter -> snapshotLoadQuerySplitter.getNextCheckpoint(snapshot, queryInfo, Option.empty()))
-        .orElse(queryInfo);
-    return Pair.of(snapshotQueryInfo, applySnapshotQueryFilters(snapshot, snapshotQueryInfo));
-  }
-
-  public Dataset<Row> applySnapshotQueryFilters(Dataset<Row> snapshot, QueryInfo snapshotQueryInfo) {
-    Dataset<Row> df = snapshot
+    Dataset<Row> snapshot = sparkSession.read()
+        .format("org.apache.hudi")
+        .option(DataSourceReadOptions.QUERY_TYPE().key(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
+        .load(sourcePath);
+    String endCompletionTime = queryContext.getMaxCompletionTime();
+    Option<String> predicate = Option.empty();
+    List<String> instantTimeList = queryContext.getInstantTimeList();
+    if (snapshotLoadQuerySplitter.isPresent()) {
+      Option<SnapshotLoadQuerySplitter.CheckpointWithPredicates> newCheckpointAndPredicate =
+          snapshotLoadQuerySplitter.get().getNextCheckpointWithPredicates(snapshot, queryContext);
+      if (newCheckpointAndPredicate.isPresent()) {
+        endCompletionTime = newCheckpointAndPredicate.get().getEndCompletionTime();
+        predicate = Option.of(newCheckpointAndPredicate.get().getPredicateFilter());
+        instantTimeList = queryContext.getInstants().stream()
+            .filter(instant -> HoodieTimeline.compareTimestamps(
+                instant.getCompletionTime(), HoodieTimeline.LESSER_THAN_OR_EQUALS,
+                newCheckpointAndPredicate.get().getEndCompletionTime()))
+            .map(HoodieInstant::getTimestamp)
+            .collect(Collectors.toList());
+      }
+    }
+    snapshot = predicate.map(snapshot::filter).orElse(snapshot);
+    snapshot = snapshot
         // add filtering so that only interested records are returned.
-        .filter(String.format("%s >= '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
-            snapshotQueryInfo.getStartInstant()))
-        .filter(String.format("%s <= '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
-            snapshotQueryInfo.getEndInstant()));
-    return snapshotQueryInfo.getPredicateFilter().map(df::filter).orElse(df);
+        .filter(String.format("%s IN ('%s')", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
+            String.join("','", instantTimeList)));
+    return Pair.of(endCompletionTime, snapshot);
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -86,7 +86,6 @@ import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.booleanThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -282,6 +282,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
 
     List<Triple<String, Long, String>> filePathSizeAndCommitTime = new ArrayList<>();
     // Add file paths and sizes to the list
+    // Triple(filePath, fileSize, commitTime)
     filePathSizeAndCommitTime.add(Triple.of("path/to/file1.json", 50L, "1"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/file2.json", 50L, "1"));
     filePathSizeAndCommitTime.add(Triple.of("path/to/skip1.json", 50L, "2"));
@@ -345,7 +346,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     when(queryRunner.run(any(QueryContext.class), any(), any(Boolean.class))).thenAnswer(invocation -> {
       QueryContext queryContext = invocation.getArgument(0);
       boolean shouldFullScan = invocation.getArgument(2);
-      if (queryContext.getInstantRange().isEmpty() || shouldFullScan) {
+      if (shouldFullScan) {
         return Pair.of(queryContext.getMaxCompletionTime(),
             inputDs.filter(String.format("%s IN ('%s')", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
                 String.join("','", queryContext.getInstantTimeList()))));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
@@ -91,6 +92,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+// TODO: remove QueryInfo from this test
 public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
   private static final Schema GCS_METADATA_SCHEMA = SchemaTestUtil.getSchemaFromResource(
@@ -326,7 +328,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
 
   private void setMockQueryRunner(Dataset<Row> inputDs, Option<String> nextCheckPointOpt) {
 
-    when(queryRunner.run(any(QueryInfo.class), any())).thenAnswer(invocation -> {
+    when(queryRunner.run(any(QueryContext.class), any())).thenAnswer(invocation -> {
       QueryInfo queryInfo = invocation.getArgument(0);
       QueryInfo updatedQueryInfo = nextCheckPointOpt.map(nextCheckPoint ->
               queryInfo.withUpdatedEndInstant(nextCheckPoint))

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -560,7 +560,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
     when(mockQueryRunner.run(Mockito.any(QueryContext.class), Mockito.any(), Mockito.any(Boolean.class))).thenAnswer(invocation -> {
       QueryContext queryContext = invocation.getArgument(0);
       boolean shouldFullScan = invocation.getArgument(2);
-      if (queryContext.getInstantRange().isEmpty() || shouldFullScan) {
+      if (shouldFullScan) {
         return Pair.of(queryContext.getMaxCompletionTime(),
             inputDs.filter(String.format("%s IN ('%s')", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
                 String.join("','", queryContext.getInstantTimeList()))));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestS3EventsHoodieIncrSource.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
@@ -88,6 +89,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+// TODO: remove QueryInfo from this test
 @ExtendWith(MockitoExtension.class)
 public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarness {
   private static final Schema S3_METADATA_SCHEMA = SchemaTestUtil.getSchemaFromResource(
@@ -556,7 +558,7 @@ public class TestS3EventsHoodieIncrSource extends SparkClientFunctionalTestHarne
 
   private void setMockQueryRunner(Dataset<Row> inputDs, Option<String> nextCheckPointOpt) {
 
-    when(mockQueryRunner.run(Mockito.any(QueryInfo.class), Mockito.any())).thenAnswer(invocation -> {
+    when(mockQueryRunner.run(Mockito.any(QueryContext.class), Mockito.any())).thenAnswer(invocation -> {
       QueryInfo queryInfo = invocation.getArgument(0);
       QueryInfo updatedQueryInfo = nextCheckPointOpt.map(nextCheckPoint ->
               queryInfo.withUpdatedEndInstant(nextCheckPoint))


### PR DESCRIPTION
### Change Logs

1. Have S3/GCSEvent source uses QueryContext instead
2. Remove QueryInfo

### Impact

S3/GCS event source will use completion time as checkpoint

### Risk level (write none, low medium or high below)

low

### Documentation Update

tbd

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
