### PR TITLE
[HUDI-8571] Fix upgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1448,8 +1448,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         tableServiceClient.rollbackFailedWrites(pendingRollbacks, true, true);
       }
 
-      new UpgradeDowngrade(metaClient, config, context, upgradeDowngradeHelper)
-          .run(HoodieTableVersion.current(), instantTime.orElse(null));
+      UpgradeDowngrade handler = new UpgradeDowngrade(metaClient, config, context, upgradeDowngradeHelper);
+      handler.run(HoodieTableVersion.current(), instantTime.orElse(null));
+      metaClient = HoodieTableMetaClient.reload(metaClient);
 
       metaClient.reloadTableConfig();
       metaClient.reloadActiveTimeline();

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
@@ -65,6 +65,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
       operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Append,
       validate = false)
+
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertEquals(HoodieTableVersion.EIGHT, metaClient.getTableConfig.getTableVersion)
     assertEquals(partitionFields, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(metaClient.getTableConfig).get())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
@@ -19,7 +19,8 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions
-import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodieRecordMerger, HoodieTableType, OverwriteWithLatestAvroPayload}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.keygen.constant.KeyGeneratorType
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
@@ -39,7 +40,10 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> KeyGeneratorType.CUSTOM.getClassName,
       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> partitionFields,
-      "hoodie.metadata.enable" -> "false")
+      "hoodie.metadata.enable" -> "false",
+      // "OverwriteWithLatestAvroPayload" is used to trigger merge mode upgrade/downgrade.
+      DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key -> classOf[OverwriteWithLatestAvroPayload].getName,
+      DataSourceWriteOptions.RECORD_MERGE_MODE.key -> RecordMergeMode.COMMIT_TIME_ORDERING.name)
 
     doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
@@ -50,6 +54,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
     // assert table version is eight and the partition fields in table config has partition type
     assertEquals(HoodieTableVersion.EIGHT, metaClient.getTableConfig.getTableVersion)
     assertEquals(partitionFields, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(metaClient.getTableConfig).get())
+    assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
 
     // downgrade table props to version seven
     // assert table version is seven and the partition fields in table config does not have partition type
@@ -58,6 +63,8 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertEquals(HoodieTableVersion.SEVEN, metaClient.getTableConfig.getTableVersion)
     assertEquals("partition", HoodieTableConfig.getPartitionFieldPropForKeyGenerator(metaClient.getTableConfig).get())
+    // The payload class should be maintained.
+    assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
 
     // auto upgrade the table
     // assert table version is eight and the partition fields in table config has partition type
@@ -69,5 +76,16 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertEquals(HoodieTableVersion.EIGHT, metaClient.getTableConfig.getTableVersion)
     assertEquals(partitionFields, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(metaClient.getTableConfig).get())
+
+    // After upgrade, based on the payload and table type, the merge mode is updated accordingly.
+    if (HoodieTableType.COPY_ON_WRITE == tableType) {
+      assertEquals(classOf[DefaultHoodieRecordPayload].getName, metaClient.getTableConfig.getPayloadClass)
+      assertEquals(RecordMergeMode.EVENT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode)
+      assertEquals(HoodieRecordMerger.DEFAULT_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+    } else {
+      assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
+      assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode)
+      assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

When upgrade a table with `OverwriteWithLatestPayload`, we follow the following rule:
1. For COW table, we change its payload class to `DefaultHoodieRecordPayload` class, and merge mode is `EventTimeOrdering`.
2. For MOR table, we keep its payload class, and set the merge mode to `CommitTimeOrdering`.

### Impact

Better upgrade process.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
