### PR TITLE
[HUDI-8468] use payload to do merging inside the expression payload

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.OperationModeAwareness;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 
+import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +113,10 @@ public class HoodieRecordUtils {
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new HoodieException("Unable to instantiate payload class ", e);
     }
+  }
+
+  public static <T extends HoodieRecordPayload> T loadPayload(String recordPayloadClass, GenericRecord record, Comparable orderingValue) {
+    return HoodieRecordUtils.loadPayload(recordPayloadClass, new Object[] {record, orderingValue}, GenericRecord.class, Comparable.class);
   }
 
   public static boolean recordTypeCompatibleEngine(HoodieRecordType recordType, EngineType engineType) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -464,6 +464,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
     )
 
+    // Append original payload class
+    writeParams ++= Seq(
+      PAYLOAD_ORIGINAL_AVRO_PAYLOAD -> hoodieCatalogTable.tableConfig.getPayloadClass
+    )
+
     val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, writeParams, sourceDF)
     if (!success) {
       throw new HoodieException("Merge into Hoodie table command failed")

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -186,8 +186,6 @@ class ExpressionPayload(@transient record: GenericRecord,
         val incomingRecordPayload = HoodieRecordUtils.loadPayload(originalPayload, incomingRecord,
           HoodieAvroUtils.getNestedFieldVal(incomingRecord, orderingField, true, consistentLogicalTimestampEnabled)
             .asInstanceOf[Comparable[_]]).asInstanceOf[HoodieRecordPayload[_ <: HoodieRecordPayload[_]]]
-        // if the PreCombine field value of targetRecord is greater
-        // than the new incoming record, just keep the old record value.
         incomingRecordPayload.combineAndGetUpdateValue(existingRecord, schema, properties)
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -23,11 +23,12 @@ import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 import org.apache.hudi.avro.AvroSchemaUtils.{isNullable, resolveNullableSchema}
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro
-import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodiePayloadProps, HoodieRecord}
+import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodiePayloadProps, HoodieRecord, HoodieRecordPayload}
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.hudi.common.util.{BinaryUtil, ConfigUtils, StringUtils, ValidationUtils, Option => HOption}
+import org.apache.hudi.common.util.{BinaryUtil, ConfigUtils, HoodieRecordUtils, StringUtils, ValidationUtils, Option => HOption}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import org.apache.avro.Schema
@@ -132,12 +133,23 @@ class ExpressionPayload(@transient record: GenericRecord,
           .serialize(resultingRow)
           .asInstanceOf[GenericRecord]
 
-        if (targetRecord.isEmpty || needUpdatingPersistedRecord(targetRecord.get, resultingAvroRecord, properties)) {
+        if (targetRecord.isEmpty) {
           resultRecordOpt = HOption.of(resultingAvroRecord)
         } else {
-          // if the PreCombine field value of targetRecord is greater
-          // than the new incoming record, just keep the old record value.
-          resultRecordOpt = HOption.of(targetRecord.get)
+          val orderingField = ConfigUtils.getOrderingField(properties)
+          if (StringUtils.isNullOrEmpty(orderingField)) {
+            resultRecordOpt = HOption.of(resultingAvroRecord)
+          } else {
+            val originalPayload = properties.getProperty(PAYLOAD_ORIGINAL_AVRO_PAYLOAD)
+            val consistentLogicalTimestampEnabled = properties.getProperty(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key,
+              KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue).toBoolean
+            val incomingRecordPayload = HoodieRecordUtils.loadPayload(originalPayload, resultingAvroRecord,
+              HoodieAvroUtils.getNestedFieldVal(resultingAvroRecord, orderingField, true, consistentLogicalTimestampEnabled)
+                .asInstanceOf[Comparable[_]]).asInstanceOf[HoodieRecordPayload[_ <: HoodieRecordPayload[_]]]
+            // if the PreCombine field value of targetRecord is greater
+            // than the new incoming record, just keep the old record value.
+            resultRecordOpt = incomingRecordPayload.combineAndGetUpdateValue(targetRecord.get, writerSchema, properties)
+          }
         }
       }
     }
