### PR TITLE
[HUDI-4818] Update partition column type to avoid type conversion failure

### DIFF
--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
@@ -70,7 +70,11 @@ object Spark3ParsePartitionUtil extends SparkParsePartitionUtil {
             castPartValueToDesiredType(typedValue.dataType, typedValue.value, tz.toZoneId)
           } catch {
             case NonFatal(_) =>
-              if (validatePartitionValues) {
+              // If the exception happens, there was some transformation on the original value.
+              // String value should be universal type for type casting.
+              if (userSpecifiedDataTypes.contains(columnName)) {
+                castPartValueToDesiredType(StringType, typedValue.value, tz.toZoneId)
+              } else if (validatePartitionValues) {
                 throw new RuntimeException(s"Failed to cast value `${typedValue.value}` to " +
                   s"`${typedValue.dataType}` for partition column `$columnName`")
               } else null


### PR DESCRIPTION

### Change Logs

When we specify `hoodie.datasource.write.partitionpath.field=ts:timestamp`, the partition column `ts` has data type `Long`. When we specify `hoodie.keygen.timebased.output.dateformat=yyyyMMdd---HH`, then the partition column `ts` value becomes a string in format `yyyyMMdd---HH`.

When the file index tries to collect the file list grouped by a partition path, Hudi parses the partition path value (`yyyyMMdd---HH`), and converted into their original data type (Long).

The solution is to avoid using their original type when they are specified using `<column>:timestamp` format, and uses `String` as their type to avoid any conversion failures.


### Impact

No failures is caused when we specified the partition using `<column>:timestamp` format.


### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
