### PR TITLE
[HUDI-8432] Fix data skipping with RLI if record key is composite

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -26,10 +26,11 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
 import org.apache.hudi.common.model.HoodieTableQueryType.SNAPSHOT
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieTimeline.{GREATER_THAN_OR_EQUALS, compareTimestamps}
+import org.apache.hudi.keygen.KeyGenUtils.DEFAULT_COMPOSITE_KEY_FILED_VALUE
 import org.apache.hudi.metadata.HoodieTableMetadataUtil
 import org.apache.hudi.storage.StoragePath
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, In, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression, In, Literal, Or}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 
 import scala.collection.JavaConverters._
@@ -122,21 +123,24 @@ object RecordLevelIndexSupport {
   val INDEX_NAME = "RECORD_LEVEL"
 
   /**
-   * If the input query is an EqualTo or IN query on simple record key columns, the function returns a tuple of
+   * If the input query is an EqualTo or IN query on record key columns, the function returns a tuple of
    * list of the query and list of record key literals present in the query otherwise returns an empty option.
    *
    * @param queryFilter The query that need to be filtered.
    * @return Tuple of filtered query and list of record key literals that need to be matched
    */
-  def filterQueryWithRecordKey(queryFilter: Expression, recordKeyOpt: Option[String]): Option[(Expression, List[String])] = {
+  def filterQueryWithRecordKey(queryFilter: Expression, recordKeyOpt: Array[String]): Option[(Expression, List[String])] = {
+    val isComplexRecordKey = recordKeyOpt.length > 1
     queryFilter match {
+      // Handle EqualTo expressions
       case equalToQuery: EqualTo =>
         val attributeLiteralTuple = getAttributeLiteralTuple(equalToQuery.left, equalToQuery.right).orNull
         if (attributeLiteralTuple != null) {
           val attribute = attributeLiteralTuple._1
           val literal = attributeLiteralTuple._2
-          if (attribute != null && attribute.name != null && attributeMatchesRecordKey(attribute.name, recordKeyOpt)) {
-            Option.apply(equalToQuery, List.apply(literal.value.toString))
+          if (attribute != null && attribute.name != null && recordKeyOpt.contains(attribute.name)) {
+            val recordKeyLiteral = getRecordKeyLiteral(attribute, literal, isComplexRecordKey)
+            Option.apply(equalToQuery, List.apply(recordKeyLiteral))
           } else {
             Option.empty
           }
@@ -144,18 +148,19 @@ object RecordLevelIndexSupport {
           Option.empty
         }
 
+      // Handle In expressions
       case inQuery: In =>
         var validINQuery = true
         inQuery.value match {
           case attribute: AttributeReference =>
-            if (!attributeMatchesRecordKey(attribute.name, recordKeyOpt)) {
+            if (!recordKeyOpt.contains(attribute.name)) {
               validINQuery = false
             }
           case _ => validINQuery = false
         }
         var literals: List[String] = List.empty
         inQuery.list.foreach {
-          case literal: Literal => literals = literals :+ literal.value.toString
+          case literal: Literal => literals = literals :+ getRecordKeyLiteral(inQuery.value.asInstanceOf[AttributeReference], literal, isComplexRecordKey)
           case _ => validINQuery = false
         }
         if (validINQuery) {
@@ -163,6 +168,33 @@ object RecordLevelIndexSupport {
         } else {
           Option.empty
         }
+
+      // Handle And expression (composite filter)
+      case andQuery: And =>
+        val leftResult = filterQueryWithRecordKey(andQuery.left, recordKeyOpt)
+        val rightResult = filterQueryWithRecordKey(andQuery.right, recordKeyOpt)
+
+        // If both left and right filters are valid, concatenate their results
+        (leftResult, rightResult) match {
+          case (Some((leftExp, leftKeys)), Some((rightExp, rightKeys))) =>
+            // Return concatenated expressions and record keys
+            Option.apply(And(leftExp, rightExp), leftKeys ++ rightKeys)
+          case _ => Option.empty
+        }
+
+      // Handle Or expression (for completeness, though usually not used for record key filtering)
+      case orQuery: Or =>
+        val leftResult = filterQueryWithRecordKey(orQuery.left, recordKeyOpt)
+        val rightResult = filterQueryWithRecordKey(orQuery.right, recordKeyOpt)
+
+        (leftResult, rightResult) match {
+          case (Some((leftExp, leftKeys)), Some((rightExp, rightKeys))) =>
+            // In the case of OR, return a valid option if either side matches
+            Option.apply(Or(leftExp, rightExp), leftKeys ++ rightKeys)
+          case _ => Option.empty
+        }
+
+      // Default case: no match for record keys
       case _ => Option.empty
     }
   }
@@ -232,6 +264,15 @@ object RecordLevelIndexSupport {
       true
     } else {
       HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == attributeName
+    }
+  }
+
+  private def getRecordKeyLiteral(attribute: AttributeReference, literal: Literal, isComplexRecordKey: Boolean): String = {
+    if (isComplexRecordKey) {
+      // For complex record keys, the record key is of the form fieldName:fieldValue
+      attribute.name + DEFAULT_COMPOSITE_KEY_FILED_VALUE + literal.value.toString
+    } else {
+      literal.value.toString
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -129,8 +129,8 @@ object RecordLevelIndexSupport {
    * @param queryFilter The query that need to be filtered.
    * @return Tuple of filtered query and list of record key literals that need to be matched
    */
-  def filterQueryWithRecordKey(queryFilter: Expression, recordKeyOpt: Array[String]): Option[(Expression, List[String])] = {
-    val isComplexRecordKey = recordKeyOpt.length > 1
+  def filterQueryWithRecordKey(queryFilter: Expression, recordKeyFields: Array[String]): Option[(Expression, List[String])] = {
+    val isComplexRecordKey = recordKeyFields.length > 1
     queryFilter match {
       // Handle EqualTo expressions
       case equalToQuery: EqualTo =>
@@ -138,7 +138,7 @@ object RecordLevelIndexSupport {
         if (attributeLiteralTuple != null) {
           val attribute = attributeLiteralTuple._1
           val literal = attributeLiteralTuple._2
-          if (attribute != null && attribute.name != null && recordKeyOpt.contains(attribute.name)) {
+          if (attribute != null && attribute.name != null && attributeMatchesRecordKey(attribute.name, recordKeyFields)) {
             val recordKeyLiteral = getRecordKeyLiteral(attribute, literal, isComplexRecordKey)
             Option.apply(equalToQuery, List.apply(recordKeyLiteral))
           } else {
@@ -153,7 +153,7 @@ object RecordLevelIndexSupport {
         var validINQuery = true
         inQuery.value match {
           case attribute: AttributeReference =>
-            if (!recordKeyOpt.contains(attribute.name)) {
+            if (!attributeMatchesRecordKey(attribute.name, recordKeyFields)) {
               validINQuery = false
             }
           case _ => validINQuery = false
@@ -171,8 +171,8 @@ object RecordLevelIndexSupport {
 
       // Handle And expression (composite filter)
       case andQuery: And =>
-        val leftResult = filterQueryWithRecordKey(andQuery.left, recordKeyOpt)
-        val rightResult = filterQueryWithRecordKey(andQuery.right, recordKeyOpt)
+        val leftResult = filterQueryWithRecordKey(andQuery.left, recordKeyFields)
+        val rightResult = filterQueryWithRecordKey(andQuery.right, recordKeyFields)
 
         // If both left and right filters are valid, concatenate their results
         (leftResult, rightResult) match {
@@ -184,8 +184,8 @@ object RecordLevelIndexSupport {
 
       // Handle Or expression (for completeness, though usually not used for record key filtering)
       case orQuery: Or =>
-        val leftResult = filterQueryWithRecordKey(orQuery.left, recordKeyOpt)
-        val rightResult = filterQueryWithRecordKey(orQuery.right, recordKeyOpt)
+        val leftResult = filterQueryWithRecordKey(orQuery.left, recordKeyFields)
+        val rightResult = filterQueryWithRecordKey(orQuery.right, recordKeyFields)
 
         (leftResult, rightResult) match {
           case (Some((leftExp, leftKeys)), Some((rightExp, rightKeys))) =>
@@ -259,12 +259,8 @@ object RecordLevelIndexSupport {
    * @param attributeName The attribute name provided in the query
    * @return true if input attribute name matches the configured simple record key
    */
-  private def attributeMatchesRecordKey(attributeName: String, recordKeyOpt: Option[String]): Boolean = {
-    if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
-      true
-    } else {
-      HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == attributeName
-    }
+  private def attributeMatchesRecordKey(attributeName: String, recordKeyFields: Array[String]): Boolean = {
+     HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == attributeName || recordKeyFields.contains(attributeName)
   }
 
   private def getRecordKeyLiteral(attribute: AttributeReference, literal: Literal, isComplexRecordKey: Boolean): String = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -118,7 +118,7 @@ object SecondaryIndexSupport {
     var secondaryKeyQueries: List[Expression] = List.empty
     var secondaryKeys: List[String] = List.empty
     for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, secondaryKeyConfigOpt).foreach({
+      filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
         case (exp: Expression, recKeys: List[String]) =>
           secondaryKeys = secondaryKeys ++ recKeys
           secondaryKeyQueries = secondaryKeyQueries :+ exp

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -117,12 +117,14 @@ object SecondaryIndexSupport {
                                     secondaryKeyConfigOpt: Option[String]): (List[Expression], List[String]) = {
     var secondaryKeyQueries: List[Expression] = List.empty
     var secondaryKeys: List[String] = List.empty
-    for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
-        case (exp: Expression, recKeys: List[String]) =>
-          secondaryKeys = secondaryKeys ++ recKeys
-          secondaryKeyQueries = secondaryKeyQueries :+ exp
-      })
+    if (secondaryKeyConfigOpt.isDefined) {
+      for (query <- queryFilters) {
+        filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
+          case (exp: Expression, recKeys: List[String]) =>
+            secondaryKeys = secondaryKeys ++ recKeys
+            secondaryKeyQueries = secondaryKeyQueries :+ exp
+        })
+      }
     }
 
     Tuple2.apply(secondaryKeyQueries, secondaryKeys)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.keygen.KeyGenUtils.DEFAULT_RECORD_KEY_PARTS_SEPARATOR
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadata}
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.catalyst.expressions.{And, Expression}
+import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, Expression, In}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
@@ -168,7 +168,15 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
           // Handle composite record keys
           RecordLevelIndexSupport.filterQueryWithRecordKey(query, recordKeysArray).foreach {
             case (exp: Expression, recKeys: List[String]) =>
-              recordKeys = recordKeys :+ recKeys.mkString(DEFAULT_RECORD_KEY_PARTS_SEPARATOR)
+              exp match {
+                // For IN, add each element individually to recordKeys
+                case _: In =>
+                  recordKeys = recordKeys ++ recKeys
+
+                // For other cases, basically EqualTo, concatenate recKeys with the default separator
+                case _ =>
+                  recordKeys = recordKeys :+ recKeys.mkString(DEFAULT_RECORD_KEY_PARTS_SEPARATOR)
+              }
               recordKeyQueries = recordKeyQueries :+ exp
           }
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -23,14 +23,13 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.keygen.KeyGenUtils.DEFAULT_RECORD_KEY_PARTS_SEPARATOR
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadata}
-import org.apache.hudi.util.JFunction
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.catalyst.expressions.{And, Expression}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
-import java.util.Collections
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
@@ -150,9 +149,10 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
   }
 
   /**
-   * Given query filters, it filters the EqualTo and IN queries on simple record key columns and returns a tuple of
+   * Given query filters, it filters the EqualTo and IN queries on record key columns and returns a tuple of
    * list of such queries and list of record key literals present in the query.
    * If record index is not available, it returns empty list for record filters and record keys
+   *
    * @param queryFilters The queries that need to be filtered.
    * @return Tuple of List of filtered queries and list of record key literals that need to be matched
    */
@@ -164,29 +164,26 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
       var recordKeys: List[String] = List.empty
       for (query <- queryFilters) {
         val recordKeyOpt = getRecordKeyConfig
-        RecordLevelIndexSupport.filterQueryWithRecordKey(query, recordKeyOpt).foreach({
-          case (exp: Expression, recKeys: List[String]) =>
-            recordKeys = recordKeys ++ recKeys
-            recordKeyQueries = recordKeyQueries :+ exp
-        })
+        recordKeyOpt.foreach { recordKeysArray =>
+          // Handle composite record keys
+          RecordLevelIndexSupport.filterQueryWithRecordKey(query, recordKeysArray).foreach {
+            case (exp: Expression, recKeys: List[String]) =>
+              recordKeys = recordKeys :+ recKeys.mkString(DEFAULT_RECORD_KEY_PARTS_SEPARATOR)
+              recordKeyQueries = recordKeyQueries :+ exp
+          }
+        }
       }
-
-      Tuple2.apply(recordKeyQueries, recordKeys)
+      (recordKeyQueries, recordKeys)
     }
   }
 
   /**
-   * Returns the configured record key for the table if it is a simple record key else returns empty option.
+   * Returns the configured record key for the table.
    */
-  private def getRecordKeyConfig: Option[String] = {
+  private def getRecordKeyConfig: Option[Array[String]] = {
     val recordKeysOpt: org.apache.hudi.common.util.Option[Array[String]] = metaClient.getTableConfig.getRecordKeyFields
-    val recordKeyOpt = recordKeysOpt.map[String](JFunction.toJavaFunction[Array[String], String](arr =>
-      if (arr.length == 1) {
-        arr(0)
-      } else {
-        null
-      }))
-    Option.apply(recordKeyOpt.orElse(null))
+    // Convert the Hudi Option to Scala Option and return if present
+    Option(recordKeysOpt.orElse(null)).filter(_.nonEmpty)
   }
 
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -17,20 +17,25 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.RECORD_KEY_METADATA_FIELD
 import org.apache.hudi.common.model.{FileSlice, HoodieTableType}
+import org.apache.hudi.common.table.view.{FileSystemViewManager, HoodieTableFileSystemView}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.metadata.HoodieMetadataFileSystemView
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.util.JFunction
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieFileIndex, RecordLevelIndexSupport}
 import org.apache.spark.sql.{DataFrame, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, Literal, Or}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.util.Properties
 import scala.util.Using
 
 @Tag("functional")
@@ -130,9 +135,13 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
   }
 
   private def verifyPruningFileCount(opts: Map[String, String], dataFilter: Expression, numFiles: Int): Unit = {
+    verifyPruningFileCount(opts, dataFilter, numFiles, HoodieTableMetaClient.reload(metaClient))
+  }
+
+  private def verifyPruningFileCount(opts: Map[String, String], dataFilter: Expression, numFiles: Int, metaClient: HoodieTableMetaClient): Unit = {
     // with data skipping
-    val commonOpts = opts + ("path" -> basePath)
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val commonOpts = opts + ("path" -> metaClient.getBasePath.toString)
+    this.metaClient = HoodieTableMetaClient.reload(metaClient)
     var fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts, includeLogFiles = true)
     val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
     val filteredFilesCount = filteredPartitionDirectories.flatMap(s => s.files).size
@@ -151,7 +160,7 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
 
   private def getLatestDataFilesCount(opts: Map[String, String], includeLogFiles: Boolean = true) = {
     var totalLatestDataFiles = 0L
-    Using(getTableFileSystenView(opts)) { fsView =>
+    Using(getTableFileSystemView(opts)) { fsView =>
       fsView.getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
         .values()
         .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
@@ -162,8 +171,10 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     }.get
   }
 
-  private def getTableFileSystenView(opts: Map[String, String]): HoodieMetadataFileSystemView = {
-    new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline, metadataWriter(getWriteConfig(opts)).getTableMetadata)
+  private def getTableFileSystemView(opts: Map[String, String]): HoodieTableFileSystemView = {
+    val props = new Properties()
+    opts.foreach(kv => props.setProperty(kv._1, kv._2))
+    FileSystemViewManager.createInMemoryFileSystemView(new HoodieSparkEngineContext(jsc), metaClient, HoodieMetadataConfig.newBuilder().fromProperties(props).build())
   }
 
   private def createTempTable(hudiOpts: Map[String, String]): Unit = {
@@ -239,5 +250,62 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     val rliIndexSupport = new RecordLevelIndexSupport(spark, getConfig.getMetadataConfig, metaClient)
     val fileNames = rliIndexSupport.computeCandidateFileNames(fileIndex, Seq(dataFilter), null, prunedPaths, false)
     assertEquals(if (includeLogFiles) 2 else 1, fileNames.get.size)
+  }
+
+  @Test
+  def testRLIWithMultipleRecordKeyFields(): Unit = {
+    val tableName = "dummy_table_multi_pk"
+    val dummyTablePath = tempDir.resolve("dummy_table_multi_pk").toAbsolutePath.toString
+    val hudiOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> tableName,
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "record_key_col,name",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_key_col",
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true"
+    ) ++ metadataOpts
+
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  record_key_col string,
+         |  name string,
+         |  not_record_key_col string,
+         |  partition_key_col string
+         |) using hudi
+         | options (
+         |  primaryKey ='record_key_col,name',
+         |  hoodie.metadata.enable = 'true',
+         |  hoodie.metadata.record.index.enable = 'true',
+         |  hoodie.datasource.write.recordkey.field = 'record_key_col,name',
+         |  hoodie.enable.data.skipping = 'true'
+         | )
+         | partitioned by(partition_key_col)
+         | location '$dummyTablePath'
+       """.stripMargin)
+    spark.sql(s"insert into $tableName values('row1', 'name1', 'a', 'p1')")
+    spark.sql(s"insert into $tableName values('row2', 'name2', 'b', 'p2')")
+    spark.sql(s"insert into $tableName values('row3', 'name3', 'c', 'p3')")
+
+    val latestSnapshotDf = spark.read.format("hudi").options(hudiOpts).load(dummyTablePath)
+    this.metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(dummyTablePath)
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .build()
+    verifyEqualToQuery(hudiOpts, Seq("record_key_col", "name"), tableName, latestSnapshotDf, HoodieTableMetaClient.reload(metaClient))
+  }
+
+  def verifyEqualToQuery(hudiOpts: Map[String, String], colNames: Seq[String], tableName: String, latestSnapshotDf: DataFrame, metaClient: HoodieTableMetaClient): Unit = {
+    val rowValues = latestSnapshotDf.limit(1).collect().map(row => {
+      colNames.map(colName => row.getAs(colName).toString)
+    }).head
+
+    // Build the data filter using EqualTo for each column and combine with And
+    val dataFilter = colNames.zip(rowValues).map {
+      case (colName, value) => EqualTo(attribute(colName), Literal(value))
+    }.reduceLeft(And)
+
+    assertEquals(1, spark.sql("select * from " + tableName + " where " + dataFilter.sql).count())
+    verifyPruningFileCount(hudiOpts, dataFilter, 1, metaClient)
   }
 }


### PR DESCRIPTION
### Change Logs

Fix data skipping with RLI if record key is composite. When there are multiple record key fields, we need to form the record keys sequence correctly. Added a test to show skipping with more than one record key fields.

### Impact

Support data skipping for complex primary keys

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
