### PR TITLE
[HUDI-8563] Populate catalogId in AWS Glue sync client

### DIFF
--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -176,6 +176,13 @@
             <version>${aws.sdk.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sts -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -97,4 +97,11 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Glue sync may fail if the Glue table exists with partitions differing from the Hoodie table or if schema evolution is not supported by Glue."
           + "Enabling this configuration will drop and create the table to match the Hoodie config");
+
+  public static final ConfigProperty<String> GLUE_CATALOG_ID = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "catalogId")
+      .noDefaultValue()
+      .sinceVersion("0.15.0")
+      .markAdvanced()
+      .withDocumentation("The catalogId needs to be populated for syncing hoodie tables in a different AWS account");
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/MockAwsGlueCatalogSyncTool.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/MockAwsGlueCatalogSyncTool.java
@@ -24,14 +24,23 @@ import org.apache.hudi.hive.HiveSyncConfig;
 
 import org.apache.hadoop.conf.Configuration;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.util.Properties;
 
+import static org.mockito.Mockito.when;
+
 class MockAwsGlueCatalogSyncTool extends AwsGlueCatalogSyncTool {
+  private static final String CATALOG_ID = "DEFAULT_AWS_ACCOUNT_ID";
 
   @Mock
   private GlueAsyncClient mockAwsGlue;
+
+  private static StsClient mockSts = Mockito.mock(StsClient.class);
 
   public MockAwsGlueCatalogSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf, Option.empty());
@@ -39,6 +48,7 @@ class MockAwsGlueCatalogSyncTool extends AwsGlueCatalogSyncTool {
 
   @Override
   protected void initSyncClient(HiveSyncConfig hiveSyncConfig, HoodieTableMetaClient metaClient) {
-    syncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, metaClient);
+    when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account(CATALOG_ID).build());
+    syncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, metaClient);
   }
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
@@ -33,6 +33,9 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
 import software.amazon.awssdk.services.glue.GlueAsyncClientBuilder;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.io.IOException;
 
@@ -48,6 +51,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TestAwsGlueSyncTool {
+  private static final String CATALOG_ID = "DEFAULT_AWS_ACCOUNT_ID";
 
   private AwsGlueCatalogSyncTool awsGlueCatalogSyncTool;
 
@@ -81,12 +85,16 @@ class TestAwsGlueSyncTool {
 
   @Test
   void validateInitThroughSyncTool() throws Exception {
-    try (MockedStatic<GlueAsyncClient> mockedStatic = mockStatic(GlueAsyncClient.class)) {
+    try (MockedStatic<GlueAsyncClient> mockedStatic = mockStatic(GlueAsyncClient.class);
+         MockedStatic<StsClient> mockedStsStatic = mockStatic(StsClient.class)) {
       GlueAsyncClientBuilder builder = mock(GlueAsyncClientBuilder.class);
       mockedStatic.when(GlueAsyncClient::builder).thenReturn(builder);
       when(builder.credentialsProvider(any())).thenReturn(builder);
       GlueAsyncClient mockClient = mock(GlueAsyncClient.class);
       when(builder.build()).thenReturn(mockClient);
+      StsClient mockSts = mock(StsClient.class);
+      mockedStsStatic.when(StsClient::create).thenReturn(mockSts);
+      when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account("").build());
       HoodieSyncTool syncTool = SyncUtilHelpers.instantiateMetaSyncTool(
           AwsGlueCatalogSyncTool.class.getName(),
           new TypedProperties(),


### PR DESCRIPTION
### Change Logs

For AWS cross account glue metasync, we need to populate catalogId in the request. CatalogId in case of Glue is nothing but the AWS account id where the glue catalog is present.

### Impact

Add functionality for AWS cross account glue sync.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

`hoodie.datasource.meta.sync.glue.catalogId`  -> Users need to populate the catalogId through this config.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
