### PR TITLE
Update sql_ddl.md for Flink SQL table creation with partitioning fix

### DIFF
--- a/website/versioned_docs/version-0.15.0/sql_ddl.md
+++ b/website/versioned_docs/version-0.15.0/sql_ddl.md
@@ -593,7 +593,8 @@ CREATE TABLE hudi_table(
   id BIGINT PRIMARY KEY NOT ENFORCED,
   name STRING,
   price DOUBLE,
-  ts BIGINT
+  ts BIGINT,
+  dt STRING
 )
 PARTITIONED BY (`dt`)
 WITH (


### PR DESCRIPTION
In the previous "Create table with record keys and ordering fields" section, the example created a table with a partitioned column `dt` that was not defined in the schema. This omission will cause errors when running the SQL code, as Flink SQL requires all partitioned columns to be present in the table schema.

This commit updates `sql_ddl.md` to include the `dt` column in the table schema when using `PARTITIONED BY (dt)`, ensuring that the example can be executed without errors. Additionally, it clarifies that all partition columns must exist in the schema to prevent similar issues.

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
