### PR TITLE
[HUDI-8612] Rename expression index config names

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
@@ -54,13 +54,13 @@ public class HoodieIndexingConfig extends HoodieConfig {
   public static final String INDEX_DEFINITION_FILE = "index.properties";
   public static final String INDEX_DEFINITION_FILE_BACKUP = "index.properties.backup";
   public static final ConfigProperty<String> INDEX_NAME = ConfigProperty
-      .key("hoodie.functional.index.name")
+      .key("hoodie.expression.index.name")
       .noDefaultValue()
       .sinceVersion("1.0.0")
       .withDocumentation("Name of the expression index. This is also used for the partition name in the metadata table.");
 
   public static final ConfigProperty<String> INDEX_TYPE = ConfigProperty
-      .key("hoodie.functional.index.type")
+      .key("hoodie.expression.index.type")
       .defaultValue(MetadataPartitionType.COLUMN_STATS.name())
       .withValidValues(
           MetadataPartitionType.COLUMN_STATS.name(),
@@ -73,7 +73,7 @@ public class HoodieIndexingConfig extends HoodieConfig {
           + "and there are functions or expressions in the command then a expression index using column stats will be created.");
 
   public static final ConfigProperty<String> INDEX_FUNCTION = ConfigProperty
-      .key("hoodie.functional.index.function")
+      .key("hoodie.expression.index.function")
       .noDefaultValue()
       .sinceVersion("1.0.0")
       .withDocumentation("Function to be used for building the expression index.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -325,21 +325,21 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "Warning: This should only be disabled when manually constructing the metadata table outside of typical Hudi writer flows.");
 
   public static final ConfigProperty<Boolean> EXPRESSION_INDEX_ENABLE_PROP = ConfigProperty
-      .key(METADATA_PREFIX + ".index.functional.enable")
+      .key(METADATA_PREFIX + ".index.expression.enable")
       .defaultValue(false)
       .sinceVersion("1.0.0")
       .withDocumentation("Enable expression index within the Metadata Table. Note that this config is to enable/disable all expression indexes. "
           + "To enable or disable each expression index individually, users still need to use CREATE/DROP INDEX SQL commands.");
 
   public static final ConfigProperty<Integer> EXPRESSION_INDEX_FILE_GROUP_COUNT = ConfigProperty
-      .key(METADATA_PREFIX + ".index.functional.file.group.count")
+      .key(METADATA_PREFIX + ".index.expression.file.group.count")
       .defaultValue(2)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("Metadata expression index partition file group count.");
 
   public static final ConfigProperty<Integer> EXPRESSION_INDEX_PARALLELISM = ConfigProperty
-      .key(METADATA_PREFIX + ".index.functional.parallelism")
+      .key(METADATA_PREFIX + ".index.expression.parallelism")
       .defaultValue(200)
       .markAdvanced()
       .sinceVersion("1.0.0")


### PR DESCRIPTION
### Change Logs

As above, to make user-facing config names consistent with the terminology.

### Impact

As above

### Risk level

none

### Documentation Update

As above

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
