### PR TITLE
[HUDI-8598] Fix AND operator to not filter unsupported query types

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -177,13 +177,7 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
                   }
                 ).foreach {
                   case (exp: Expression, recKeys: List[String]) =>
-                    exp match {
-                      // For IN, add each element individually to recordKeys
-                      case _: In => recordKeys = recordKeys ++ recKeys
-
-                      // For other cases, basically EqualTo, concatenate recKeys with the default separator
-                      case _ => recordKeys = recordKeys ++ recKeys
-                    }
+                    recordKeys = recordKeys ++ recKeys
                     recordKeyQueries = recordKeyQueries :+ exp
                 }
               }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestRecordLevelIndexSupport.scala
@@ -125,5 +125,10 @@ class TestRecordLevelIndexSupport {
     testFilter = And(rk3InFilter, Or(rk2EqFilter, rk1EqFilter))
     result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk1"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
     assertTrue(result.isEmpty)
+
+    // Case 11: Test unsupported query type with And. Here the unsupported query OR is at second level from the root query type
+    testFilter = And(rk1EqFilter, And(rk1InFilter, Or(rk1EqFilter, rk1EqFilter)))
+    result = RecordLevelIndexSupport.filterQueryWithRecordKey(testFilter, Option.apply("rk1"), RecordLevelIndexSupport.getComplexKeyLiteralGenerator())
+    assertTrue(result.isEmpty)
   }
 }


### PR DESCRIPTION
### Change Logs

Currently AND operator can allow other operators like OR and allow to filter records. We need to disallow the behavior as it can lead to some records not getting filtered. Ideally for other unsupported operators it should not filter any records.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
