### PR TITLE
[HUDI-8395] Fix metaClient handling when running upgrade or downgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1446,7 +1446,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     UpgradeDowngrade upgradeDowngrade =
         new UpgradeDowngrade(metaClient, config, context, upgradeDowngradeHelper);
 
-    if (upgradeDowngrade.needsUpgradeOrDowngrade(HoodieTableVersion.current())) {
+    if (upgradeDowngrade.needsUpgradeOrDowngrade(config.getWriteVersion())) {
       metaClient = HoodieTableMetaClient.reload(metaClient);
       // Ensure no inflight commits by setting EAGER policy and explicitly cleaning all failed commits
       List<String> instantsToRollback = tableServiceClient.getInstantsToRollback(metaClient, HoodieFailedWritesCleaningPolicy.EAGER, instantTime);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -48,8 +48,6 @@ public class UpgradeDowngrade {
   private HoodieTableMetaClient metaClient;
   protected HoodieWriteConfig config;
   protected HoodieEngineContext context;
-  private StoragePath updatedPropsFilePath;
-  private StoragePath propsFilePath;
 
   public UpgradeDowngrade(
       HoodieTableMetaClient metaClient, HoodieWriteConfig config, HoodieEngineContext context,
@@ -57,9 +55,15 @@ public class UpgradeDowngrade {
     this.metaClient = metaClient;
     this.config = config;
     this.context = context;
-    this.updatedPropsFilePath = new StoragePath(metaClient.getMetaPath(), HOODIE_UPDATED_PROPERTY_FILE);
-    this.propsFilePath = new StoragePath(metaClient.getMetaPath(), HoodieTableConfig.HOODIE_PROPERTIES_FILE);
     this.upgradeDowngradeHelper = upgradeDowngradeHelper;
+  }
+
+  public HoodieTableMetaClient getMetaClient() {
+    return metaClient;
+  }
+
+  public void setMetaClient(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
   }
 
   public boolean needsUpgradeOrDowngrade(HoodieTableVersion toWriteVersion) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -58,14 +58,6 @@ public class UpgradeDowngrade {
     this.upgradeDowngradeHelper = upgradeDowngradeHelper;
   }
 
-  public HoodieTableMetaClient getMetaClient() {
-    return metaClient;
-  }
-
-  public void setMetaClient(HoodieTableMetaClient metaClient) {
-    this.metaClient = metaClient;
-  }
-
   public boolean needsUpgradeOrDowngrade(HoodieTableVersion toWriteVersion) {
     HoodieTableVersion fromTableVersion = metaClient.getTableConfig().getTableVersion();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
@@ -28,8 +28,8 @@ public class CommonClientUtils {
   public static void validateTableVersion(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
     // mismatch of table versions.
     if (!tableConfig.getTableVersion().equals(writeConfig.getWriteVersion())) {
-      throw new HoodieNotSupportedException(String.format("Table version (%s) and Writer version (%s) do not match.",
-          tableConfig.getTableVersion(), writeConfig.getWriteVersion()));
+      throw new HoodieNotSupportedException(String.format("Table version (%s) and Writer version (%s) do not match for table at: %s.",
+          tableConfig.getTableVersion(), writeConfig.getWriteVersion(), writeConfig.getBasePath()));
     }
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -381,14 +381,13 @@ public class HoodieFlinkWriteClient<T> extends
   }
 
   @Override
-  protected HoodieTableMetaClient initTableAndGetMetaClient(WriteOperationType operationType, HoodieTableMetaClient metaClient, Option<String> instantTime) {
+  protected void doInitTable(WriteOperationType operationType, HoodieTableMetaClient metaClient, Option<String> instantTime) {
     // do nothing.
 
     // flink executes the upgrade/downgrade once when initializing the first instant on start up,
     // no need to execute the upgrade/downgrade on each write in streaming.
 
     // flink performs metadata table bootstrap on the coordinator when it starts up.
-    return metaClient;
   }
 
   public void completeTableService(

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -381,13 +381,14 @@ public class HoodieFlinkWriteClient<T> extends
   }
 
   @Override
-  protected void doInitTable(WriteOperationType operationType, HoodieTableMetaClient metaClient, Option<String> instantTime) {
+  protected HoodieTableMetaClient initTableAndGetMetaClient(WriteOperationType operationType, HoodieTableMetaClient metaClient, Option<String> instantTime) {
     // do nothing.
 
     // flink executes the upgrade/downgrade once when initializing the first instant on start up,
     // no need to execute the upgrade/downgrade on each write in streaming.
 
     // flink performs metadata table bootstrap on the coordinator when it starts up.
+    return metaClient;
   }
 
   public void completeTableService(

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -438,6 +438,14 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   /**
+   * Reload the table config properties.
+   */
+  public synchronized void reloadTableConfig() {
+    this.tableConfig = new HoodieTableConfig(this.storage, metaPath,
+        this.tableConfig.getRecordMergeMode(), this.tableConfig.getKeyGeneratorClassName(), this.tableConfig.getRecordMergeStrategyId());
+  }
+
+  /**
    * Returns next instant time in the correct format. Lock is enabled by default.
    */
   public String createNewInstantTime() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
@@ -137,6 +138,7 @@ public class HoodieTestUtils {
   public static HoodieTableMetaClient init(String basePath, HoodieTableType tableType, HoodieTableVersion version) throws IOException {
     Properties properties = new Properties();
     properties.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(version.versionCode()));
+    properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition");
     return init(getDefaultStorageConf(), basePath, tableType, properties);
   }
 


### PR DESCRIPTION
### Change Logs

After debugging, I found that upgrade path is invoked but the `metaClient` is not reloaded after that. Simply reloading in `tryUpgrade` is not enough because we call that in a lambda. So, this PR fixes the issue as follows:

- Updated `doInitTable()` to return the potentially reloaded `metaClient`, allowing `initTable()` to access the updated `metaClient` reference after an upgrade. 
- Enhanced `HoodieCommitMetadata.fromBytes()` method with a fallback mechanism for JSON deserialization given that commit metadata serialization changed from json to avro in 1.0.

Tested manually by running the same steps as mentioned in HUDI-8395.

### Impact

Refactor metaClient handling during upgrade/downgrade, and implement fallback in JSON deserialization.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
