### PR TITLE
Upgraded avro & commons-io dependency

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -176,6 +176,16 @@
     </resources>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.16.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Hoodie -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                (hudi.spark.common.modules.*) -->
     <hudi.spark.common.modules.1>hudi-spark3-common</hudi.spark.common.modules.1>
     <hudi.spark.common.modules.2>hudi-spark3.2plus-common</hudi.spark.common.modules.2>
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.11.4</avro.version>
     <bijection-avro.version>0.9.7</bijection-avro.version>
     <caffeine.version>2.9.1</caffeine.version>
     <commons.io.version>2.11.0</commons.io.version>
@@ -223,7 +223,7 @@
     <disruptor.version>3.4.2</disruptor.version>
     <antlr.version>4.8</antlr.version>
     <aws.sdk.version>2.25.69</aws.sdk.version>
-    <proto.version>3.21.7</proto.version>
+    <proto.version>3.25.5</proto.version>
     <protoc.version>3.21.5</protoc.version>
     <dynamodb.lockclient.version>1.2.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>


### PR DESCRIPTION
Upgrade commons-io version to 1.11.4
Upgrade avro version to 1.11.4
Upgrade proto version to 3.25.5

Reference PR - https://github.com/apache/hudi/pull/11964

Change Logs
This issue will address the below CVE from hudi-presto-bundle:0.14.0 jar
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47561
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254

Impact
No user facing impacts

Risk level (write none, low medium or high below)
Included the new changes in presto and we haven't seen any regression issues

Documentation Update
None

Contributor's checklist
 Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
 Change Logs and Impact were stated clearly
 Adequate tests were added if applicable
 CI passed