### PR TITLE
[HUDI-7503] Not allowing start time earlier than active timeline with CDC queries

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -218,8 +219,8 @@ public class HoodieCDCExtractor {
       Set<String> requiredActions = new HashSet<>(Arrays.asList(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION));
       HoodieActiveTimeline activeTimeLine = metaClient.getActiveTimeline();
       if (instantRange.getStartInstant().isPresent() && !metaClient.getArchivedTimeline().empty()
-          && activeTimeLine.getWriteTimeline().filterCompletedInstants().isBeforeTimelineStarts(instantRange.getStartInstant().get())) {
-        throw new HoodieIOException("Start instant time " + instantRange.getStartInstant().get()
+          && InstantComparison.compareTimestamps(metaClient.getArchivedTimeline().lastInstant().get().requestedTime(), InstantComparison.GREATER_THAN, instantRange.getStartInstant().get())) {
+        throw new HoodieException("Start instant time " + instantRange.getStartInstant().get()
             + " for CDC query has to be in the active timeline. Beginning of active timeline " + activeTimeLine.firstInstant().get().requestedTime());
       }
       this.commits = activeTimeLine.getInstantsAsStream()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -217,6 +217,11 @@ public class HoodieCDCExtractor {
     try {
       Set<String> requiredActions = new HashSet<>(Arrays.asList(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION));
       HoodieActiveTimeline activeTimeLine = metaClient.getActiveTimeline();
+      if (instantRange.getStartInstant().isPresent() && !metaClient.getArchivedTimeline().empty()
+          && activeTimeLine.getWriteTimeline().filterCompletedInstants().isBeforeTimelineStarts(instantRange.getStartInstant().get())) {
+        throw new HoodieIOException("Start instant time " + instantRange.getStartInstant().get()
+            + " for CDC query has to be in the active timeline. Beginning of active timeline " + activeTimeLine.firstInstant().get().requestedTime());
+      }
       this.commits = activeTimeLine.getInstantsAsStream()
           .filter(instant ->
               instant.isCompleted()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -558,5 +558,14 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
       curAvroRecord, avroSchema, payloadProps).get()
   }
 
-  override def close(): Unit = {}
+  override def close(): Unit = {
+    recordIter = Iterator.empty
+    logRecordIter = Iterator.empty
+    beforeImageRecords.clear()
+    afterImageRecords.clear()
+    if (cdcLogRecordIterator != null) {
+      cdcLogRecordIterator.close()
+      cdcLogRecordIterator = null
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCRelation.scala
@@ -26,12 +26,12 @@ import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode._
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils._
 import org.apache.hudi.common.table.log.InstantRange
 import org.apache.hudi.common.table.log.InstantRange.RangeType
+import org.apache.hudi.common.table.timeline.{HoodieTimeline, InstantComparison}
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.internal.schema.InternalSchema
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SparkSession, SQLContext}
+import org.apache.spark.sql.{Row, SQLContext, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
@@ -202,11 +202,6 @@ object CDCRelation {
     val endCompletionTime = options.getOrElse(DataSourceReadOptions.END_COMMIT.key(),
       getTimestampOfLatestInstant(metaClient)
     )
-
-    if (!metaClient.getArchivedTimeline.empty() && metaClient.getActiveTimeline.isBeforeTimelineStarts(startCompletionTime)) {
-      throw new HoodieException(s"Start Completion time $startCompletionTime has to be in active timeline. First entry in active timeline "
-        + metaClient.getActiveTimeline.firstInstant().get())
-    }
 
     new CDCRelation(sqlContext, metaClient, startCompletionTime, endCompletionTime, options, rangeType)
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCRelation.scala
@@ -202,8 +202,10 @@ object CDCRelation {
     val endCompletionTime = options.getOrElse(DataSourceReadOptions.END_COMMIT.key(),
       getTimestampOfLatestInstant(metaClient)
     )
-    if (startCompletionTime > endCompletionTime) {
-      throw new HoodieException(s"This is not a valid range between $startCompletionTime and $endCompletionTime")
+
+    if (!metaClient.getArchivedTimeline.empty() && metaClient.getActiveTimeline.isBeforeTimelineStarts(startCompletionTime)) {
+      throw new HoodieException(s"Start Completion time $startCompletionTime has to be in active timeline. First entry in active timeline "
+        + metaClient.getActiveTimeline.firstInstant().get())
     }
 
     new CDCRelation(sqlContext, metaClient, startCompletionTime, endCompletionTime, options, rangeType)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
@@ -227,6 +227,8 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     totalInsertedCnt += 20
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
+
+    // test
   }
 
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
@@ -29,11 +29,12 @@ import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.common.testutils.RawTripTestPayload.{deleteRecordsToStrings, recordsToStrings}
 import org.apache.hudi.config.HoodieWriteConfig
-
 import org.apache.avro.generic.GenericRecord
+import org.apache.hudi.exception.{HoodieException, HoodieIOException}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{Row, SaveMode}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
 
@@ -205,7 +206,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     totalInsertedCnt = 60 + insertedCnt7
     totalUpdatedCnt = updatedCnt7
     totalDeletedCnt = 0
-    allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
+    allVisibleCDCData = cdcDataFrame((commitTime4.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
 
     // Bulk_Insert Operation With Clean Operation
@@ -225,12 +226,14 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     val cdcDataOnly8 = cdcDataFrame((commitTime8.toLong - 1).toString)
     assertCDCOpCnt(cdcDataOnly8, 20, 0, 0)
     totalInsertedCnt += 20
-    allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
+    allVisibleCDCData = cdcDataFrame((commitTime4.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
 
-    // test
+    // test start commit time in archived timeline. cdc query should fail
+    assertThrows(classOf[HoodieException], () => {
+      cdcDataFrame((commitTime1.toLong - 1).toString)
+    })
   }
-
 
   /**
    * Step1: Insert 100
@@ -634,9 +637,8 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     assertCDCOpCnt(cdcDataOnly2, insertedCnt2, updatedCnt2, 0)
   }
 
-  @ParameterizedTest
-  @EnumSource(classOf[HoodieCDCSupplementalLoggingMode])
-  def testCDCWithAWSDMSPayload(loggingMode: HoodieCDCSupplementalLoggingMode): Unit = {
+  @Test
+  def testCDCWithAWSDMSPayload(): Unit = {
     val options = Map(
       "hoodie.table.name" -> "test",
       "hoodie.datasource.write.recordkey.field" -> "id",


### PR DESCRIPTION
### Change Logs

- Not allowing start time earlier than active timeline with CDC queries. Also cleans up some resources in CDCFileGroupIterator.

### Impact

- Not allowing start time earlier than active timeline with CDC queries. Also cleans up some resources in CDCFileGroupIterator.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
