### PR TITLE
[HUDI-8455] Logic for partition column values parse is localized in `HoodieSparkUtils`

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkPartitionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkPartitionUtils.java
@@ -40,7 +40,7 @@ public class SparkPartitionUtils {
       return new Object[0];
     }
     SparkParsePartitionUtil sparkParsePartitionUtil = SparkAdapterSupport$.MODULE$.sparkAdapter().getSparkParsePartitionUtil();
-    return HoodieSparkUtils.parsePartitionColumnValues(
+    return HoodieSparkUtils.doParsePartitionColumnValues(
         partitionFields.get(),
         partitionPath,
         new StoragePath(basePath),

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -229,7 +229,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
     sparkAdapter.createSparkRowSerDe(structType)
   }
 
-  def doParsePartitionColumnValues(partitionColumns: Array[String],
+  def parsePartitionColumnValues(partitionColumns: Array[String],
                                    partitionPath: String,
                                    tableBasePath: StoragePath,
                                    tableSchema: StructType,
@@ -249,12 +249,12 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
       // But the output for these cases is in a string format, so we can pass partitionPath as UTF8String
       Array.fill(partitionColumns.length)(UTF8String.fromString(partitionPath))
     } else {
-      parsePartitionColumnValues(partitionColumns, partitionPath, tableBasePath, tableSchema, timeZoneId,
+      doParsePartitionColumnValues(partitionColumns, partitionPath, tableBasePath, tableSchema, timeZoneId,
         sparkParsePartitionUtil, shouldValidatePartitionColumns)
     }
   }
 
-  def parsePartitionColumnValues(partitionColumns: Array[String],
+  def doParsePartitionColumnValues(partitionColumns: Array[String],
                                  partitionPath: String,
                                  basePath: StoragePath,
                                  schema: StructType,

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -28,6 +28,9 @@ import org.apache.hudi.util.ExceptionWrappingIterator
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig
+import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator
+import org.apache.hudi.keygen.constant.KeyGeneratorType
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -224,6 +227,31 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
 
   def getCatalystRowSerDe(structType: StructType): SparkRowSerDe = {
     sparkAdapter.createSparkRowSerDe(structType)
+  }
+
+  def doParsePartitionColumnValues(partitionColumns: Array[String],
+                                   partitionPath: String,
+                                   tableBasePath: StoragePath,
+                                   tableSchema: StructType,
+                                   tableConfig: java.util.Map[String, String],
+                                   timeZoneId: String,
+                                   sparkParsePartitionUtil: SparkParsePartitionUtil,
+                                   shouldValidatePartitionColumns: Boolean): Array[Object] = {
+    val keyGeneratorClass = KeyGeneratorType.getKeyGeneratorClassName(tableConfig)
+    val timestampKeyGeneratorType = tableConfig.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key())
+
+    if (null != keyGeneratorClass
+      && null != timestampKeyGeneratorType
+      && keyGeneratorClass.equals(KeyGeneratorType.TIMESTAMP.getClassName)
+      && !timestampKeyGeneratorType.matches(TimestampBasedAvroKeyGenerator.TimestampType.DATE_STRING.toString)) {
+      // For TIMESTAMP key generator when TYPE is not DATE_STRING (like SCALAR, UNIX_TIMESTAMP, EPOCHMILLISECONDS, etc.),
+      // we couldn't reconstruct initial partition column values from partition paths due to lost data after formatting.
+      // But the output for these cases is in a string format, so we can pass partitionPath as UTF8String
+      Array.fill(partitionColumns.length)(UTF8String.fromString(partitionPath))
+    } else {
+      parsePartitionColumnValues(partitionColumns, partitionPath, tableBasePath, tableSchema, timeZoneId,
+        sparkParsePartitionUtil, shouldValidatePartitionColumns)
+    }
   }
 
   def parsePartitionColumnValues(partitionColumns: Array[String],

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -169,7 +169,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     doRefresh();
   }
 
-  protected abstract Object[] doParsePartitionColumnValues(String[] partitionColumns, String partitionPath);
+  protected abstract Object[] parsePartitionColumnValues(String[] partitionColumns, String partitionPath);
 
   /**
    * Returns latest completed instant as seen by this instance of the file-index
@@ -360,7 +360,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   }
 
   private Object[] getPartitionColumnValues(String[] partitionColumns, String partitionPath) {
-    Object[] partitionColumnValues = doParsePartitionColumnValues(partitionColumns, partitionPath);
+    Object[] partitionColumnValues = parsePartitionColumnValues(partitionColumns, partitionPath);
     if (shouldListLazily && partitionColumnValues.length != partitionColumns.length) {
       throw new HoodieException("Failed to parse partition column values from the partition-path:"
           + " likely non-encoded slashes being used in partition column's values. You can try to"

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -359,7 +359,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     }
   }
 
-  private Object[] parsePartitionColumnValues(String[] partitionColumns, String partitionPath) {
+  private Object[] getPartitionColumnValues(String[] partitionColumns, String partitionPath) {
     Object[] partitionColumnValues = doParsePartitionColumnValues(partitionColumns, partitionPath);
     if (shouldListLazily && partitionColumnValues.length != partitionColumns.length) {
       throw new HoodieException("Failed to parse partition column values from the partition-path:"
@@ -484,7 +484,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   }
 
   protected PartitionPath convertToPartitionPath(String partitionPath) {
-    Object[] partitionColumnValues = parsePartitionColumnValues(partitionColumns, partitionPath);
+    Object[] partitionColumnValues = getPartitionColumnValues(partitionColumns, partitionPath);
     return new PartitionPath(partitionPath, partitionColumnValues);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorType.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.KEY_GENERATOR_CLASS_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.KEY_GENERATOR_TYPE;
@@ -128,6 +129,16 @@ public enum KeyGeneratorType {
       return config.getString(KEY_GENERATOR_CLASS_NAME);
     } else if (config.contains(KEY_GENERATOR_TYPE)) {
       return KeyGeneratorType.valueOf(config.getString(KEY_GENERATOR_TYPE)).getClassName();
+    }
+    return null;
+  }
+
+  @Nullable
+  public static String getKeyGeneratorClassName(Map<String, String> config) {
+    if (config.containsKey(KEY_GENERATOR_CLASS_NAME.key())) {
+      return config.get(KEY_GENERATOR_CLASS_NAME.key());
+    } else if (config.containsKey(KEY_GENERATOR_TYPE.key())) {
+      return KeyGeneratorType.valueOf(config.get(KEY_GENERATOR_TYPE.key())).getClassName();
     }
     return null;
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
@@ -75,7 +75,7 @@ public class HiveHoodieTableFileIndex extends BaseHoodieTableFileIndex {
   }
 
   @Override
-  public Object[] doParsePartitionColumnValues(String[] partitionColumns, String partitionPath) {
+  public Object[] parsePartitionColumnValues(String[] partitionColumns, String partitionPath) {
     // NOTE: Parsing partition path into partition column values isn't required on Hive,
     //       since Hive does partition pruning in a different way (based on the input-path being
     //       fetched by the query engine)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -495,11 +495,12 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
       val partitionPathWithoutScheme = file.getPath.getParent.getPathWithoutSchemeAndAuthority
       val relativePath = tablePathWithoutScheme.toUri.relativize(partitionPathWithoutScheme.toUri).toString
       val timeZoneId = conf.get("timeZone", sparkSession.sessionState.conf.sessionLocalTimeZone)
-      val rowValues = HoodieSparkUtils.parsePartitionColumnValues(
+      val rowValues = HoodieSparkUtils.doParsePartitionColumnValues(
         partitionColumns,
         relativePath,
         basePath,
         tableStructSchema,
+        tableConfig.propsMap,
         timeZoneId,
         sparkAdapter.getSparkParsePartitionUtil,
         conf.getBoolean("spark.sql.sources.validatePartitionColumns", true))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -495,7 +495,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
       val partitionPathWithoutScheme = file.getPath.getParent.getPathWithoutSchemeAndAuthority
       val relativePath = tablePathWithoutScheme.toUri.relativize(partitionPathWithoutScheme.toUri).toString
       val timeZoneId = conf.get("timeZone", sparkSession.sessionState.conf.sessionLocalTimeZone)
-      val rowValues = HoodieSparkUtils.doParsePartitionColumnValues(
+      val rowValues = HoodieSparkUtils.parsePartitionColumnValues(
         partitionColumns,
         relativePath,
         basePath,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCDCFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCDCFileIndex.scala
@@ -53,7 +53,7 @@ class HoodieCDCFileIndex (override val spark: SparkSession,
         val partitionPath = if (fileGroupId.getPartitionPath.isEmpty) emptyPartitionPath else fileGroupId.getPartitionPath
         val partitionFields = metaClient.getTableConfig.getPartitionFields
         val partitionValues: InternalRow = if (partitionFields.isPresent) {
-          new GenericInternalRow(doParsePartitionColumnValues(partitionFields.get(), partitionPath).asInstanceOf[Array[Any]])
+          new GenericInternalRow(parsePartitionColumnValues(partitionFields.get(), partitionPath).asInstanceOf[Array[Any]])
         } else {
           InternalRow.empty
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -376,8 +376,8 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
   /**
    * @VisibleForTesting
    */
-  def doParsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
-    HoodieSparkUtils.doParsePartitionColumnValues(
+  def parsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
+    HoodieSparkUtils.parsePartitionColumnValues(
       partitionColumns,
       partitionPath,
       getBasePath,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -377,22 +377,15 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
    * @VisibleForTesting
    */
   def doParsePartitionColumnValues(partitionColumns: Array[String], partitionPath: String): Array[Object] = {
-    val tableConfig = metaClient.getTableConfig
-    if (null != tableConfig.getKeyGeneratorClassName
-      && tableConfig.getKeyGeneratorClassName.equals(KeyGeneratorType.TIMESTAMP.getClassName)
-      && null != tableConfig.propsMap.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key())
-      && tableConfig.propsMap.get(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key())
-      .matches("SCALAR|UNIX_TIMESTAMP|EPOCHMILLISECONDS|EPOCHMICROSECONDS")) {
-      // For TIMESTAMP key generator when TYPE is SCALAR, UNIX_TIMESTAMP,
-      // EPOCHMILLISECONDS, or EPOCHMICROSECONDS,
-      // we couldn't reconstruct initial partition column values from partition paths due to lost data after formatting in most cases.
-      // But the output for these cases is in a string format, so we can pass partitionPath as UTF8String
-      Array.fill(partitionColumns.length)(UTF8String.fromString(partitionPath))
-    } else {
-      HoodieSparkUtils.parsePartitionColumnValues(partitionColumns, partitionPath, getBasePath, schema,
-        configProperties.getString(DateTimeUtils.TIMEZONE_OPTION, SQLConf.get.sessionLocalTimeZone),
-        sparkParsePartitionUtil, shouldValidatePartitionColumns(spark))
-    }
+    HoodieSparkUtils.doParsePartitionColumnValues(
+      partitionColumns,
+      partitionPath,
+      getBasePath,
+      schema,
+      metaClient.getTableConfig.propsMap,
+      configProperties.getString(DateTimeUtils.TIMEZONE_OPTION, SQLConf.get.sessionLocalTimeZone),
+      sparkParsePartitionUtil,
+      shouldValidatePartitionColumns(spark))
   }
 
   private def arePartitionPathsUrlEncoded: Boolean =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -112,9 +112,9 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
   }
 
   /**
-   * Unit test for `doParsePartitionColumnValues` method in `HoodieFileIndex`.
+   * Unit test for `parsePartitionColumnValues` method in `SparkHoodieTableFileIndex`.
    *
-   * This test verifies that the `doParsePartitionColumnValues` method correctly returns
+   * This test verifies that the `parsePartitionColumnValues` method correctly returns
    * partition values when the `propsMap` in the table configuration does not contain the
    * expected timestamp configuration key, simulating a `null` scenario. Specifically,
    * this test validates the behavior for the `TIMESTAMP` key generator type, ensuring
@@ -136,7 +136,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val partitionPath = "2023/10/28"
     val fileIndex = HoodieFileIndex(spark, metaClient, Some(schema), queryOpts)
     // Create file index and validate the result
-    val result = fileIndex.doParsePartitionColumnValues(partitionColumns, partitionPath)
+    val result = fileIndex.parsePartitionColumnValues(partitionColumns, partitionPath)
     assertEquals(1, result.length)
     assertEquals(UTF8String.fromString(partitionPath), result(0))
   }


### PR DESCRIPTION
### Change Logs

 Logic for partition column values parse is removed from `SparkHoodieTableFileIndex`, and localized in `HoodieSparkUtils`.

**Before:**
![before refactor](https://github.com/user-attachments/assets/de5a5860-7cdd-49e9-80ab-f3c90358c4ae)

**After:**
![after refactor](https://github.com/user-attachments/assets/355e0493-62d6-4a6a-8046-952fe1221e7e)

### Impact

No

### Risk level (write none, low medium or high below)

None

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
