### PR TITLE
[HUDI-8559] Avoid adding the conf file twice

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -123,7 +123,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       LOG.warn("Cannot load default config file: " + DEFAULT_PATH, e);
     }
     Option<StoragePath> defaultConfPath = getConfPathFromEnv();
-    if (defaultConfPath.isPresent()) {
+    if (defaultConfPath.isPresent() && !defaultConfPath.get().equals(DEFAULT_PATH)) {
       conf.addPropsFromFile(defaultConfPath.get());
     }
     return conf.getProps();


### PR DESCRIPTION
### Change Logs

`/etc/hudi/conf` is the default hudi conf path, We add it to conf paths by default.
When we do `export HUDI_CONF_DIR=/etc/hudi/conf`,  it is double referenced.
To avoid confusing error message, we check if the default conf path has been added before we add it.

### Impact

Avoid confusing message.

### Risk level (write none, low medium or high below)

Better UX.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
