### PR TITLE
[MINOR] Avoid log warn message about closing the writer for normal write operations

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -518,7 +518,7 @@ class HoodieSparkSqlWriterInternal {
             } catch {
               case e: HoodieException =>
                 // close the write client in all cases
-                handleWriteClientClosure(client, tableConfig, parameters, jsc.hadoopConfiguration(), Option.apply(e))
+                handleWriteClientClosure(client, tableConfig, parameters, jsc.hadoopConfiguration())
                 throw e
             }
         }
@@ -538,16 +538,12 @@ class HoodieSparkSqlWriterInternal {
     }
   }
 
-  private def handleWriteClientClosure(writeClient: SparkRDDWriteClient[_], tableConfig: HoodieTableConfig, parameters: Map[String, String], configuration: Configuration, e: Option[HoodieException] = None): Unit = {
+  private def handleWriteClientClosure(writeClient: SparkRDDWriteClient[_], tableConfig: HoodieTableConfig, parameters: Map[String, String], configuration: Configuration): Unit = {
     // close the write client in all cases
     val asyncCompactionEnabled = isAsyncCompactionEnabled(writeClient, tableConfig, parameters, configuration)
     val asyncClusteringEnabled = isAsyncClusteringEnabled(writeClient, parameters)
     if (!asyncCompactionEnabled && !asyncClusteringEnabled) {
-      if (e.isDefined) {
-        log.warn("Closing write client for the exception: " + e.get.getMessage)
-      } else {
-        log.info("Closing write client")
-      }
+      log.info("Closing write client")
       writeClient.close()
     }
   }


### PR DESCRIPTION
### Change Logs

Avoid log warn message about closing the writer for normal write operations:

we got this warn message each time we perform writing

```
24/10/23 11:16:18 WARN HoodieSparkSqlWriterInternal: Closing write client
```

### Impact

Avoid log warn message about closing the writer for normal write operations

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
