### PR TITLE
[HUDI-8565]: Fix RetryHelper sleep with negative time

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,5 +50,20 @@ public class TestRetryHelper {
     retryHelper =  new RetryHelper(INTERVAL_TIME, NUM, INTERVAL_TIME, Exception.class.getName());
     retry = (boolean) privateOne.invoke(retryHelper, new UnsupportedOperationException("test"));
     assertTrue(retry);
+  }
+
+  @Test
+  public void testCheckTooManyTimes() {
+    int maxRetries = 100;
+    RetryHelper retryHelper = new RetryHelper(INTERVAL_TIME, maxRetries, INTERVAL_TIME, null);
+    AtomicInteger counter = new AtomicInteger(0);
+    assertDoesNotThrow(() -> {
+      retryHelper.start(() -> {
+        if (counter.incrementAndGet() < maxRetries) {
+          throw new IOException("test");
+        }
+        return true;
+      });
+    });
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/RetryHelper.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/RetryHelper.java
@@ -139,7 +139,13 @@ public class RetryHelper<T, R extends Exception> implements Serializable {
       return initialIntervalTime;
     }
 
-    return (long) Math.pow(2, retryCount) * initialIntervalTime + random.nextInt(100);
+    // avoid long type overflow
+    long waitTime = (long) Math.pow(2, retryCount) * initialIntervalTime;
+    if (waitTime < 0) {
+      return Long.MAX_VALUE;
+    }
+    waitTime += random.nextInt(100);
+    return waitTime < 0 ? Long.MAX_VALUE : waitTime;
   }
 
   /**


### PR DESCRIPTION

issue: https://github.com/apache/hudi/issues/12315

### Change Logs
1. Fix RetryHelper sleep with negative time because of Long Type overflow.
_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._
none
- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
