### PR TITLE
[HUDI-8456] add drop partition config if we are using fake partition

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -112,7 +112,7 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
     // the same with the table schema.
     try {
       if (StringUtils.isNullOrEmpty(config.getInternalSchema())) {
-        Schema readerSchema = schemaResolver.getTableAvroSchema(false);
+        Schema readerSchema = schemaResolver.getTableAvroSchemaWithoutAddedColumns();
         config.setSchema(readerSchema.toString());
       }
     } catch (Exception e) {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
@@ -30,6 +30,7 @@ import org.apache.hudi.data.HoodieJavaRDD
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.index.HoodieIndex.BucketIndexEngineType
 import org.apache.hudi.index.{HoodieIndex, SparkHoodieIndexFactory}
+import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
 import org.apache.hudi.keygen.{AutoRecordGenWrapperKeyGenerator, BuiltinKeyGenerator, KeyGenUtils}
 import org.apache.hudi.table.action.commit.{BulkInsertDataInternalWriterHelper, ConsistentBucketBulkInsertDataInternalWriterHelper, ParallelismHelper}
 import org.apache.hudi.table.{BulkInsertPartitioner, HoodieTable}
@@ -242,13 +243,8 @@ object HoodieDatasetBulkInsertHelper
   }
 
   private def getPartitionPathFields(config: HoodieWriteConfig): mutable.Seq[String] = {
-    val keyGeneratorClassName = config.getString(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME)
-    if (keyGeneratorClassName != null) {
-      val keyGenerator = ReflectionUtils.loadClass(keyGeneratorClassName, new TypedProperties(config.getProps)).asInstanceOf[BuiltinKeyGenerator]
-      keyGenerator.getPartitionPathFields.asScala
-    } else {
-      mutable.Seq.empty
-    }
+    val keyGenerator = HoodieSparkKeyGeneratorFactory.getKeyGenerator(config.getProps).get()
+    keyGenerator.getPartitionPathFields.asScala
   }
 
   def getPartitionPathCols(config: HoodieWriteConfig): Seq[String] = {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
@@ -243,8 +243,12 @@ object HoodieDatasetBulkInsertHelper
 
   private def getPartitionPathFields(config: HoodieWriteConfig): mutable.Seq[String] = {
     val keyGeneratorClassName = config.getString(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME)
-    val keyGenerator = ReflectionUtils.loadClass(keyGeneratorClassName, new TypedProperties(config.getProps)).asInstanceOf[BuiltinKeyGenerator]
-    keyGenerator.getPartitionPathFields.asScala
+    if (keyGeneratorClassName != null) {
+      val keyGenerator = ReflectionUtils.loadClass(keyGeneratorClassName, new TypedProperties(config.getProps)).asInstanceOf[BuiltinKeyGenerator]
+      keyGenerator.getPartitionPathFields.asScala
+    } else {
+      mutable.Seq.empty
+    }
   }
 
   def getPartitionPathCols(config: HoodieWriteConfig): Seq[String] = {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -170,6 +170,11 @@ public class TableSchemaResolver {
         .orElseThrow(schemaNotFoundError());
   }
 
+  public Schema getTableAvroSchemaWithoutAddedColumns() throws Exception {
+    return getTableAvroSchemaInternal(false, Option.empty(), false)
+        .orElseThrow(schemaNotFoundError());
+  }
+
   /**
    * Fetches tables schema in Avro format as of the given instant
    *

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -165,6 +165,11 @@ public class TableSchemaResolver {
         .orElseThrow(schemaNotFoundError());
   }
 
+  public Schema getTableAvroSchemaWithoutPartitionCols() throws Exception {
+    return getTableAvroSchemaInternal(metaClient.getTableConfig().populateMetaFields(), Option.empty(), false)
+        .orElseThrow(schemaNotFoundError());
+  }
+
   /**
    * Fetches tables schema in Avro format as of the given instant
    *

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -199,6 +199,7 @@ public class TableSchemaResolver {
   private Option<Schema> getTableAvroSchemaInternal(boolean includeMetadataFields, Option<HoodieInstant> instantOpt) {
     return getTableAvroSchemaInternal(includeMetadataFields, instantOpt, metaClient.getTableConfig().shouldDropPartitionColumns());
   }
+
   private Option<Schema> getTableAvroSchemaInternal(boolean includeMetadataFields, Option<HoodieInstant> instantOpt, boolean tryAddPartitionCols) {
     Option<Schema> schema =
         (instantOpt.isPresent()

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -204,6 +204,7 @@ public class HoodieTestUtils {
     if (!Objects.equals(keyGen, "org.apache.hudi.keygen.NonpartitionedKeyGenerator")
         && !properties.containsKey("hoodie.datasource.write.partitionpath.field")) {
       builder.setPartitionFields("some_nonexistent_field");
+      builder.setShouldDropPartitionColumns(true);
     }
 
     return builder.fromProperties(properties)

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
@@ -223,7 +223,7 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
   private static Schema getLatestTableSchema(HoodieTableMetaClient metaClient, JobConf jobConf, String latestCommitTime) {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
     try {
-      Schema schema = tableSchemaResolver.getTableAvroSchema(latestCommitTime);
+      Schema schema = tableSchemaResolver.getTableAvroSchemaWithoutPartitionCols(latestCommitTime);
       // Add partitioning fields to writer schema for resulting row to contain null values for these fields
       return HoodieRealtimeRecordReaderUtils.addPartitionFields(schema, getPartitionFieldNames(jobConf));
     } catch (Exception e) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
@@ -131,7 +131,7 @@ public class SchemaEvolutionContext {
         json -> Option.ofNullable(new Schema.Parser().parse(json)));
     if (avroSchemaOpt == null) {
       // the code path should only be invoked in tests.
-      return new TableSchemaResolver(this.metaClient).getTableAvroSchema();
+      return new TableSchemaResolver(this.metaClient).getTableAvroSchemaWithoutPartitionCols();
     }
     return avroSchemaOpt.orElseThrow(() -> new HoodieValidationException("The avro schema cache should always be set up together with the internal schema cache"));
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -408,7 +408,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
         for (String path : uniqTablePaths) {
           HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setBasePath(path).setConf(new HadoopStorageConfiguration(job)).build();
           TableSchemaResolver schemaUtil = new TableSchemaResolver(metaClient);
-          String avroSchema = schemaUtil.getTableAvroSchema().toString();
+          String avroSchema = schemaUtil.getTableAvroSchemaWithoutPartitionCols().toString();
           Option<InternalSchema> internalSchema = schemaUtil.getTableInternalSchemaFromCommitMetadata();
           if (internalSchema.isPresent()) {
             LOG.info("Set internal and avro schema cache with path: " + path);


### PR DESCRIPTION
### Change Logs

A significant number of tests set the partition column name to a column that doesn't exist in the table schema. I tried to get rid of this: https://github.com/apache/hudi/pull/12176, but this is deeply embedded in our testing, and some of the tables are actually partitioned. How I resolve this illegal table state is by setting the drop partition config in the same place where the fake partition name is added. Nearly all tests still passed after this change, but it exposed some minor bugs with how we handle drop partition cols. 

Those places that were fixed are:

compaction -> either it is not dropping the column, or the commit metadata has the partition column

row writer clustering -> write configs not set for partition column names and recordkey column names, also, key generator is not deduced properly

Hive reader context -> didn't handle drop partition columns correctly

### Impact

tests reflect a real situation, fixed a few bugs with drop partition config

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
