### PR TITLE
[HUDI-8412] Fix enum reading in spark for Avro log blocks

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -1246,9 +1246,10 @@ public class HoodieAvroUtils {
       case UNION:
         return recordNeedsRewriteForExtendedAvroTypePromotion(getActualSchemaFromUnion(writerSchema, null), getActualSchemaFromUnion(readerSchema, null));
       case ENUM:
+        return needsRewriteToString(writerSchema, true);
       case STRING:
       case BYTES:
-        return needsRewriteToString(writerSchema);
+        return needsRewriteToString(writerSchema, false);
       default:
         return false;
     }
@@ -1259,7 +1260,7 @@ public class HoodieAvroUtils {
    * int, long, float, double, or bytes because avro doesn't support evolution from those types to
    * string so some intervention is needed
    */
-  private static boolean needsRewriteToString(Schema schema) {
+  private static boolean needsRewriteToString(Schema schema, boolean isEnum) {
     switch (schema.getType()) {
       case INT:
       case LONG:
@@ -1267,6 +1268,8 @@ public class HoodieAvroUtils {
       case DOUBLE:
       case BYTES:
         return true;
+      case ENUM:
+        return !isEnum;
       default:
         return false;
     }


### PR DESCRIPTION
### Change Logs

Avro logs blocks written not with spark datasource will actually be enum type. When we read with spark we will try to read it as a string. To fix this we add it to the extended avro type promotion.

### Impact

Prevent failure when reading table with spark that was written with a different engine and has enums and is mor

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
