### PR TITLE
[HUDI-8573] Fix performance degradation in RowDataKeyGen

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
@@ -204,7 +204,7 @@ public class RowDataKeyGen implements Serializable {
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordPartitionPath
-  public static String getRecordPartitionPath(
+  private static String getRecordPartitionPath(
       Object[] partValues,
       String[] partFields,
       boolean hiveStylePartitioning,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
@@ -56,7 +56,6 @@ public class RowDataKeyGen implements Serializable {
   private static final String EMPTY_RECORDKEY_PLACEHOLDER = "__empty__";
 
   private static final String DEFAULT_PARTITION_PATH_SEPARATOR = "/";
-  private static final String HIVE_PARTITION_TEMPLATE = "%s=%s";
   private static final String DEFAULT_FIELD_SEPARATOR = ",";
 
   private final String[] recordKeyFields;
@@ -205,7 +204,7 @@ public class RowDataKeyGen implements Serializable {
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordPartitionPath
-  private static String getRecordPartitionPath(
+  public static String getRecordPartitionPath(
       Object[] partValues,
       String[] partFields,
       boolean hiveStylePartitioning,
@@ -215,12 +214,12 @@ public class RowDataKeyGen implements Serializable {
       String partField = partFields[i];
       String partValue = StringUtils.objToString(partValues[i]);
       if (partValue == null || partValue.isEmpty()) {
-        partitionPath.append(hiveStylePartitioning ? HIVE_PARTITION_TEMPLATE + partField + DEFAULT_PARTITION_PATH : DEFAULT_PARTITION_PATH);
+        partitionPath.append(hiveStylePartitioning ? partField + "=" + DEFAULT_PARTITION_PATH : DEFAULT_PARTITION_PATH);
       } else {
         if (encodePartitionPath) {
           partValue = escapePathName(partValue);
         }
-        partitionPath.append(hiveStylePartitioning ? HIVE_PARTITION_TEMPLATE + partField + partValue : partValue);
+        partitionPath.append(hiveStylePartitioning ? partField + "=" + partValue : partValue);
       }
       if (i != partFields.length - 1) {
         partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
@@ -259,7 +258,7 @@ public class RowDataKeyGen implements Serializable {
       partitionPath = escapePathName(partitionPath);
     }
     if (hiveStylePartitioning) {
-      partitionPath = HIVE_PARTITION_TEMPLATE + partField + partitionPath;
+      partitionPath = partField + "=" + partitionPath;
     }
     return partitionPath;
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
@@ -215,12 +215,12 @@ public class RowDataKeyGen implements Serializable {
       String partField = partFields[i];
       String partValue = StringUtils.objToString(partValues[i]);
       if (partValue == null || partValue.isEmpty()) {
-        partitionPath.append(hiveStylePartitioning ? String.format(HIVE_PARTITION_TEMPLATE, partField, DEFAULT_PARTITION_PATH) : DEFAULT_PARTITION_PATH);
+        partitionPath.append(hiveStylePartitioning ? HIVE_PARTITION_TEMPLATE + partField + DEFAULT_PARTITION_PATH : DEFAULT_PARTITION_PATH);
       } else {
         if (encodePartitionPath) {
           partValue = escapePathName(partValue);
         }
-        partitionPath.append(hiveStylePartitioning ? String.format(HIVE_PARTITION_TEMPLATE, partField, partValue) : partValue);
+        partitionPath.append(hiveStylePartitioning ? HIVE_PARTITION_TEMPLATE + partField + partValue : partValue);
       }
       if (i != partFields.length - 1) {
         partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
@@ -259,7 +259,7 @@ public class RowDataKeyGen implements Serializable {
       partitionPath = escapePathName(partitionPath);
     }
     if (hiveStylePartitioning) {
-      partitionPath = String.format(HIVE_PARTITION_TEMPLATE, partField, partitionPath);
+      partitionPath = HIVE_PARTITION_TEMPLATE + partField + partitionPath;
     }
     return partitionPath;
   }


### PR DESCRIPTION
### Change Logs

There seems to be some code changes that introduced performance degradation in [HUDI-7660](https://issues.apache.org/jira/browse/HUDI-7660).

This PR addresses the performance issues by removing `String.format` usages. 

####  Simple unit test results
Concat operator is the implementation for the fixed version.
`String.format` is the original implementation.

![image](https://github.com/user-attachments/assets/b0938757-57ed-4e9e-96b3-00397d95363d)


There is a **8.74x** slowdown​.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
