### PR TITLE
[HUDI-8466] Fixed the async Compaction task configuration error in CompactOperator

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -692,6 +692,12 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(true) // default true for MOR write
       .withDescription("Async Compaction, enabled by default for MOR");
 
+  public static final ConfigOption<Boolean> COMPACTION_TASK_ASYNC_ENABLED = ConfigOptions
+      .key("compaction.task.async.enabled")
+      .booleanType()
+      .defaultValue(true)
+      .withDescription("Execute compaction tasks asynchronously, enabled by default in streaming mode and permanently disabled in batch mode");
+
   @AdvancedConfig
   public static final ConfigOption<Integer> COMPACTION_TASKS = ConfigOptions
       .key("compaction.tasks")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
@@ -192,8 +192,8 @@ public class FlinkCompactionConfig extends Configuration {
     conf.setLong(FlinkOptions.COMPACTION_TARGET_IO, config.compactionTargetIo);
     conf.setInteger(FlinkOptions.COMPACTION_TASKS, config.compactionTasks);
     conf.setBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED, config.cleanAsyncEnable);
-    // use synchronous compaction always
-    conf.setBoolean(FlinkOptions.COMPACTION_ASYNC_ENABLED, false);
+    // Execute compaction tasks synchronously
+    conf.setBoolean(FlinkOptions.COMPACTION_TASK_ASYNC_ENABLED, false);
     conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, config.schedule);
     // Map memory
     conf.setString(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(), config.spillableMapPath);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
@@ -119,7 +119,7 @@ public class HoodieTableSink implements
       if (OptionsResolver.needsAsyncCompaction(conf)) {
         // use synchronous compaction for bounded source.
         if (context.isBounded()) {
-          conf.setBoolean(FlinkOptions.COMPACTION_ASYNC_ENABLED, false);
+          conf.setBoolean(FlinkOptions.COMPACTION_TASK_ASYNC_ENABLED, false);
         }
         return Pipelines.compact(conf, pipeline);
       } else {


### PR DESCRIPTION
### Change Logs

In the CompactOperator, the Async Compaction configuration was mistakenly used for executing Compaction Task configurations, resulting in Compaction Tasks only being executed asynchronously when using Async Compaction.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
