### PR TITLE
[HUDI-8533] Bloom functional Index creation without function fails

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -151,7 +151,7 @@ public class SparkMetadataWriterUtils {
   }
 
   public static HoodieData<HoodieRecord> getFunctionalIndexRecordsUsingBloomFilter(Dataset<Row> dataset, String columnToIndex,
-                                                                                   HoodieWriteConfig metadataWriteConfig, String instantTime) {
+                                                                                   HoodieWriteConfig metadataWriteConfig, String instantTime, String indexName) {
     // Group data using functional index metadata and then create bloom filter on the group
     Dataset<HoodieRecord> bloomFilterRecords = dataset.select(columnToIndex, SparkMetadataWriterUtils.getFunctionalIndexColumnNames())
         // row.get(1) refers to partition path value and row.get(2) refers to file name.
@@ -166,7 +166,7 @@ public class SparkMetadataWriterUtils {
             bloomFilter.add(key);
           });
           ByteBuffer bloomByteBuffer = ByteBuffer.wrap(getUTF8Bytes(bloomFilter.serializeToString()));
-          HoodieRecord bloomFilterRecord = createBloomFilterMetadataRecord(partition, fileName, instantTime, metadataWriteConfig.getBloomFilterType(), bloomByteBuffer, false);
+          HoodieRecord bloomFilterRecord = createBloomFilterMetadataRecord(partition, fileName, instantTime, metadataWriteConfig.getBloomFilterType(), bloomByteBuffer, false, indexName);
           return Collections.singletonList(bloomFilterRecord).iterator();
         }), Encoders.kryo(HoodieRecord.class));
     return HoodieJavaRDD.of(bloomFilterRecords.javaRDD());

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -216,7 +216,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_COLUMN_STATS)) {
       return SparkMetadataWriterUtils.getFunctionalIndexRecordsUsingColumnStats(rowDataset, functionalIndex, columnToIndex);
     } else if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_BLOOM_FILTERS)) {
-      return SparkMetadataWriterUtils.getFunctionalIndexRecordsUsingBloomFilter(rowDataset, columnToIndex, metadataWriteConfig, instantTime);
+      return SparkMetadataWriterUtils.getFunctionalIndexRecordsUsingBloomFilter(rowDataset, columnToIndex, metadataWriteConfig, instantTime, indexDefinition.getIndexName());
     } else {
       throw new UnsupportedOperationException(indexDefinition.getIndexType() + " is not yet supported");
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -194,6 +194,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
           long fileSize = filePathSizePair.getValue();
           List<Row> rowsForFilePath = readRecordsAsRows(new StoragePath[] {new StoragePath(filePath)}, sqlContext, metaClient, readerSchema, dataWriteConfig,
               FSUtils.isBaseFile(new StoragePath(filePath.substring(filePath.lastIndexOf("/") + 1))));
+          //FIXME-vc: this may OOM. since its not done lazily.
           List<Row> rowsWithIndexMetadata = SparkMetadataWriterUtils.getRowsWithFunctionalIndexMetadata(rowsForFilePath, partition, filePath, fileSize);
           return rowsWithIndexMetadata.iterator();
         });

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -90,6 +90,7 @@ import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.index.functional.HoodieFunctionalIndex.SPARK_IDENTITY;
 import static org.apache.hudi.io.storage.HoodieIOFactory.getIOFactory;
 
 /**
@@ -218,7 +219,7 @@ public class HoodieTableMetaClient implements Serializable {
         "Index metadata is already present");
     String indexMetaPath = getIndexDefinitionPath();
     List<String> columnNames = new ArrayList<>(columns.keySet());
-    HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition(indexName, indexType, options.get("func"), columnNames, options);
+    HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition(indexName, indexType, options.getOrDefault("func", SPARK_IDENTITY), columnNames, options);
     if (indexMetadataOpt.isPresent()) {
       indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -223,7 +223,9 @@ public class HoodieTableMetaClient implements Serializable {
     if (indexMetadataOpt.isPresent()) {
       indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
     } else {
-      indexMetadataOpt = Option.of(new HoodieIndexMetadata(Collections.singletonMap(indexName, indexDefinition)));
+      Map<String, HoodieIndexDefinition> indexDefinitionMap = new HashMap<>();
+      indexDefinitionMap.put(indexName, indexDefinition);
+      indexMetadataOpt = Option.of(new HoodieIndexMetadata(indexDefinitionMap));
     }
     try {
       FileIOUtils.createFileInPath(storage, new StoragePath(indexMetaPath), Option.of(getUTF8Bytes(indexMetadataOpt.get().toJson())));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -71,7 +71,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public interface HoodieFunctionalIndex<S, T> extends Serializable {
 
-  String HOODIE_FUNCTIONAL_INDEX_FILE_PATH = "_hoodie_functional_index_file_path";
+  String HOODIE_FUNCTIONAL_INDEX_RELATIVE_FILE_PATH = "_hoodie_functional_index_relative_file_path";
   String HOODIE_FUNCTIONAL_INDEX_PARTITION = "_hoodie_functional_index_partition";
   String HOODIE_FUNCTIONAL_INDEX_FILE_SIZE = "_hoodie_functional_index_file_size";
   String SPARK_DATE_FORMAT = "date_format";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -166,14 +166,14 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
   }
 
   @Override
-  public Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName) throws HoodieMetadataException {
-    if (!dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.BLOOM_FILTERS)) {
-      LOG.error("Metadata bloom filter index is disabled!");
+  public Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName, final String metadataPartitionName) throws HoodieMetadataException {
+    if (!dataMetaClient.getTableConfig().getMetadataPartitions().contains(metadataPartitionName)) {
+      LOG.error("Metadata partition not found {}", metadataPartitionName);
       return Option.empty();
     }
 
     final Pair<String, String> partitionFileName = Pair.of(partitionName, fileName);
-    Map<Pair<String, String>, BloomFilter> bloomFilters = getBloomFilters(Collections.singletonList(partitionFileName));
+    Map<Pair<String, String>, BloomFilter> bloomFilters = getBloomFilters(Collections.singletonList(partitionFileName), metadataPartitionName);
     if (bloomFilters.isEmpty()) {
       LOG.error("Meta index: missing bloom filter for partition: {}, file: {}", partitionName, fileName);
       return Option.empty();
@@ -184,10 +184,10 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
   }
 
   @Override
-  public Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList)
+  public Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList, final String metadataPartitionName)
       throws HoodieMetadataException {
-    if (!dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.BLOOM_FILTERS)) {
-      LOG.error("Metadata bloom filter index is disabled!");
+    if (!dataMetaClient.getTableConfig().getMetadataPartitions().contains(metadataPartitionName)) {
+      LOG.error("Metadata partition not found {}", metadataPartitionName);
       return Collections.emptyMap();
     }
     if (partitionNameFileNameList.isEmpty()) {
@@ -206,7 +206,7 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
 
     List<String> partitionIDFileIDStringsList = new ArrayList<>(partitionIDFileIDStrings);
     Map<String, HoodieRecord<HoodieMetadataPayload>> hoodieRecords =
-        getRecordsByKeys(partitionIDFileIDStringsList, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+        getRecordsByKeys(partitionIDFileIDStringsList, metadataPartitionName);
     metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_BLOOM_FILTERS_METADATA_STR, timer.endTimer()));
     metrics.ifPresent(m -> m.setMetric(HoodieMetadataMetrics.LOOKUP_BLOOM_FILTERS_FILE_COUNT_STR, partitionIDFileIDStringsList.size()));
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -168,7 +168,7 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
   @Override
   public Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName, final String metadataPartitionName) throws HoodieMetadataException {
     if (!dataMetaClient.getTableConfig().getMetadataPartitions().contains(metadataPartitionName)) {
-      LOG.error("Metadata partition not found {}", metadataPartitionName);
+      LOG.error("Metadata bloom filter index is disabled!");
       return Option.empty();
     }
 
@@ -187,7 +187,7 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
   public Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList, final String metadataPartitionName)
       throws HoodieMetadataException {
     if (!dataMetaClient.getTableConfig().getMetadataPartitions().contains(metadataPartitionName)) {
-      LOG.error("Metadata partition not found {}", metadataPartitionName);
+      LOG.error("Metadata bloom filter index is disabled!");
       return Collections.emptyMap();
     }
     if (partitionNameFileNameList.isEmpty()) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -285,13 +285,13 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     // no-op
   }
 
-  public Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName)
+  public Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName, final String metadataPartitionName)
       throws HoodieMetadataException {
     throw new HoodieMetadataException("Unsupported operation: getBloomFilter for " + fileName);
   }
 
   @Override
-  public Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList)
+  public Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList, final String metadataPartitionName)
       throws HoodieMetadataException {
     throw new HoodieMetadataException("Unsupported operation: getBloomFilters!");
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -288,6 +288,15 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     return new HoodieAvroRecord<>(key, payload);
   }
 
+  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecord(final String partitionName,
+                                                                                    final String baseFileName,
+                                                                                    final String timestamp,
+                                                                                    final String bloomFilterType,
+                                                                                    final ByteBuffer bloomFilter,
+                                                                                    final boolean isDeleted) {
+    return createBloomFilterMetadataRecord(partitionName, baseFileName, timestamp, bloomFilterType, bloomFilter, isDeleted, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+  }
+
   /**
    * Create bloom filter metadata record.
    *
@@ -303,12 +312,13 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
                                                                                     final String timestamp,
                                                                                     final String bloomFilterType,
                                                                                     final ByteBuffer bloomFilter,
-                                                                                    final boolean isDeleted) {
+                                                                                    final boolean isDeleted,
+                                                                                    String metadataPartitionName) {
     checkArgument(!baseFileName.contains(StoragePath.SEPARATOR)
             && FSUtils.isBaseFile(new StoragePath(baseFileName)),
         "Invalid base file '" + baseFileName + "' for MetaIndexBloomFilter!");
     final String bloomFilterIndexKey = getBloomFilterRecordKey(partitionName, baseFileName);
-    HoodieKey key = new HoodieKey(bloomFilterIndexKey, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+    HoodieKey key = new HoodieKey(bloomFilterIndexKey, metadataPartitionName);
 
     HoodieMetadataBloomFilter metadataBloomFilter =
         new HoodieMetadataBloomFilter(bloomFilterType, timestamp, bloomFilter, isDeleted);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -202,7 +202,21 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * @return BloomFilter if available, otherwise empty
    * @throws HoodieMetadataException
    */
