### PR TITLE
[HUDI-8285] Use the filegroup reader for row writer clustering

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -82,11 +82,6 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
   }
 
   @Override
-  public String getRecordKey(InternalRow row, Schema schema) {
-    return getFieldValueFromInternalRow(row, schema, RECORD_KEY_METADATA_FIELD).toString();
-  }
-
-  @Override
   public HoodieRecord<InternalRow> constructHoodieRecord(Option<InternalRow> rowOption,
                                                          Map<String, Object> metadataMap) {
     if (!rowOption.isPresent()) {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -114,6 +114,10 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
     }
   }
 
+  override def getRecordKey(record: InternalRow, schema: Schema): String = {
+    getValue(record, schema, recordKeyColumn).toString
+  }
+
   /**
    * Converts an Avro record, e.g., serialized in the log files, to an [[InternalRow]].
    *

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.client.utils.SparkRowSerDe
+import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.storage.StoragePath
 
@@ -191,6 +192,15 @@ trait SparkAdapter extends Serializable {
                      metaClient: HoodieTableMetaClient,
                      schema: Schema,
                      globPaths: Array[StoragePath],
+                     parameters: java.util.Map[String, String]): BaseRelation
+
+  /**
+   * Create Hoodie relation based on globPaths, otherwise use tablePath if it's empty
+   */
+  def createRelation(sqlContext: SQLContext,
+                     metaClient: HoodieTableMetaClient,
+                     schema: Schema,
+                     fileSlices: java.util.Map[String, java.util.List[FileSlice]],
                      parameters: java.util.Map[String, String]): BaseRelation
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -488,7 +488,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     return new PartitionPath(partitionPath, partitionColumnValues);
   }
 
