### PR TITLE
[HUDI-8541] Change to relative paths for the index defs json

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieIndexClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieIndexClient.java
@@ -19,8 +19,10 @@
 
 package org.apache.hudi.table.action.index.functional;
 
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.storage.StoragePath;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,8 +49,8 @@ public abstract class BaseHoodieIndexClient {
     metaClient.buildIndexDefinition(indexName, indexType, columns, options);
     // update table config if necessary
     String indexMetaPath = metaClient.getIndexDefinitionPath();
-    if (!metaClient.getTableConfig().getProps().containsKey(HoodieTableConfig.INDEX_DEFINITION_PATH) || !metaClient.getTableConfig().getIndexDefinitionPath().isPresent()) {
-      metaClient.getTableConfig().setValue(HoodieTableConfig.INDEX_DEFINITION_PATH, indexMetaPath);
+    if (!metaClient.getTableConfig().getProps().containsKey(HoodieTableConfig.RELATIVE_INDEX_DEFINITION_PATH) || !metaClient.getTableConfig().getRelativeIndexDefinitionPath().isPresent()) {
+      metaClient.getTableConfig().setValue(HoodieTableConfig.RELATIVE_INDEX_DEFINITION_PATH, FSUtils.getRelativePartitionPath(metaClient.getBasePath(), new StoragePath(indexMetaPath)));
       HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), metaClient.getTableConfig().getProps());
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -331,11 +331,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("0.13.0")
       .withDocumentation("The metadata of secondary indexes");
 
-  public static final ConfigProperty<String> INDEX_DEFINITION_PATH = ConfigProperty
+  public static final ConfigProperty<String> RELATIVE_INDEX_DEFINITION_PATH = ConfigProperty
       .key("hoodie.table.index.defs.path")
       .noDefaultValue()
       .sinceVersion("1.0.0")
-      .withDocumentation("Absolute path where the index definitions are stored");
+      .withDocumentation("Relative path to table base path where the index definitions are stored");
 
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
@@ -970,8 +970,8 @@ public class HoodieTableConfig extends HoodieConfig {
   /**
    * @returns the index definition path.
    */
-  public Option<String> getIndexDefinitionPath() {
-    return Option.ofNullable(getString(INDEX_DEFINITION_PATH));
+  public Option<String> getRelativeIndexDefinitionPath() {
+    return Option.ofNullable(getString(RELATIVE_INDEX_DEFINITION_PATH));
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -240,7 +240,7 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     assertEquals(metaClient.getMetaPath() + "/.index_defs/index.json", metaClient.getIndexDefinitionPath());
 
     String randomDefinitionPath = "/a/b/c";
-    metaClient.getTableConfig().setValue(HoodieTableConfig.INDEX_DEFINITION_PATH.key(), "/a/b/c");
+    metaClient.getTableConfig().setValue(HoodieTableConfig.RELATIVE_INDEX_DEFINITION_PATH.key(), "/a/b/c");
     assertEquals(randomDefinitionPath, metaClient.getIndexDefinitionPath());
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -94,7 +94,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
       throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + userIndexName);
     }
 
-    if (!metaClient.getTableConfig().getIndexDefinitionPath().isPresent()
+    if (!metaClient.getTableConfig().getRelativeIndexDefinitionPath().isPresent()
         || !metaClient.getIndexMetadata().isPresent()
         || !metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(fullIndexName)) {
       LOG.info("Index definition is not present. Registering the index first");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -31,7 +31,7 @@ import org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_RECORD_KEY
 import org.apache.hudi.metadata.SecondaryIndexKeyUtils
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
@@ -130,7 +130,10 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
             .setBasePath(basePath)
             .setConf(HoodieTestUtils.getDefaultStorageConf)
             .build()
+          assertFalse(metaClient.getTableConfig.getRelativeIndexDefinitionPath.get().contains(metaClient.getBasePath))
+          assertTrue(metaClient.getIndexDefinitionPath.contains(metaClient.getBasePath.toString))
           val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.values().stream().findFirst().get()
+
           metaClient.getTableConfig.setMetadataPartitionState(metaClient, indexDefinition.getIndexName, false)
           checkAnswer(s"drop index idx_price on $tableName")()
           checkAnswer(s"show indexes from $tableName")(


### PR DESCRIPTION
### Change Logs

We cannot have absolute paths here. lets make them relative, so copy works.

hoodie.table.index.defs.path=file\:/tmp/hudi_test_table/.hoodie/.index_defs/index.json  

PR changes the corresponding config and makes it relative instead.

After PR - 

```
hoodie.table.index.defs.path=.hoodie/.index_defs/index.json
```

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
