### PR TITLE
[HUDI-8606] Use spark engineContext to parallelize secondary keys lookup

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -180,7 +180,7 @@ stages:
             displayName: Top 100 long-running testcases
       - job: UT_FT_2
         displayName: UT flink & FT common & flink & spark-client & hudi-spark
-        timeoutInMinutes: '90'
+        timeoutInMinutes: '120'
         steps:
           - task: Maven@4
             displayName: maven install
@@ -248,7 +248,7 @@ stages:
             displayName: Top 100 long-running testcases
       - job: UT_FT_4
         displayName: UT spark-datasource DML & others
-        timeoutInMinutes: '90'
+        timeoutInMinutes: '120'
         steps:
           - task: Maven@4
             displayName: maven install

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1176,7 +1176,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
         .sum();
     // approximate task partition size of 100MB
     // (TODO: make this configurable)
-    long targetPartitionSize = 100_000_000L;
+    long targetPartitionSize = 100 * 1024 * 1024;
     int parallelism = (int) Math.max(1, (totalWriteBytesForSecondaryIndex + targetPartitionSize - 1) / targetPartitionSize);
 
     return readSecondaryKeysFromBaseFiles(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
@@ -84,6 +85,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1167,7 +1169,15 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     // This could be an expensive operation for a large commit (updating/deleting millions of rows)
     Map<String, String> recordKeySecondaryKeyMap = metadata.getSecondaryKeys(keysToRemove, indexDefinition.getIndexName());
     HoodieData<HoodieRecord> deletedRecords = getDeletedSecondaryRecordMapping(engineContext, recordKeySecondaryKeyMap, indexDefinition);
-    int parallelism = Math.min(partitionFilePairs.size(), dataWriteConfig.getMetadataConfig().getSecondaryIndexParallelism());
+    // first deduce parallelism to avoid too few tasks for large number of records.
+    long totalWriteBytesForSecondaryIndex = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream)
+        .mapToLong(HoodieWriteStat::getTotalWriteBytes)
+        .sum();
+    // approximate task partition size of 100MB
+    // (TODO: make this configurable)
+    long targetPartitionSize = 100_000_000L;
+    int parallelism = (int) Math.max(1, (totalWriteBytesForSecondaryIndex + targetPartitionSize - 1) / targetPartitionSize);
 
     return readSecondaryKeysFromBaseFiles(
         engineContext,

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -265,18 +265,24 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     final int numFileSlices = partitionFileSlices.size();
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
-    // Parallel lookup for large sized partitions with many file slices
-    // Partition the keys by the file slice which contains it
-    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-    result = new HashMap<>(keys.size());
-    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-    getEngineContext().map(partitionedKeys, keysList -> {
-      if (keysList.isEmpty()) {
-        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-      }
-      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-      return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-    }, partitionedKeys.size()).forEach(result::putAll);
+    // Lookup keys from each file slice
+    if (numFileSlices == 1) {
+      // Optimization for a single slice for smaller metadata table partitions
+      result = lookupKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
+    } else {
+      // Parallel lookup for large sized partitions with many file slices
+      // Partition the keys by the file slice which contains it
+      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+      result = new HashMap<>(keys.size());
+      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+      getEngineContext().map(partitionedKeys, keysList -> {
+        if (keysList.isEmpty()) {
+          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+        }
+        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+        return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+      }, partitionedKeys.size()).forEach(result::putAll);
+    }
 
     return result;
   }
