### PR TITLE
Revert "[HUDI-4818] Update the data type to string to avoid type convertion failure (#12165)"

### DIFF
--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/Spark3ParsePartitionUtil.scala
@@ -70,11 +70,7 @@ object Spark3ParsePartitionUtil extends SparkParsePartitionUtil {
             castPartValueToDesiredType(typedValue.dataType, typedValue.value, tz.toZoneId)
           } catch {
             case NonFatal(_) =>
-              // If the exception happens, there was some transformation on the original value.
-              // String value should be universal type for type casting.
-              if (userSpecifiedDataTypes.contains(columnName)) {
-                castPartValueToDesiredType(StringType, typedValue.value, tz.toZoneId)
-              } else if (validatePartitionValues) {
+              if (validatePartitionValues) {
                 throw new RuntimeException(s"Failed to cast value `${typedValue.value}` to " +
                   s"`${typedValue.dataType}` for partition column `$columnName`")
               } else null


### PR DESCRIPTION
This reverts commit 3d81ea0a313bba1902065de87de4ee2be38538e3.

### Change Logs

As said yihua here https://github.com/apache/hudi/pull/12165#pullrequestreview-2419134364
"This PR is not ready to merge and the logic can cause correctness issue. Let's revert it."

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
