### PR TITLE
[HUDI-8519] Fix update with multiple secondary indexes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1169,14 +1169,16 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     HoodieData<HoodieRecord> deletedRecords = getDeletedSecondaryRecordMapping(engineContext, recordKeySecondaryKeyMap, indexDefinition);
     int parallelism = Math.min(partitionFilePairs.size(), dataWriteConfig.getMetadataConfig().getSecondaryIndexParallelism());
 
-    return deletedRecords.union(readSecondaryKeysFromBaseFiles(
+    return readSecondaryKeysFromBaseFiles(
         engineContext,
         partitionFilePairs,
         parallelism,
         this.getClass().getSimpleName(),
         dataMetaClient,
         getEngineType(),
-        indexDefinition));
+        indexDefinition)
+        .union(deletedRecords)
+        .distinctWithKey(HoodieRecord::getKey, parallelism);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -907,7 +907,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
         fileGroupCount, partitionName, metadataPartition.getFileIdPrefix(), instantTime);
     LOG.info(msg);
     final List<String> fileGroupFileIds = IntStream.range(0, fileGroupCount)
-        .mapToObj(i -> HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i))
+        .mapToObj(i -> HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i, partitionName))
         .collect(Collectors.toList());
     ValidationUtils.checkArgument(fileGroupFileIds.size() == fileGroupCount);
     engineContext.setJobStatus(this.getClass().getSimpleName(), msg);

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -2408,7 +2408,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
   @Test
   public void testGetFileGroupIndexFromFileId() {
     int index = new Random().nextInt(10000);
-    String fileId = HoodieTableMetadataUtil.getFileIDForFileGroup(FILES, index);
+    String fileId = HoodieTableMetadataUtil.getFileIDForFileGroup(FILES, index, FILES.getPartitionPath());
     assertEquals(fileId.substring(0, fileId.length() - 2), HoodieTableMetadataUtil.getFileGroupPrefix(fileId));
     assertEquals(index, HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -3140,7 +3140,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   @Test
   public void testGetFileGroupIndexFromFileId() {
     int index = new Random().nextInt(10000);
-    String fileId = HoodieTableMetadataUtil.getFileIDForFileGroup(FILES, index);
+    String fileId = HoodieTableMetadataUtil.getFileIDForFileGroup(FILES, index, FILES.getPartitionPath());
     assertEquals(fileId.substring(0, fileId.length() - 2), HoodieTableMetadataUtil.getFileGroupPrefix(fileId));
     assertEquals(index, HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId));
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1660,7 +1660,10 @@ public class HoodieTableMetadataUtil {
    * @param index         Index of the file group within the partition
    * @return The fileID
    */
-  public static String getFileIDForFileGroup(MetadataPartitionType partitionType, int index) {
+  public static String getFileIDForFileGroup(MetadataPartitionType partitionType, int index, String partitionName) {
+    if (MetadataPartitionType.FUNCTIONAL_INDEX.equals(partitionType) || MetadataPartitionType.SECONDARY_INDEX.equals(partitionType)) {
+      return String.format("%s%04d-%d", partitionName.replaceAll("_", "-").concat("-"), index, 0);
+    }
     return String.format("%s%04d-%d", partitionType.getFileIdPrefix(), index, 0);
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getFileIDForFileGroup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -305,5 +306,26 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
       writer.writeWithMetadata(record.getKey(), record, HoodieTestDataGenerator.AVRO_SCHEMA_WITH_METADATA_FIELDS);
     }
     writer.close();
+  }
+
+  @Test
+  public void testGetFileGroupIndexFromFileId() {
+    String result = getFileIDForFileGroup(MetadataPartitionType.FILES, 1, "test_partition");
+    assertEquals("files-0001-0", result);
+
+    result = getFileIDForFileGroup(MetadataPartitionType.COLUMN_STATS, 2, "stats_partition");
+    assertEquals("col-stats-0002-0", result);
+
+    result = getFileIDForFileGroup(MetadataPartitionType.BLOOM_FILTERS, 3, "bloom_partition");
+    assertEquals("bloom-filters-0003-0", result);
+
+    result = getFileIDForFileGroup(MetadataPartitionType.RECORD_INDEX, 4, "record_partition");
+    assertEquals("record-index-0004-0", result);
+
+    result = getFileIDForFileGroup(MetadataPartitionType.SECONDARY_INDEX, 6, "secondary_index_idx_ts");
+    assertEquals("secondary-index-idx-ts-0006-0", result);
+
+    result = getFileIDForFileGroup(MetadataPartitionType.FUNCTIONAL_INDEX, 5, "func_index_ts");
+    assertEquals("func-index-ts-0005-0", result);
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -51,7 +51,7 @@ import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource}
 import org.scalatest.Assertions.{assertResult, assertThrows}
 
 import java.util.concurrent.Executors
-import scala.collection.JavaConverters
+import scala.collection.{JavaConverters, Seq}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -195,14 +195,24 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       // update the secondary key column after creating multiple secondary indexes
       spark.sql(s"update $tableName set not_record_key_col = 'xyz' where record_key_col = 'row1'")
       // validate the secondary index records themselves
-      checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7 and key like '%row1'")(
-        Seq(s"xyz${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false)
+      checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7")(
+        // row1 record is updated
+        Seq(s"xyz${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false),
+        Seq(s"cde${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
+        Seq(s"def${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row3", false),
+        Seq(s"1${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false),
+        Seq(s"2${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
+        Seq(s"3${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row3", false)
       )
       // validate data and data skipping
       checkAnswer(s"select ts, record_key_col, not_record_key_col, partition_key_col from $tableName where record_key_col = 'row1'")(
         Seq(1, "row1", "xyz", "p1")
       )
+      checkAnswer(s"select ts, record_key_col, not_record_key_col, partition_key_col from $tableName where ts = 1")(
+        Seq(1, "row1", "xyz", "p1")
+      )
       verifyQueryPredicate(hudiOpts, "not_record_key_col", "abc")
+      verifyQueryPredicate(hudiOpts, "ts")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -51,7 +51,7 @@ import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource}
 import org.scalatest.Assertions.{assertResult, assertThrows}
 
 import java.util.concurrent.Executors
-import scala.collection.{JavaConverters, Seq}
+import scala.collection.JavaConverters
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.scalatest.Ignore
 
 import java.util.stream.Collectors
-import scala.collection.{JavaConverters, Seq}
+import scala.collection.JavaConverters
 
 @Ignore
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -551,7 +551,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           Seq("ts", null, null, "2020-09-26", "2021-09-26", false), // for file in name=a1
           Seq("ts", null, null, "2022-09-26", "2022-09-26", false), // for file in name=a2
           Seq("price", 10.0, 10.0, null, null, false), // for file in name=a1
-          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a2
+          Seq("price", 10.0, 10.0, null, null, false) // for file in name=a2
         )
 
         // do an update after initializing the index
@@ -577,7 +577,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           Seq("ts", null, null, "2022-09-26", "2022-09-26", false), // for file in name=a2
           Seq("price", 10.0, 10.0, null, null, false), // for file in name=a1
           Seq("price", 5.0, 5.0, null, null, false), // for update of id=1
-          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a2
+          Seq("price", 10.0, 10.0, null, null, false) // for file in name=a2
         )
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.scalatest.Ignore
 
 import java.util.stream.Collectors
-import scala.collection.JavaConverters
+import scala.collection.{JavaConverters, Seq}
 
 @Ignore
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {
@@ -498,6 +498,86 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           Seq("2020-09-26", "2021-09-26"),
           Seq("2022-09-26", "2022-09-26"),
           Seq("2024-09-26", "2024-09-26") // for file in name=a3
+        )
+      }
+    }
+  }
+
+  test("Test Multiple Functional Index Update") {
+    if (HoodieSparkUtils.gteqSpark3_3) {
+      withTempDir { tmp =>
+        // create a simple partitioned mor table and insert some records
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  price double,
+             |  ts long,
+             |  name string
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = 'mor',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(name)
+             | location '$basePath'
+       """.stripMargin)
+        // a record with from_unixtime(ts, 'yyyy-MM-dd') = 2020-09-26
+        spark.sql(s"insert into $tableName values(1, 10, 1601098924, 'a1')")
+        // a record with from_unixtime(ts, 'yyyy-MM-dd') = 2021-09-26
+        spark.sql(s"insert into $tableName values(2, 10, 1632634924, 'a1')")
+        // a record with from_unixtime(ts, 'yyyy-MM-dd') = 2022-09-26
+        spark.sql(s"insert into $tableName values(3, 10, 1664170924, 'a2')")
+        // create functional index and verify
+        spark.sql(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
+        var metaClient = createMetaClient(spark, basePath)
+        assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_datestr"))
+        assertTrue(metaClient.getIndexMetadata.isPresent)
+        assertEquals(1, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+
+        // create functional index and verify
+        spark.sql(s"create index idx_price on $tableName using column_stats(price) options(func='identity')")
+        metaClient = createMetaClient(spark, basePath)
+        assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains("func_index_idx_price"))
+        assertEquals(2, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+
+        // verify functional index records by querying metadata table
+        val metadataSql = s"select ColumnStatsMetadata.columnName, ColumnStatsMetadata.minValue.member4.value, ColumnStatsMetadata.maxValue.member4.value, " +
+          s"ColumnStatsMetadata.minValue.member6.value, ColumnStatsMetadata.maxValue.member6.value, ColumnStatsMetadata.isDeleted from hudi_metadata('$tableName') where type=3"
+        checkAnswer(metadataSql)(
+          Seq("ts", null, null, "2020-09-26", "2021-09-26", false), // for file in name=a1
+          Seq("ts", null, null, "2022-09-26", "2022-09-26", false), // for file in name=a2
+          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a1
+          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a2
+        )
+
+        // do an update after initializing the index
+        // set price as 5.0 for id=1
+        spark.sql(s"update $tableName set price = 5.0 where id = 1")
+
+        // check query result for predicates including both the functional index columns
+        checkAnswer(s"select id, price from $tableName where price <= 8")(
+          Seq(1, 5.0)
+        )
+        checkAnswer(s"select id, price from $tableName where price > 8")(
+          Seq(2, 10.0),
+          Seq(3, 10.0)
+        )
+        checkAnswer(s"select id, name from $tableName where from_unixtime(ts, 'yyyy-MM-dd') >= '2022-09-26'")(
+          Seq(3, "a2")
+        )
+
+        // verify there are new updates to functional index
+        checkAnswer(metadataSql)(
+          Seq("ts", null, null, "2020-09-26", "2021-09-26", false), // for file in name=a1
+          Seq("ts", null, null, "2020-09-26", "2020-09-26", false), // for update of id=1
+          Seq("ts", null, null, "2022-09-26", "2022-09-26", false), // for file in name=a2
+          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a1
+          Seq("price", 5.0, 5.0, null, null, false), // for update of id=1
+          Seq("price", 10.0, 10.0, null, null, false), // for file in name=a2
         )
       }
     }


### PR DESCRIPTION
### Change Logs

Multiple secondary indexes (or functional index) exist in different partitions but still we use the same file id prefix. So, thre is a chance of collision in the append handle when two different secondary index have same file id prefix and same shard. This PR fixes the file id prefix in such a case. Added updates to the existing test case which creates multiple secondary index.

### Impact

Fix updates with multiple secondary indexes.

### Risk level (write none, low medium or high below)

low
only affects sec index and func index.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
