### PR TITLE
[HUDI-8285] Use the filegroup reader for row writer clustering

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
@@ -38,6 +38,7 @@ import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
 import org.apache.hudi.common.table.log.block.HoodieCorruptBlock;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.FooterMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType;
 import org.apache.hudi.common.util.FileIOUtils;
@@ -91,7 +92,7 @@ public class HoodieLogFileCommand {
         storage, new StoragePath(logFilePathPattern)).stream()
         .map(status -> status.getPath().toString()).collect(Collectors.toList());
     Map<String, List<Tuple3<Tuple2<String, HoodieLogBlockType>, Tuple2<Map<HeaderMetadataType, String>,
-        Map<HeaderMetadataType, String>>, Integer>>> commitCountAndMetadata =
+        Map<FooterMetadataType, String>>, Integer>>> commitCountAndMetadata =
         new HashMap<>();
     int numCorruptBlocks = 0;
     int dummyInstantTimeCount = 0;
@@ -145,7 +146,7 @@ public class HoodieLogFileCommand {
                     new Tuple2<>(n.getLogBlockHeader(), n.getLogBlockFooter()), recordCount.get()));
           } else {
             List<Tuple3<Tuple2<String, HoodieLogBlockType>, Tuple2<Map<HeaderMetadataType, String>,
-                Map<HeaderMetadataType, String>>, Integer>> list =
+                Map<FooterMetadataType, String>>, Integer>> list =
                 new ArrayList<>();
             list.add(
                 new Tuple3<>(new Tuple2<>(fileName, n.getBlockType()),
@@ -158,11 +159,11 @@ public class HoodieLogFileCommand {
     List<Comparable[]> rows = new ArrayList<>();
     ObjectMapper objectMapper = new ObjectMapper();
     for (Map.Entry<String, List<Tuple3<Tuple2<String, HoodieLogBlockType>, Tuple2<Map<HeaderMetadataType, String>,
-        Map<HeaderMetadataType, String>>, Integer>>> entry : commitCountAndMetadata
+        Map<FooterMetadataType, String>>, Integer>>> entry : commitCountAndMetadata
         .entrySet()) {
       String instantTime = entry.getKey();
       for (Tuple3<Tuple2<String, HoodieLogBlockType>, Tuple2<Map<HeaderMetadataType, String>,
-          Map<HeaderMetadataType, String>>, Integer> tuple3 : entry
+          Map<FooterMetadataType, String>>, Integer> tuple3 : entry
           .getValue()) {
         Comparable[] output = new Comparable[6];
         output[0] = tuple3._1()._1();

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -82,11 +82,6 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
   }
 
   @Override
-  public String getRecordKey(InternalRow row, Schema schema) {
-    return getFieldValueFromInternalRow(row, schema, RECORD_KEY_METADATA_FIELD).toString();
-  }
-
-  @Override
   public HoodieRecord<InternalRow> constructHoodieRecord(Option<InternalRow> rowOption,
                                                          Map<String, Object> metadataMap) {
     if (!rowOption.isPresent()) {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -114,6 +114,10 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
     }
   }
 
+  override def getRecordKey(record: InternalRow, schema: Schema): String = {
+    getValue(record, schema, recordKeyColumn).toString
+  }
+
   /**
    * Converts an Avro record, e.g., serialized in the log files, to an [[InternalRow]].
    *

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.client.utils.SparkRowSerDe
+import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.storage.StoragePath
 
@@ -191,6 +192,15 @@ trait SparkAdapter extends Serializable {
                      metaClient: HoodieTableMetaClient,
                      schema: Schema,
                      globPaths: Array[StoragePath],
+                     parameters: java.util.Map[String, String]): BaseRelation
+
+  /**
+   * Create Hoodie relation based on globPaths, otherwise use tablePath if it's empty
+   */
+  def createRelation(sqlContext: SQLContext,
+                     metaClient: HoodieTableMetaClient,
+                     schema: Schema,
+                     fileSlices: java.util.Map[String, java.util.List[FileSlice]],
                      parameters: java.util.Map[String, String]): BaseRelation
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -488,7 +488,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     return new PartitionPath(partitionPath, partitionColumnValues);
   }
 
-  private static long fileSliceSize(FileSlice fileSlice) {
+  public static long fileSliceSize(FileSlice fileSlice) {
     long logFileSize = fileSlice.getLogFiles().map(HoodieLogFile::getFileSize)
         .filter(s -> s > 0)
         .reduce(0L, Long::sum);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.log.block.HoodieCorruptBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieHFileDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.FooterMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType;
 import org.apache.hudi.common.table.log.block.HoodieParquetDataBlock;
@@ -154,7 +155,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     // 4. Read the header for a log block, if present
 
     Map<HeaderMetadataType, String> header =
-        nextBlockVersion.hasHeader() ? HoodieLogBlock.getLogMetadata(inputStream) : null;
+        nextBlockVersion.hasHeader() ? HoodieLogBlock.getHeaderMetadata(inputStream) : null;
 
     // 5. Read the content length for the content
     // Fallback to full-block size if no content-length
@@ -168,8 +169,8 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     Option<byte[]> content = HoodieLogBlock.tryReadContent(inputStream, contentLength, shouldReadLazily);
 
     // 7. Read footer if any
-    Map<HeaderMetadataType, String> footer =
-        nextBlockVersion.hasFooter() ? HoodieLogBlock.getLogMetadata(inputStream) : null;
+    Map<FooterMetadataType, String> footer =
+        nextBlockVersion.hasFooter() ? HoodieLogBlock.getFooterMetadata(inputStream) : null;
 
     // 8. Read log block length, if present. This acts as a reverse pointer when traversing a
     // log file in reverse

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -82,7 +82,7 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
                              HoodieLogBlockContentLocation logBlockContentLocation,
                              Option<Schema> readerSchema,
                              Map<HeaderMetadataType, String> header,
-                             Map<HeaderMetadataType, String> footer,
+                             Map<FooterMetadataType, String> footer,
                              String keyField) {
     super(content, inputStreamSupplier, readBlockLazily, Option.of(logBlockContentLocation), readerSchema, header, footer, keyField, false);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCommandBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCommandBlock.java
@@ -46,7 +46,7 @@ public class HoodieCommandBlock extends HoodieLogBlock {
 
   public HoodieCommandBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                             Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
-                            Map<HeaderMetadataType, String> footer) {
+                            Map<FooterMetadataType, String> footer) {
     super(header, footer, blockContentLocation, content, inputStreamSupplier, readBlockLazily);
     this.type =
         HoodieCommandBlockTypeEnum.values()[Integer.parseInt(header.get(HeaderMetadataType.COMMAND_BLOCK_TYPE))];

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCorruptBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieCorruptBlock.java
@@ -34,7 +34,7 @@ public class HoodieCorruptBlock extends HoodieLogBlock {
 
   public HoodieCorruptBlock(Option<byte[]> corruptedBytes, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                             Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
-                            Map<HeaderMetadataType, String> footer) {
+                            Map<FooterMetadataType, String> footer) {
     super(header, footer, blockContentLocation, corruptedBytes, inputStreamSupplier, readBlockLazily);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDataBlock.java
@@ -81,7 +81,7 @@ public abstract class HoodieDataBlock extends HoodieLogBlock {
   public HoodieDataBlock(List<HoodieRecord> records,
                          boolean shouldWriteRecordPositions,
                          Map<HeaderMetadataType, String> header,
-                         Map<HeaderMetadataType, String> footer,
+                         Map<FooterMetadataType, String> footer,
                          String keyFieldName) {
     super(header, footer, Option.empty(), Option.empty(), null, false);
     if (shouldWriteRecordPositions) {
@@ -116,7 +116,7 @@ public abstract class HoodieDataBlock extends HoodieLogBlock {
                             Option<HoodieLogBlockContentLocation> blockContentLocation,
                             Option<Schema> readerSchema,
                             Map<HeaderMetadataType, String> headers,
-                            Map<HeaderMetadataType, String> footer,
+                            Map<FooterMetadataType, String> footer,
                             String keyFieldName,
                             boolean enablePointLookups) {
     super(headers, footer, blockContentLocation, content, inputStreamSupplier, readBlockLazily);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -100,14 +100,14 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
 
   public HoodieDeleteBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                            Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
-                           Map<HeaderMetadataType, String> footer) {
+                           Map<FooterMetadataType, String> footer) {
     // Setting `shouldWriteRecordPositions` to false as this constructor is only used by the reader
     this(content, inputStreamSupplier, readBlockLazily, blockContentLocation, header, footer, false);
   }
 
   HoodieDeleteBlock(Option<byte[]> content, Supplier<SeekableDataInputStream> inputStreamSupplier, boolean readBlockLazily,
                     Option<HoodieLogBlockContentLocation> blockContentLocation, Map<HeaderMetadataType, String> header,
-                    Map<HeaderMetadataType, String> footer, boolean shouldWriteRecordPositions) {
+                    Map<FooterMetadataType, String> footer, boolean shouldWriteRecordPositions) {
     super(header, footer, blockContentLocation, content, inputStreamSupplier, readBlockLazily);
     this.shouldWriteRecordPositions = shouldWriteRecordPositions;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -73,7 +73,7 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
                               HoodieLogBlockContentLocation logBlockContentLocation,
                               Option<Schema> readerSchema,
                               Map<HeaderMetadataType, String> header,
-                              Map<HeaderMetadataType, String> footer,
+                              Map<FooterMetadataType, String> footer,
                               boolean enablePointLookups,
                               StoragePath pathForReader,
                               boolean useNativeHFileReader) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -43,6 +43,7 @@ import java.io.InterruptedIOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -63,7 +64,7 @@ public abstract class HoodieLogBlock {
   // Header for each log block
   private final Map<HeaderMetadataType, String> logBlockHeader;
   // Footer for each log block
-  private final Map<HeaderMetadataType, String> logBlockFooter;
+  private final Map<FooterMetadataType, String> logBlockFooter;
   // Location of a log block on disk
   private final Option<HoodieLogBlockContentLocation> blockContentLocation;
   // data for a specific block
@@ -74,7 +75,7 @@ public abstract class HoodieLogBlock {
 
   public HoodieLogBlock(
       @Nonnull Map<HeaderMetadataType, String> logBlockHeader,
-      @Nonnull Map<HeaderMetadataType, String> logBlockFooter,
+      @Nonnull Map<FooterMetadataType, String> logBlockFooter,
       @Nonnull Option<HoodieLogBlockContentLocation> blockContentLocation,
       @Nonnull Option<byte[]> content,
       @Nullable Supplier<SeekableDataInputStream> inputStreamSupplier,
@@ -114,7 +115,7 @@ public abstract class HoodieLogBlock {
     return logBlockHeader;
   }
 
-  public Map<HeaderMetadataType, String> getLogBlockFooter() {
+  public Map<FooterMetadataType, String> getLogBlockFooter() {
     return logBlockFooter;
   }
 
@@ -255,42 +256,31 @@ public abstract class HoodieLogBlock {
   }
 
   /**
-   * Convert log metadata to bytes 1. Write size of metadata 2. Write enum ordinal 3. Write actual bytes
+   * Convert header metadata to bytes 1. Write size of metadata 2. Write enum ordinal 3. Write actual bytes
    */
-  public static byte[] getLogMetadataBytes(Map<HeaderMetadataType, String> metadata) throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    DataOutputStream output = new DataOutputStream(baos);
-    output.writeInt(metadata.size());
-    for (Map.Entry<HeaderMetadataType, String> entry : metadata.entrySet()) {
-      output.writeInt(entry.getKey().ordinal());
-      byte[] bytes = getUTF8Bytes(entry.getValue());
-      output.writeInt(bytes.length);
-      output.write(bytes);
-    }
-    return baos.toByteArray();
+  public static byte[] getHeaderMetadataBytes(Map<HeaderMetadataType, String> metadata) throws IOException {
+    return getLogMetadataBytes(metadata);
   }
 
   /**
-   * Convert bytes to LogMetadata, follow the same order as {@link HoodieLogBlock#getLogMetadataBytes}.
+   * Convert bytes to Header Metadata, follow the same order as {@link HoodieLogBlock#getHeaderMetadataBytes}.
    */
-  public static Map<HeaderMetadataType, String> getLogMetadata(SeekableDataInputStream dis) throws IOException {
+  public static Map<HeaderMetadataType, String> getHeaderMetadata(SeekableDataInputStream dis) throws IOException {
+    return getLogMetadata(dis, index -> HeaderMetadataType.values()[index]);
+  }
 
-    Map<HeaderMetadataType, String> metadata = new HashMap<>();
-    // 1. Read the metadata written out
-    int metadataCount = dis.readInt();
-    try {
-      while (metadataCount > 0) {
-        int metadataEntryIndex = dis.readInt();
-        int metadataEntrySize = dis.readInt();
-        byte[] metadataEntry = new byte[metadataEntrySize];
-        dis.readFully(metadataEntry, 0, metadataEntrySize);
-        metadata.put(HeaderMetadataType.values()[metadataEntryIndex], new String(metadataEntry));
-        metadataCount--;
-      }
-      return metadata;
-    } catch (EOFException eof) {
-      throw new IOException("Could not read metadata fields ", eof);
-    }
+  /**
+   * Convert footer metadata to bytes 1. Write size of metadata 2. Write enum ordinal 3. Write actual bytes
+   */
+  public static byte[] getFooterMetadataBytes(Map<FooterMetadataType, String> metadata) throws IOException {
+    return getLogMetadataBytes(metadata);
+  }
+
+  /**
+   * Convert bytes to Footer Metadata, follow the same order as {@link HoodieLogBlock#getFooterMetadataBytes}.
+   */
+  public static Map<FooterMetadataType, String> getFooterMetadata(SeekableDataInputStream dis) throws IOException {
+    return getLogMetadata(dis, index -> FooterMetadataType.values()[index]);
   }
 
   /**
@@ -342,5 +332,63 @@ public abstract class HoodieLogBlock {
    */
   protected void deflate() {
     content = Option.empty();
+  }
+
+  /**
+   * Converts a given map of log metadata into a byte array representation.
+   *
+   * The conversion process involves the following steps:
+   * 1. Write the size of the metadata map (number of entries).
+   * 2. For each entry in the map:
+   *    - Write the ordinal of the enum key (to identify the type of metadata).
+   *    - Write the length of the value string.
+   *    - Write the actual bytes of the value string in UTF-8 encoding.
+   *
+   * @param metadata A map containing metadata entries, where the key is an enum type representing
+   *                 the metadata type and the value is the corresponding string representation.
+   * @return A byte array containing the serialized metadata.
+   * @throws IOException If an I/O error occurs during the writing process, such as failure to write
+   *                     to the underlying output stream.
+   */
+  private static <T extends Enum<T>> byte[] getLogMetadataBytes(Map<T, String> metadata) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream output = new DataOutputStream(baos);
+    output.writeInt(metadata.size());
+    for (Map.Entry<T, String> entry : metadata.entrySet()) {
+      output.writeInt(entry.getKey().ordinal());
+      byte[] bytes = getUTF8Bytes(entry.getValue());
+      output.writeInt(bytes.length);
+      output.write(bytes);
+    }
+    return baos.toByteArray();
+  }
+
+  /**
+   * Convert bytes to Log Metadata, following the same order as {@link HoodieLogBlock#getHeaderMetadataBytes}
+   * and {@link HoodieLogBlock#getFooterMetadataBytes}.
+   *
+   * @param dis The SeekableDataInputStream to read the metadata from.
+   * @param typeMapper A function to map the ordinal index to the corresponding metadata type enum.
+   * @param <T> The type of the metadata enum (either HeaderMetadataType or FooterMetadataType).
+   * @return A Map containing the metadata type as the key and the metadata value as the value.
+   * @throws IOException If an I/O error occurs while reading the metadata.
+   */
+  private static <T> Map<T, String> getLogMetadata(SeekableDataInputStream dis, Function<Integer, T> typeMapper) throws IOException {
+    Map<T, String> metadata = new HashMap<>();
+    // 1. Read the metadata written out
+    int metadataCount = dis.readInt();
+    try {
+      while (metadataCount > 0) {
+        int metadataEntryIndex = dis.readInt();
+        int metadataEntrySize = dis.readInt();
+        byte[] metadataEntry = new byte[metadataEntrySize];
+        dis.readFully(metadataEntry, 0, metadataEntrySize);
+        metadata.put(typeMapper.apply(metadataEntryIndex), new String(metadataEntry));
+        metadataCount--;
+      }
+      return metadata;
+    } catch (EOFException eof) {
+      throw new IOException("Could not read metadata fields ", eof);
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
@@ -59,7 +59,7 @@ public class HoodieParquetDataBlock extends HoodieDataBlock {
                                 HoodieLogBlockContentLocation logBlockContentLocation,
                                 Option<Schema> readerSchema,
                                 Map<HeaderMetadataType, String> header,
-                                Map<HeaderMetadataType, String> footer,
+                                Map<FooterMetadataType, String> footer,
                                 String keyField) {
     super(content, inputStreamSupplier, readBlockLazily, Option.of(logBlockContentLocation), readerSchema, header, footer, keyField, false);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.avro.model.HoodieSliceInfo;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -41,6 +42,9 @@ import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -301,6 +306,32 @@ public class ClusteringUtils {
         .setDeltaFilePaths(slice.getLogFiles().map(f -> f.getPath().getName()).collect(Collectors.toList()))
         .setBootstrapFilePath(slice.getBaseFile().map(bf -> bf.getBootstrapBaseFile().map(BaseFile::getPath).orElse(null)).orElse(null))
         .build()).collect(Collectors.toList());
+  }
+
+  public static FileSlice fromSliceInfo(HoodieSliceInfo sliceInfo, HoodieStorage storage) throws IOException {
+    List<HoodieLogFile> logFiles = new ArrayList<>();
+    if (sliceInfo.getDeltaFilePaths() != null) {
+      for (String path : sliceInfo.getDeltaFilePaths()) {
+        if (!StringUtils.isNullOrEmpty(path)) {
+          logFiles.add(new HoodieLogFile(getPathInfo(path, storage)));
+        }
+      }
+    }
+
+    HoodieBaseFile baseFile = null;
+    if (!StringUtils.isNullOrEmpty(sliceInfo.getDataFilePath())) {
+      BaseFile bootstrapBaseFile = null;
+      if (!StringUtils.isNullOrEmpty(sliceInfo.getBootstrapFilePath())) {
+        bootstrapBaseFile = new BaseFile(getPathInfo(sliceInfo.getBootstrapFilePath(), storage));
+      }
+
+      baseFile = new HoodieBaseFile(getPathInfo(sliceInfo.getDataFilePath(), storage), bootstrapBaseFile);
+    }
+    return new FileSlice(new HoodieFileGroupId(sliceInfo.getPartitionPath(), sliceInfo.getFileId()), "", baseFile, logFiles);
+  }
+
+  private static StoragePathInfo getPathInfo(String path, HoodieStorage storage) throws IOException {
+    return storage.getPathInfo(new StoragePath(path));
   }
 
   private static Map<String, Double> buildMetrics(List<FileSlice> fileSlices) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -145,7 +145,17 @@ public class HoodieTestUtils {
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType)
       throws IOException {
-    return init(storageConf, basePath, tableType, new Properties());
+    return initInternal(storageConf, basePath, tableType, false);
+  }
+
+  public static HoodieTableMetaClient initWithFakePartitionColumn(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType)
+      throws IOException {
+    return initInternal(storageConf, basePath, tableType, true);
+  }
+
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType, boolean addFakePartitionCol)
+      throws IOException {
+    return initInternal(storageConf, basePath, tableType, new Properties(), addFakePartitionCol);
   }
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
@@ -157,20 +167,40 @@ public class HoodieTestUtils {
   }
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
-                                           HoodieFileFormat baseFileFormat, String databaseName)
+                                           HoodieFileFormat baseFileFormat, String databaseName) throws IOException {
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, databaseName, false);
+  }
+
+  public static HoodieTableMetaClient initWithFakePartitionColumn(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                           HoodieFileFormat baseFileFormat, String databaseName) throws IOException {
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, databaseName, true);
+  }
+
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      HoodieFileFormat baseFileFormat, String databaseName, boolean addFakePartitionCol)
       throws IOException {
     Properties properties = new Properties();
     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), baseFileFormat.toString());
-    return init(storageConf, basePath, tableType, properties, databaseName);
+    return initInternal(storageConf, basePath, tableType, properties, databaseName, addFakePartitionCol);
   }
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
                                            HoodieFileFormat baseFileFormat) throws IOException {
-    return init(storageConf, basePath, tableType, baseFileFormat, false, null, true);
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, false);
   }
 
-  public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
-                                           HoodieFileFormat baseFileFormat, boolean setKeyGen, String keyGenerator, boolean populateMetaFields)
+  public static HoodieTableMetaClient initWithFakePartitionColumn(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                           HoodieFileFormat baseFileFormat) throws IOException {
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, true);
+  }
+
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      HoodieFileFormat baseFileFormat, boolean addFakePartitionCol) throws IOException {
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, false, null, true, addFakePartitionCol);
+  }
+
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      HoodieFileFormat baseFileFormat, boolean setKeyGen, String keyGenerator, boolean populateMetaFields, boolean addFakePartitionCol)
       throws IOException {
     Properties properties = new Properties();
     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), baseFileFormat.toString());
@@ -178,16 +208,21 @@ public class HoodieTestUtils {
       properties.setProperty("hoodie.datasource.write.keygenerator.class", keyGenerator);
     }
     properties.setProperty("hoodie.populate.meta.fields", Boolean.toString(populateMetaFields));
-    return init(storageConf, basePath, tableType, properties);
+    return initInternal(storageConf, basePath, tableType, properties, addFakePartitionCol);
   }
 
   public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
                                            Properties properties) throws IOException {
-    return init(storageConf, basePath, tableType, properties, null);
+    return initInternal(storageConf, basePath, tableType, properties, false);
   }
 
