### PR TITLE
[HUDI-8499] Complex data types and nested schema support in DataHubSyncTool

### DIFF
--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSchemaExtractor.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSchemaExtractor.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.sync.datahub;
+
+import com.linkedin.schema.SchemaField;
+import com.linkedin.schema.SchemaFieldDataType;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hudi.sync.datahub.DataHubSyncClient.toSchemaFieldDataType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestDataHubSchemaExtractor {
+
+  private SchemaField createSchemaField(
+      String fieldPath, SchemaFieldDataType dataType, String nativeType) {
+    return createSchemaField(fieldPath, dataType, nativeType, false);
+  }
+
+  private SchemaField createSchemaField(
+      String fieldPath, SchemaFieldDataType dataType, String nativeType, boolean isNullable) {
+    return new SchemaField()
+        .setFieldPath(fieldPath)
+        .setType(dataType)
+        .setNativeDataType(nativeType)
+        .setNullable(isNullable);
+  }
+
+  @Test
+  void testPrimitiveTypes() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/primitives.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].intField", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].intFieldV2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].nullField", toSchemaFieldDataType(Schema.Type.NULL), "null"),
+        createSchemaField("[version=2.0].nullFieldV2", toSchemaFieldDataType(Schema.Type.NULL), "null"),
+        createSchemaField("[version=2.0].longField", toSchemaFieldDataType(Schema.Type.LONG), "long"),
+        createSchemaField("[version=2.0].floatField", toSchemaFieldDataType(Schema.Type.FLOAT), "float"),
+        createSchemaField("[version=2.0].doubleField", toSchemaFieldDataType(Schema.Type.DOUBLE), "double"),
+        createSchemaField("[version=2.0].stringField", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].booleanField", toSchemaFieldDataType(Schema.Type.BOOLEAN), "boolean"),
+        createSchemaField("[version=2.0].nullableIntField", toSchemaFieldDataType(Schema.Type.INT), "int", true),
+        createSchemaField("[version=2.0].nullableLongField", toSchemaFieldDataType(Schema.Type.LONG), "long", true),
+        createSchemaField("[version=2.0].nullableStringField", toSchemaFieldDataType(Schema.Type.STRING), "string", true),
+        createSchemaField("[version=2.0].status", toSchemaFieldDataType(Schema.Type.ENUM), "enum")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  @Test
+  void testFailureOnDuplicateNullType() {
+    AvroRuntimeException exception = assertThrows(AvroRuntimeException.class, () -> readAvroSchema("schema/invalid_union.avsc"));
+    assertEquals("Duplicate in union:null", exception.getMessage());
+  }
+
+  @Test
+  void testLogicalTypes() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/logical_types.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].decimalField", toSchemaFieldDataType(Schema.Type.BYTES), "decimal(9,2)"),
+        createSchemaField("[version=2.0].decimalFieldWithoutPrecisionAndScale", toSchemaFieldDataType(Schema.Type.BYTES), "bytes"),
+        createSchemaField("[version=2.0].timestampMillisField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp_ntz_millis"),
+        createSchemaField("[version=2.0].timestampMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp_ntz_micros"),
+        createSchemaField("[version=2.0].dateField", toSchemaFieldDataType(Schema.Type.INT), "date"),
+        createSchemaField("[version=2.0].timeMillisField", toSchemaFieldDataType(Schema.Type.INT), "time_millis"),
+        createSchemaField("[version=2.0].timeMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "time_micros"),
+        createSchemaField("[version=2.0].uuidField", toSchemaFieldDataType(Schema.Type.STRING), "uuid")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  @Test
+  void testComplexTypes_Map() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/complex_map.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].mapOfString", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfString.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfString.value", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfComplexType", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfComplexType.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfComplexType.value", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].mapOfComplexType.value.field1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfComplexType.value.field2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].mapOfNullableString", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfNullableString.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfNullableString.value", toSchemaFieldDataType(Schema.Type.STRING), "string", true),
+        createSchemaField("[version=2.0].mapOfNullableComplexType", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfNullableComplexType.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfNullableComplexType.value", toSchemaFieldDataType(Schema.Type.RECORD), "record", true),
+        createSchemaField("[version=2.0].mapOfNullableComplexType.value.field1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfNullableComplexType.value.field2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].mapOfArray", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfArray.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfArray.value", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].mapOfArray.value.element", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfMap", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfMap.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfMap.value", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfMap.value.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfMap.value.value", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].mapOfUnion", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].mapOfUnion.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfUnion.value", toSchemaFieldDataType(Schema.Type.UNION), "union", true),
+        createSchemaField("[version=2.0].mapOfUnion.value.string", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].mapOfUnion.value.int", toSchemaFieldDataType(Schema.Type.INT), "int")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  @Test
+  void testComplexTypes_Array() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/complex_array.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].arrayOfString", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfString.element", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfMap", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfMap.element", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].arrayOfMap.element.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfMap.element.value", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfRecord", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfRecord.element", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].arrayOfRecord.element.field1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfRecord.element.field2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].arrayOfArray", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfArray.element", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfArray.element.element", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfUnion", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfUnion.element", toSchemaFieldDataType(Schema.Type.UNION), "union"),
+        createSchemaField("[version=2.0].arrayOfUnion.element.string", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfUnion.element.int", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].arrayOfUnion.element.boolean", toSchemaFieldDataType(Schema.Type.BOOLEAN), "boolean"),
+        createSchemaField("[version=2.0].arrayOfNullableString", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfNullableString.element", toSchemaFieldDataType(Schema.Type.STRING), "string", true),
+        createSchemaField("[version=2.0].arrayOfNullableRecord", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].arrayOfNullableRecord.element", toSchemaFieldDataType(Schema.Type.RECORD), "record", true),
+        createSchemaField("[version=2.0].arrayOfNullableRecord.element.field1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].arrayOfNullableRecord.element.field2", toSchemaFieldDataType(Schema.Type.INT), "int")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  @Test
+  void testComplexTypes_Struct() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/complex_struct.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].structField", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].structField.fieldString", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldInt", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].structField.fieldBoolean", toSchemaFieldDataType(Schema.Type.BOOLEAN), "boolean"),
+        createSchemaField("[version=2.0].structField.fieldMap", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].structField.fieldMap.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldMap.value", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldRecord", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].structField.fieldRecord.nestedField1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldRecord.nestedField2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].structField.fieldArray", toSchemaFieldDataType(Schema.Type.ARRAY), "array"),
+        createSchemaField("[version=2.0].structField.fieldArray.element", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldUnion", toSchemaFieldDataType(Schema.Type.UNION), "union", true),
+        createSchemaField("[version=2.0].structField.fieldUnion.string", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldUnion.int", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].structField.fieldNullableMap", toSchemaFieldDataType(Schema.Type.MAP), "map", true),
+        createSchemaField("[version=2.0].structField.fieldNullableMap.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].structField.fieldNullableMap.value", toSchemaFieldDataType(Schema.Type.STRING), "string")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  @Test
+  void testComplexTypes_Union() throws IOException {
+    List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/complex_union.avsc"));
+    List<SchemaField> expectedSchemaFields = Arrays.asList(
+        createSchemaField("[version=2.0].fieldUnionNullablePrimitives", toSchemaFieldDataType(Schema.Type.UNION), "union", true),
+        createSchemaField("[version=2.0].fieldUnionNullablePrimitives.string", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionNullablePrimitives.int", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].fieldUnionNullablePrimitives.boolean", toSchemaFieldDataType(Schema.Type.BOOLEAN), "boolean"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes", toSchemaFieldDataType(Schema.Type.UNION), "union", true),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.NestedRecord", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.NestedRecord.nestedField1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.NestedRecord.nestedField2", toSchemaFieldDataType(Schema.Type.INT), "int"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.map", toSchemaFieldDataType(Schema.Type.MAP), "map"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.map.key", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionComplexTypes.map.value", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionPrimitiveAndComplex", toSchemaFieldDataType(Schema.Type.UNION), "union", true),
+        createSchemaField("[version=2.0].fieldUnionPrimitiveAndComplex.string", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionPrimitiveAndComplex.ComplexTypeRecord", toSchemaFieldDataType(Schema.Type.RECORD), "record"),
+        createSchemaField("[version=2.0].fieldUnionPrimitiveAndComplex.ComplexTypeRecord.complexField1", toSchemaFieldDataType(Schema.Type.STRING), "string"),
+        createSchemaField("[version=2.0].fieldUnionPrimitiveAndComplex.ComplexTypeRecord.complexField2", toSchemaFieldDataType(Schema.Type.INT), "int")
+    );
+
+    assertEquals(expectedSchemaFields, schemaFields);
+  }
+
+  private Schema readAvroSchema(String schemaFileName) throws IOException {
+    String schemaPath = getClass().getClassLoader().getResource(schemaFileName).getPath();
+    File schemaFile = new File(schemaPath);
+    return new Schema.Parser().parse(schemaFile);
+  }
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSchemaExtractor.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSchemaExtractor.java
@@ -83,12 +83,13 @@ class TestDataHubSchemaExtractor {
     List<SchemaField> schemaFields = DataHubSyncClient.createSchemaFields(readAvroSchema("schema/logical_types.avsc"));
     List<SchemaField> expectedSchemaFields = Arrays.asList(
         createSchemaField("[version=2.0].decimalField", toSchemaFieldDataType(Schema.Type.BYTES), "decimal(9,2)"),
+        createSchemaField("[version=2.0].decimalFieldWithoutScale", toSchemaFieldDataType(Schema.Type.BYTES), "decimal(9,0)"),
         createSchemaField("[version=2.0].decimalFieldWithoutPrecisionAndScale", toSchemaFieldDataType(Schema.Type.BYTES), "bytes"),
-        createSchemaField("[version=2.0].timestampMillisField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp_ntz_millis"),
-        createSchemaField("[version=2.0].timestampMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp_ntz_micros"),
+        createSchemaField("[version=2.0].timestampMillisField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp-millis"),
+        createSchemaField("[version=2.0].timestampMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "timestamp-micros"),
         createSchemaField("[version=2.0].dateField", toSchemaFieldDataType(Schema.Type.INT), "date"),
-        createSchemaField("[version=2.0].timeMillisField", toSchemaFieldDataType(Schema.Type.INT), "time_millis"),
-        createSchemaField("[version=2.0].timeMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "time_micros"),
+        createSchemaField("[version=2.0].timeMillisField", toSchemaFieldDataType(Schema.Type.INT), "time-millis"),
+        createSchemaField("[version=2.0].timeMicrosField", toSchemaFieldDataType(Schema.Type.LONG), "time-micros"),
         createSchemaField("[version=2.0].uuidField", toSchemaFieldDataType(Schema.Type.STRING), "uuid")
     );
 

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_array.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_array.avsc
@@ -1,0 +1,87 @@
+{
+  "type": "record",
+  "name": "ArrayType",
+  "fields": [
+    {
+      "name": "arrayOfString",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "arrayOfMap",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "map",
+          "values": "string"
+        }
+      }
+    },
+    {
+      "name": "arrayOfRecord",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ComplexType",
+          "fields": [
+            {
+              "name": "field1",
+              "type": "string"
+            },
+            {
+              "name": "field2",
+              "type": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "arrayOfArray",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": "string"
+        }
+      }
+    },
+    {
+      "name": "arrayOfUnion",
+      "type": {
+        "type": "array",
+        "items": ["string", "int", "boolean"]
+      }
+    },
+    {
+      "name": "arrayOfNullableString",
+      "type": {
+        "type": "array",
+        "items": ["null", "string"]
+      }
+    },
+    {
+      "name": "arrayOfNullableRecord",
+      "type": {
+        "type": "array",
+        "items": ["null", {
+          "type": "record",
+          "name": "ComplexTypeNullable",
+          "fields": [
+            {
+              "name": "field1",
+              "type": "string"
+            },
+            {
+              "name": "field2",
+              "type": "int"
+            }
+          ]
+        }]
+      }
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_map.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_map.avsc
@@ -1,0 +1,87 @@
+{
+  "type": "record",
+  "name": "MapType",
+  "fields": [
+    {
+      "name": "mapOfString",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
+    },
+    {
+      "name": "mapOfComplexType",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "ComplexType",
+          "fields": [
+            {
+              "name": "field1",
+              "type": "string"
+            },
+            {
+              "name": "field2",
+              "type": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "mapOfNullableString",
+      "type": {
+        "type": "map",
+        "values": ["null", "string"]
+      }
+    },
+    {
+      "name": "mapOfNullableComplexType",
+      "type": {
+        "type": "map",
+        "values": ["null", {
+          "type": "record",
+          "name": "ComplexTypeNullable",
+          "fields": [
+            {
+              "name": "field1",
+              "type": "string"
+            },
+            {
+              "name": "field2",
+              "type": "int"
+            }
+          ]
+        }]
+      }
+    },
+    {
+      "name": "mapOfArray",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "array",
+          "items": "string"
+        }
+      }
+    },
+    {
+      "name": "mapOfMap",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "map",
+          "values": "int"
+        }
+      }
+    },
+    {
+      "name": "mapOfUnion",
+      "type": {
+        "type": "map",
+        "values": ["null", "string", "int"]
+      }
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_struct.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_struct.avsc
@@ -1,0 +1,76 @@
+{
+  "type": "record",
+  "name": "StructType",
+  "fields": [
+    {
+      "name": "structField",
+      "type": {
+        "type": "record",
+        "name": "ComplexStruct",
+        "fields": [
+          {
+            "name": "fieldString",
+            "type": "string"
+          },
+          {
+            "name": "fieldInt",
+            "type": "int"
+          },
+          {
+            "name": "fieldBoolean",
+            "type": "boolean"
+          },
+          {
+            "name": "fieldMap",
+            "type": {
+              "type": "map",
+              "values": "string"
+            }
+          },
+          {
+            "name": "fieldRecord",
+            "type": {
+              "type": "record",
+              "name": "NestedRecord",
+              "fields": [
+                {
+                  "name": "nestedField1",
+                  "type": "string"
+                },
+                {
+                  "name": "nestedField2",
+                  "type": "int"
+                }
+              ]
+            }
+          },
+          {
+            "name": "fieldArray",
+            "type": {
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "fieldUnion",
+            "type": [
+              "null",
+              "string",
+              "int"
+            ]
+          },
+          {
+            "name": "fieldNullableMap",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "string"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_union.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/complex_union.avsc
@@ -1,0 +1,60 @@
+{
+  "type": "record",
+  "name": "UnionType",
+  "fields": [
+    {
+      "name": "fieldUnionNullablePrimitives",
+      "type": [
+        "null",
+        "string",
+        "int",
+        "boolean"
+      ]
+    },
+    {
+      "name": "fieldUnionComplexTypes",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "NestedRecord",
+          "fields": [
+            {
+              "name": "nestedField1",
+              "type": "string"
+            },
+            {
+              "name": "nestedField2",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ]
+    },
+    {
+      "name": "fieldUnionPrimitiveAndComplex",
+      "type": [
+        "null",
+        "string",
+        {
+          "type": "record",
+          "name": "ComplexTypeRecord",
+          "fields": [
+            {
+              "name": "complexField1",
+              "type": "string"
+            },
+            {
+              "name": "complexField2",
+              "type": "int"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/invalid_union.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/invalid_union.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "PrimitiveType",
+  "fields": [
+    {
+      "name": "intField",
+      "type": "int"
+    },
+    {
+      "name": "nullField",
+      "type": "null"
+    },
+    {
+      "name": "nullFieldV2",
+      "type": ["null", "long", "null"]
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/logical_types.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/logical_types.avsc
@@ -1,0 +1,64 @@
+{
+  "type": "record",
+  "name": "LogicalTypes",
+  "fields": [
+    {
+      "name": "decimalField",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
+    },
+    {
+      "name": "decimalFieldWithoutPrecisionAndScale",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal"
+      }
+    },
+    {
+      "name": "timestampMillisField",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
+      "name": "timestampMicrosField",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-micros"
+      }
+    },
+    {
+      "name": "dateField",
+      "type": {
+        "type": "int",
+        "logicalType": "date"
+      }
+    },
+    {
+      "name": "timeMillisField",
+      "type": {
+        "type": "int",
+        "logicalType": "time-millis"
+      }
+    },
+    {
+      "name": "timeMicrosField",
+      "type": {
+        "type": "long",
+        "logicalType": "time-micros"
+      }
+    },
+    {
+      "name": "uuidField",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    }
+  ]
+}

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/logical_types.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/logical_types.avsc
@@ -12,6 +12,14 @@
       }
     },
     {
+      "name": "decimalFieldWithoutScale",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9
+      }
+    },
+    {
       "name": "decimalFieldWithoutPrecisionAndScale",
       "type": {
         "type": "bytes",

--- a/hudi-sync/hudi-datahub-sync/src/test/resources/schema/primitives.avsc
+++ b/hudi-sync/hudi-datahub-sync/src/test/resources/schema/primitives.avsc
@@ -1,0 +1,62 @@
+{
+  "type": "record",
+  "name": "PrimitiveType",
+  "fields": [
+    {
+      "name": "intField",
+      "type": "int"
+    },
+    {
+      "name": "intFieldV2",
+      "type": ["int"]
+    },
+    {
+      "name": "nullField",
+      "type": "null"
+    },
+    {
+      "name": "nullFieldV2",
+      "type": ["null"]
+    },
+    {
+      "name": "longField",
+      "type": "long"
+    },
+    {
+      "name": "floatField",
+      "type": "float"
+    },
+    {
+      "name": "doubleField",
+      "type": "double"
+    },
+    {
+      "name": "stringField",
+      "type": "string"
+    },
+    {
+      "name": "booleanField",
+      "type": "boolean"
+    },
+    {
+      "name": "nullableIntField",
+      "type": ["null", "int"]
+    },
+    {
+      "name": "nullableLongField",
+      "type": ["null", "long"]
+    },
+    {
+      "name": "nullableStringField",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "status",
+      "type": {
+        "type": "enum",
+        "name": "StatusEnum",
+        "symbols": ["ACTIVE", "INACTIVE", "PENDING"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Change Logs

Currently, nested schema and complex data types are not handled properly in DataHubSyncTool and only root level fields get synced leaving behind child ones. This PR adds support for complex data types and nested schema which makes schema navigation in the DataHub UI more intuitive

### Impact

No api changes. This PR updates a helper method in DataHubSyncClient for creating DataHub schema out of Avro schema

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
