### PR TITLE
[MINOR] Fix NPE while parsing partition values in file index

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -373,7 +373,10 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
       staticPartitionColumnValues.map(_._1): _*)
   }
 
-  protected def doParsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
+  /**
+   * @VisibleForTesting
+   */
+  def doParsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
     val tableConfig = metaClient.getTableConfig
     if (null != tableConfig.getKeyGeneratorClassName
       && tableConfig.getKeyGeneratorClassName.equals(KeyGeneratorType.TIMESTAMP.getClassName)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -377,6 +377,7 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
     val tableConfig = metaClient.getTableConfig
     if (null != tableConfig.getKeyGeneratorClassName
       && tableConfig.getKeyGeneratorClassName.equals(KeyGeneratorType.TIMESTAMP.getClassName)
+      && null != tableConfig.propsMap.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key())
       && tableConfig.propsMap.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key())
       .matches("SCALAR|UNIX_TIMESTAMP|EPOCHMILLISECONDS|EPOCHMICROSECONDS")) {
       // For TIMESTAMP key generator when TYPE is SCALAR, UNIX_TIMESTAMP,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -49,6 +49,7 @@ import org.apache.spark.sql.execution.datasources.{NoopCache, PartitionDirectory
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -108,6 +109,36 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     metaClient = HoodieTableMetaClient.reload(metaClient)
     val fileIndex = HoodieFileIndex(spark, metaClient, None, queryOpts)
     assertEquals("partition", fileIndex.partitionSchema.fields.map(_.name).mkString(","))
+  }
+
+  /**
+   * Unit test for `doParsePartitionColumnValues` method in `HoodieFileIndex`.
+   *
+   * This test verifies that the `doParsePartitionColumnValues` method correctly returns
+   * partition values when the `propsMap` in the table configuration does not contain the
+   * expected timestamp configuration key, simulating a `null` scenario. Specifically,
+   * this test validates the behavior for the `TIMESTAMP` key generator type, ensuring
+   * that the partition path string is passed as `UTF8String` in the result array.
+   */
+  @Test
+  def testParsePartitionValues(): Unit = {
+    // Set up table configuration and schema to use TIMESTAMP key generator
+    val tableConfig = metaClient.getTableConfig
+    tableConfig.setValue(HoodieTableConfig.KEY_GENERATOR_TYPE, KeyGeneratorType.TIMESTAMP.name())
+    tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "col1")
+    // Define schema with one partition column (col1)
+    val fields = List(
+      StructField.apply("f1", DataTypes.DoubleType, nullable = true),
+      StructField.apply("col1", DataTypes.LongType, nullable = true))
+    val schema = StructType.apply(fields)
+    // Set partition column and partition path for testing
+    val partitionColumns = Array("col1")
+    val partitionPath = "2023/10/28"
+    val fileIndex = HoodieFileIndex(spark, metaClient, Some(schema), queryOpts)
+    // Create file index and validate the result
+    val result = fileIndex.doParsePartitionColumnValues(partitionColumns, partitionPath)
+    assertEquals(1, result.length)
+    assertEquals(UTF8String.fromString(partitionPath), result(0))
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

For timestamp keygen, timestamp type was [recently added](https://github.com/apache/hudi/pull/11615/files#diff-53ae78ff1f1bd5d8b0f87cb69853299e5228b44f30b770e27f60c0c3c27d4185R288) to the table config. In case this property is not present in table config, we still need to be backward compatible and fallback to the usual way of parsing partition values. Otherwise, NPE is thrown as below. This PR adds the null check.

```
Caused by: java.lang.NullPointerException
	at org.apache.hudi.SparkHoodieTableFileIndex.doParsePartitionColumnValues(SparkHoodieTableFileIndex.scala:381)
	at org.apache.hudi.BaseHoodieTableFileIndex.parsePartitionColumnValues(BaseHoodieTableFileIndex.java:363)
	at org.apache.hudi.BaseHoodieTableFileIndex.convertToPartitionPath(BaseHoodieTableFileIndex.java:487)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at org.apache.hudi.BaseHoodieTableFileIndex.listPartitionPaths(BaseHoodieTableFileIndex.java:335)
	at org.apache.hudi.BaseHoodieTableFileIndex.getAllQueryPartitionPaths(BaseHoodieTableFileIndex.java:219)
	at org.apache.hudi.SparkHoodieTableFileIndex.listMatchingPartitionPaths(SparkHoodieTableFileIndex.scala:197)
	at org.apache.hudi.HoodieFileIndex.prunePartitionsAndGetFileSlices(HoodieFileIndex.scala:346)
	at org.apache.hudi.HoodieFileIndex.filterFileSlices(HoodieFileIndex.scala:240)
	at org.apache.spark.sql.hudi.analysis.HoodiePruneFileSourcePartitions$$anonfun$apply$1.applyOrElse(HoodiePruneFileSourcePartitions.scala:55)
	at org.apache.spark.sql.hudi.analysis.HoodiePruneFileSourcePartitions$$anonfun$apply$1.applyOrElse(HoodiePruneFileSourcePartitions.scala:43)
```

### Impact

bug fix

### Risk level (write none, low medium or high below)

low

affects timestamp keygen only with certain outout types.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
