### PR TITLE
[MINOR] Update Avro URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ analytical datasets on DFS (Cloud stores, HDFS or any Hadoop FileSystem compatib
 * Optimize data lake layout with clustering
  
 Hudi supports three types of queries:
- * **Snapshot Query** - Provides snapshot queries on real-time data, using a combination of columnar & row-based storage (e.g [Parquet](https://parquet.apache.org/) + [Avro](https://avro.apache.org/)).
+ * **Snapshot Query** - Provides snapshot queries on real-time data, using a combination of columnar & row-based storage (e.g [Parquet](https://parquet.apache.org/) + [Avro](https://avro.apache.org/docs/)).
  * **Incremental Query** - Provides a change stream with records inserted or updated after a point in time.
  * **Read Optimized Query** - Provides excellent snapshot query performance via purely columnar storage (e.g. [Parquet](https://parquet.apache.org/)).
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ analytical datasets on DFS (Cloud stores, HDFS or any Hadoop FileSystem compatib
 * Optimize data lake layout with clustering
  
 Hudi supports three types of queries:
- * **Snapshot Query** - Provides snapshot queries on real-time data, using a combination of columnar & row-based storage (e.g [Parquet](https://parquet.apache.org/) + [Avro](https://avro.apache.org/docs/current/mr.html)).
+ * **Snapshot Query** - Provides snapshot queries on real-time data, using a combination of columnar & row-based storage (e.g [Parquet](https://parquet.apache.org/) + [Avro](https://avro.apache.org/)).
  * **Incremental Query** - Provides a change stream with records inserted or updated after a point in time.
  * **Read Optimized Query** - Provides excellent snapshot query performance via purely columnar storage (e.g. [Parquet](https://parquet.apache.org/)).
 


### PR DESCRIPTION
### Change Logs
The previous [Avro documentation URL](https://avro.apache.org/docs/current/mr.html) was outdated and non-functional. This has been updated in the README to [the correct Avro documentation link](https://avro.apache.org/docs/).


### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
Yes

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
