### PR TITLE
[HUDI-8549] Fixing flaky tests TestSecondaryIndexPruning.testSecondaryIndexWithClusteringAndCleaning

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -1059,12 +1059,11 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       )
       verifyQueryPredicate(hudiOpts, "not_record_key_col")
 
-      // update the secondary key column by insert.
-      spark.sql(s"insert into $tableName values (5, 'row2',  'efg', 'p2')")
+      // update the secondary key column by update.
+      spark.sql(s"update $tableName set not_record_key_col = 'efg' where record_key_col = 'row2'")
       confirmLastCommitType(ActionType.replacecommit)
       // validate the secondary index records themselves
       checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7")(
-        Seq(s"cde${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"def${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row3", false),
         Seq(s"efg${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"xyz${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false))
@@ -1075,7 +1074,6 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       // validate the secondary index records themselves
       checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7")(
         Seq(s"def${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row3", false),
-        Seq(s"cde${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"fgh${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"xyz${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false))
 
@@ -1084,7 +1082,6 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       confirmLastCommitType(ActionType.replacecommit)
       // validate the secondary index records themselves
       checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7")(
-        Seq(s"cde${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"fgh${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row2", false),
         Seq(s"xyz${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}row1", false)
       )


### PR DESCRIPTION
### Change Logs

Fixing flaky tests TestSecondaryIndexPruning.testSecondaryIndexWithClusteringAndCleaning. Its a test set up issue, where duplicate records were inserted. SI is not expected to work deterministically if there are duplicates in the data table. 

### Impact

no more CI failures due to this flaky test. 

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