-  private static long fileSliceSize(FileSlice fileSlice) {
+  public static long fileSliceSize(FileSlice fileSlice) {
     long logFileSize = fileSlice.getLogFiles().map(HoodieLogFile::getFileSize)
         .filter(s -> s > 0)
         .reduce(0L, Long::sum);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.avro.model.HoodieSliceInfo;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -41,6 +42,9 @@ import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -301,6 +306,32 @@ public class ClusteringUtils {
         .setDeltaFilePaths(slice.getLogFiles().map(f -> f.getPath().getName()).collect(Collectors.toList()))
         .setBootstrapFilePath(slice.getBaseFile().map(bf -> bf.getBootstrapBaseFile().map(BaseFile::getPath).orElse(null)).orElse(null))
         .build()).collect(Collectors.toList());
+  }
+
+  public static FileSlice fromSliceInfo(HoodieSliceInfo sliceInfo, HoodieStorage storage) throws IOException {
+    List<HoodieLogFile> logFiles = new ArrayList<>();
+    if (sliceInfo.getDeltaFilePaths() != null) {
+      for (String path : sliceInfo.getDeltaFilePaths()) {
+        if (!StringUtils.isNullOrEmpty(path)) {
+          logFiles.add(new HoodieLogFile(getPathInfo(path, storage)));
+        }
+      }
+    }
+
+    HoodieBaseFile baseFile = null;
+    if (!StringUtils.isNullOrEmpty(sliceInfo.getDataFilePath())) {
+      BaseFile bootstrapBaseFile = null;
+      if (!StringUtils.isNullOrEmpty(sliceInfo.getBootstrapFilePath())) {
+        bootstrapBaseFile = new BaseFile(getPathInfo(sliceInfo.getBootstrapFilePath(), storage));
+      }
+
+      baseFile = new HoodieBaseFile(getPathInfo(sliceInfo.getDataFilePath(), storage), bootstrapBaseFile);
+    }
+    return new FileSlice(new HoodieFileGroupId(sliceInfo.getPartitionPath(), sliceInfo.getFileId()), "", baseFile, logFiles);
+  }
+
+  private static StoragePathInfo getPathInfo(String path, HoodieStorage storage) throws IOException {
+    return storage.getPathInfo(new StoragePath(path));
   }
 
   private static Map<String, Double> buildMetrics(List<FileSlice> fileSlices) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFixedFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFixedFileIndex.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.util.JFunction
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.datasources.PartitionDirectory
+import org.apache.spark.sql.types.StructType
+
+import java.util.stream.Collectors
+
+import scala.collection.JavaConverters._
+
+class HoodieFixedFileIndex(metaClient: HoodieTableMetaClient,
+                           fileSlices: Map[InternalRow, Seq[FileSlice]],
+                           schema: StructType,
+                           dSchema: StructType,
+                           pSchema: StructType) extends HoodieSparkFileIndex with SparkAdapterSupport {
+
+  override def rootPaths: Seq[Path] = Seq(new Path(metaClient.getBasePath.toUri))
+
+  override def listFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    assert(partitionFilters.isEmpty)
+    assert(dataFilters.isEmpty)
+    fileSlices.map(u => HoodieHadoopFsRelationFactory.slicesToPartitionDirectory(u._1, u._2, sparkAdapter.getSparkPartitionedFileUtils)).toSeq
+  }
+
+  override def inputFiles: Array[String] = {
+    fileSlices.values.toStream
+      .flatMap(f => f.toStream)
+      .flatMap(f => {
+        val logFilesStatus = f.getLogFiles.map[String](JFunction.toJavaFunction[HoodieLogFile, String](lf => lf.getPath.toString))
+        val files = logFilesStatus.collect(Collectors.toList[String]).asScala
+        if (f.getBaseFile.isPresent) {
+          files.append(f.getBaseFile.get().getPath)
+        }
+        files
+      }).toArray
+  }
+
+  override def refresh(): Unit = {
+  }
+
+  override def sizeInBytes: Long = {
+    fileSlices.values.toStream
+      .flatMap(f => f.toStream)
+      .map(f => BaseHoodieTableFileIndex.fileSliceSize(f))
+      .sum
+  }
+
+  override def partitionSchema: StructType = pSchema
+
+  override def dataSchema: StructType = dSchema
+
+  def getSchema: StructType = schema
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{SQLContext, SparkSession}
 
 import scala.collection.JavaConverters._
+import scala.reflect.internal.util.Collections
 import scala.util.{Failure, Success, Try}
 
 trait HoodieHadoopFsRelationFactory {
@@ -492,7 +493,7 @@ object HoodieHadoopFsRelationFactory extends SparkAdapterSupport{
     val shouldValidate: Boolean = sqlContext.sparkSession.sessionState.conf.getConfString("spark.sql.sources.validatePartitionColumns", "true").toBoolean
     val timestampPartitionIndexes = HoodieSparkUtils.getTimestampPartitionIndex(metaClient.getTableConfig)
     new HoodieFixedFileIndex(metaClient,
-      fileSlices.map(u => (HoodieSparkUtils.parsePartitionColumnValuesToInternalRow(metaClient.getTableConfig.getPartitionFields.get(),
+      fileSlices.map(u => (HoodieSparkUtils.parsePartitionColumnValuesToInternalRow(metaClient.getTableConfig.getPartitionFields.orElse(Array.empty),
         u._1, metaClient.getBasePath, schema, tzp, sparkAdapter.getSparkParsePartitionUtil, shouldValidate, timestampPartitionIndexes, true), u._2)),
       schema, dataSchema, partitionSchema)
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkFileIndex.scala
@@ -19,28 +19,11 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.common.model.FileSlice
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.FileIndex
+import org.apache.spark.sql.types.StructType
 
-class HoodiePartitionFileSliceMapping(values: InternalRow,
-                                      slices: Map[String, FileSlice])
-  extends HoodiePartitionValues(values) {
+trait HoodieSparkFileIndex extends FileIndex with SparkAdapterSupport {
 
-  def getSlice(fileId: String): Option[FileSlice] = {
-    slices.get(fileId)
-  }
+  def dataSchema: StructType
 
-  def getPartitionValues: InternalRow = values
-}
-
-object HoodiePartitionFileSliceMapping {
-
-  def tryWrap(values: InternalRow,
-              slices: Map[String, FileSlice]): InternalRow = {
-    if (slices.nonEmpty) {
-      new HoodiePartitionFileSliceMapping(values, slices)
-    } else {
-      values
-    }
-  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/FileFormatUtilsForFileGroupReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/FileFormatUtilsForFileGroupReader.scala
@@ -18,7 +18,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.hudi.{HoodieCDCFileIndex, SparkAdapterSupport, SparkHoodieTableFileIndex}
+import org.apache.hudi.{HoodieCDCFileIndex, HoodieFixedFileIndex, SparkAdapterSupport, SparkHoodieTableFileIndex}
 
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Contains, EndsWith, EqualNullSafe, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, NamedExpression, Not, Or, StartsWith}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
@@ -36,6 +36,7 @@ object FileFormatUtilsForFileGroupReader extends SparkAdapterSupport {
     val tableSchema = fs.location match {
       case index: HoodieCDCFileIndex => index.cdcRelation.schema
       case index: SparkHoodieTableFileIndex => index.schema
+      case index: HoodieFixedFileIndex => index.getSchema
     }
     val resolvedSchema = logicalRelation.resolve(tableSchema, fs.sparkSession.sessionState.analyzer.resolver)
     val unfilteredPlan = if (!fs.partitionSchema.fields.isEmpty && sparkAdapter.getCatalystPlanUtils.produceSameOutput(scanOperation, logicalRelation)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -867,19 +867,19 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "f3, f4")
     tableConfig.setValue(HoodieTableConfig.KEY_GENERATOR_TYPE, KeyGeneratorType.CUSTOM.name())
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:SIMPLE,f2:TIMESTAMP")
-    assertEquals(Set(1), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(1), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Custom key generator with both field partition types as timestamp would return both the indices
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:TIMESTAMP,f2:TIMESTAMP")
-    assertEquals(Set(0, 1), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(0, 1), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Custom key generator with both field partition types as simple would return empty set
     tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, "f1:SIMPLE,f2:SIMPLE")
-    assertEquals(Set(), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
 
     // Timestamp based key generators have only a single partition field
     tableConfig.setValue(HoodieTableConfig.KEY_GENERATOR_TYPE, KeyGeneratorType.TIMESTAMP.name())
-    assertEquals(Set(0), HoodieFileIndex.getTimestampPartitionIndex(tableConfig))
+    assertEquals(Set(0), HoodieSparkUtils.getTimestampPartitionIndex(tableConfig))
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -97,7 +97,7 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
                               parameters: java.util.Map[String, String]): BaseRelation = {
     val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType)
     HoodieHadoopFsRelationFactory.createRelation(sqlContext, metaClient, dataSchema,
-      fileSlices.asScala.map(u => (u._1, u._2.asScala)).toMap, parameters.asScala.toMap)
+      fileSlices.asScala.map(u => (u._1, u._2.asScala.toSeq)).toMap, parameters.asScala.toMap)
   }
 
   override def convertStorageLevelToString(level: StorageLevel): String

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -18,14 +18,16 @@
 package org.apache.spark.sql.adapter
 
 import org.apache.avro.Schema
-import org.apache.hudi.{AvroConversionUtils, DefaultSource, HoodieSparkUtils, Spark3RowSerDe}
+import org.apache.hudi.{AvroConversionUtils, DefaultSource, HoodieHadoopFsRelationFactory, HoodieSparkUtils, Spark3RowSerDe}
 import org.apache.hudi.client.utils.SparkRowSerDe
+import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.JsonUtils
 import org.apache.hudi.spark3.internal.ReflectUtil
 import org.apache.hudi.storage.StoragePath
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{HoodieSpark3CatalogUtils, SparkSession, SQLContext}
+import org.apache.spark.sql.{HoodieSpark3CatalogUtils, SQLContext, SparkSession}
 import org.apache.spark.sql.avro.{HoodieAvroSchemaConverters, HoodieSparkAvroSchemaConverters}
 import org.apache.spark.sql.catalyst.expressions.{Expression, InterpretedPredicate, Predicate}
 import org.apache.spark.sql.catalyst.util.DateFormatter
@@ -34,7 +36,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 import org.apache.spark.storage.StorageLevel
 
 import java.time.ZoneId
@@ -86,6 +88,16 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
                               parameters: java.util.Map[String, String]): BaseRelation = {
     val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType).orNull
     DefaultSource.createRelation(sqlContext, metaClient, dataSchema, globPaths, parameters.asScala.toMap)
+  }
+
+  override def createRelation(sqlContext: SQLContext,
+                              metaClient: HoodieTableMetaClient,
+                              schema: Schema,
+                              fileSlices: java.util.Map[String, java.util.List[FileSlice]],
+                              parameters: java.util.Map[String, String]): BaseRelation = {
+    val dataSchema = Option(schema).map(AvroConversionUtils.convertAvroSchemaToStructType)
+    HoodieHadoopFsRelationFactory.createRelation(sqlContext, metaClient, dataSchema,
+      fileSlices.asScala.map(u => (u._1, u._2.asScala)).toMap, parameters.asScala.toMap)
   }
 
   override def convertStorageLevelToString(level: StorageLevel): String


### PR DESCRIPTION
### Change Logs

Move fg reader creation into the hadoopfs factory

Move some spark utils from HoodieFileIndex to HoodieSparkUtils

add spark adapter method so we can create the relation and pass in the filegroups to read. 

Create hoodie fixed file index for reading a fixed set of filegroups.

Reuse code for embedding the file slices into the internal row

### Impact

Clustering with row writer can now use the fg reader implementation for reading.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
