### PR TITLE
[HUDI-8433] Fix not update issuedOffset when stream read empty commits

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -284,7 +284,8 @@ public class StreamReadMonitoringFunction
     readMetrics.registerMetrics();
   }
 
-  public String getIssuedInstant() {
-    return issuedInstant;
+  public String getIssuedOffset() {
+    return issuedOffset;
   }
+
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.source;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -214,7 +215,8 @@ public class StreamReadMonitoringFunction
     }
     IncrementalInputSplits.Result result =
         incrementalInputSplits.inputSplits(metaClient, this.issuedOffset, this.cdcEnabled);
-    if (result.equals(IncrementalInputSplits.Result.EMPTY)) {
+
+    if (result.isEmpty() && StringUtils.isNullOrEmpty(result.getEndInstant())) {
       // no new instants, returns early
       LOG.info("result is empty, do not update issuedInstant.");
       return;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -218,7 +218,7 @@ public class StreamReadMonitoringFunction
 
     if (result.isEmpty() && StringUtils.isNullOrEmpty(result.getEndInstant())) {
       // no new instants, returns early
-      LOG.info("result is empty, do not update issuedInstant.");
+      LOG.warn("Result is empty, do not update issuedInstant.");
       return;
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -214,8 +214,9 @@ public class StreamReadMonitoringFunction
     }
     IncrementalInputSplits.Result result =
         incrementalInputSplits.inputSplits(metaClient, this.issuedOffset, this.cdcEnabled);
-    if (result.isEmpty()) {
+    if (result.equals(IncrementalInputSplits.Result.EMPTY)) {
       // no new instants, returns early
+      LOG.info("result is empty, do not update issuedInstant.");
       return;
     }
 
@@ -281,5 +282,9 @@ public class StreamReadMonitoringFunction
     MetricGroup metrics = getRuntimeContext().getMetricGroup();
     readMetrics = new FlinkStreamReadMetrics(metrics);
     readMetrics.registerMetrics();
+  }
+
+  public String getIssuedInstant() {
+    return issuedInstant;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
@@ -53,11 +53,11 @@ import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -186,7 +186,7 @@ public class TestStreamReadMonitoringFunction {
       // Step3: assert current IssuedOffset couldn't be null.
       // Base on "IncrementalInputSplits#inputSplits => .startCompletionTime(issuedOffset != null ? issuedOffset : this.conf.getString(FlinkOptions.READ_START_COMMIT))"
       // If IssuedOffset still was null, hudi would take FlinkOptions.READ_START_COMMIT again, which means streaming read is blocked.
-      assertTrue(function.getIssuedOffset() != null);
+      assertNotNull(function.getIssuedOffset());
       // Stop the stream task.
       function.close();
     }
@@ -485,20 +485,6 @@ public class TestStreamReadMonitoringFunction {
       }
     });
     task.start();
-  }
-
-  private Integer intervalBetween2Instants(HoodieTimeline timeline, String instant1, String instant2) {
-    Integer idxInstant1 = getInstantIdxInTimeline(timeline, instant1);
-    Integer idxInstant2 = getInstantIdxInTimeline(timeline, instant2);
-    return (idxInstant1 != -1 && idxInstant2 != -1) ? Math.abs(idxInstant1 - idxInstant2) : -1;
-  }
-
-  private Integer getInstantIdxInTimeline(HoodieTimeline timeline, String instant) {
-    List<HoodieInstant> instants = timeline.getInstants();
-    return IntStream.range(0, instants.size())
-        .filter(i -> instants.get(i).getTimestamp().equals(instant))
-        .findFirst()
-        .orElse(-1);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
@@ -39,7 +39,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
-import org.apache.flink.streaming.util.CollectingSourceContext;
 import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Change Logs

When empty commits are allowed , if number of continuous empty commits exceeds 'read.commits.limit' ,    IssuedInstant will not be updated which will block stream read.

### Impact

hudi-flink-datasource

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
