### PR TITLE
[DNM] Local branch changes trying to get bloom_filters back on track.

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -194,6 +194,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
           long fileSize = filePathSizePair.getValue();
           List<Row> rowsForFilePath = readRecordsAsRows(new StoragePath[] {new StoragePath(filePath)}, sqlContext, metaClient, readerSchema, dataWriteConfig,
               FSUtils.isBaseFile(new StoragePath(filePath.substring(filePath.lastIndexOf("/") + 1))));
+          //FIXME-vc: this may OOM. since its not done lazily.
           List<Row> rowsWithIndexMetadata = SparkMetadataWriterUtils.getRowsWithFunctionalIndexMetadata(rowsForFilePath, partition, filePath, fileSize);
           return rowsWithIndexMetadata.iterator();
         });

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestSecondaryIndexSupport.scala
@@ -101,5 +101,4 @@ class TestSecondaryIndexSupport {
     result = filterQueriesWithSecondaryKey(Seq(testFilter), Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))._2
     assertTrue(result.isEmpty)
   }
-
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -56,7 +56,6 @@ import org.scalatest.Ignore
 import java.util.stream.Collectors
 import scala.collection.JavaConverters
 
-@Ignore
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {
 
   override protected def beforeAll(): Unit = {
@@ -685,10 +684,8 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
                  | $partitionByClause
                  | location '$basePath'
        """.stripMargin)
-            if (tableType == "mor") {
-              spark.sql("set hoodie.compact.inline=true")
-              spark.sql("set hoodie.compact.inline.max.delta.commits=2")
-            }
+
+            setCompactionConfigs(tableType)
             if (!isPartitioned) {
               // setting this for non-partitioned table to ensure multiple file groups are created
               spark.sql(s"set ${HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key()}=0")
@@ -756,6 +753,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           val tableName = generateTableName + s"_init_$tableType$isPartitioned"
           val partitionByClause = if (isPartitioned) "partitioned by(price)" else ""
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          setCompactionConfigs(tableType)
           spark.sql(
             s"""
                |create table $tableName (
@@ -773,7 +771,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
                | location '$basePath'
        """.stripMargin)
 
-          writeRecordsAndValidateFunctionalIndex(tableName, basePath, "update", isDelete = false, shouldCompact = false, shouldCluster = false, shouldRollback = false)
+          writeRecordsAndValidateFunctionalIndex(tableName, basePath, isDelete = false, shouldCompact = false, shouldCluster = false, shouldRollback = false)
         }
       }
     }
@@ -787,6 +785,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           val tableName = generateTableName + s"_rollback_$tableType$isPartitioned"
           val partitionByClause = if (isPartitioned) "partitioned by(price)" else ""
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          setCompactionConfigs(tableType)
           spark.sql(
             s"""
                |create table $tableName (
@@ -804,9 +803,16 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
                | location '$basePath'
        """.stripMargin)
 
-          writeRecordsAndValidateFunctionalIndex(tableName, basePath, "update", isDelete = false, shouldCompact = false, shouldCluster = false, shouldRollback = true)
+          writeRecordsAndValidateFunctionalIndex(tableName, basePath, isDelete = false, shouldCompact = false, shouldCluster = false, shouldRollback = true)
         }
       }
+    }
+  }
+
+  private def setCompactionConfigs(tableType: String): Unit = {
+    spark.sql(s"set hoodie.compact.inline= ${if (tableType == "mor") "true" else "false"}")
+    if (tableType == "mor") {
+      spark.sql("set hoodie.compact.inline.max.delta.commits=2")
     }
   }
 
@@ -815,12 +821,10 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
    */
   private def writeRecordsAndValidateFunctionalIndex(tableName: String,
                                                      basePath: String,
-                                                     operationType: String,
                                                      isDelete: Boolean,
                                                      shouldCompact: Boolean,
                                                      shouldCluster: Boolean,
-                                                     shouldRollback: Boolean,
-                                                     shouldValidate: Boolean = true): Unit = {
+                                                     shouldRollback: Boolean): Unit = {
     // a record with from_unixtime(ts, 'yyyy-MM-dd') = 2020-09-26
     spark.sql(s"insert into $tableName values(1, 'a1', 1601098924, 10)")
     // a record with from_unixtime(ts, 'yyyy-MM-dd') = 2021-09-26


### PR DESCRIPTION
 - Take the new tests in TestSecondaryIndexSupport, need to add query predicate verification asserts
 - See changes in both production files, around fixing one-off errors and wrong filepath/filename to build bloom index.
   - This needs to be done in a clean way
 - See changes in TestFunctionalIndex to unignore it and have it passing. take these changes.
 - Ignore my comments on memory management for now.

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
