### PR TITLE
[HUDI-8609] always read partition column from file if it is the precombine

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -1559,6 +1559,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
   test("Test Create Table with Same Value for Partition and Precombine") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
+        // simple partition path
         val tableName = generateTableName
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
         spark.sql(
@@ -1578,9 +1579,77 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
              | location '$basePath'
        """.stripMargin)
         spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
-        // check query result
-        checkAnswer(s"select id, name from $tableName where from_unixtime(ts, 'yyyy-MM-dd') = '1970-01-01'")(
+        checkAnswer(s"select id, name from $tableName")(
           Seq(1, "a1")
+        )
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        // complex keygen, variable timestamp partition is precombine
+        val tableName2 = generateTableName
+        val basePath2 = s"${tmp.getCanonicalPath}/$tableName2"
+        spark.sql(
+          s"""
+             |create table $tableName2 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  segment string,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts',
+             |  'hoodie.datasource.write.partitionpath.field' = 'segment:simple,ts:timestamp',
+             |  'hoodie.datasource.write.keygenerator.class' = 'org.apache.hudi.keygen.CustomKeyGenerator',
+             |  'hoodie.keygen.timebased.timestamp.type' = 'SCALAR',
+             |  'hoodie.keygen.timebased.output.dateformat' = 'YYYY',
+             |  'hoodie.keygen.timebased.timestamp.scalar.time.unit' = 'seconds'
+             | )
+             | partitioned by(segment,ts)
+             | location '$basePath2'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName2 values(1, 'a1', 10, 'seg1', 1000)")
+        checkAnswer(s"select id, name from $tableName2")(
+          Seq(1, "a1")
+        )
+        checkAnswer(s"select id, name, price, segment, ts from $tableName2")(
+          Seq(1, "a1", 10.0, "seg1", 1000)
+        )
+
+        // complex keygen, simple partition is precombine
+        val tableName3 = generateTableName
+        val basePath3 = s"${tmp.getCanonicalPath}/$tableName3"
+        spark.sql(
+          s"""
+             |create table $tableName3 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  segment string,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'segment',
+             |  'hoodie.datasource.write.partitionpath.field' = 'segment:simple,ts:timestamp',
+             |  'hoodie.datasource.write.keygenerator.class' = 'org.apache.hudi.keygen.CustomKeyGenerator',
+             |  'hoodie.keygen.timebased.timestamp.type' = 'SCALAR',
+             |  'hoodie.keygen.timebased.output.dateformat' = 'YYYY',
+             |  'hoodie.keygen.timebased.timestamp.scalar.time.unit' = 'seconds'
+             | )
+             | partitioned by(segment,ts)
+             | location '$basePath3'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName3 values(1, 'a1', 10, 'seg1', 1000)")
+        checkAnswer(s"select id, name from $tableName3")(
+          Seq(1, "a1")
+        )
+        checkAnswer(s"select id, name, price, segment, ts from $tableName3")(
+          Seq(1, "a1", 10.0, "seg1", 1000)
         )
       }
     }


### PR DESCRIPTION
### Change Logs

If one of the partition columns is the precombine, always read that column from the file. This is not recommended at all to do this, but it should not fail if the user decides to do this for some reason. 

### Impact

Prevent read failure for case where partition and precombine are the same field

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
