### PR TITLE
[HUDI-8260] Fix col stats metadata validation so that log files are also validated

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1277,10 +1277,8 @@ public class HoodieTableMetadataUtil {
    * Read column range metadata from log file.
    */
   @VisibleForTesting
-  protected static List<HoodieColumnRangeMetadata<Comparable>> getLogFileColumnRangeMetadata(String filePath,
-                                                                                             HoodieTableMetaClient datasetMetaClient,
-                                                                                             List<String> columnsToIndex,
-                                                                                             Option<Schema> writerSchemaOpt) {
+  public static List<HoodieColumnRangeMetadata<Comparable>> getLogFileColumnRangeMetadata(String filePath, HoodieTableMetaClient datasetMetaClient,
+                                                                                          List<String> columnsToIndex, Option<Schema> writerSchemaOpt) {
     if (writerSchemaOpt.isPresent()) {
       List<Schema.Field> fieldsToIndex = writerSchemaOpt.get().getFields().stream()
           .filter(field -> columnsToIndex.contains(field.name()))

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -806,12 +806,12 @@ public class HoodieMetadataTableValidator implements Serializable {
    * @param metadataTableBasedContext Validation context containing information based on metadata table
    * @param fsBasedContext            Validation context containing information based on the file system
    * @param partitionPath             Partition path String
-   * @param baseDataFilesForCleaning    Base files for un-complete cleaner action
+   * @param baseDataFilesForCleaning  Base files for un-complete cleaner action
    */
   private void validateFilesInPartition(
       HoodieMetadataValidationContext metadataTableBasedContext,
       HoodieMetadataValidationContext fsBasedContext, String partitionPath,
-      Set<String> baseDataFilesForCleaning) {
+      Set<String> baseDataFilesForCleaning) throws Exception {
     if (cfg.validateLatestFileSlices) {
       validateLatestFileSlices(metadataTableBasedContext, fsBasedContext, partitionPath, baseDataFilesForCleaning);
     }
@@ -955,17 +955,14 @@ public class HoodieMetadataTableValidator implements Serializable {
   }
 
   @SuppressWarnings("rawtypes")
-  private void validateAllColumnStats(
-      HoodieMetadataValidationContext metadataTableBasedContext,
-      HoodieMetadataValidationContext fsBasedContext,
-      String partitionPath,
-      Set<String> baseDataFilesForCleaning) {
+  private void validateAllColumnStats(HoodieMetadataValidationContext metadataTableBasedContext, HoodieMetadataValidationContext fsBasedContext,
+                                      String partitionPath, Set<String> baseDataFilesForCleaning) throws Exception {
 
-    List<String> latestBaseFilenameList = getLatestBaseFileNames(fsBasedContext, partitionPath, baseDataFilesForCleaning);
+    List<String> latestFileNames = getLatestFileNames(fsBasedContext, partitionPath, baseDataFilesForCleaning);
     List<HoodieColumnRangeMetadata<Comparable>> metadataBasedColStats = metadataTableBasedContext
-        .getSortedColumnStatsList(partitionPath, latestBaseFilenameList);
+        .getSortedColumnStatsList(partitionPath, latestFileNames);
     List<HoodieColumnRangeMetadata<Comparable>> fsBasedColStats = fsBasedContext
-        .getSortedColumnStatsList(partitionPath, latestBaseFilenameList);
+        .getSortedColumnStatsList(partitionPath, latestFileNames);
 
     validate(metadataBasedColStats, fsBasedColStats, partitionPath, "column stats");
   }
@@ -1004,8 +1001,7 @@ public class HoodieMetadataTableValidator implements Serializable {
           baseDataFilesForCleaning);
       List<String> latestFileNames = new ArrayList<>();
       latestFileSlicesFromMetadataTable.stream().filter(fs -> fs.getBaseFile().isPresent()).forEach(fs -> {
-        latestFileNames.add(fs.getBaseFile().get().getFileName());
-        latestFileNames.addAll(fs.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList()));
+        getLatestFiles(fs, latestFileNames);
       });
       List<HoodieColumnRangeMetadata<Comparable>> colStats = metadataTableBasedContext
           .getSortedColumnStatsList(partitionPath, latestFileNames);
@@ -1028,6 +1024,11 @@ public class HoodieMetadataTableValidator implements Serializable {
           .collect(Collectors.toList())
           .iterator();
     });
+  }
+
+  private static void getLatestFiles(FileSlice fs, List<String> latestFileNames) {
+    latestFileNames.add(fs.getBaseFile().get().getFileName());
+    latestFileNames.addAll(fs.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList()));
   }
 
   /**
@@ -1335,6 +1336,18 @@ public class HoodieMetadataTableValidator implements Serializable {
       sb.append("<empty>");
     }
     return sb.toString();
+  }
+
+  private List<String> getLatestFileNames(HoodieMetadataValidationContext fsBasedContext, String partitionPath, Set<String> baseDataFilesForCleaning) {
+    List<String> latestFileNames = new ArrayList<>();
+    List<FileSlice> latestFileSlices;
+    if (!baseDataFilesForCleaning.isEmpty()) {
+      latestFileSlices = filterFileSliceBasedOnInflightCleaning(fsBasedContext.getSortedLatestFileSliceList(partitionPath), baseDataFilesForCleaning);
+    } else {
+      latestFileSlices = fsBasedContext.getSortedLatestFileSliceList(partitionPath);
+    }
+    latestFileSlices.forEach(fileSlice -> getLatestFiles(fileSlice, latestFileNames));
+    return latestFileNames;
   }
 
   private List<String> getLatestBaseFileNames(HoodieMetadataValidationContext fsBasedContext, String partitionPath, Set<String> baseDataFilesForCleaning) {
@@ -1714,7 +1727,7 @@ public class HoodieMetadataTableValidator implements Serializable {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public List<HoodieColumnRangeMetadata<Comparable>> getSortedColumnStatsList(
-        String partitionPath, List<String> fileNames) {
+        String partitionPath, List<String> fileNames) throws Exception {
       LOG.info("All column names for getting column stats: {}", allColumnNameList);
       if (enableMetadataTable) {
         List<Pair<String, String>> partitionFileNameList = fileNames.stream()
@@ -1730,11 +1743,24 @@ public class HoodieMetadataTableValidator implements Serializable {
       } else {
         FileFormatUtils formatUtils = HoodieIOFactory.getIOFactory(metaClient.getStorage())
             .getFileFormatUtils(HoodieFileFormat.PARQUET);
-        return fileNames.stream().flatMap(filename ->
-                formatUtils.readColumnStatsFromMetadata(
-                        metaClient.getStorage(),
-                        new StoragePath(FSUtils.constructAbsolutePath(metaClient.getBasePath(), partitionPath), filename),
-                        allColumnNameList).stream())
+        Schema readerSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+        return fileNames.stream().flatMap(filename -> {
+              if (filename.endsWith(HoodieFileFormat.PARQUET.getFileExtension())) {
+                return formatUtils.readColumnStatsFromMetadata(
+                    metaClient.getStorage(),
+                    new StoragePath(FSUtils.constructAbsolutePath(metaClient.getBasePath(), partitionPath), filename),
+                    allColumnNameList
+                ).stream();
+              } else {
+                StoragePath storagePartitionPath = new StoragePath(metaClient.getBasePath(), partitionPath);
+                String filePath = new StoragePath(storagePartitionPath, filename).toString();
+                return HoodieTableMetadataUtil.getLogFileColumnRangeMetadata(filePath, metaClient, allColumnNameList, Option.of(readerSchema))
+                    .stream()
+                    // We need to convert file path and use only the file name instead of the complete file path
+                    .map(m -> (HoodieColumnRangeMetadata<Comparable>) HoodieColumnRangeMetadata.<Comparable>create(filename, m.getColumnName(), m.getMinValue(), m.getMaxValue(),
+                        m.getNullCount(), m.getValueCount(), m.getTotalSize(), m.getTotalUncompressedSize()));
+              }
+            })
             .sorted(new HoodieColumnRangeMetadataComparator())
             .collect(Collectors.toList());
       }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -290,6 +290,36 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
   @ParameterizedTest
   @ValueSource(strings = {"MERGE_ON_READ", "COPY_ON_WRITE"})
+  public void testColumnStatsValidation(String tableType) {
+    Map<String, String> writeOptions = new HashMap<>();
+    writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+    writeOptions.put("hoodie.table.name", "test_table");
+    writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
+    writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
+    writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+    writeOptions.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+
+    Dataset<Row> inserts = makeInsertDf("000", 5);
+    inserts.write().format("hudi").options(writeOptions)
+        .option(DataSourceWriteOptions.OPERATION().key(), WriteOperationType.BULK_INSERT.value())
+        .mode(SaveMode.Overwrite)
+        .save(basePath);
+    // validate MDT column stats
+    validateColumnStats();
+
+    Dataset<Row> updates = makeUpdateDf("001", 5);
+    updates.write().format("hudi").options(writeOptions)
+        .option(DataSourceWriteOptions.OPERATION().key(), WriteOperationType.UPSERT.value())
+        .mode(SaveMode.Append)
+        .save(basePath);
+
+    // validate MDT column stats
+    validateColumnStats();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"MERGE_ON_READ", "COPY_ON_WRITE"})
   public void testPartitionStatsValidation(String tableType) {
     // TODO: Add validation for compaction and clustering cases
     Map<String, String> writeOptions = new HashMap<>();
@@ -322,6 +352,18 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
     // validate MDT partition stats
     validatePartitionStats();
+  }
+
+  private void validateColumnStats() {
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    config.validateLatestFileSlices = false;
+    config.validateAllFileGroups = false;
+    config.validateAllColumnStats = true;
+    HoodieMetadataTableValidator validator = new HoodieMetadataTableValidator(jsc, config);
+    assertTrue(validator.run());
+    assertFalse(validator.hasValidationFailure());
+    assertTrue(validator.getThrowables().isEmpty());
   }
 
   private void validatePartitionStats() {


### PR DESCRIPTION
### Change Logs

Currently log files are not validated while validating column stats. The Jira aims to fix the validation logic so that log files are also validated along with base files.
Also if col stats validation fails, partition stats validation can be skipped since partition stats validation depends on col stats validation.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
