### PR TITLE
[HUDI-8410] Fix a flaky test for partition stats

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -184,20 +184,7 @@ class PartitionStatsIndexTestBase extends HoodieSparkClientTestBase {
     } else {
       latestBatch = recordsToStrings(dataGen.generateInserts(getInstantTime, 20)).asScala
     }
-    val latestBatchDf = spark.read.json(spark.sparkContext.parallelize(latestBatch.toSeq, 2))
-    latestBatchDf.cache()
-    latestBatchDf.write.format("org.apache.hudi")
-      .options(hudiOpts)
-      .option(OPERATION.key, operation)
-      .mode(saveMode)
-      .save(basePath)
-    val deletedDf = calculateMergedDf(latestBatchDf, operation)
-    deletedDf.cache()
-    if (validate) {
-      validateDataAndPartitionStats(deletedDf)
-    }
-    deletedDf.unpersist()
-    latestBatchDf
+    doWriteAndValidateDataAndPartitionStats(latestBatch, hudiOpts, operation, saveMode, validate)
   }
 
   protected def doWriteAndValidateDataAndPartitionStats(records: mutable.Buffer[String],

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -25,11 +25,11 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.transaction.SimpleConcurrentFileWritesConflictResolutionStrategy
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider
 import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.model.{FileSlice, HoodieBaseFile, HoodieCommitMetadata, HoodieFailedWritesCleaningPolicy, HoodieTableType, WriteConcurrencyMode, WriteOperationType}
+import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
-import org.apache.hudi.config.{HoodieCleanConfig, HoodieClusteringConfig, HoodieCompactionConfig, HoodieLockConfig, HoodieWriteConfig}
+import org.apache.hudi.config._
 import org.apache.hudi.exception.HoodieWriteConflictException
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieMetadataFileSystemView, MetadataPartitionType}
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource}
 import java.util.concurrent.Executors
 import java.util.stream.Stream
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -165,17 +166,27 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       HoodieLockConfig.WRITE_CONFLICT_RESOLUTION_STRATEGY_CLASS_NAME.key() -> classOf[SimpleConcurrentFileWritesConflictResolutionStrategy].getName
     )
 
-    doWriteAndValidateDataAndPartitionStats(hudiOpts,
+    val firstBatch: mutable.Buffer[String] =
+      recordsToStrings(dataGen.generateInserts(getInstantTime, 20)).asScala
+    doWriteAndValidateDataAndPartitionStats(
+      firstBatch,
+      hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Overwrite,
       validate = false)
 
+    val latestBatch1: mutable.Buffer[String] = firstBatch
+    val latestBatch2: mutable.Buffer[String] =
+      if (useUpsert) firstBatch else recordsToStrings(dataGen.generateInserts(getInstantTime, 20)).asScala
+
     val executor = Executors.newFixedThreadPool(2)
     implicit val executorContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
-    val function = new Function0[Boolean] {
-      override def apply(): Boolean = {
+    val function = new Function1[mutable.Buffer[String], Boolean] {
+      def apply(latestBatch: mutable.Buffer[String]): Boolean = {
         try {
-          doWriteAndValidateDataAndPartitionStats(hudiOpts,
+          doWriteAndValidateDataAndPartitionStats(
+            latestBatch,
+            hudiOpts,
             operation = if (useUpsert) UPSERT_OPERATION_OPT_VAL else BULK_INSERT_OPERATION_OPT_VAL,
             saveMode = SaveMode.Append,
             validate = false)
@@ -187,10 +198,10 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       }
     }
     val f1 = Future[Boolean] {
-      function.apply()
+      function.apply(latestBatch1)
     }
     val f2 = Future[Boolean] {
-      function.apply()
+      function.apply(latestBatch2)
     }
 
     Await.result(f1, Duration("5 minutes"))


### PR DESCRIPTION
### Change Logs

When we expected there is a conflict between two upserts, which may not happen since the these two commits may not update existing records.

Created a function to take in records to ensure the conflict happens.

### Impact

Less flaky.

### Risk level (write none, low medium or high below)

Low.
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
