### PR TITLE
[HUDI-8504] Fix missing database config when building Hudi configs in Spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodieRecordMer
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.util.{ReflectionUtils, StringUtils}
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieInternalConfig, HoodieWriteConfig}
+import org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME
 import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
 import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder, MultiPartKeysValueExtractor}
 import org.apache.hudi.hive.ddl.HiveSyncMode
@@ -82,6 +83,7 @@ trait ProvidesHoodieConfig extends Logging {
     val overridingOpts = Map[String, String](
       "path" -> hoodieCatalogTable.tableLocation,
       RECORDKEY_FIELD.key -> hoodieCatalogTable.primaryKeys.mkString(","),
+      DATABASE_NAME.key -> hoodieCatalogTable.table.database,
       TBL_NAME.key -> hoodieCatalogTable.tableName,
       PRECOMBINE_FIELD.key -> preCombineField,
       HIVE_STYLE_PARTITIONING.key -> tableConfig.getHiveStylePartitioningEnable,
@@ -328,6 +330,7 @@ trait ProvidesHoodieConfig extends Logging {
     val overridingOpts = extraOptions ++ Map(
       "path" -> path,
       TABLE_TYPE.key -> tableType,
+      DATABASE_NAME.key -> hoodieCatalogTable.table.database,
       TBL_NAME.key -> hoodieCatalogTable.tableName,
       OPERATION.key -> operation,
       HIVE_STYLE_PARTITIONING.key -> hiveStylePartitioningEnable,
@@ -422,6 +425,7 @@ trait ProvidesHoodieConfig extends Logging {
     val overridingOpts = Map(
       "path" -> hoodieCatalogTable.tableLocation,
       TBL_NAME.key -> hoodieCatalogTable.tableName,
+      DATABASE_NAME.key -> hoodieCatalogTable.table.database,
       TABLE_TYPE.key -> hoodieCatalogTable.tableTypeName,
       OPERATION.key -> DataSourceWriteOptions.DELETE_PARTITION_OPERATION_OPT_VAL,
       PARTITIONS_TO_DELETE.key -> partitionsToDrop,
@@ -471,6 +475,7 @@ trait ProvidesHoodieConfig extends Logging {
       "path" -> path,
       RECORDKEY_FIELD.key -> hoodieCatalogTable.primaryKeys.mkString(","),
       TBL_NAME.key -> tableConfig.getTableName,
+      DATABASE_NAME.key -> hoodieCatalogTable.table.database,
       HIVE_STYLE_PARTITIONING.key -> tableConfig.getHiveStylePartitioningEnable,
       URL_ENCODE_PARTITIONING.key -> tableConfig.getUrlEncodePartitioning,
       OPERATION.key -> DataSourceWriteOptions.DELETE_OPERATION_OPT_VAL,

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
@@ -24,8 +24,9 @@ import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.hive.HiveSyncConfig
 import org.apache.hudi.keygen.{ComplexKeyGenerator, CustomKeyGenerator}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.{RuntimeConfig, SQLContext, SparkSession}
-import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HoodieCatalogTable}
 import org.apache.spark.sql.internal.{SQLConf, SessionState, StaticSQLConf}
 import org.apache.spark.sql.types.StructType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -95,7 +96,11 @@ class TestProvidesHoodieConfig {
     when(mockCatalog.preCombineKey).thenCallRealMethod()
     when(mockCatalog.partitionSchema).thenReturn(StructType(Nil))
     when(mockCatalog.primaryKeys).thenReturn(Array("key"))
-    when(mockCatalog.tableName).thenReturn("hudi_table")
+    when(mockCatalog.table).thenReturn(CatalogTable.apply(
+      TableIdentifier.apply("hudi_table", Option.apply("hudi_database")),
+      CatalogTableType.EXTERNAL,
+      CatalogStorageFormat.empty,
+      StructType(Nil)))
     val props = new TypedProperties()
     props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key, "segment")
     val mockTableConfig = spy(classOf[HoodieTableConfig])


### PR DESCRIPTION
### Change Logs

The current implementation missed database when building hudi config, which will lead to obtain the incorrect table even though the table exists. Such as the case of `spark writing data`
https://github.com/apache/hudi/blob/cea81e82fdeecec4e1d7eb53ae1f8e9eaeede11c/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala#L97

https://github.com/apache/hudi/blob/cea81e82fdeecec4e1d7eb53ae1f8e9eaeede11c/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala#L251-L254
Because the value of `DATABASE_NAME.key` is lost when `buildHoodieInsertConfig`, so `databaseName` is empty in `tableIdentifier`.
https://github.com/apache/hudi/blob/cea81e82fdeecec4e1d7eb53ae1f8e9eaeede11c/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala#L667-L670

https://github.com/apache/hudi/blob/cea81e82fdeecec4e1d7eb53ae1f8e9eaeede11c/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala#L674-L680
Then the table under the `databaseName` cannot be obtained or the table under the `default database` is obtained, it is obviously inconsistent with expectation.

this PR fix this bug.
### Impact

hudi-spark-common

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
