### PR TITLE
[HUDI-8626] fix: using rename to create consistent-hash-metadata file

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -185,7 +185,7 @@ public class ConsistentBucketIndexUtils {
         table.getMetaClient().getHashingMetadataPath(), metadata.getPartitionPath());
     StoragePath fullPath = new StoragePath(dir, metadata.getFilename());
     try {
-      storage.createImmutableFileInPath(fullPath, Option.of(metadata.toBytes()), true);
+      storage.createImmutableFileInPath(fullPath, Option.of(metadata.toBytes()));
       return true;
     } catch (IOException e) {
       LOG.warn("Failed to update bucket metadata: " + metadata, e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
@@ -103,7 +103,9 @@ public class HoodieSparkConsistentBucketIndex extends HoodieConsistentBucketInde
           .collect(Collectors.toList());
       HoodieConsistentHashingMetadata newMeta = new HoodieConsistentHashingMetadata(meta.getVersion(), meta.getPartitionPath(),
           instantTime, meta.getNumBuckets(), seqNo + 1, newNodes);
-      ConsistentBucketIndexUtils.saveMetadata(hoodieTable, newMeta, true);
+      if (!ConsistentBucketIndexUtils.saveMetadata(hoodieTable, newMeta)) {
+        throw new HoodieIndexException("Failed to save metadata for partition: " + partition);
+      }
     });
 
     return writeStatuses;

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -370,7 +370,7 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final boolean needCreateTempFile() {
-    return StorageSchemes.HDFS.getScheme().equals(getScheme()) || StorageSchemes.FILE.getScheme().equals(getScheme());
+    return StorageSchemes.HDFS.getScheme().equals(getScheme());
   }
 
   /**

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -309,15 +309,10 @@ public abstract class HoodieStorage implements Closeable {
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final void createImmutableFileInPath(StoragePath path,
                                               Option<byte[]> content) throws HoodieIOException {
-    createImmutableFileInPath(path, content, needCreateTempFile());
-  }
-
-  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public final void createImmutableFileInPath(StoragePath path,
-                                              Option<byte[]> content, boolean needTempFile) throws HoodieIOException {
     OutputStream fsout = null;
     StoragePath tmpPath = null;
 
+    boolean needTempFile = needCreateTempFile();
     try {
       if (!content.isPresent()) {
         fsout = create(path, false);
@@ -375,7 +370,7 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final boolean needCreateTempFile() {
-    return StorageSchemes.HDFS.getScheme().equals(getScheme());
+    return !StorageSchemes.isWriteTransactional(getScheme());
   }
 
   /**

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -309,10 +309,14 @@ public abstract class HoodieStorage implements Closeable {
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final void createImmutableFileInPath(StoragePath path,
                                               Option<byte[]> content) throws HoodieIOException {
+    createImmutableFileInPath(path, content, needCreateTempFile());
+  }
+
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public final void createImmutableFileInPath(StoragePath path,
+                                              Option<byte[]> content, boolean needTempFile) throws HoodieIOException {
     OutputStream fsout = null;
     StoragePath tmpPath = null;
-
-    boolean needTempFile = needCreateTempFile();
 
     try {
       if (!content.isPresent()) {

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -370,7 +370,7 @@ public abstract class HoodieStorage implements Closeable {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public final boolean needCreateTempFile() {
-    return !StorageSchemes.isWriteTransactional(getScheme());
+    return StorageSchemes.HDFS.getScheme().equals(getScheme()) || StorageSchemes.FILE.getScheme().equals(getScheme());
   }
 
   /**


### PR DESCRIPTION
In the consistent-bucket mode, the creation of the `hash_metadata_file` may be read by another task or job. In this case, the Metadata may be loaded incorrectly because the `hash_metadata_file` may be read in the intermediate state.
For example, two task load `p_date=20241202` partition's hash-metadata:
1. task-a load from fs but found nothing.
2. task-a start to create initial-hash-metadata-file
3. initial-hash-metadata-file created
4. task-b load form fs and found created but empty initial-hash-metadata-file
5. task-b throw exception
6. task-a write metadata content to initial-hash-metadata-file

So task-b can see the ntermediate state of hash-metadata-file.

I wrote a UT to verify it.
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/ad8d2280-ada1-44ca-9f93-99fcdee825a7">

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/6bf01b5b-6fdb-4e6d-b909-b035b54bb000">



### Change Logs

1. using rename to create consistent-hash-metadata file

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
