### PR TITLE
[HUDI-6371] Indexing catchup tasks should handle failed commits based on heartbeat

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/IndexingCatchupTaskFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/IndexingCatchupTaskFactory.java
@@ -42,10 +42,9 @@ public class IndexingCatchupTaskFactory {
                                                       HoodieTableMetaClient metadataMetaClient,
                                                       String currentCaughtupInstant,
                                                       TransactionManager transactionManager,
-                                                      HoodieEngineContext engineContext) {
+                                                      HoodieEngineContext engineContext,
+                                                      HoodieHeartbeatClient heartbeatClient) {
     HoodieTableMetaClient metaClient = table.getMetaClient();
-    HoodieHeartbeatClient heartbeatClient = new HoodieHeartbeatClient(table.getStorage(), metaClient.getBasePath().toString(), table.getConfig().getHoodieClientHeartbeatIntervalInMs(),
-        table.getConfig().getHoodieClientHeartbeatTolerableMisses());
     boolean hasRecordLevelIndexing = indexPartitionInfos.stream()
         .anyMatch(partitionInfo -> partitionInfo.getMetadataPartitionPath().equals(MetadataPartitionType.RECORD_INDEX.getPartitionPath()));
     if (hasRecordLevelIndexing) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.table.action.index;
 
+import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
@@ -34,6 +35,7 @@ import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+import org.apache.hudi.table.HoodieTable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,8 +54,10 @@ public class RecordBasedIndexingCatchupTask extends AbstractIndexingCatchupTask 
                                         HoodieTableMetaClient metadataMetaClient,
                                         String currentCaughtupInstant,
                                         TransactionManager transactionManager,
-                                        HoodieEngineContext engineContext) {
-    super(metadataWriter, instantsToIndex, metadataCompletedInstants, metaClient, metadataMetaClient, transactionManager, currentCaughtupInstant, engineContext);
+                                        HoodieEngineContext engineContext,
+                                        HoodieTable table,
+                                        HoodieHeartbeatClient heartbeatClient) {
+    super(metadataWriter, instantsToIndex, metadataCompletedInstants, metaClient, metadataMetaClient, transactionManager, currentCaughtupInstant, engineContext, table, heartbeatClient);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.action.index;
 import org.apache.hudi.avro.model.HoodieIndexCommitMetadata;
 import org.apache.hudi.avro.model.HoodieIndexPartitionInfo;
 import org.apache.hudi.avro.model.HoodieIndexPlan;
+import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -279,10 +280,12 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
   private void catchupWithInflightWriters(HoodieTableMetadataWriter metadataWriter, List<HoodieInstant> instantsToIndex,
                                           HoodieTableMetaClient metadataMetaClient, Set<String> metadataCompletedTimestamps,
                                           List<HoodieIndexPartitionInfo> indexPartitionInfos) {
+    HoodieHeartbeatClient heartbeatClient = new HoodieHeartbeatClient(table.getStorage(), table.getMetaClient().getBasePath().toString(),
+        table.getConfig().getHoodieClientHeartbeatIntervalInMs(), table.getConfig().getHoodieClientHeartbeatTolerableMisses());
     ExecutorService executorService = Executors.newFixedThreadPool(MAX_CONCURRENT_INDEXING);
     Future<?> indexingCatchupTaskFuture = executorService.submit(
         IndexingCatchupTaskFactory.createCatchupTask(indexPartitionInfos, metadataWriter, instantsToIndex, metadataCompletedTimestamps,
-            table, metadataMetaClient, currentCaughtupInstant, txnManager, context));
+            table, metadataMetaClient, currentCaughtupInstant, txnManager, context, heartbeatClient));
     try {
       LOG.info("Starting index catchup task");
       HoodieTimer timer = HoodieTimer.start();
@@ -293,6 +296,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
       throw new HoodieIndexException(String.format("Index catchup failed. Current indexed instant = %s. Aborting!", currentCaughtupInstant), e);
     } finally {
       executorService.shutdownNow();
+      heartbeatClient.close();
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -282,7 +282,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
     ExecutorService executorService = Executors.newFixedThreadPool(MAX_CONCURRENT_INDEXING);
     Future<?> indexingCatchupTaskFuture = executorService.submit(
         IndexingCatchupTaskFactory.createCatchupTask(indexPartitionInfos, metadataWriter, instantsToIndex, metadataCompletedTimestamps,
-            table.getMetaClient(), metadataMetaClient, currentCaughtupInstant, txnManager, context));
+            table, metadataMetaClient, currentCaughtupInstant, txnManager, context));
     try {
       LOG.info("Starting index catchup task");
       HoodieTimer timer = HoodieTimer.start();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
@@ -19,12 +19,14 @@
 
 package org.apache.hudi.table.action.index;
 
+import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+import org.apache.hudi.table.HoodieTable;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,8 +44,10 @@ public class WriteStatBasedIndexingCatchupTask extends AbstractIndexingCatchupTa
                                            HoodieTableMetaClient metadataMetaClient,
                                            String currentCaughtupInstant,
                                            TransactionManager txnManager,
-                                           HoodieEngineContext engineContext) {
-    super(metadataWriter, instantsToIndex, metadataCompletedInstants, metaClient, metadataMetaClient, txnManager, currentCaughtupInstant, engineContext);
+                                           HoodieEngineContext engineContext,
+                                           HoodieTable table,
+                                           HoodieHeartbeatClient heartbeatClient) {
+    super(metadataWriter, instantsToIndex, metadataCompletedInstants, metaClient, metadataMetaClient, txnManager, currentCaughtupInstant, engineContext, table, heartbeatClient);
   }
 
   @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -39,7 +39,6 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
@@ -291,11 +290,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
 
     // start the indexer and validate files index is completely built out
     HoodieIndexer indexer = new HoodieIndexer(jsc(), config);
-    // The catchup won't finish due to inflight delta commit, and this is expected
-    Throwable cause = assertThrows(RuntimeException.class, () ->  indexer.start(0))
-        .getCause();
-    assertTrue(cause instanceof HoodieMetadataException);
-    assertTrue(cause.getMessage().contains("Failed to index partition"));
+    // The catchup must finish even with inflight delta commit
+    assertEquals(0, indexer.start(0));
 
     // Now, make sure that the inflight delta commit happened before the async indexer
     // is intact


### PR DESCRIPTION
### Change Logs

Indexing catchup task iterates over all the commits to sync them to MDT. It will periodically check if the commit completed. But if the commit actually failed then it will forever be in inflight mode and hence the indexing run will not progress. This PR fixes the issue by using heartbeat to detect failed commits and ignore them. Without the change in `awaitInstantCaughtUp`, the new test `testHeartbeatExpired` will fail.

### Impact

Indexer can be used even with pending/failed commits.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
