### PR TITLE
 [HUDI-8545] Handle unsupported payloads with Secondary Index creation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1491,7 +1491,6 @@ public class HoodieTableMetaClient implements Serializable {
       createTableLayoutOnStorage(storageConf, basePath, props);
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(storageConf).setBasePath(basePath)
           .setMetaserverConfig(props)
-          .setPayloadClassName((String) props.getOrDefault(PAYLOAD_CLASS_NAME.key(), "org.apache.hudi.common.model.DefaultHoodieRecordPayload"))
           .build();
       LOG.info("Finished initializing Table of type {} from {}", metaClient.getTableConfig().getTableType(), basePath);
       return metaClient;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1491,6 +1491,7 @@ public class HoodieTableMetaClient implements Serializable {
       createTableLayoutOnStorage(storageConf, basePath, props);
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(storageConf).setBasePath(basePath)
           .setMetaserverConfig(props)
+          .setPayloadClassName((String) props.getOrDefault(PAYLOAD_CLASS_NAME.key(), "org.apache.hudi.common.model.DefaultHoodieRecordPayload"))
           .build();
       LOG.info("Finished initializing Table of type {} from {}", metaClient.getTableConfig().getTableType(), basePath);
       return metaClient;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -219,6 +219,64 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test Secondary Index Creation Failure For Unsupported payloads") {
+    if (HoodieSparkUtils.gteqSpark3_3) {
+      withTempDir {
+        tmp => {
+          val tableName = generateTableName
+          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  ts bigint,
+               |  id string,
+               |  rider string,
+               |  driver string,
+               |  fare int,
+               |  city string,
+               |  state string
+               |) using hudi
+               | options (
+               |  primaryKey ='id',
+               |  type = 'mor',
+               |  preCombineField = 'ts',
+               |  hoodie.metadata.enable = 'true',
+               |  hoodie.metadata.record.index.enable = 'true',
+               |  hoodie.metadata.index.secondary.enable = 'true',
+               |  hoodie.datasource.write.recordkey.field = 'id',
+               |  hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.DefaultHoodieRecordPayload'
+               | )
+               | partitioned by(state)
+               | location '$basePath'
+       """.stripMargin)
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | values
+               | (1695159649087, '334e26e9-8355-45cc-97c6-c31daf0df330', 'rider-A', 'driver-K', 19, 'san_francisco', 'california'),
+               | (1695091554787, 'e96c4396-3fad-413a-a942-4cb36106d720', 'rider-B', 'driver-M', 27, 'austin', 'texas')
+               | """.stripMargin
+          )
+
+          // validate record_index created successfully
+          val metadataDF = spark.sql(s"select key from hudi_metadata('$basePath') where type=5")
+          assert(metadataDF.count() == 2)
+
+          val metaClient = HoodieTableMetaClient.builder()
+            .setBasePath(basePath)
+            .setConf(HoodieTestUtils.getDefaultStorageConf)
+            .build()
+          assert(metaClient.getTableConfig.getMetadataPartitions.contains("record_index"))
+          // create secondary index throws error when trying to create on multiple fields at a time
+          checkException(sql = s"create index idx_city on $tableName using secondary_index(city)")(
+            "Secondary Index can only be enabled on table with OverwriteWithLatestAvroPayload payload class or Merge mode set to OVERWRITE_WITH_LATEST"
+          )
+        }
+      }
+    }
+  }
+
   test("Test Secondary Index With Updates Compaction Clustering Deletes") {
     if (HoodieSparkUtils.gteqSpark3_3) {
       withTempDir { tmp =>

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -279,7 +279,8 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
             + "hoodie.metadata.record.index.enable = 'true', "
             + "hoodie.datasource.write.recordkey.field = 'record_key_col', "
             + "hoodie.enable.data.skipping = 'true', "
-            + "hoodie.datasource.write.precombine.field = 'ts'"
+            + "hoodie.datasource.write.precombine.field = 'ts', "
+            + "hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'"
             + ") "
             + "partitioned by(partition_key_col) "
             + "location '" + basePath + "'");


### PR DESCRIPTION
### Change Logs

In this patch, we handle unsupported payloads with Secondary Index creation. Only OverwriteWithLatestPayload is supported for SI with current release. We will be adding support for other payloads in next release.

### Impact

Handle unsupported flows properly.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