-  public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
-                                           Properties properties, String databaseName)
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      Properties properties, boolean addFakePartitionCol) throws IOException {
+    return initInternal(storageConf, basePath, tableType, properties, null, addFakePartitionCol);
+  }
+
+  protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      Properties properties, String databaseName, boolean addFakePartitionCol)
       throws IOException {
     HoodieTableMetaClient.TableBuilder builder =
         HoodieTableMetaClient.newTableBuilder()
@@ -197,6 +232,10 @@ public class HoodieTestUtils {
 
     if (properties.getProperty(HoodieTableConfig.KEY_GENERATOR_TYPE.key()) != null) {
       builder.setKeyGeneratorType(properties.getProperty(HoodieTableConfig.KEY_GENERATOR_TYPE.key()));
+    }
+
+    if (addFakePartitionCol) {
+      builder.setPartitionFields("some_nonexistent_field");
     }
 
     return builder.fromProperties(properties)

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -200,12 +200,6 @@ public class HoodieTestUtils {
       builder.setKeyGeneratorType(properties.getProperty(HoodieTableConfig.KEY_GENERATOR_TYPE.key()));
     }
 
-    String keyGen = properties.getProperty("hoodie.datasource.write.keygenerator.class");
-    if (!Objects.equals(keyGen, "org.apache.hudi.keygen.NonpartitionedKeyGenerator")
-        && !properties.containsKey("hoodie.datasource.write.partitionpath.field")) {
-      builder.setPartitionFields("some_nonexistent_field");
-    }
-
     return builder.fromProperties(properties)
         .initTable(storageConf.newInstance(), basePath);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -199,6 +199,11 @@ public class HoodieTestUtils {
     return initInternal(storageConf, basePath, tableType, baseFileFormat, false, null, true, addFakePartitionCol);
   }
 
+  public static HoodieTableMetaClient init(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
+                                                      HoodieFileFormat baseFileFormat, boolean setKeyGen, String keyGenerator, boolean populateMetaFields) throws IOException {
+    return initInternal(storageConf, basePath, tableType, baseFileFormat, setKeyGen, keyGenerator, populateMetaFields, false);
+  }
+
   protected static HoodieTableMetaClient initInternal(StorageConfiguration<?> storageConf, String basePath, HoodieTableType tableType,
                                                       HoodieFileFormat baseFileFormat, boolean setKeyGen, String keyGenerator, boolean populateMetaFields, boolean addFakePartitionCol)
       throws IOException {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -146,11 +146,11 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       outputStream.write(HoodieLogFormat.MAGIC);
 
       // bytes for header
-      byte[] headerBytes = HoodieLogBlock.getLogMetadataBytes(block.getLogBlockHeader());
+      byte[] headerBytes = HoodieLogBlock.getHeaderMetadataBytes(block.getLogBlockHeader());
       // content bytes
       byte[] content = block.getContentBytes(storage);
       // bytes for footer
-      byte[] footerBytes = HoodieLogBlock.getLogMetadataBytes(block.getLogBlockFooter());
+      byte[] footerBytes = HoodieLogBlock.getFooterMetadataBytes(block.getLogBlockFooter());
 
       // 2. Write the total size of the block (excluding Magic)
       outputStream.writeLong(getLogBlockLength(content.length, headerBytes.length, footerBytes.length));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -1246,7 +1246,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
 
     // Write out some header
-    outputStream.write(HoodieLogBlock.getLogMetadataBytes(header));
+    outputStream.write(HoodieLogBlock.getHeaderMetadataBytes(header));
     outputStream.writeLong(getUTF8Bytes("something-random").length);
     outputStream.write(getUTF8Bytes("something-random"));
     outputStream.flush();
@@ -2569,7 +2569,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.writeInt(1);
     // Write out some metadata
     // TODO : test for failure to write metadata - NA ?
-    outputStream.write(HoodieLogBlock.getLogMetadataBytes(header));
+    outputStream.write(HoodieLogBlock.getHeaderMetadataBytes(header));
     outputStream.write(getUTF8Bytes("something-random"));
     outputStream.flush();
     outputStream.close();

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
@@ -151,7 +151,7 @@ public class TestHoodieHFileInputFormat {
   @Test
   public void testInputFormatLoad() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -181,7 +181,7 @@ public class TestHoodieHFileInputFormat {
   @Test
   public void testInputFormatUpdates() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -208,7 +208,7 @@ public class TestHoodieHFileInputFormat {
   @Test
   public void testInputFormatWithCompaction() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -241,7 +241,7 @@ public class TestHoodieHFileInputFormat {
   @Test
   public void testIncrementalSimple() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     createCommitFile(basePath, "100", "2016/05/01");
 
     // Add the paths
@@ -249,7 +249,7 @@ public class TestHoodieHFileInputFormat {
 
     InputFormatTestUtil.setupIncremental(jobConf, "100", 1);
 
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
+    HoodieTableMetaClient metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
         HoodieTableType.COPY_ON_WRITE, baseFileFormat);
     assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
         "When hoodie.database.name is not set, it should default to null");
@@ -264,7 +264,7 @@ public class TestHoodieHFileInputFormat {
     assertEquals(0, files.length,
         "We should exclude commit 100 when returning incremental pull with start commit time as 100");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, HoodieTestUtils.HOODIE_DATABASE);
     assertEquals(HoodieTestUtils.HOODIE_DATABASE, metaClient.getTableConfig().getDatabaseName(),
         String.format("The hoodie.database.name should be %s ", HoodieTestUtils.HOODIE_DATABASE));
@@ -278,7 +278,7 @@ public class TestHoodieHFileInputFormat {
   @Test
   public void testIncrementalWithDatabaseName() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     createCommitFile(basePath, "100", "2016/05/01");
 
     // Add the paths
@@ -286,7 +286,7 @@ public class TestHoodieHFileInputFormat {
 
     InputFormatTestUtil.setupIncremental(jobConf, "100", 1, HoodieTestUtils.HOODIE_DATABASE, true);
 
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
+    HoodieTableMetaClient metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
         HoodieTableType.COPY_ON_WRITE, baseFileFormat);
     assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
         "When hoodie.database.name is not set, it should default to null");
@@ -295,7 +295,7 @@ public class TestHoodieHFileInputFormat {
     assertEquals(10, files.length,
         "When hoodie.database.name is null, then the incremental query will not take effect");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, "");
     assertEquals("", metaClient.getTableConfig().getDatabaseName(),
         "The hoodie.database.name should be empty");
@@ -304,7 +304,7 @@ public class TestHoodieHFileInputFormat {
     assertEquals(10, files.length,
         "When hoodie.database.name is empty, then the incremental query will not take effect");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, HoodieTestUtils.HOODIE_DATABASE);
     assertEquals(HoodieTestUtils.HOODIE_DATABASE, metaClient.getTableConfig().getDatabaseName(),
         String.format("The hoodie.database.name should be %s ", HoodieTestUtils.HOODIE_DATABASE));

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -178,7 +178,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testInputFormatLoad() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -229,7 +229,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testInputFormatUpdates() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -271,7 +271,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testPointInTimeQueryWithUpdates() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -305,7 +305,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testInputFormatWithCompaction() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     InputFormatTestUtil.commit(basePath, "100");
 
     // Add the paths
@@ -338,7 +338,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testIncrementalSimple() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     createCommitFile(basePath, "100", "2016/05/01");
 
     // Add the paths
@@ -346,7 +346,7 @@ public class TestHoodieParquetInputFormat {
 
     InputFormatTestUtil.setupIncremental(jobConf, "100", 1);
 
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
+    HoodieTableMetaClient metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
         HoodieTableType.COPY_ON_WRITE, baseFileFormat);
     assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
         "When hoodie.database.name is not set, it should default to null");
@@ -361,7 +361,7 @@ public class TestHoodieParquetInputFormat {
     assertEquals(0, files.length,
         "We should exclude commit 100 when returning incremental pull with start commit time as 100");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, HoodieTestUtils.HOODIE_DATABASE);
     assertEquals(HoodieTestUtils.HOODIE_DATABASE, metaClient.getTableConfig().getDatabaseName(),
         String.format("The hoodie.database.name should be %s ", HoodieTestUtils.HOODIE_DATABASE));
@@ -375,7 +375,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testIncrementalWithDatabaseName() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     createCommitFile(basePath, "100", "2016/05/01");
 
     // Add the paths
@@ -383,7 +383,7 @@ public class TestHoodieParquetInputFormat {
 
     InputFormatTestUtil.setupIncremental(jobConf, "100", 1, HoodieTestUtils.HOODIE_DATABASE, true);
 
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
+    HoodieTableMetaClient metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(),
         HoodieTableType.COPY_ON_WRITE, baseFileFormat);
     assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
         "When hoodie.database.name is not set, it should default to null");
@@ -392,7 +392,7 @@ public class TestHoodieParquetInputFormat {
     assertEquals(10, files.length,
         "When hoodie.database.name is null, then the incremental query will not take effect");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, "");
     assertEquals("", metaClient.getTableConfig().getDatabaseName(),
         "The hoodie.database.name should be empty");
@@ -401,7 +401,7 @@ public class TestHoodieParquetInputFormat {
     assertEquals(10, files.length,
         "When hoodie.database.name is empty, then the incremental query will not take effect");
 
-    metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+    metaClient = HoodieTestUtils.initWithFakePartitionColumn(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, HoodieTestUtils.HOODIE_DATABASE);
     assertEquals(HoodieTestUtils.HOODIE_DATABASE, metaClient.getTableConfig().getDatabaseName(),
         String.format("The hoodie.database.name should be %s ", HoodieTestUtils.HOODIE_DATABASE));
@@ -659,7 +659,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testSnapshotPreCommitValidate() throws IOException {
     // initial commit
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 10, "100");
     createCommitFile(basePath, "100", "2016/05/01");
 
     // Add the paths
@@ -705,7 +705,7 @@ public class TestHoodieParquetInputFormat {
   @Test
   public void testSnapshotPreCommitValidateWithInflights() throws IOException {
     // Create commit and data files with commit 000
-    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 5, "000");
+    File partitionDir = InputFormatTestUtil.prepareTableWithFakePartitionColumn(basePath, baseFileFormat, 5, "000");
     createCommitFile(basePath, "000", "2016/05/01");
 
     // create inflight commit add more files with same file_id.

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
@@ -287,7 +287,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     String commitTime = "100";
     final int numRecords = 1000;
     // Create 3 parquet files with 1000 records each
-    File partitionDir = InputFormatTestUtil.prepareParquetTable(tempDir, schema, 3, numRecords, commitTime);
+    File partitionDir = InputFormatTestUtil.prepareParquetTableWithFakePartitionColumn(tempDir, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
     FileCreateUtils.createCommit(tempDir.toString(), commitTime, Option.of(commitMetadata));
@@ -366,11 +366,11 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     StorageConfiguration<Configuration> conf = HoodieTestUtils.getDefaultStorageConf();
     // initial commit
     Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
-    HoodieTestUtils.init(conf, tempDir.toAbsolutePath().toString(), HoodieTableType.MERGE_ON_READ);
+    HoodieTestUtils.initWithFakePartitionColumn(conf, tempDir.toAbsolutePath().toString(), HoodieTableType.MERGE_ON_READ);
     String commitTime = "100";
     final int numRecords = 1000;
     // Create 3 parquet files with 1000 records each
-    File partitionDir = InputFormatTestUtil.prepareParquetTable(tempDir, schema, 3, numRecords, commitTime);
+    File partitionDir = InputFormatTestUtil.prepareParquetTableWithFakePartitionColumn(tempDir, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
     FileCreateUtils.createCommit(tempDir.toString(), commitTime, Option.of(commitMetadata));

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFixedFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFixedFileIndex.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.util.JFunction
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.datasources.PartitionDirectory
+import org.apache.spark.sql.types.StructType
+
+import java.util.stream.Collectors
+
+import scala.collection.JavaConverters._
+
+class HoodieFixedFileIndex(metaClient: HoodieTableMetaClient,
+                           fileSlices: Map[InternalRow, Seq[FileSlice]],
+                           schema: StructType,
+                           dSchema: StructType,
+                           pSchema: StructType) extends HoodieSparkFileIndex with SparkAdapterSupport {
+
+  override def rootPaths: Seq[Path] = Seq(new Path(metaClient.getBasePath.toUri))
+
+  override def listFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    assert(partitionFilters.isEmpty)
+    assert(dataFilters.isEmpty)
+    fileSlices.map(u => HoodieHadoopFsRelationFactory.slicesToPartitionDirectory(u._1, u._2, sparkAdapter.getSparkPartitionedFileUtils)).toSeq
+  }
+
+  override def inputFiles: Array[String] = {
+    fileSlices.values.toStream
+      .flatMap(f => f.toStream)
+      .flatMap(f => {
+        val logFilesStatus = f.getLogFiles.map[String](JFunction.toJavaFunction[HoodieLogFile, String](lf => lf.getPath.toString))
+        val files = logFilesStatus.collect(Collectors.toList[String]).asScala
+        if (f.getBaseFile.isPresent) {
+          files.append(f.getBaseFile.get().getPath)
+        }
+        files
+      }).toArray
+  }
+
+  override def refresh(): Unit = {
+  }
+
+  override def sizeInBytes: Long = {
+    fileSlices.values.toStream
+      .flatMap(f => f.toStream)
+      .map(f => BaseHoodieTableFileIndex.fileSliceSize(f))
+      .sum
+  }
+
+  override def partitionSchema: StructType = pSchema
+
+  override def dataSchema: StructType = dSchema
+
+  def getSchema: StructType = schema
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{SQLContext, SparkSession}
 
 import scala.collection.JavaConverters._
+import scala.reflect.internal.util.Collections
 import scala.util.{Failure, Success, Try}
 
 trait HoodieHadoopFsRelationFactory {
@@ -492,7 +493,7 @@ object HoodieHadoopFsRelationFactory extends SparkAdapterSupport{
     val shouldValidate: Boolean = sqlContext.sparkSession.sessionState.conf.getConfString("spark.sql.sources.validatePartitionColumns", "true").toBoolean
     val timestampPartitionIndexes = HoodieSparkUtils.getTimestampPartitionIndex(metaClient.getTableConfig)
     new HoodieFixedFileIndex(metaClient,
-      fileSlices.map(u => (HoodieSparkUtils.parsePartitionColumnValuesToInternalRow(metaClient.getTableConfig.getPartitionFields.get(),
+      fileSlices.map(u => (HoodieSparkUtils.parsePartitionColumnValuesToInternalRow(metaClient.getTableConfig.getPartitionFields.orElse(Array.empty),
         u._1, metaClient.getBasePath, schema, tzp, sparkAdapter.getSparkParsePartitionUtil, shouldValidate, timestampPartitionIndexes, true), u._2)),
       schema, dataSchema, partitionSchema)
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkFileIndex.scala
@@ -19,28 +19,11 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.common.model.FileSlice
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.FileIndex
+import org.apache.spark.sql.types.StructType
 
-class HoodiePartitionFileSliceMapping(values: InternalRow,
-                                      slices: Map[String, FileSlice])
-  extends HoodiePartitionValues(values) {
+trait HoodieSparkFileIndex extends FileIndex with SparkAdapterSupport {
 
-  def getSlice(fileId: String): Option[FileSlice] = {
-    slices.get(fileId)
-  }
+  def dataSchema: StructType
 
-  def getPartitionValues: InternalRow = values
-}
-
-object HoodiePartitionFileSliceMapping {
-
-  def tryWrap(values: InternalRow,
-              slices: Map[String, FileSlice]): InternalRow = {
-    if (slices.nonEmpty) {
-      new HoodiePartitionFileSliceMapping(values, slices)
-    } else {
-      values
-    }
-  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/FileFormatUtilsForFileGroupReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/FileFormatUtilsForFileGroupReader.scala
@@ -18,7 +18,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.hudi.{HoodieCDCFileIndex, SparkAdapterSupport, SparkHoodieTableFileIndex}
+import org.apache.hudi.{HoodieCDCFileIndex, HoodieFixedFileIndex, SparkAdapterSupport, SparkHoodieTableFileIndex}
 
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Contains, EndsWith, EqualNullSafe, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, NamedExpression, Not, Or, StartsWith}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
@@ -36,6 +36,7 @@ object FileFormatUtilsForFileGroupReader extends SparkAdapterSupport {
     val tableSchema = fs.location match {
       case index: HoodieCDCFileIndex => index.cdcRelation.schema
       case index: SparkHoodieTableFileIndex => index.schema
+      case index: HoodieFixedFileIndex => index.getSchema
     }
     val resolvedSchema = logicalRelation.resolve(tableSchema, fs.sparkSession.sessionState.analyzer.resolver)
     val unfilteredPlan = if (!fs.partitionSchema.fields.isEmpty && sparkAdapter.getCatalystPlanUtils.produceSameOutput(scanOperation, logicalRelation)) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileMetadataProcedure.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.common.model.HoodieLogFile
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.TableSchemaResolver
 import org.apache.hudi.common.table.log.HoodieLogFormat
-import org.apache.hudi.common.table.log.block.HoodieLogBlock.{HeaderMetadataType, HoodieLogBlockType}
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.{FooterMetadataType, HeaderMetadataType, HoodieLogBlockType}
 import org.apache.hudi.common.table.log.block.{HoodieCorruptBlock, HoodieDataBlock}
 import org.apache.hudi.storage.StoragePath
 
@@ -60,7 +60,7 @@ class ShowHoodieLogFileMetadataProcedure extends BaseProcedure with ProcedureBui
     val logFilePaths = FSUtils.getGlobStatusExcludingMetaFolder(storage, new StoragePath(logFilePathPattern)).iterator().asScala
       .map(_.getPath.toString).toList
     val commitCountAndMetadata =
-      new java.util.HashMap[String, java.util.List[(HoodieLogBlockType, (java.util.Map[HeaderMetadataType, String], java.util.Map[HeaderMetadataType, String]), Int)]]()
+      new java.util.HashMap[String, java.util.List[(HoodieLogBlockType, (java.util.Map[HeaderMetadataType, String], java.util.Map[FooterMetadataType, String]), Int)]]()
     var numCorruptBlocks = 0
     var dummyInstantTimeCount = 0
     logFilePaths.foreach {
@@ -102,7 +102,7 @@ class ShowHoodieLogFileMetadataProcedure extends BaseProcedure with ProcedureBui
             val list = commitCountAndMetadata.get(instantTime)
             list.add((block.getBlockType, (block.getLogBlockHeader, block.getLogBlockFooter), recordCount.get()))
           } else {
-            val list = new java.util.ArrayList[(HoodieLogBlockType, (java.util.Map[HeaderMetadataType, String], java.util.Map[HeaderMetadataType, String]), Int)]
+            val list = new java.util.ArrayList[(HoodieLogBlockType, (java.util.Map[HeaderMetadataType, String], java.util.Map[FooterMetadataType, String]), Int)]
             list.add(block.getBlockType, (block.getLogBlockHeader, block.getLogBlockFooter), recordCount.get())
             commitCountAndMetadata.put(instantTime, list)
           }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -867,19 +867,19 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "f3, f4")
     tableConfig.setValue(HoodieTableConfig.KEY_GENERATOR_TYPE, KeyGeneratorType.CUSTOM.name())
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:SIMPLE,f2:TIMESTAMP")
-    assertEquals(Set(1), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(1), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Custom key generator with both field partition types as timestamp would return both the indices
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:TIMESTAMP,f2:TIMESTAMP")
-    assertEquals(Set(0, 1), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(0, 1), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Custom key generator with both field partition types as simple would return empty set
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:SIMPLE,f2:SIMPLE")
-    assertEquals(Set(), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Timestamp based key generators have only a single partition field
     tableConfig.setValue(HoodieTableConfig.KEY_GENERATOR_TYPE, KeyGeneratorType.TIMESTAMP.name())
-    assertEquals(Set(0), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(0), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -97,7 +97,7 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
                               parameters: java.util.Map[String, String]): BaseRelation = {
     val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType)
     HoodieHadoopFsRelationFactory.createRelation(sqlContext, metaClient, dataSchema,
-      fileSlices.asScala.map(u => (u._1, u._2.asScala)).toMap, parameters.asScala.toMap)
+      fileSlices.asScala.map(u => (u._1, u._2.asScala.toSeq)).toMap, parameters.asScala.toMap)
   }
 
   override def convertStorageLevelToString(level: StorageLevel): String

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -18,14 +18,16 @@
 package org.apache.spark.sql.adapter
 
 import org.apache.avro.Schema
-import org.apache.hudi.{AvroConversionUtils, DefaultSource, HoodieSparkUtils, Spark3RowSerDe}
+import org.apache.hudi.{AvroConversionUtils, DefaultSource, HoodieHadoopFsRelationFactory, HoodieSparkUtils, Spark3RowSerDe}
 import org.apache.hudi.client.utils.SparkRowSerDe
+import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.JsonUtils
 import org.apache.hudi.spark3.internal.ReflectUtil
 import org.apache.hudi.storage.StoragePath
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{HoodieSpark3CatalogUtils, SparkSession, SQLContext}
+import org.apache.spark.sql.{HoodieSpark3CatalogUtils, SQLContext, SparkSession}
 import org.apache.spark.sql.avro.{HoodieAvroSchemaConverters, HoodieSparkAvroSchemaConverters}
 import org.apache.spark.sql.catalyst.expressions.{Expression, InterpretedPredicate, Predicate}
 import org.apache.spark.sql.catalyst.util.DateFormatter
@@ -34,7 +36,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 import org.apache.spark.storage.StorageLevel
 
 import java.time.ZoneId
@@ -86,6 +88,16 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
                               parameters: java.util.Map[String, String]): BaseRelation = {
     val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType).orNull
     DefaultSource.createRelation(sqlContext, metaClient, dataSchema, globPaths, parameters.asScala.toMap)
+  }
+
+  override def createRelation(sqlContext: SQLContext,
+                              metaClient: HoodieTableMetaClient,
+                              schema: Schema,
+                              fileSlices: java.util.Map[String, java.util.List[FileSlice]],
+                              parameters: java.util.Map[String, String]): BaseRelation = {
+    val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType)
+    HoodieHadoopFsRelationFactory.createRelation(sqlContext, metaClient, dataSchema,
+      fileSlices.asScala.map(u => (u._1, u._2.asScala)).toMap, parameters.asScala.toMap)
   }
 
   override def convertStorageLevelToString(level: StorageLevel): String


### PR DESCRIPTION
### Change Logs

# DO NOT MERGE. Currently based ontop of https://github.com/apache/hudi/pull/12176

Move fg reader creation into the hadoopfs factory

Move some spark utils from HoodieFileIndex to HoodieSparkUtils

add spark adapter method so we can create the relation and pass in the filegroups to read. 

Create hoodie fixed file index for reading a fixed set of filegroups.

Reuse code for embedding the file slices into the internal row

### Impact

Clustering with row writer can now use the fg reader implementation for reading.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
