### PR TITLE
[HUDI-8500] Add line wrapping indentation check

### DIFF
--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -198,6 +198,7 @@
             <property name="caseIndent" value="2"/>
             <property name="throwsIndent" value="4"/>
             <property name="lineWrappingIndentation" value="4"/>
+            <property name="forceStrictCondition" value="true"/>
             <property name="arrayInitIndent" value="2"/>
         </module>
         <!--


### PR DESCRIPTION
### Change Logs

Add line wrapping indentation check: `forceStrictCondition=true`

Explanation about CheckStyle Option `forceStrictCondition`:
```
Force strict indent level in line wrapping case.
 If value is true, line wrap indent have to be same as lineWrappingIndentation parameter. 
 If value is false, line wrap indent could be bigger on any value user would like.
```

### Impact
Help identify issues with inconsistent line wrapping and indentation, such as:

#### 1. Function Parameter Line Wrapping
```
// `Context context` is indented by 6 characters
public StreamWriteOperatorCoordinator(
      Configuration conf,
         Context context) {
    this.conf = conf;
    this.context = context;
    this.parallelism = context.currentParallelism();
    this.storageConf = HadoopFSUtils.getStorageConfWithCopy(HadoopConfigurations.getHiveConf(conf));
  }
```

```
  // `int numEntries` is aligned with `(`
  private static void verifyHFileReadCompatibility(String filename,
                                                   int numEntries,
                                                   Option<Function<Integer, String>> keyCreator) throws IOException {
    try (HFileReader reader = getHFileReader(filename)) {
      reader.initializeMetadata();
      verifyHFileMetadataCompatibility(reader, numEntries);
      verifyHFileValuesInSequentialReads(reader, numEntries, keyCreator);
    }
  }
```

#### 2. Inconsistent Line Wrapping and Indentation
```
validatePathInfoList(
        Arrays.stream(new StoragePathInfo[] {
            getStoragePathInfo("x/1.file", false),
            getStoragePathInfo("x/2.file", false),
            getStoragePathInfo("x/y", true),
            getStoragePathInfo("x/z", true)
        }).collect(Collectors.toList()),
        storage.listDirectEntries(new StoragePath(getTempDir(), "x")));
```

### Risk level (write none, low medium or high below)

high

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
