### PR TITLE
 [HUDI-8432] Fix data skipping with RLI if record key is composite

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -92,7 +92,7 @@ class FunctionalIndexSupport(spark: SparkSession,
   def filterQueriesWithFunctionalFilterKey(queryFilters: Seq[Expression], sourceFieldOpt: Option[String]): List[Tuple2[Expression, List[String]]] = {
     var functionalIndexQueries: List[Tuple2[Expression, List[String]]] = List.empty
     for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, sourceFieldOpt, false, (expr: Expression) => {
+      filterQueryWithRecordKey(query, sourceFieldOpt, (expr: Expression) => {
         expr match {
           case expression: UnaryExpression => expression.child
           case other => other

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -92,7 +92,7 @@ class FunctionalIndexSupport(spark: SparkSession,
   def filterQueriesWithFunctionalFilterKey(queryFilters: Seq[Expression], sourceFieldOpt: Option[String]): List[Tuple2[Expression, List[String]]] = {
     var functionalIndexQueries: List[Tuple2[Expression, List[String]]] = List.empty
     for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, sourceFieldOpt, (expr: Expression) => {
+      filterQueryWithRecordKey(query, sourceFieldOpt, false, (expr: Expression) => {
         expr match {
           case expression: UnaryExpression => expression.child
           case other => other

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -119,7 +119,7 @@ object SecondaryIndexSupport {
     var secondaryKeys: List[String] = List.empty
     if (secondaryKeyConfigOpt.isDefined) {
       for (query <- queryFilters) {
-        filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
+        filterQueryWithRecordKey(query, secondaryKeyConfigOpt, false).foreach({
           case (exp: Expression, recKeys: List[String]) =>
             secondaryKeys = secondaryKeys ++ recKeys
             secondaryKeyQueries = secondaryKeyQueries :+ exp

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -118,7 +118,7 @@ object SecondaryIndexSupport {
     var secondaryKeyQueries: List[Expression] = List.empty
     var secondaryKeys: List[String] = List.empty
     for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, secondaryKeyConfigOpt).foreach({
+      filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
         case (exp: Expression, recKeys: List[String]) =>
           secondaryKeys = secondaryKeys ++ recKeys
           secondaryKeyQueries = secondaryKeyQueries :+ exp

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -117,12 +117,14 @@ object SecondaryIndexSupport {
                                     secondaryKeyConfigOpt: Option[String]): (List[Expression], List[String]) = {
     var secondaryKeyQueries: List[Expression] = List.empty
     var secondaryKeys: List[String] = List.empty
-    for (query <- queryFilters) {
-      filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
-        case (exp: Expression, recKeys: List[String]) =>
-          secondaryKeys = secondaryKeys ++ recKeys
-          secondaryKeyQueries = secondaryKeyQueries :+ exp
-      })
+    if (secondaryKeyConfigOpt.isDefined) {
+      for (query <- queryFilters) {
+        filterQueryWithRecordKey(query, Array(secondaryKeyConfigOpt.get)).foreach({
+          case (exp: Expression, recKeys: List[String]) =>
+            secondaryKeys = secondaryKeys ++ recKeys
+            secondaryKeyQueries = secondaryKeyQueries :+ exp
+        })
+      }
     }
 
     Tuple2.apply(secondaryKeyQueries, secondaryKeys)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -119,7 +119,7 @@ object SecondaryIndexSupport {
     var secondaryKeys: List[String] = List.empty
     if (secondaryKeyConfigOpt.isDefined) {
       for (query <- queryFilters) {
-        filterQueryWithRecordKey(query, secondaryKeyConfigOpt, false).foreach({
+        filterQueryWithRecordKey(query, secondaryKeyConfigOpt).foreach({
           case (exp: Expression, recKeys: List[String]) =>
             secondaryKeys = secondaryKeys ++ recKeys
             secondaryKeyQueries = secondaryKeyQueries :+ exp

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -39,27 +39,27 @@ class TestRecordLevelIndexSupport {
     val fmt = "yyyy-MM-dd HH:mm:ss"
     val fromUnixTime = FromUnixTime(Literal(0L), Literal(fmt), Some(TimeZone.getDefault.getID))
     var testFilter: Expression = EqualTo(fromUnixTime, Literal("2020-01-01 00:10:20"))
-    var result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array())
+    var result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     // Case 2: EqualTo filters not on Literal and not on simple AttributeReference should return empty result
     testFilter = EqualTo(Literal("2020-01-01 00:10:20"), fromUnixTime)
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array())
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     // Case 3: EqualTo filters on simple AttributeReference and non-Literal should return empty result
     testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), fromUnixTime)
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array())
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
     testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(recordKeyField))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField), isComplexRecordKey = false)
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("row1")))
 
     // case 5: EqualTo on fields other than record key should return empty result unless it's _hoodie_record_key
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array("blah"))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"), isComplexRecordKey = false)
     if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
       assertTrue(result.isDefined)
       assertEquals(result, Option.apply(testFilter, List.apply("row1")))
@@ -69,7 +69,7 @@ class TestRecordLevelIndexSupport {
 
     // Case 6: In filter on fields other than record key should return empty result unless it's _hoodie_record_key
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array("blah"))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"), isComplexRecordKey = false)
     if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
       assertTrue(result.isDefined)
       assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
@@ -79,26 +79,30 @@ class TestRecordLevelIndexSupport {
 
     // Case 7: In filter on record key should return non-empty result
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(recordKeyField))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField), isComplexRecordKey = false)
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
+      isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     // Case 9: Anything other than EqualTo and In predicate is not supported. Hence it returns empty result
     testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
+      isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime)))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
+      isComplexRecordKey = false)
     assertTrue(result.isEmpty)
 
     testFilter = GreaterThan(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Array(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
+      isComplexRecordKey = false)
     assertTrue(result.isEmpty)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -20,7 +20,7 @@
 package org.apache.hudi
 
 import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, FromUnixTime, GreaterThan, In, Literal, Not}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression, FromUnixTime, GreaterThan, In, Literal, Not, Or}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
@@ -39,27 +39,27 @@ class TestRecordLevelIndexSupport {
     val fmt = "yyyy-MM-dd HH:mm:ss"
     val fromUnixTime = FromUnixTime(Literal(0L), Literal(fmt), Some(TimeZone.getDefault.getID))
     var testFilter: Expression = EqualTo(fromUnixTime, Literal("2020-01-01 00:10:20"))
-    var result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
+    var result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty)
     assertTrue(result.isEmpty)
 
     // Case 2: EqualTo filters not on Literal and not on simple AttributeReference should return empty result
     testFilter = EqualTo(Literal("2020-01-01 00:10:20"), fromUnixTime)
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty)
     assertTrue(result.isEmpty)
 
     // Case 3: EqualTo filters on simple AttributeReference and non-Literal should return empty result
     testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), fromUnixTime)
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty, isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.empty)
     assertTrue(result.isEmpty)
 
     // Case 4: EqualTo filters on simple AttributeReference and Literal which should return non-empty result
     testFilter = EqualTo(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField), isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("row1")))
 
     // case 5: EqualTo on fields other than record key should return empty result unless it's _hoodie_record_key
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"), isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"))
     if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
       assertTrue(result.isDefined)
       assertEquals(result, Option.apply(testFilter, List.apply("row1")))
@@ -69,7 +69,7 @@ class TestRecordLevelIndexSupport {
 
     // Case 6: In filter on fields other than record key should return empty result unless it's _hoodie_record_key
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"), isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("blah"))
     if (filterColumnName.equals(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName)) {
       assertTrue(result.isDefined)
       assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
@@ -79,30 +79,51 @@ class TestRecordLevelIndexSupport {
 
     // Case 7: In filter on record key should return non-empty result
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc")))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField), isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(recordKeyField))
     assertTrue(result.isDefined)
     assertEquals(result, Option.apply(testFilter, List.apply("xyz", "abc")))
 
     // Case 8: In filter on simple AttributeReference(on record-key) and non-Literal should return empty result
     testFilter = In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
-      isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
     // Case 9: Anything other than EqualTo and In predicate is not supported. Hence it returns empty result
     testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(Literal("xyz"), Literal("abc"))))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
-      isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
     testFilter = Not(In(AttributeReference(filterColumnName, StringType, nullable = true)(), List.apply(fromUnixTime)))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
-      isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
     assertTrue(result.isEmpty)
 
     testFilter = GreaterThan(AttributeReference(filterColumnName, StringType, nullable = true)(), Literal("row1"))
-    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName),
-      isComplexRecordKey = false)
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName))
+    assertTrue(result.isEmpty)
+
+    // Case 10: Complex AND query with IN query on multiple columns returns the corresponding literals
+    val rk1InFilter = In(AttributeReference("rk1", StringType, nullable = true)(), List.apply(Literal("a1"), Literal("a2")))
+    val rk2InFilter = In(AttributeReference("rk2", StringType, nullable = true)(), List.apply(Literal("b1"), Literal("b2")))
+    val rk3InFilter = In(AttributeReference("rk3", StringType, nullable = true)(), List.apply(Literal("c1"), Literal("c2")))
+    testFilter = And(rk3InFilter, And(rk2InFilter, rk1InFilter))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk1"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
+    assertTrue(result.get._2.contains("rk1:a1"))
+    assertTrue(result.get._2.contains("rk1:a2"))
+
+    // Case 11: Complex AND query with EqualTo and In query on multiple columns returns the corresponding literals
+    var rk1EqFilter = EqualTo(AttributeReference("rk1", StringType, nullable = true)(), Literal("a1"))
+    var rk2EqFilter = EqualTo(AttributeReference("rk2", StringType, nullable = true)(), Literal("b1"))
+    testFilter = And(rk3InFilter, And(rk2EqFilter, rk1EqFilter))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk1"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
+    assertTrue(result.get._2.contains("rk1:a1"))
+
+    // Case 12: Test negative case with complex query using the above testFilter on a different record key
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk4"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
+    assertTrue(result.isEmpty)
+
+    // Case 11: Test unsupported query type with And
+    testFilter = And(rk3InFilter, Or(rk2EqFilter, rk1EqFilter))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk1"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
     assertTrue(result.isEmpty)
   }
 }


### PR DESCRIPTION
### Change Logs

Fix data skipping with RLI if record key is composite. When there are multiple record key fields, we need to form the record keys sequence correctly. Added a test to show skipping with more than one record key fields.
We make a call to filterRecord key function for every record key and verify if there are literals available for every record key. If that is the case we can filter on the combination of such literals.

### Impact

Support data skipping for complex primary keys

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
