### PR TITLE
[HUDI-8513] Fix equals in HoodieRecordGlobalLocation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
@@ -67,8 +67,7 @@ public final class HoodieRecordGlobalLocation extends HoodieRecordLocation {
     HoodieRecordGlobalLocation otherLoc = (HoodieRecordGlobalLocation) o;
     return Objects.equals(partitionPath, otherLoc.partitionPath)
         && Objects.equals(instantTime, otherLoc.instantTime)
-        && Objects.equals(fileId, otherLoc.fileId)
-        && Objects.equals(position, otherLoc.position);
+        && Objects.equals(fileId, otherLoc.fileId);
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordGlobalLocation.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordGlobalLocation.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestHoodieRecordGlobalLocation {
+  @Test
+  void testEquals() {
+    String partitionPath = "any_partition";
+    String instantTime = "any_instant_time";
+    String fileId = "any_file_id";
+    HoodieRecordGlobalLocation thisLocation =
+        new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId, 0L);
+    HoodieRecordGlobalLocation thatLocation =
+        new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId, 1L);
+    assertTrue(thisLocation.equals(thatLocation));
+  }
+}


### PR DESCRIPTION
### Change Logs

We remove the `position` from the `equals` function; otherwise, the workload profile will be huge and can cause OOM issue.

### Impact

Better performance when using global indexes.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
