### PR TITLE
[HUDI-8571] Fix the upgrade for OverwriteWithLatestPayload

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -69,7 +69,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     Map<ConfigProperty, String> tablePropsToAdd = new HashMap<>();
     tablePropsToAdd.put(HoodieTableConfig.TIMELINE_PATH, HoodieTableConfig.TIMELINE_PATH.defaultValue());
     upgradePartitionFields(config, tableConfig, tablePropsToAdd);
-    upgradeMergeMode(config, tableConfig, tablePropsToAdd);
+    upgradeMergeMode(tableConfig, tablePropsToAdd);
 
     // Handle timeline upgrade:
     //  - Rewrite instants in active timeline to new format
@@ -126,20 +126,20 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     }
   }
 
-  private static void upgradeMergeMode(HoodieWriteConfig config, HoodieTableConfig tableConfig, Map<ConfigProperty, String> tablePropsToAdd) {
+  private static void upgradeMergeMode(HoodieTableConfig tableConfig, Map<ConfigProperty, String> tablePropsToAdd) {
     if (tableConfig.getPayloadClass() != null
         && tableConfig.getPayloadClass().equals(OverwriteWithLatestAvroPayload.class.getName())) {
       if (HoodieTableType.COPY_ON_WRITE == tableConfig.getTableType()) {
+        tablePropsToAdd.put(
+            HoodieTableConfig.RECORD_MERGE_MODE,
+            RecordMergeMode.COMMIT_TIME_ORDERING.name());
+      } else {
         tablePropsToAdd.put(
             HoodieTableConfig.PAYLOAD_CLASS_NAME,
             DefaultHoodieRecordPayload.class.getName());
         tablePropsToAdd.put(
             HoodieTableConfig.RECORD_MERGE_MODE,
             RecordMergeMode.EVENT_TIME_ORDERING.name());
-      } else {
-        tablePropsToAdd.put(
-            HoodieTableConfig.RECORD_MERGE_MODE,
-            RecordMergeMode.COMMIT_TIME_ORDERING.name());
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
@@ -79,12 +79,12 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
 
     // After upgrade, based on the payload and table type, the merge mode is updated accordingly.
     if (HoodieTableType.COPY_ON_WRITE == tableType) {
-      assertEquals(classOf[DefaultHoodieRecordPayload].getName, metaClient.getTableConfig.getPayloadClass)
-      assertEquals(RecordMergeMode.EVENT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
-    } else {
       assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
       assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
       assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+    } else {
+      assertEquals(classOf[DefaultHoodieRecordPayload].getName, metaClient.getTableConfig.getPayloadClass)
+      assertEquals(RecordMergeMode.EVENT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Previously we update the merge mode for COW to be event time ordering; for MOR to be commit time. However, for COW tables with OverwriteWithLatestPayload, their compactions work as expected, since they don't have logs files, and records within different commits obeys commit time ordering. However, for MOR, since there could multiple log files for a base file, the merge orders for records from different logs may not obey 
Since we want to avoid the compaction issue for MOR, we upgrade the opposite way.

### Impact

Fix inconsistent behavior.

### Risk level (write none, low medium or high below)

LOW.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
