### PR TITLE
[HUDI-8590] fix: wrong file path for consistent-bucket-commit-marker-file

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -104,7 +104,6 @@ public class ConsistentBucketIndexUtils {
   public static Option<HoodieConsistentHashingMetadata> loadMetadata(HoodieTable table, String partition) {
     HoodieTableMetaClient metaClient = table.getMetaClient();
     StoragePath metadataPath = FSUtils.constructAbsolutePath(metaClient.getHashingMetadataPath(), partition);
-    StoragePath partitionPath = FSUtils.constructAbsolutePath(metaClient.getBasePath(), partition);
     try {
       Predicate<StoragePathInfo> hashingMetaCommitFilePredicate = pathInfo -> {
         String filename = pathInfo.getPath().getName();
@@ -141,6 +140,16 @@ public class ConsistentBucketIndexUtils {
 
       // fix the in-consistency between un-committed and committed hashing metadata files.
       List<StoragePathInfo> fixed = new ArrayList<>();
+      if (maxCommitMetaFileTs != null) {
+        // add max committed metadata file to fixed list, we should return max committed metadata file if there is not any metadata file can be successfully fixed.
+        Option<StoragePathInfo> maxCommittedMetadataFileOpt = Option.fromJavaOptional(hashingMetaFiles.stream().filter(hashingMetaFile -> {
+          String timestamp = getTimestampFromFile(hashingMetaFile.getPath().getName());
+          return maxCommitMetaFileTs.equals(timestamp);
+        }).findFirst());
+        ValidationUtils.checkState(maxCommittedMetadataFileOpt.isPresent(),
+            () -> "Failed to find max committed metadata file but commit marker file exist with instant: " + maxCommittedMetadataFileOpt);
+        fixed.add(maxCommittedMetadataFileOpt.get());
+      }
       hashingMetaFiles.forEach(hashingMetaFile -> {
         StoragePath path = hashingMetaFile.getPath();
         String timestamp = HoodieConsistentHashingMetadata.getTimestampFromFile(path.getName());
@@ -152,7 +161,7 @@ public class ConsistentBucketIndexUtils {
         if (isRehashingCommitted) {
           if (!commitMetaTss.contains(timestamp)) {
             try {
-              createCommitMarker(table, path, partitionPath);
+              createCommitMarker(table, path, metadataPath);
             } catch (IOException e) {
               throw new HoodieIOException("Exception while creating marker file " + path.getName() + " for partition " + partition, e);
             }
@@ -211,12 +220,12 @@ public class ConsistentBucketIndexUtils {
    *
    * @param table         Hoodie table
    * @param path          File for which commit marker should be created
-   * @param partitionPath Partition path the file belongs to
+   * @param metadataPath Consistent-Bucket metadata path the file belongs to
    * @throws IOException
    */
-  private static void createCommitMarker(HoodieTable table, StoragePath path, StoragePath partitionPath) throws IOException {
+  private static void createCommitMarker(HoodieTable table, StoragePath path, StoragePath metadataPath) throws IOException {
     HoodieStorage storage = table.getStorage();
-    StoragePath fullPath = new StoragePath(partitionPath,
+    StoragePath fullPath = new StoragePath(metadataPath,
         getTimestampFromFile(path.getName()) + HASHING_METADATA_COMMIT_FILE_SUFFIX);
     if (storage.exists(fullPath)) {
       return;
@@ -272,7 +281,7 @@ public class ConsistentBucketIndexUtils {
    * @return true if hashing metadata file is latest else false
    */
   private static boolean recommitMetadataFile(HoodieTable table, StoragePathInfo metaFile, String partition) {
-    StoragePath partitionPath = FSUtils.constructAbsolutePath(table.getMetaClient().getBasePath(), partition);
+    StoragePath metadataPath = FSUtils.constructAbsolutePath(table.getMetaClient().getHashingMetadataPath(), partition);
     String timestamp = getTimestampFromFile(metaFile.getPath().getName());
     if (table.getPendingCommitsTimeline().containsInstant(timestamp)) {
       return false;
@@ -290,7 +299,7 @@ public class ConsistentBucketIndexUtils {
     if (table.getBaseFileOnlyView().getLatestBaseFiles(partition)
         .map(fileIdPrefix -> FSUtils.getFileIdPfxFromFileId(fileIdPrefix.getFileId())).anyMatch(hoodieFileGroupIdPredicate)) {
       try {
-        createCommitMarker(table, metaFile.getPath(), partitionPath);
+        createCommitMarker(table, metaFile.getPath(), metadataPath);
         return true;
       } catch (IOException e) {
         throw new HoodieIOException("Exception while creating marker file " + metaFile.getPath().getName() + " for partition " + partition, e);

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
@@ -78,4 +78,13 @@ public class ValidationUtils {
       throw new IllegalStateException(errorMessage);
     }
   }
+
+  /**
+   * Ensures the truth of an expression, throwing the custom errorMessage otherwise.
+   */
+  public static void checkState(final boolean expression, final Supplier<String> errorMessageSupplier) {
+    if (!expression) {
+      throw new IllegalArgumentException(errorMessageSupplier.get());
+    }
+  }
 }


### PR DESCRIPTION
issue: https://github.com/apache/hudi/issues/12338

### Change Logs
1. wrong file path for consistent-bucket-commit-marker-file

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none
### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
