### PR TITLE
[HUDI-8484] Instant heartbeats memory leak

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -184,13 +184,14 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
    * @param instantTime The instant time for the heartbeat.
    * @throws HoodieException
    */
-  public void stop(String instantTime) throws HoodieException {
-    Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
+  public Heartbeat stop(String instantTime) throws HoodieException {
+    Heartbeat heartbeat = instantToHeartbeatMap.remove(instantTime);
     if (isHeartbeatStarted(heartbeat)) {
       stopHeartbeatTimer(heartbeat);
       HeartbeatUtils.deleteHeartbeatFile(storage, basePath, instantTime);
       LOG.info("Deleted heartbeat file for instant " + instantTime);
     }
+    return heartbeat;
   }
 
   /**


### PR DESCRIPTION
### Change Logs

The heartbeat should be removed from memory when it has been explicitly stopped (in the post-commit step, which means the instant has been committed), otherwise the heartbeat is left in memory until the write client has been stopped entirely. In streaming pipeline, the write client is been reused for multiple instants.

The heartbeats are mainly designed for lazy cleaning and very probaly the clean table service is executed asynchronously on another workload, the in-memory heatbeat does not make any sense for a committed instant actually.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
