### PR TITLE
[HUDI-8434] Support Flink Async Archive

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncArchiveService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncArchiveService.java
@@ -41,7 +41,7 @@ public class AsyncArchiveService extends HoodieAsyncTableService {
   private final BaseHoodieWriteClient writeClient;
   private final transient ExecutorService executor = Executors.newSingleThreadExecutor();
 
-  protected AsyncArchiveService(BaseHoodieWriteClient writeClient) {
+  public AsyncArchiveService(BaseHoodieWriteClient writeClient) {
     super(writeClient.getConfig());
     this.writeClient = writeClient;
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -346,6 +346,32 @@ public class HoodieFlinkWriteClient<T> extends
     }
   }
 
+  /**
+   * Starts async archiving service for finished commits.
+   *
+   * <p>The Flink write client is designed to write data set as buckets
+   * but archiving action should trigger after all the write actions within a
+   * checkpoint finish.
+   */
+  public void startAsyncArchiving() {
+    tableServiceClient.startAsyncArchiveService(this);
+  }
+
+  /**
+   * Blocks and wait for the async archiving service to finish.
+   *
+   * <p>The Flink write client is designed to write data set as buckets
+   * but archiving action should trigger after all the write actions within a
+   * checkpoint finish.
+   */
+  public void waitForArchivingFinish() {
+    if (tableServiceClient.asyncArchiveService != null) {
+      LOG.info("Archiver has been spawned already. Waiting for it to finish");
+      tableServiceClient.asyncArchive();
+      LOG.info("Archiver has finished");
+    }
+  }
+
   @Override
   public List<WriteStatus> postWrite(HoodieWriteMetadata<List<WriteStatus>> result,
                                      String instantTime,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -238,6 +239,15 @@ public class OptionsResolver {
    */
   public static boolean needsAsyncClustering(Configuration conf) {
     return isInsertOperation(conf) && conf.getBoolean(FlinkOptions.CLUSTERING_ASYNC_ENABLED);
+  }
+
+  /**
+   * Returns whether there is need to execute the async archive.
+   *
+   * @param conf The flink configuration.
+   */
+  public static boolean needsAsyncArchive(Configuration conf) {
+    return conf.getBoolean(HoodieArchivalConfig.ASYNC_ARCHIVE.key(), Boolean.valueOf(HoodieArchivalConfig.ASYNC_ARCHIVE.defaultValue()));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/ArchiveFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/ArchiveFunction.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink;
+
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.sink.utils.NonThrownExecutor;
+import org.apache.hudi.util.FlinkWriteClients;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArchiveFunction<T> extends RichMapFunction<Object, Object> implements CheckpointedFunction, CheckpointListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ArchiveFunction.class);
+
+  private final Configuration conf;
+
+  protected volatile boolean isArchiving;
+
+  private NonThrownExecutor executor;
+
+  private transient HoodieFlinkWriteClient writeClient;
+
+  public ArchiveFunction(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    this.executor = NonThrownExecutor.builder(LOG).waitForTasksFinish(true).build();
+    this.writeClient = FlinkWriteClients.createWriteClient(conf, getRuntimeContext());
+  }
+
+  @Override
+  public void snapshotState(FunctionSnapshotContext context) throws Exception {
+    if (OptionsResolver.needsAsyncArchive(conf) && !isArchiving) {
+      try {
+        this.writeClient.startAsyncArchiving();
+        this.isArchiving = true;
+        LOG.warn("start async archiving for checkpoint " + context.getCheckpointId());
+      } catch (Throwable throwable) {
+        // catch the exception to not affect the normal checkpointing
+        LOG.warn("Error while start async archiving", throwable);
+      }
+    }
+  }
+
+  @Override
+  public void notifyCheckpointComplete(long checkpointId) throws Exception {
+    if (OptionsResolver.needsAsyncArchive(conf) && isArchiving) {
+      executor.execute(() -> {
+        try {
+          this.writeClient.waitForArchivingFinish();
+          LOG.info("wait for archiving finish for checkpoint " + checkpointId);
+        } finally {
+          // ensure to switch the isCleaning flag
+          this.isArchiving = false;
+        }
+      }, "wait for archiving finish");
+    }
+  }
+
+  @Override
+  public void initializeState(FunctionInitializationContext context) throws Exception {
+    // no operation
+  }
+
+  @Override
+  public Object map(Object value) throws Exception {
+    return value;
+  }
+
+  public boolean isArchiving() {
+    return isArchiving;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -27,6 +27,7 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.sink.ArchiveFunction;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.sink.StreamWriteOperator;
 import org.apache.hudi.sink.append.AppendWriteOperator;
@@ -480,6 +481,15 @@ public class Pipelines {
         .name("clean_commits");
     cleanCommitDataStream.getTransformation().setMaxParallelism(1);
     return cleanCommitDataStream;
+  }
+
+  public static DataStream<Object> archive(Configuration conf, DataStream<Object> dataStream) {
+    DataStream<Object> archiveCommitDataStream = dataStream.map(new ArchiveFunction<>(conf))
+        .setParallelism(1)
+        .name("archive_commits")
+        .uid(opUID("archive_commits", conf));
+    archiveCommitDataStream.getTransformation().setMaxParallelism(1);
+    return archiveCommitDataStream;
   }
 
   public static DataStreamSink<Object> dummySink(DataStream<Object> dataStream) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestArchiveFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestArchiveFunction.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink;
+
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.config.HoodieArchivalConfig;
+import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.table.HoodieFlinkTable;
+import org.apache.hudi.util.FlinkTables;
+import org.apache.hudi.util.FlinkWriteClients;
+import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.utils.TestConfigurations;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.api.operators.collect.utils.MockFunctionSnapshotContext;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestArchiveFunction {
+  private HoodieActiveTimeline timeline;
+  private Configuration conf;
+
+  @TempDir
+  File tempFile;
+
+  @BeforeEach
+  public void before() throws IOException {
+    conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    StreamerUtil.initTableIfNotExists(conf);
+  }
+
+  @Test
+  void testSyncedPartitions() throws Exception {
+    // Step1: build 4 completed HoodieInstant in active timeline
+    HoodieInstant instant1 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "001");
+    HoodieInstant instant1Inflight = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "001");
+    HoodieInstant instant1Completed = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "001");
+
+    HoodieInstant instant2 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "002");
+    HoodieInstant instant2Inflight = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "002");
+    HoodieInstant instant2Completed = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "002");
+
+    HoodieInstant instant3 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "003");
+    HoodieInstant instant3Inflight = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "003");
+    HoodieInstant instant3Completed = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003");
+
+    HoodieInstant instant4 = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "004");
+    HoodieInstant instant4Inflight = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "004");
+    HoodieInstant instant4Completed = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "004");
+
+    HoodieFlinkTable<?> table = FlinkTables.createTable(conf);
+    FlinkWriteClients.createWriteClient(conf);
+    timeline = table.getActiveTimeline();
+    timeline.createNewInstant(instant1);
+    timeline.createNewInstant(instant1Inflight);
+    timeline.createCompleteInstant(instant1Completed);
+
+    timeline.createNewInstant(instant2);
+    timeline.createNewInstant(instant2Inflight);
+    timeline.createCompleteInstant(instant2Completed);
+
+    timeline.createNewInstant(instant3);
+    timeline.createNewInstant(instant3Inflight);
+    timeline.createCompleteInstant(instant3Completed);
+
+    timeline.createNewInstant(instant4);
+    timeline.createNewInstant(instant4Inflight);
+    timeline.createCompleteInstant(instant4Completed);
+
+    // Step2: execute async archive
+    conf.setString(HoodieArchivalConfig.ASYNC_ARCHIVE.key(), "true");
+    conf.setString(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1");
+    conf.set(FlinkOptions.ARCHIVE_MAX_COMMITS, 3);
+    conf.set(FlinkOptions.ARCHIVE_MIN_COMMITS, 2);
+    ArchiveFunction archiveFunction = new ArchiveFunction(conf);
+    OneInputStreamOperatorTestHarness operatorTestHarness = new OneInputStreamOperatorTestHarness<>(new StreamMap(archiveFunction));
+    operatorTestHarness.open();
+    archiveFunction.snapshotState(new MockFunctionSnapshotContext(-1));
+    archiveFunction.notifyCheckpointComplete(-1);
+    // wait for archive finished
+    while (archiveFunction.isArchiving()) {
+      continue;
+    }
+
+    // Step3: check whether the result of archive is correct
+    timeline = timeline.reload();
+    assertTrue(timeline.getCommitsTimeline().countInstants() == 2);
+  }
+}


### PR DESCRIPTION
### Change Logs

archive operation is now executed in Flink JM in sync mode,  which blocks starting a new Instant in heavy work load. 
thus, write performance is affected.
this PR enables async archive in Flink operator.

### Impact

hudi-flink-datasource

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
