### PR TITLE
[HUDI-8398] Refactoring HoodieIndexMetadata to HoodieIndexFunctionalOrSecondaryIndexMetadata

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -39,7 +39,7 @@ import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
-import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieIndexFunctionalOrSecondaryIndexMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordDelegate;
@@ -568,7 +568,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   }
 
   private HoodieIndexDefinition getFunctionalIndexDefinition(String indexName) {
-    Option<HoodieIndexMetadata> functionalIndexMetadata = dataMetaClient.getIndexMetadata();
+    Option<HoodieIndexFunctionalOrSecondaryIndexMetadata> functionalIndexMetadata = dataMetaClient.getFunctionalAndSecondaryIndexMetadata();
     if (functionalIndexMetadata.isPresent()) {
       return functionalIndexMetadata.get().getIndexDefinitions().get(indexName);
     } else {
@@ -577,10 +577,10 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   }
 
   private Set<String> getIndexPartitionsToInit(MetadataPartitionType partitionType) {
-    if (dataMetaClient.getIndexMetadata().isEmpty()) {
+    if (dataMetaClient.getFunctionalAndSecondaryIndexMetadata().isEmpty()) {
       return Collections.emptySet();
     }
-    Set<String> secondaryIndexPartitions = dataMetaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+    Set<String> secondaryIndexPartitions = dataMetaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().values().stream()
         .map(HoodieIndexDefinition::getIndexName)
         .filter(indexName -> indexName.startsWith(partitionType.getPartitionPath()))
         .collect(Collectors.toSet());

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexFunctionalOrSecondaryIndexMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexFunctionalOrSecondaryIndexMetadata.java
@@ -36,18 +36,18 @@ import java.util.StringJoiner;
  * Represents the metadata for all functional and secondary indexes in Hudi.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class HoodieIndexMetadata implements Serializable {
+public class HoodieIndexFunctionalOrSecondaryIndexMetadata implements Serializable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieIndexMetadata.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieIndexFunctionalOrSecondaryIndexMetadata.class);
 
   // Map to hold the index definitions keyed by their names.
   private Map<String, HoodieIndexDefinition> indexDefinitions;
 
-  public HoodieIndexMetadata() {
+  public HoodieIndexFunctionalOrSecondaryIndexMetadata() {
     this.indexDefinitions = new HashMap<>();
   }
 
-  public HoodieIndexMetadata(Map<String, HoodieIndexDefinition> indexDefinitions) {
+  public HoodieIndexFunctionalOrSecondaryIndexMetadata(Map<String, HoodieIndexDefinition> indexDefinitions) {
     this.indexDefinitions = indexDefinitions;
   }
 
@@ -80,16 +80,16 @@ public class HoodieIndexMetadata implements Serializable {
    * @return Deserialized instance of HoodieIndexesMetadata.
    * @throws IOException If any deserialization errors occur.
    */
-  public static HoodieIndexMetadata fromJson(String json) throws IOException {
+  public static HoodieIndexFunctionalOrSecondaryIndexMetadata fromJson(String json) throws IOException {
     if (json == null || json.isEmpty()) {
-      return new HoodieIndexMetadata();
+      return new HoodieIndexFunctionalOrSecondaryIndexMetadata();
     }
-    return JsonUtils.getObjectMapper().readValue(json, HoodieIndexMetadata.class);
+    return JsonUtils.getObjectMapper().readValue(json, HoodieIndexFunctionalOrSecondaryIndexMetadata.class);
   }
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", HoodieIndexMetadata.class.getSimpleName() + "[", "]")
+    return new StringJoiner(", ", HoodieIndexFunctionalOrSecondaryIndexMetadata.class.getSimpleName() + "[", "]")
         .add("indexDefinitions=" + indexDefinitions)
         .toString();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
@@ -30,7 +30,7 @@ import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
-import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieIndexFunctionalOrSecondaryIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecordDelegate;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordLocation;
@@ -105,7 +105,7 @@ public class HoodieCommonKryoRegistrar {
         HoodieMetaserverConfig.class,
         HoodieTimeGeneratorConfig.class,
         Option.class,
-        HoodieIndexMetadata.class,
+        HoodieIndexFunctionalOrSecondaryIndexMetadata.class,
         HashMap.class,
         StoragePath.class,
         HoodieTableMetaClient.class

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -53,7 +53,7 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
-import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieIndexFunctionalOrSecondaryIndexMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -582,9 +582,9 @@ public class HoodieTableMetadataUtil {
                                                               String instantTime, HoodieTableMetaClient dataMetaClient,
                                                               int bloomIndexParallelism, int columnStatsIndexParallelism,
                                                               Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap) {
-    Option<HoodieIndexMetadata> indexMetadata = dataMetaClient.getIndexMetadata();
+    Option<HoodieIndexFunctionalOrSecondaryIndexMetadata> indexMetadata = dataMetaClient.getFunctionalAndSecondaryIndexMetadata();
     if (indexMetadata.isPresent()) {
-      HoodieIndexMetadata metadata = indexMetadata.get();
+      HoodieIndexFunctionalOrSecondaryIndexMetadata metadata = indexMetadata.get();
       Map<String, HoodieIndexDefinition> indexDefinitions = metadata.getIndexDefinitions();
       if (indexDefinitions.isEmpty()) {
         throw new HoodieMetadataException("Functional index metadata not found");

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -183,8 +183,8 @@ public enum MetadataPartitionType {
 
     @Override
     public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
-      if (metaClient.getIndexMetadata().isPresent()) {
-        return metaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+      if (metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent()) {
+        return metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().values().stream()
             .anyMatch(indexDef -> indexDef.getIndexName().startsWith(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX));
       }
       return false;
@@ -192,8 +192,8 @@ public enum MetadataPartitionType {
 
     @Override
     public String getPartitionPath(HoodieTableMetaClient metaClient, String indexName) {
-      checkArgument(metaClient.getIndexMetadata().isPresent(), "Index definition is not present for index: " + indexName);
-      return metaClient.getIndexMetadata().get().getIndexDefinitions().get(indexName).getIndexName();
+      checkArgument(metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent(), "Index definition is not present for index: " + indexName);
+      return metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().get(indexName).getIndexName();
     }
   },
   SECONDARY_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX, "secondary-index-", 7) {
@@ -206,8 +206,8 @@ public enum MetadataPartitionType {
 
     @Override
     public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
-      if (metaClient.getIndexMetadata().isPresent()) {
-        return metaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+      if (metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent()) {
+        return metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().values().stream()
             .anyMatch(indexDef -> indexDef.getIndexName().startsWith(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX));
       }
       return false;
@@ -224,8 +224,8 @@ public enum MetadataPartitionType {
 
     @Override
     public String getPartitionPath(HoodieTableMetaClient metaClient, String indexName) {
-      checkArgument(metaClient.getIndexMetadata().isPresent(), "Index definition is not present for index: " + indexName);
-      return metaClient.getIndexMetadata().get().getIndexDefinitions().get(indexName).getIndexName();
+      checkArgument(metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent(), "Index definition is not present for index: " + indexName);
+      return metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().get(indexName).getIndexName();
     }
   },
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -21,7 +21,7 @@ package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
-import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieIndexFunctionalOrSecondaryIndexMetadata;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
@@ -56,7 +56,7 @@ public class TestMetadataPartitionType {
     // Simulate the configuration enabling given partition type, but the meta client not having it available (yet to initialize the partition)
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(partitionType)).thenReturn(false);
-    Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    Mockito.when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.empty());
     HoodieMetadataConfig.Builder metadataConfigBuilder = HoodieMetadataConfig.newBuilder();
     int expectedEnabledPartitions;
     switch (partitionType) {
@@ -107,7 +107,7 @@ public class TestMetadataPartitionType {
     // Simulate the meta client having RECORD_INDEX available but config not enabling it
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
-    Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    Mockito.when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.empty());
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).withEnableRecordIndex(false).build();
 
@@ -126,7 +126,7 @@ public class TestMetadataPartitionType {
 
     // Neither config nor availability allows any partitions
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
-    Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    Mockito.when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.empty());
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(Mockito.any())).thenReturn(false);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(false).build();
 
@@ -144,9 +144,9 @@ public class TestMetadataPartitionType {
     // Simulate the meta client having FUNCTIONAL_INDEX available
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
-    HoodieIndexMetadata functionalIndexMetadata =
-        new HoodieIndexMetadata(Collections.singletonMap("func_index_dummy", new HoodieIndexDefinition("func_index_dummy", null, null, null, null)));
-    Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.of(functionalIndexMetadata));
+    HoodieIndexFunctionalOrSecondaryIndexMetadata functionalIndexMetadata =
+        new HoodieIndexFunctionalOrSecondaryIndexMetadata(Collections.singletonMap("func_index_dummy", new HoodieIndexDefinition("func_index_dummy", null, null, null, null)));
+    Mockito.when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.of(functionalIndexMetadata));
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.FUNCTIONAL_INDEX)).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
 
@@ -201,8 +201,8 @@ public class TestMetadataPartitionType {
     indexDefinitions.put(
         secondaryIndexName,
         new HoodieIndexDefinition("secondary_index_dummySecondaryIndex", null, null, Collections.singletonList("name"), null));
-    HoodieIndexMetadata indexMetadata = new HoodieIndexMetadata(indexDefinitions);
-    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    HoodieIndexFunctionalOrSecondaryIndexMetadata indexMetadata = new HoodieIndexFunctionalOrSecondaryIndexMetadata(indexDefinitions);
+    when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.of(indexMetadata));
     if (partitionType == MetadataPartitionType.FUNCTIONAL_INDEX) {
       assertEquals("func_index_dummyFunctionalIndex", partitionType.getPartitionPath(metaClient, functionalIndexName));
     } else if (partitionType == MetadataPartitionType.SECONDARY_INDEX) {
@@ -216,7 +216,7 @@ public class TestMetadataPartitionType {
   public void testExceptionForMissingFunctionalIndexMetadata() {
     MetadataPartitionType partitionType = MetadataPartitionType.FUNCTIONAL_INDEX;
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
-    when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    when(metaClient.getFunctionalAndSecondaryIndexMetadata()).thenReturn(Option.empty());
 
     assertThrows(IllegalArgumentException.class,
         () -> partitionType.getPartitionPath(metaClient, "testIndex"));

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -93,16 +93,16 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     }
 
     if (!metaClient.getTableConfig().getIndexDefinitionPath().isPresent()
-        || !metaClient.getIndexMetadata().isPresent()
-        || !metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(indexName)) {
+        || !metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent()
+        || !metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().containsKey(indexName)) {
       LOG.info("Index definition is not present. Registering the index first");
       register(metaClient, indexName, indexType, columns, options);
     }
 
-    ValidationUtils.checkState(metaClient.getIndexMetadata().isPresent(), "Index definition is not present");
+    ValidationUtils.checkState(metaClient.getFunctionalAndSecondaryIndexMetadata().isPresent(), "Index definition is not present");
 
     LOG.info("Creating index {} of using {}", indexName, indexType);
-    HoodieIndexDefinition functionalIndexDefinition = metaClient.getIndexMetadata().get().getIndexDefinitions().get(indexName);
+    HoodieIndexDefinition functionalIndexDefinition = metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().get(indexName);
     try (SparkRDDWriteClient writeClient = HoodieCLIUtils.createHoodieWriteClient(
         sparkSession, metaClient.getBasePath().toString(), mapAsScalaImmutableMap(buildWriteConfig(metaClient, functionalIndexDefinition)), toScalaOption(Option.empty()))) {
       // generate index plan
@@ -127,7 +127,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     }
 
     LOG.info("Dropping index {}", indexName);
-    HoodieIndexDefinition indexDefinition = metaClient.getIndexMetadata().get().getIndexDefinitions().get(indexName);
+    HoodieIndexDefinition indexDefinition = metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().get(indexName);
     try (SparkRDDWriteClient writeClient = HoodieCLIUtils.createHoodieWriteClient(
         sparkSession, metaClient.getBasePath().toString(), mapAsScalaImmutableMap(buildWriteConfig(metaClient, indexDefinition)), toScalaOption(Option.empty()))) {
       writeClient.dropIndex(Collections.singletonList(indexName));

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -77,7 +77,7 @@ class FunctionalIndexSupport(spark: SparkSession,
    * Return true if metadata table is enabled and functional index metadata partition is available.
    */
   def isIndexAvailable: Boolean = {
-    metadataConfig.isEnabled && metaClient.getIndexMetadata.isPresent && !metaClient.getIndexMetadata.get().getIndexDefinitions.isEmpty
+    metadataConfig.isEnabled && metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent && !metaClient.getFunctionalAndSecondaryIndexMetadata.get().getIndexDefinitions.isEmpty
   }
 
   /**
@@ -99,7 +99,7 @@ class FunctionalIndexSupport(spark: SparkSession,
       // Currently, only one functional index in the query is supported. HUDI-7620 for supporting multiple functions.
       checkState(functionToColumnNames.size == 1, "Currently, only one function with functional index in the query is supported")
       val (indexFunction, targetColumnName) = functionToColumnNames.head
-      val indexDefinitions = metaClient.getIndexMetadata.get().getIndexDefinitions
+      val indexDefinitions = metaClient.getFunctionalAndSecondaryIndexMetadata.get().getIndexDefinitions
       indexDefinitions.asScala.collectFirst {
         case (indexPartition, indexDefinition)
           if indexDefinition.getIndexFunction.equals(indexFunction) && indexDefinition.getSourceFields.contains(targetColumnName) =>
@@ -138,7 +138,7 @@ class FunctionalIndexSupport(spark: SparkSession,
   private def loadFunctionalIndexDataFrame(indexPartition: String,
                                            shouldReadInMemory: Boolean): DataFrame = {
     val colStatsDF = {
-      val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.get(indexPartition)
+      val indexDefinition = metaClient.getFunctionalAndSecondaryIndexMetadata.get().getIndexDefinitions.get(indexPartition)
       val indexType = indexDefinition.getIndexType
       // NOTE: Currently only functional indexes created using column_stats is supported.
       // HUDI-7007 tracks for adding support for other index types such as bloom filters.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -66,7 +66,7 @@ class SecondaryIndexSupport(spark: SparkSession,
    * Return true if metadata table is enabled and functional index metadata partition is available.
    */
   override def isIndexAvailable: Boolean = {
-    metadataConfig.isEnabled && metaClient.getIndexMetadata.isPresent && !metaClient.getIndexMetadata.get().getIndexDefinitions.isEmpty
+    metadataConfig.isEnabled && metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent && !metaClient.getFunctionalAndSecondaryIndexMetadata.get().getIndexDefinitions.isEmpty
   }
 
   /**
@@ -102,7 +102,7 @@ class SecondaryIndexSupport(spark: SparkSession,
    */
   private def getSecondaryKeyConfig(queryReferencedColumns: Seq[String],
                                     metaClient: HoodieTableMetaClient): Option[(String, String)] = {
-    val indexDefinitions = metaClient.getIndexMetadata.get.getIndexDefinitions.asScala
+    val indexDefinitions = metaClient.getFunctionalAndSecondaryIndexMetadata.get.getIndexDefinitions.asScala
     indexDefinitions.values
       .find(indexDef => indexDef.getIndexType.equals(PARTITION_NAME_SECONDARY_INDEX) &&
         queryReferencedColumns.contains(indexDef.getSourceFields.get(0)))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -765,7 +765,7 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       metaClient = HoodieTableMetaClient.reload(metaClient)
       assertFalse(metaClient.getTableConfig.getMetadataPartitions.contains(MetadataPartitionType.PARTITION_STATS.getPartitionPath))
       // however index definition should still be present
-      assertTrue(metaClient.getIndexMetadata.isPresent && metaClient.getIndexMetadata.get.getIndexDefinitions.get(secondaryIndexPartition).getIndexType.equals("secondary_index"))
+      assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent && metaClient.getFunctionalAndSecondaryIndexMetadata.get.getIndexDefinitions.get(secondaryIndexPartition).getIndexType.equals("secondary_index"))
 
       // update the secondary key column
       spark.sql(s"update $tableName set not_record_key_col = 'xyz' where record_key_col = 'row1'")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -89,8 +89,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           // create functional index
           spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
           val metaClient = createMetaClient(spark, basePath)
-          assertTrue(metaClient.getIndexMetadata.isPresent)
-          val functionalIndexMetadata = metaClient.getIndexMetadata.get()
+          assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+          val functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
@@ -235,8 +235,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
 
           spark.sql(createIndexSql)
           metaClient = createMetaClient(spark, basePath)
-          assertTrue(metaClient.getIndexMetadata.isPresent)
-          var functionalIndexMetadata = metaClient.getIndexMetadata.get()
+          assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+          var functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
@@ -244,7 +244,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           createIndexSql = s"create index name_lower on $tableName using column_stats(ts) options(func='identity')"
           spark.sql(createIndexSql)
           metaClient = createMetaClient(spark, basePath)
-          functionalIndexMetadata = metaClient.getIndexMetadata.get()
+          functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
           assertEquals(2, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_name_lower", functionalIndexMetadata.getIndexDefinitions.get("func_index_name_lower").getIndexName)
 
@@ -301,15 +301,15 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         // create functional index
         spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
         metaClient = createMetaClient(spark, basePath)
-        assertTrue(metaClient.getIndexMetadata.isPresent)
-        var functionalIndexMetadata = metaClient.getIndexMetadata.get()
+        assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+        var functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
         assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
         assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
         // Verify one can create more than one functional index
         spark.sql(s"create index name_lower on $tableName using column_stats(ts) options(func='identity')")
         metaClient = createMetaClient(spark, basePath)
-        functionalIndexMetadata = metaClient.getIndexMetadata.get()
+        functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
         assertEquals(2, functionalIndexMetadata.getIndexDefinitions.size())
         assertEquals("func_index_name_lower", functionalIndexMetadata.getIndexDefinitions.get("func_index_name_lower").getIndexName)
 
@@ -362,11 +362,11 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         var createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
         spark.sql(createIndexSql)
         var metaClient = createMetaClient(spark, basePath)
-        var functionalIndexMetadata = metaClient.getIndexMetadata.get()
+        var functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
         assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
         assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_datestr"))
-        assertTrue(metaClient.getIndexMetadata.isPresent)
+        assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
 
         // do another insert after initializing the index
         spark.sql(s"insert into $tableName values(4, 'a4', 10, 10000000)")
@@ -379,7 +379,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         createIndexSql = s"create index name_lower on $tableName using column_stats(ts) options(func='identity')"
         spark.sql(createIndexSql)
         metaClient = createMetaClient(spark, basePath)
-        functionalIndexMetadata = metaClient.getIndexMetadata.get()
+        functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
         assertEquals(2, functionalIndexMetadata.getIndexDefinitions.size())
         assertEquals("func_index_name_lower", functionalIndexMetadata.getIndexDefinitions.get("func_index_name_lower").getIndexName)
 
@@ -421,8 +421,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
           // validate index created successfully
           val metaClient = createMetaClient(spark, basePath)
-          assertTrue(metaClient.getIndexMetadata.isPresent)
-          val functionalIndexMetadata = metaClient.getIndexMetadata.get()
+          assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+          val functionalIndexMetadata = metaClient.getFunctionalAndSecondaryIndexMetadata.get()
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
@@ -466,8 +466,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
         val metaClient = createMetaClient(spark, basePath)
         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_datestr"))
-        assertTrue(metaClient.getIndexMetadata.isPresent)
-        assertEquals(1, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+        assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+        assertEquals(1, metaClient.getFunctionalAndSecondaryIndexMetadata.get.getIndexDefinitions.size())
 
         // verify functional index records by querying metadata table
         val metadataSql = s"select ColumnStatsMetadata.minValue.member6.value, ColumnStatsMetadata.maxValue.member6.value from hudi_metadata('$tableName') where type=3"
@@ -526,8 +526,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
         val metaClient = createMetaClient(spark, basePath)
         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_datestr"))
-        assertTrue(metaClient.getIndexMetadata.isPresent)
-        assertEquals(1, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+        assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+        assertEquals(1, metaClient.getFunctionalAndSecondaryIndexMetadata.get.getIndexDefinitions.size())
 
         // verify functional index records by querying metadata table
         val metadataSql = s"select ColumnStatsMetadata.minValue.member6.value, ColumnStatsMetadata.maxValue.member6.value from hudi_metadata('$tableName') where type=3"
@@ -615,8 +615,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
             // validate index created successfully
             val metaClient = createMetaClient(spark, basePath)
             assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_datestr"))
-            assertTrue(metaClient.getIndexMetadata.isPresent)
-            assertEquals(1, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+            assertTrue(metaClient.getFunctionalAndSecondaryIndexMetadata.isPresent)
+            assertEquals(1, metaClient.getFunctionalAndSecondaryIndexMetadata.get.getIndexDefinitions.size())
 
             // verify functional index records by querying metadata table
             val metadataSql = s"select ColumnStatsMetadata.minValue.member6.value, ColumnStatsMetadata.maxValue.member6.value from hudi_metadata('$tableName') where type=3"

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1079,7 +1079,7 @@ public class HoodieMetadataTableValidator implements Serializable {
 
   private void validateSecondaryIndex(HoodieSparkEngineContext engineContext, HoodieMetadataValidationContext metadataContext,
                                       HoodieTableMetaClient metaClient) {
-    Collection<HoodieIndexDefinition> indexDefinitions = metaClient.getIndexMetadata().get().getIndexDefinitions().values();
+    Collection<HoodieIndexDefinition> indexDefinitions = metaClient.getFunctionalAndSecondaryIndexMetadata().get().getIndexDefinitions().values();
     for (HoodieIndexDefinition indexDefinition : indexDefinitions) {
       validateSecondaryIndex(engineContext, metadataContext, metaClient, indexDefinition);
     }


### PR DESCRIPTION
### Change Logs

This change refactors the `HoodieIndexMetadata` class by renaming it to `HoodieIndexFunctionalOrSecondaryIndexMetadata`. This refactoring aims to enhance clarity by better representing the class’s purpose, which now explicitly relates to functional and secondary indexing metadata

### Impact

NONE

### Risk level

**Low**
No functional changes are introduced

### Documentation Update

- NA
- **JIRA Ticket:** [HUDI-8398](https://issues.apache.org/jira/projects/HUDI/issues/HUDI-8398)

No new features, configs, or user-facing functionality were introduced.

### Contributor's Checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed