### PR TITLE
[HUDI-8411] Fix unmerged reader to skip delete blocks and avoid NPE

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -357,11 +357,4 @@ public abstract class HoodieReaderContext<T> {
   public boolean supportsParquetRowIndex() {
     return false;
   }
-
-  /**
-   * Constructs engine specific delete record.
-   */
-  public T constructRawDeleteRecord(Map<String, Object> metadata) {
-    return null;
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
@@ -37,7 +37,6 @@ import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -77,7 +76,7 @@ public class HoodieUnmergedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
       if (nextRecordInfo.getLeft().isPresent()) {
         nextRecord = nextRecordInfo.getKey().get();
       } else {
-        nextRecord = readerContext.constructRawDeleteRecord(nextRecordInfo.getRight());
+        throw new IllegalStateException("No deletes should exist in unmerged reading mode");
       }
       return true;
     }
@@ -120,15 +119,12 @@ public class HoodieUnmergedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
 
   @Override
   public void processDeleteBlock(HoodieDeleteBlock deleteBlock) {
-    Iterator<DeleteRecord> it = Arrays.stream(deleteBlock.getRecordsToDelete()).iterator();
-    while (it.hasNext()) {
-      DeleteRecord record = it.next();
-      processNextDeletedRecord(record, putIndex++);
-    }
+    // no-op
   }
 
   @Override
   public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable index) {
+    //never used for now
     records.put(index, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
         deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue(), orderingFieldType)));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
@@ -124,7 +124,7 @@ public class HoodieUnmergedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
 
   @Override
   public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable index) {
-    //never used for now
+    // never used for now
     records.put(index, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
         deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue(), orderingFieldType)));
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieTestReaderContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieTestReaderContext.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.common.testutils.reader;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
-import org.apache.hudi.avro.model.HoodieDeleteRecord;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
@@ -208,14 +207,6 @@ public class HoodieTestReaderContext extends HoodieReaderContext<IndexedRecord> 
       throw new UnsupportedOperationException("Cast from " + value.getClass() + " to " + newType + " is not supported");
     }
     return (Comparable) HoodieAvroUtils.rewritePrimaryType(value, oldType, newSchema);
-  }
-
-  @Override
-  public IndexedRecord constructRawDeleteRecord(Map<String, Object> metadata) {
-    return new HoodieDeleteRecord(
-        (String) metadata.get(INTERNAL_META_RECORD_KEY),
-        (String) metadata.get(INTERNAL_META_PARTITION_PATH),
-        metadata.get(INTERNAL_META_ORDERING_FIELD));
   }
 
   private Object getFieldValueFromIndexedRecord(


### PR DESCRIPTION
### Change Logs

reader context had default implementation of get engine delete representation as null. The unmerged reader does not have handling for that. When compared with the other unmerged reader implementations they never process delete blocks, so the unmerged buffer is now updated to skip delete blocks

### Impact

Spark npe is avoided and should be a slight perf boost. Also 1 less reader context method which is good.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
