### PR TITLE
[HUDI-8399]  Upgrade protobuf version to 3.25.5 to fix CVE-2024-7254

### DIFF
--- a/dependencies/hudi-kafka-connect-bundle.txt
+++ b/dependencies/hudi-kafka-connect-bundle.txt
@@ -218,7 +218,7 @@ parquet-encoding/org.apache.parquet/1.10.1//parquet-encoding-1.10.1.jar
 parquet-format/org.apache.parquet/2.4.0//parquet-format-2.4.0.jar
 parquet-hadoop/org.apache.parquet/1.10.1//parquet-hadoop-1.10.1.jar
 parquet-jackson/org.apache.parquet/1.10.1//parquet-jackson-1.10.1.jar
-protobuf-java/com.google.protobuf/3.17.3//protobuf-java-3.17.3.jar
+protobuf-java/com.google.protobuf/3.25.5//protobuf-java-3.25.5.jar
 py4j/net.sf.py4j/0.10.7//py4j-0.10.7.jar
 pyrolite/net.razorvine/4.13//pyrolite-4.13.jar
 reactive-streams/org.reactivestreams/1.0.2//reactive-streams-1.0.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -222,8 +222,8 @@
     <disruptor.version>3.4.2</disruptor.version>
     <antlr.version>4.8</antlr.version>
     <aws.sdk.version>2.25.69</aws.sdk.version>
-    <proto.version>3.21.7</proto.version>
-    <protoc.version>3.21.5</protoc.version>
+    <proto.version>3.25.5</proto.version>
+    <protoc.version>3.25.5</protoc.version>
     <dynamodb.lockclient.version>1.2.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <openjdk.jol.version>0.16</openjdk.jol.version>


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

Upgrade protobuf version to 3.25.5 to fix CVE-2024-7254

### Impact

_Describe any public API or user-facing feature change or any performance impact._

protobuf version ,which is less than 3.25 version, is having vulnerability  CVE-2024-7254

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

High

### Documentation Update

Upgrade protobuf version to 3.25.5 to fix CVE-2024-7254

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [x] CI passed