@@ -306,18 +312,24 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     final int numFileSlices = partitionFileSlices.size();
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
-    // Parallel lookup for large sized partitions with many file slices
-    // Partition the keys by the file slice which contains it
-    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-    result = new HashMap<>(keys.size());
-    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-    getEngineContext().map(partitionedKeys, keysList -> {
-      if (keysList.isEmpty()) {
-        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-      }
-      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-      return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-    }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
+    // Lookup keys from each file slice
+    if (numFileSlices == 1) {
+      // Optimization for a single slice for smaller metadata table partitions
+      result = lookupAllKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
+    } else {
+      // Parallel lookup for large sized partitions with many file slices
+      // Partition the keys by the file slice which contains it
+      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+      result = new HashMap<>(keys.size());
+      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+      getEngineContext().map(partitionedKeys, keysList -> {
+        if (keysList.isEmpty()) {
+          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+        }
+        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+        return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+      }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
+    }
 
     return result;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FULL_SCAN_LOG_FILES;
 import static org.apache.hudi.common.util.CollectionUtils.toStream;
@@ -799,8 +800,12 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     // Parallel lookup keys from each file slice
     Map<String, String> reverseSecondaryKeyMap = new HashMap<>(recordKeys.size());
     getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Lookup secondary keys from metadata table partition " + partitionName);
-    getEngineContext().map(partitionFileSlices, fileSlice -> reverseLookupSecondaryKeys(partitionName, recordKeys, fileSlice), partitionFileSlices.size()).forEach(reverseSecondaryKeyMap::putAll);
+    List<Pair<String, String>> secondaryToRecordKeyPairList = getEngineContext().flatMap(partitionFileSlices,
+        (SerializableFunction<FileSlice, Stream<Pair<String, String>>>) v1 -> reverseLookupSecondaryKeys(partitionName, recordKeys, v1)
+            .entrySet().stream()
+            .map(entry -> Pair.of(entry.getKey(), entry.getValue())).collect(Collectors.toList()).stream(), partitionFileSlices.size());
 
+    secondaryToRecordKeyPairList.forEach(pair -> reverseSecondaryKeyMap.put(pair.getKey(), pair.getValue()));
     return reverseSecondaryKeyMap;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -847,7 +847,7 @@ public class HoodieTableMetadataUtil {
       }).sum();
       // approximate task partition size of 100MB
       // (TODO: make this configurable)
-      long targetPartitionSize = 100_000_000L;
+      long targetPartitionSize = 100 * 1024 * 1024;
       parallelism = (int) Math.max(1, (totalWriteBytesForRLI + targetPartitionSize - 1) / targetPartitionSize);
       return reduceByKeys(recordIndexRecords, parallelism);
     } catch (Exception e) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestHoodieTableValuedFunction.scala
@@ -245,7 +245,6 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
                | """.stripMargin
           )
           val result1DF = spark.sql(s"select * from hudi_filesystem_view('$identifier', 'price*')")
-          result1DF.show(false)
           val result1Array = result1DF.select(
             col("Partition_Path")
           ).orderBy("Partition_Path").take(10)
@@ -484,7 +483,6 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           )
 
           val result2DF = spark.sql(s"select * from hudi_query_timeline('$identifier', 'false')")
-          result2DF.show(false)
           val result2Array = result2DF.select(
             col("action"),
             col("state"),
@@ -507,7 +505,6 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           )
 
           val result3DF = spark.sql(s"select * from hudi_query_timeline('$identifier', 'true')")
-          result3DF.show(false)
           val result3Array = result3DF.select(
             col("action"),
             col("state"),
@@ -535,7 +532,6 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           val result5DF = spark.sql(
             s"select * from hudi_query_timeline('$identifier', 'false')  where action = '$action'"
           )
-          result5DF.show(false)
           val result5Array = result5DF.select(
             col("action"),
             col("state"),
@@ -555,7 +551,6 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
           val result6DF = spark.sql(
             s"select action, state from hudi_query_timeline('$identifier', 'false')  where timestamp > '202312190000000'"
           )
-          result6DF.show(false)
           val result6Array = result6DF.take(10)
           checkAnswer(result6Array)(
             Seq(action, "COMPLETED"),


### PR DESCRIPTION
### Change Logs

- Parallelize lookup of secondary keys using engine context
- Remove the optimization for single file slice, use executors even for reading single file slice.

### Impact

Avoid OOM in driver.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
