### PR TITLE
[HUDI-8485] Fix JSON Reader tests

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonDFSSource.java
@@ -38,7 +38,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,7 +80,9 @@ public class TestJsonDFSSource extends AbstractDFSSourceTestBase {
     RemoteIterator<LocatedFileStatus> files = fs.listFiles(generateOneFile("3", "000", 10), true);
 
     FileStatus file1Status = files.next();
-    InputBatch<Dataset<Row>> batch = sourceFormatAdapter.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE);
+    Map<String, String> dataframeReaderOptions = Collections.singletonMap("mode", "FAILFAST");
+    InputBatch<Dataset<Row>> batch = sourceFormatAdapter.fetchNewDataInRowFormat(
+        Option.empty(), Long.MAX_VALUE, dataframeReaderOptions);
     corruptFile(file1Status.getPath());
     assertTrue(batch.getBatch().isPresent());
     Throwable t = assertThrows(Exception.class,


### PR DESCRIPTION
### Change Logs

Fix JSON Reader tests to pass through the reader option to fail fast.


### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