@@ -313,6 +325,11 @@ object ExpressionPayload {
    * Property holding record's original (Avro) schema
    */
   val PAYLOAD_RECORD_AVRO_SCHEMA = "hoodie.payload.record.schema"
+
+  /**
+   * Original record payload
+   */
+  val PAYLOAD_ORIGINAL_AVRO_PAYLOAD = "hoodie.payload.original.avro.payload"
 
   /**
    * Property associated w/ expected combined schema of the joined records of the source (incoming batch)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -167,10 +167,10 @@ class ExpressionPayload(@transient record: GenericRecord,
                             existingRecord: IndexedRecord,
                             schema: Schema,
                             properties: Properties): HOption[IndexedRecord] = {
-    val originalPayload = properties.getProperty(PAYLOAD_ORIGINAL_AVRO_PAYLOAD)
-    if (originalPayload.equals(classOf[OverwriteWithLatestAvroPayload].getName)) {
+    val tablePayloadClass = properties.getProperty(PAYLOAD_ORIGINAL_AVRO_PAYLOAD)
+    if (tablePayloadClass.equals(classOf[OverwriteWithLatestAvroPayload].getName)) {
       HOption.of(incomingRecord)
-    } else if (originalPayload.equals(classOf[DefaultHoodieRecordPayload].getName)) {
+    } else if (tablePayloadClass.equals(classOf[DefaultHoodieRecordPayload].getName)) {
       if (needUpdatingPersistedRecord(existingRecord, incomingRecord, properties)) {
         HOption.of(incomingRecord)
       } else {
@@ -183,7 +183,7 @@ class ExpressionPayload(@transient record: GenericRecord,
       } else {
         val consistentLogicalTimestampEnabled = properties.getProperty(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key,
           KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue).toBoolean
-        val incomingRecordPayload = HoodieRecordUtils.loadPayload(originalPayload, incomingRecord,
+        val incomingRecordPayload = HoodieRecordUtils.loadPayload(tablePayloadClass, incomingRecord,
           HoodieAvroUtils.getNestedFieldVal(incomingRecord, orderingField, true, consistentLogicalTimestampEnabled)
             .asInstanceOf[Comparable[_]]).asInstanceOf[HoodieRecordPayload[_ <: HoodieRecordPayload[_]]]
         incomingRecordPayload.combineAndGetUpdateValue(existingRecord, schema, properties)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.common.config.RecordMergeMode
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
@@ -1029,5 +1030,84 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
       // check partitions
       checkAnswer(s"show partitions $destTable")(Seq("dt=2022-09-26"))
     }
+  }
+
+  test("Test MergeInto with various payloads") {
+      withTempDir { tmp =>
+        Seq(RecordMergeMode.EVENT_TIME_ORDERING.name(),
+          RecordMergeMode.OVERWRITE_WITH_LATEST.name()).foreach { recordMergeMode =>
+          val sourceTable = generateTableName
+          spark.sql(
+            s"""
+               |CREATE TABLE $sourceTable (
+               |    id INT,
+               |    name STRING,
+               |    price INT,
+               |    ts BIGINT
+               |) USING hudi
+               |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
+               |""".stripMargin)
+          spark.sql(
+            s"""
+               | INSERT INTO $sourceTable
+               | VALUES (1, 'John Doe', 19, 1),
+               |        (4, 'Alice Johnson', 49, 2)
+               |""".stripMargin)
+
+          val targetTable = generateTableName
+          spark.sql(
+            s"""
+               |create table $targetTable (
+               |  id INT,
+               |  name STRING,
+               |  price INT,
+               |  ts BIGINT
+               |) using hudi
+               |TBLPROPERTIES (
+               |  type = 'cow',
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts',
+               |  recordMergeMode = '$recordMergeMode'
+               | )
+               |LOCATION '${tmp.getCanonicalPath}/$targetTable'
+               |""".stripMargin)
+
+          spark.sql(
+            s"""
+               |INSERT INTO $targetTable
+               |SELECT id, name, price, ts
+               |FROM (
+               |    SELECT 1 as id, 'John Doe' as name, 19 as price, 1598886001 as ts
+               |     UNION ALL
+               |     SELECT 2, 'Jane Doe', 24, 1598972400
+               |     UNION ALL
+               |     SELECT 3, 'Bob Smith', 14, 1599058800
+               |)
+               |""".stripMargin)
+
+          spark.sql(
+            s"""
+               |MERGE INTO $targetTable t
+               |USING $sourceTable s
+               |ON t.price = s.price
+               |WHEN MATCHED THEN UPDATE SET
+               |    t.id = s.id,
+               |    t.name = s.name,
+               |    t.price = s.price,
+               |    t.ts = s.ts
+               |WHEN NOT MATCHED THEN INSERT
+               |    (id, name, price, ts)
+               |VALUES
+               |    (s.id, s.name, s.price, s.ts)
+               |""".stripMargin)
+
+
+          checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
+            Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.EVENT_TIME_ORDERING.name()) 1598886001L else 1L),
+            Seq(2, "Jane Doe", 24, 1598972400L),
+            Seq(3, "Bob Smith", 14, 1599058800L),
+            Seq(4, "Alice Johnson", 49, 2L))
+        }
+      }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.model.FirstValueAvroPayload
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
@@ -952,7 +953,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
 
   test("Test MOR Table with create empty partitions") {
     withTempDir { tmp =>
-
       val sourceTable = generateTableName
       val path1 = tmp.getCanonicalPath.concat("/source")
       spark.sql(
@@ -1032,10 +1032,18 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
     }
   }
 
+
+
   test("Test MergeInto with various payloads") {
       withTempDir { tmp =>
         Seq(RecordMergeMode.EVENT_TIME_ORDERING.name(),
-          RecordMergeMode.OVERWRITE_WITH_LATEST.name()).foreach { recordMergeMode =>
+          RecordMergeMode.OVERWRITE_WITH_LATEST.name(),
+          RecordMergeMode.CUSTOM.name()).foreach { recordMergeMode =>
+          val payloadClassExtraString = if (recordMergeMode == RecordMergeMode.CUSTOM.name()) {
+            s" payloadClass = '${classOf[FirstValueAvroPayload].getName}',"
+          } else {
+            ""
+          }
           val sourceTable = generateTableName
           spark.sql(
             s"""
@@ -1051,7 +1059,8 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
             s"""
                | INSERT INTO $sourceTable
                | VALUES (1, 'John Doe', 19, 1),
-               |        (4, 'Alice Johnson', 49, 2)
+               |        (4, 'Alice Johnson', 49, 2),
+               |        (5, 'Baker Mayfield', 6, 10)
                |""".stripMargin)
 
           val targetTable = generateTableName
@@ -1067,6 +1076,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |  type = 'cow',
                |  primaryKey = 'id',
                |  preCombineField = 'ts',
+               |  $payloadClassExtraString
                |  recordMergeMode = '$recordMergeMode'
                | )
                |LOCATION '${tmp.getCanonicalPath}/$targetTable'
@@ -1082,6 +1092,8 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |     SELECT 2, 'Jane Doe', 24, 1598972400
                |     UNION ALL
                |     SELECT 3, 'Bob Smith', 14, 1599058800
+               |     UNION ALL
+               |     SELECT 5, 'Baker Mayfield', 60, 10
                |)
                |""".stripMargin)
 
@@ -1103,10 +1115,11 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
 
 
           checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
-            Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.EVENT_TIME_ORDERING.name()) 1598886001L else 1L),
+            Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.OVERWRITE_WITH_LATEST.name()) 1L else 1598886001L),
             Seq(2, "Jane Doe", 24, 1598972400L),
             Seq(3, "Bob Smith", 14, 1599058800L),
-            Seq(4, "Alice Johnson", 49, 2L))
+            Seq(4, "Alice Johnson", 49, 2L),
+            Seq(5, "Baker Mayfield", if (recordMergeMode == RecordMergeMode.CUSTOM.name()) 60 else 6, 10L))
         }
       }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -1045,6 +1045,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
             ""
           }
           val sourceTable = generateTableName
+
           spark.sql(
             s"""
                |CREATE TABLE $sourceTable (
@@ -1055,6 +1056,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |) USING hudi
                |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
                |""".stripMargin)
+
           spark.sql(
             s"""
                | INSERT INTO $sourceTable
@@ -1112,7 +1114,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |VALUES
                |    (s.id, s.name, s.price, s.ts)
                |""".stripMargin)
-
 
           checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
             Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.OVERWRITE_WITH_LATEST.name()) 1L else 1598886001L),


### PR DESCRIPTION
### Change Logs
Use payload to do merging inside of expression payload.
If your tables payload was overwrite with latest, and you did MIT, it would use ordering field if defined. Now we will use the actual payload.

### Impact
MIT is more correct

### Risk level (write none, low medium or high below)
low

### Documentation Update
N/A



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