-  Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName)
+  default Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName)
+      throws HoodieMetadataException {
+    return getBloomFilter(partitionName, fileName, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+  }
+
+  /**
+   * Get the bloom filter for the FileID from the metadata table.
+   *
+   * @param partitionName         - Partition name
+   * @param fileName              - File name for which bloom filter needs to be retrieved
+   * @param metadataPartitionName - Metadata partition name
+   * @return BloomFilter if available, otherwise empty
+   * @throws HoodieMetadataException
+   */
+  Option<BloomFilter> getBloomFilter(final String partitionName, final String fileName, final String metadataPartitionName)
       throws HoodieMetadataException;
 
   /**
@@ -212,7 +226,20 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * @return Map of partition file name pair to its bloom filter
    * @throws HoodieMetadataException
    */
-  Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList)
+  default Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList)
+      throws HoodieMetadataException {
+    return getBloomFilters(partitionNameFileNameList, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+  }
+
+  /**
+   * Get bloom filters for files from the metadata table index.
+   *
+   * @param partitionNameFileNameList - List of partition and file name pair for which bloom filters need to be retrieved
+   * @param metadataPartitionName     - Metadata partition name
+   * @return Map of partition file name pair to its bloom filter
+   * @throws HoodieMetadataException
+   */
+  Map<Pair<String, String>, BloomFilter> getBloomFilters(final List<Pair<String, String>> partitionNameFileNameList, final String metadataPartitionName)
       throws HoodieMetadataException;
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -335,6 +335,13 @@ public enum MetadataPartitionType {
         || metadataPartitionPath.startsWith(FUNCTIONAL_INDEX.getPartitionPath());
   }
 
+  public static String getGenericIndexNameWithoutPrefix(String indexName) {
+    String prefix = indexName.startsWith(SECONDARY_INDEX.getPartitionPath())
+        ? SECONDARY_INDEX.getPartitionPath()
+        : FUNCTIONAL_INDEX.getPartitionPath();
+    return indexName.substring(prefix.length());
+  }
+
   // Partition path in metadata table.
   private final String partitionPath;
   // FileId prefix used for all file groups in this partition.

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -18,13 +18,16 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.StoragePath;
 
 import org.apache.hadoop.fs.Path;
@@ -33,6 +36,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -242,5 +248,28 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     String randomDefinitionPath = "/a/b/c";
     metaClient.getTableConfig().setValue(HoodieTableConfig.INDEX_DEFINITION_PATH.key(), "/a/b/c");
     assertEquals(randomDefinitionPath, metaClient.getIndexDefinitionPath());
+  }
+
+  @Test
+  public void testDeleteDefinition() throws IOException {
+    final String basePath = tempDir.toAbsolutePath() + Path.SEPARATOR + "t7";
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.newTableBuilder()
+        .setTableType(HoodieTableType.COPY_ON_WRITE.name())
+        .setTableName("table")
+        .initTable(this.metaClient.getStorageConf(), basePath);
+    Map<String, Map<String, String>> columnsMap = new HashMap<>();
+    columnsMap.put("c1", Collections.emptyMap());
+    String indexName = MetadataPartitionType.FUNCTIONAL_INDEX.getPartitionPath() + "idx";
+    metaClient.buildIndexDefinition(indexName, "column_stats",
+        columnsMap, Collections.emptyMap());
+    assertTrue(metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(indexName));
+    assertTrue(metaClient.getStorage().exists(new StoragePath(metaClient.getIndexDefinitionPath())));
+    metaClient.deleteIndexDefinition(indexName);
+    assertTrue(metaClient.getIndexMetadata().isEmpty());
+    assertTrue(metaClient.getStorage().exists(new StoragePath(metaClient.getIndexDefinitionPath())));
+    // Read from storage
+    HoodieIndexMetadata indexMetadata = HoodieIndexMetadata.fromJson(
+        new String(FileIOUtils.readDataFromPath(metaClient.getStorage(), new StoragePath(metaClient.getIndexDefinitionPath())).get()));
+    assertTrue(indexMetadata.getIndexDefinitions().isEmpty());
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -219,7 +219,7 @@ class FunctionalIndexSupport(spark: SparkSession,
     columnStatsRecords
   }
 
-  private def getPrunedPartitionsAndFileNamesMap(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
+  def getPrunedPartitionsAndFileNamesMap(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
                                                  includeLogFiles: Boolean = false): Map[String, Set[String]] = {
     prunedPartitionsAndFileSlices.foldLeft(Map.empty[String, Set[String]]) {
       case (partitionToFileMap, (partitionPathOpt, fileSlices)) =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -22,19 +22,20 @@ package org.apache.hudi
 import org.apache.hudi.FunctionalIndexSupport._
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.HoodieSparkFunctionalIndex.SPARK_FUNCTION_MAP
+import org.apache.hudi.RecordLevelIndexSupport.filterQueryWithRecordKey
 import org.apache.hudi.avro.model.{HoodieMetadataColumnStats, HoodieMetadataRecord}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieData
-import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
+import org.apache.hudi.common.model.{FileSlice, HoodieIndexDefinition, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.hash.{ColumnIndexID, PartitionIndexID}
 import org.apache.hudi.data.HoodieJavaRDD
-import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
+import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil, MetadataPartitionType}
 import org.apache.hudi.util.JFunction
 import org.apache.spark.sql.HoodieUnsafeUtils.{createDataFrameFromInternalRows, createDataFrameFromRDD}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -57,9 +58,9 @@ class FunctionalIndexSupport(spark: SparkSession,
                                          prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
                                          shouldPushDownFilesFilter: Boolean
                                         ): Option[Set[String]] = {
-    lazy val functionalIndexPartitionOpt = getFunctionalIndexPartition(queryFilters)
+    lazy val functionalIndexPartitionOpt = getFunctionalIndexPartitionAndLiterals(queryFilters)
     if (isIndexAvailable && queryFilters.nonEmpty && functionalIndexPartitionOpt.nonEmpty) {
-      val indexPartition = functionalIndexPartitionOpt.get
+      val (indexPartition, literals) = functionalIndexPartitionOpt.get
       val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.get(indexPartition)
       if (indexDefinition.getIndexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS)) {
         val readInMemory = shouldReadInMemory(fileIndex, queryReferencedColumns, inMemoryProjectionThreshold)
@@ -68,8 +69,7 @@ class FunctionalIndexSupport(spark: SparkSession,
         Some(getCandidateFiles(indexDf, queryFilters, prunedFileNames))
       } else if (indexDefinition.getIndexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS)) {
         val prunedPartitionAndFileNames = getPrunedPartitionsAndFileNamesMap(prunedPartitionsAndFileSlices, includeLogFiles = true)
-        // TODO: we should get the list of keys to pass from queryFilters
-        Option.apply(getCandidateFilesForKeys(indexPartition, prunedPartitionAndFileNames, List("sunnyvale")))
+        Option.apply(getCandidateFilesForKeys(indexPartition, prunedPartitionAndFileNames, literals))
       } else {
         Option.empty
       }
@@ -89,6 +89,23 @@ class FunctionalIndexSupport(spark: SparkSession,
     metadataConfig.isEnabled && metaClient.getIndexMetadata.isPresent && !metaClient.getIndexMetadata.get().getIndexDefinitions.isEmpty
   }
 
+  def filterQueriesWithFunctionalFilterKey(queryFilters: Seq[Expression], sourceFieldOpt: Option[String]): List[Tuple2[Expression, List[String]]] = {
+    var functionalIndexQueries: List[Tuple2[Expression, List[String]]] = List.empty
+    for (query <- queryFilters) {
+      filterQueryWithRecordKey(query, sourceFieldOpt, (expr: Expression) => {
+        expr match {
+          case expression: UnaryExpression => expression.child
+          case other => other
+        }
+      }).foreach({
+        case (exp: Expression, literals: List[String]) =>
+          functionalIndexQueries = functionalIndexQueries :+ Tuple2.apply(exp, literals)
+      })
+    }
+
+    functionalIndexQueries
+  }
+
   /**
    * Searches for an index partition based on the specified index function and target column name.
    *
@@ -102,18 +119,19 @@ class FunctionalIndexSupport(spark: SparkSession,
    * @return An `Option` containing the index partition identifier if a matching index definition is found.
    *         Returns `None` if no matching index definition is found.
    */
-  private def getFunctionalIndexPartition(queryFilters: Seq[Expression]): Option[String] = {
-    val functionToColumnNames = extractSparkFunctionNames(queryFilters)
-    if (functionToColumnNames.nonEmpty) {
-      // Currently, only one functional index in the query is supported. HUDI-7620 for supporting multiple functions.
-      checkState(functionToColumnNames.size == 1, "Currently, only one function with functional index in the query is supported")
-      val (indexFunction, targetColumnName) = functionToColumnNames.head
-      val indexDefinitions = metaClient.getIndexMetadata.get().getIndexDefinitions
-      indexDefinitions.asScala.collectFirst {
-        case (indexPartition, indexDefinition)
-          if indexDefinition.getIndexFunction.equals(indexFunction) && indexDefinition.getSourceFields.contains(targetColumnName) =>
-          indexPartition
-      }
+  private def getFunctionalIndexPartitionAndLiterals(queryFilters: Seq[Expression]): Option[Tuple2[String, List[String]]] = {
+    val indexDefinitions = metaClient.getIndexMetadata.get().getIndexDefinitions.asScala
+    if (indexDefinitions.nonEmpty) {
+      val functionDefinitions = indexDefinitions.values
+        .filter(definition => MetadataPartitionType.fromPartitionPath(definition.getIndexName).equals(MetadataPartitionType.FUNCTIONAL_INDEX))
+        .toList
+      functionDefinitions.foreach(indexDefinition => {
+        val queryInfoOpt = extractQueryAndLiterals(queryFilters, indexDefinition)
+        if (queryInfoOpt.isDefined) {
+          return Option.apply(Tuple2.apply(indexDefinition.getIndexName, queryInfoOpt.get._2))
+        }
+      })
+      Option.empty
     } else {
       Option.empty
     }
@@ -128,26 +146,17 @@ class FunctionalIndexSupport(spark: SparkSession,
    * one of the functions and operates on a single column, this method maps the function name to the
    * column name.
    */
-  private def extractSparkFunctionNames(queryFilters: Seq[Expression]): Map[String, String] = {
-    queryFilters.flatMap { expr =>
-      // Support only simple binary expression on single column
-      if (expr.references.size == 1) {
-        val targetColumnName = expr.references.head.name
-        // Check if the expression string contains any of the function names
-        val exprString = expr.toString
-        val functionNameOption = SPARK_FUNCTION_MAP.asScala.keys
-          .find(exprString.contains)
-
-        // TODO: We should check the index metadata first to see if there is a functional index matching the column name
-        //       in the expression. If so, then check whether the indexFunction in that index metadata is also present
-        //       in the expression. If so, then return the indexFunction and the column name. If not, then return identity.
-        //       If there is no functional index metadata for the column name, then return None.
-        val functionName = functionNameOption.getOrElse("identity")
-        Some(functionName -> targetColumnName)
-      } else {
-        None // Skip expressions that do not match the criteria
+  private def extractQueryAndLiterals(queryFilters: Seq[Expression], indexDefinition: HoodieIndexDefinition): Option[(Expression, List[String])] = {
+    val functionalIndexQueries = filterQueriesWithFunctionalFilterKey(queryFilters, Option.apply(indexDefinition.getSourceFields.get(0)))
+    functionalIndexQueries.foreach { tuple =>
+      val (expr, literals) = (tuple._1, tuple._2)
+      val functionNameOption = SPARK_FUNCTION_MAP.asScala.keys.find(expr.toString.contains)
+      val functionName = functionNameOption.getOrElse("identity")
+      if (indexDefinition.getIndexFunction.equals(functionName)) {
+        return Option.apply(Tuple2.apply(expr, literals))
       }
-    }.toMap
+    }
+    Option.empty
   }
 
   def loadFunctionalIndexDataFrame(indexPartition: String,

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
@@ -101,5 +101,4 @@ class TestSecondaryIndexSupport {
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
   }
-
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.JsonUtils
 import org.apache.hudi.exception.HoodieIndexException
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
-import org.apache.hudi.metadata.MetadataPartitionType
+import org.apache.hudi.metadata.{HoodieTableMetadataUtil, MetadataPartitionType}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -51,7 +51,9 @@ case class CreateIndexCommand(table: CatalogTable,
       new util.LinkedHashMap[String, java.util.Map[String, String]]()
     columns.map(c => columnsMap.put(c._1.mkString("."), c._2.asJava))
 
-    if (options.contains("func") || indexType.equals("secondary_index")) {
+    if (indexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX)
+      || indexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS)
+      || indexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS)) {
       val extraOpts = options ++ table.properties
       HoodieSparkIndexClient.getInstance(sparkSession).create(
         metaClient, indexName, indexType, columnsMap, extraOpts.asJava)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -1236,6 +1236,9 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       spark.sql("set hoodie.parquet.small.file.limit=0")
       spark.sql("set hoodie.enable.data.skipping=true")
       spark.sql("set hoodie.metadata.enable=true")
+      if (HoodieSparkUtils.gteqSpark3_4) {
+        spark.sql("set spark.sql.defaultColumn.enabled=false")
+      }
 
       spark.sql(
         s"""|INSERT INTO $tableName(ts, id, rider, driver, fare, city, state) VALUES

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -1289,8 +1289,7 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
            |    hoodie.metadata.enable = 'true',
            |    hoodie.metadata.record.index.enable = 'true',
            |    hoodie.datasource.write.recordkey.field = 'id',
-           |    hoodie.enable.data.skipping = 'true',
-           |    hoodie.metadata.record.index.enable='true'
+           |    hoodie.enable.data.skipping = 'true'
            | )
            | PARTITIONED BY (city, state)
            | location '$basePath'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -988,7 +988,6 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
     }
   }
 
-
   /**
    * Test case to write with updates and validate secondary index with clustering.
    */
@@ -1112,6 +1111,8 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
     }
   }
 
+
+
   private def confirmLastCommitType(actionType: ActionType): Unit = {
     metaClient = HoodieTableMetaClient.reload(metaClient)
     val instants = metaClient.getActiveTimeline.getInstants
@@ -1197,13 +1198,169 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
     }
   }
 
+  @Test
+  def testBloomFiltersIndexWithChanges(): Unit = {
+    if (HoodieSparkUtils.gteqSpark3_3) {
+      val tableName = "test_bloom_filters_index_with_changes"
+      val hudiOpts = commonOpts ++ Map(
+        DataSourceWriteOptions.TABLE_TYPE.key -> MOR_TABLE_TYPE_OPT_VAL,
+        DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
+      val sqlTableType = "cow"
+
+      spark.sql(
+        s"""
+           CREATE TABLE $tableName (
+           |    ts BIGINT,
+           |    id STRING,
+           |    rider STRING,
+           |    driver STRING,
+           |    fare DOUBLE,
+           |    city STRING,
+           |    state STRING
+           |) USING HUDI
+           |options(
+           |    primaryKey ='id',
+           |    type = '$sqlTableType',
+           |    hoodie.metadata.enable = 'true',
+           |    hoodie.datasource.write.recordkey.field = 'id',
+           |    hoodie.enable.data.skipping = 'true'
+           |)
+           |PARTITIONED BY (state)
+           |location '$basePath'
+       """.stripMargin)
+
+      spark.sql("set hoodie.parquet.small.file.limit=0")
+      spark.sql("set hoodie.enable.data.skipping=true")
+      spark.sql("set hoodie.metadata.enable=true")
+
+      spark.sql(s"""
+           |insert into $tableName(ts, id, rider, driver, fare, city, state) VALUES
+           |  (1695159649,'trip1','rider-A','driver-K',19.10,'san_francisco','california'),
+           |  (1695414531,'trip6','rider-C','driver-K',17.14,'san_diego','california'),
+           |  (1695332066,'trip3','rider-E','driver-O',93.50,'austin','texas'),
+           |  (1695516137,'trip4','rider-F','driver-P',34.15,'houston','texas')
+           |""".stripMargin)
+
+      spark.sql(
+        s"""
+           |insert into $tableName(ts, id, rider, driver, fare, city, state) VALUES
+           |  (1695091554,'trip2','rider-C','driver-M',27.70,'sunnyvale','california'),
+           |  (1699349649,'trip5','rider-A','driver-Q',3.32,'san_diego','texas')
+           |""".stripMargin)
+
+      spark.sql(s"create index idx_bloom_$tableName on $tableName using bloom_filters(city) options(numHashFunctions=1, fpp=0.00000000001)")
+
+      checkAnswer(s"select id, rider from $tableName where city = 'sunnyvale'")(
+        Seq("trip2", "rider-C")
+      )
+
+      if (true) {
+        val a = 1;
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testUpdatesReInsertsDeletes(hoodieTableType: HoodieTableType): Unit = {
+    if (HoodieSparkUtils.gteqSpark3_3) {
+      val tableType = hoodieTableType.name()
+      var hudiOpts = commonOpts
+      hudiOpts = hudiOpts ++ Map(
+        DataSourceWriteOptions.TABLE_TYPE.key -> tableType,
+        DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
+      val sqlTableType = if (tableType.equals(HoodieTableType.COPY_ON_WRITE.name())) "cow" else "mor"
+      val tableName = s"test_updates_reinserts_deletes_$sqlTableType"
+
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |    ts BIGINT,
+           |    id STRING,
+           |    rider STRING,
+           |    driver STRING,
+           |    fare DOUBLE,
+           |    city STRING,
+           |    state STRING
+           |) USING HUDI
+           | options(
+           |    primaryKey ='id',
+           |    type = '$sqlTableType',
+           |    hoodie.metadata.enable = 'true',
+           |    hoodie.metadata.record.index.enable = 'true',
+           |    hoodie.datasource.write.recordkey.field = 'id',
+           |    hoodie.enable.data.skipping = 'true',
+           |    hoodie.metadata.record.index.enable='true'
+           | )
+           | PARTITIONED BY (city, state)
+           | location '$basePath'
+           |""".stripMargin)
+
+      spark.sql("set hoodie.parquet.small.file.limit=0")
+      spark.sql("set hoodie.enable.data.skipping=true")
+      spark.sql("set hoodie.metadata.enable=true")
+
+      spark.sql(
+        s"""|INSERT INTO $tableName(ts, id, rider, driver, fare, city, state) VALUES
+            |    (1695159649,'trip1','rider-A','driver-K',19.10,'san_francisco','california'),
+            |    (1695091554,'trip2','rider-C','driver-M',27.70,'sunnyvale','california'),
+            |    (1695332066,'trip3','rider-E','driver-O',93.50,'austin','texas'),
+            |    (1695516137,'trip4','rider-F','driver-P',34.15,'houston','texas');
+            |    """.stripMargin)
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName;")(
+        Seq(1695159649, "trip1", "rider-A", "driver-K", 19.10, "san_francisco", "california"),
+        Seq(1695091554, "trip2", "rider-C", "driver-M", 27.70, "sunnyvale", "california"),
+        Seq(1695332066, "trip3", "rider-E", "driver-O", 93.50, "austin", "texas"),
+        Seq(1695516137, "trip4", "rider-F", "driver-P", 34.15, "houston", "texas"))
+
+      spark.sql(s"create index idx_rider_$tableName ON $tableName USING secondary_index(rider)")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where rider = 'rider-E'")(
+        Seq(1695332066, "trip3", "rider-E", "driver-O", 93.50, "austin", "texas"))
+
+      spark.sql(s"create index idx_driver_$tableName ON $tableName USING secondary_index(driver)")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where driver = 'driver-P'")(
+        Seq(1695516137, "trip4", "rider-F", "driver-P", 34.15, "houston", "texas")
+      )
+
+      // update such that there are two rider-E records
+      spark.sql(s"update $tableName set rider = 'rider-E' where rider = 'rider-F'")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where rider = 'rider-E'")(
+        Seq(1695332066, "trip3", "rider-E", "driver-O", 93.50, "austin", "texas"),
+        Seq(1695516137, "trip4", "rider-E", "driver-P", 34.15, "houston", "texas")
+      )
+
+      // delete one of those records
+      spark.sql(s"delete from $tableName where id = 'trip4'")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where rider = 'rider-E'")(
+        Seq(1695332066, "trip3", "rider-E", "driver-O", 93.50, "austin", "texas")
+      )
+
+      // reinsert a rider-E record  while changing driver value as well.
+      spark.sql(s"insert into $tableName values(1695516137,'trip4','rider-G','driver-Q',34.15,'houston','texas')")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where driver = 'driver-Q';")(
+        Seq(1695516137, "trip4", "rider-G", "driver-Q", 34.15, "houston", "texas")
+      )
+
+      // update two other records to rider-E as well.
+      spark.sql(s"update $tableName set rider = 'rider-E' where rider in ('rider-C','rider-G');")
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where rider = 'rider-E'")(
+        Seq(1695091554, "trip2", "rider-E", "driver-M", 27.70, "sunnyvale", "california"),
+        Seq(1695332066, "trip3", "rider-E", "driver-O", 93.50, "austin", "texas"),
+        Seq(1695516137, "trip4", "rider-E", "driver-Q", 34.15, "houston", "texas")
+      )
+      checkAnswer(s"select ts, id, rider, driver, fare, city, state from $tableName where driver = 'driver-Q'")(
+        Seq(1695516137, "trip4", "rider-E", "driver-Q", 34.15, "houston", "texas")
+      )
+    }
+  }
+
   private def checkAnswer(query: String)(expects: Seq[Any]*): Unit = {
     assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(query).collect().sortBy(_.toString()))
   }
 
-  private def verifyQueryPredicate(hudiOpts: Map[String, String], columnName: String, nonExistantKey: String = ""): Unit = {
+  private def verifyQueryPredicate(hudiOpts: Map[String, String], columnName: String, nonExistentKey: String = ""): Unit = {
     mergedDfList = mergedDfList :+ spark.read.format("hudi").options(hudiOpts).load(basePath).repartition(1).cache()
-    val secondaryKey = mergedDfList.last.limit(2).collect().filter(row => !row.getAs(columnName).toString.equals(nonExistantKey))
+    val secondaryKey = mergedDfList.last.limit(2).collect().filter(row => !row.getAs(columnName).toString.equals(nonExistentKey))
       .map(row => row.getAs(columnName).toString).head
     val dataFilter = EqualTo(attribute(columnName), Literal(secondaryKey))
     verifyFilePruning(hudiOpts, dataFilter)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -1198,68 +1198,6 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
     }
   }
 
-  @Test
-  def testBloomFiltersIndexWithChanges(): Unit = {
-    if (HoodieSparkUtils.gteqSpark3_3) {
-      val tableName = "test_bloom_filters_index_with_changes"
-      val hudiOpts = commonOpts ++ Map(
-        DataSourceWriteOptions.TABLE_TYPE.key -> MOR_TABLE_TYPE_OPT_VAL,
-        DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
-      val sqlTableType = "cow"
-
-      spark.sql(
-        s"""
-           CREATE TABLE $tableName (
-           |    ts BIGINT,
-           |    id STRING,
-           |    rider STRING,
-           |    driver STRING,
-           |    fare DOUBLE,
-           |    city STRING,
-           |    state STRING
-           |) USING HUDI
-           |options(
-           |    primaryKey ='id',
-           |    type = '$sqlTableType',
-           |    hoodie.metadata.enable = 'true',
-           |    hoodie.datasource.write.recordkey.field = 'id',
-           |    hoodie.enable.data.skipping = 'true'
-           |)
-           |PARTITIONED BY (state)
-           |location '$basePath'
-       """.stripMargin)
-
-      spark.sql("set hoodie.parquet.small.file.limit=0")
-      spark.sql("set hoodie.enable.data.skipping=true")
-      spark.sql("set hoodie.metadata.enable=true")
-
-      spark.sql(s"""
-           |insert into $tableName(ts, id, rider, driver, fare, city, state) VALUES
-           |  (1695159649,'trip1','rider-A','driver-K',19.10,'san_francisco','california'),
-           |  (1695414531,'trip6','rider-C','driver-K',17.14,'san_diego','california'),
-           |  (1695332066,'trip3','rider-E','driver-O',93.50,'austin','texas'),
-           |  (1695516137,'trip4','rider-F','driver-P',34.15,'houston','texas')
-           |""".stripMargin)
-
-      spark.sql(
-        s"""
-           |insert into $tableName(ts, id, rider, driver, fare, city, state) VALUES
-           |  (1695091554,'trip2','rider-C','driver-M',27.70,'sunnyvale','california'),
-           |  (1699349649,'trip5','rider-A','driver-Q',3.32,'san_diego','texas')
-           |""".stripMargin)
-
-      spark.sql(s"create index idx_bloom_$tableName on $tableName using bloom_filters(city) options(numHashFunctions=1, fpp=0.00000000001)")
-
-      checkAnswer(s"select id, rider from $tableName where city = 'sunnyvale'")(
-        Seq("trip2", "rider-C")
-      )
-
-      if (true) {
-        val a = 1;
-      }
-    }
-  }
-
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
   def testUpdatesReInsertsDeletes(hoodieTableType: HoodieTableType): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -249,8 +249,9 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
           assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
 
-          // Verify one can create more than one functional index
-          createIndexSql = s"create index name_lower on $tableName using column_stats(ts) options(func='identity')"
+          // Verify one can create more than one functional index. When function is not provided,
+          // default identity function is used
+          createIndexSql = s"create index name_lower on $tableName using column_stats(ts)"
           spark.sql(createIndexSql)
           metaClient = createMetaClient(spark, basePath)
           functionalIndexMetadata = metaClient.getIndexMetadata.get()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -778,6 +778,10 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           spark.sql("set hoodie.enable.data.skipping=true")
           spark.sql("set hoodie.metadata.enable=true")
 
+          if (HoodieSparkUtils.gteqSpark3_4) {
+            spark.sql("spark.sql.defaultColumn.enabled=false")
+          }
+
           spark.sql(
             s"""
                |insert into $tableName(ts, id, rider, driver, fare, city, state) VALUES


### PR DESCRIPTION
### Change Logs

Allow creation of functional index without an input function. The PR uses a default function in such a case.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
