### PR TITLE
Update docker_demo.md to explicitily use Scala Version 2.11 for the demo build

### DIFF
--- a/website/versioned_docs/version-0.15.0/docker_demo.md
+++ b/website/versioned_docs/version-0.15.0/docker_demo.md
@@ -51,7 +51,7 @@ NOTE: Make sure you've cloned the [Hudi repository](https://github.com/apache/hu
 
 ```java
 cd <HUDI_WORKSPACE>
-mvn clean package -Pintegration-tests -DskipTests
+mvn clean package -Pintegration-tests -DskipTests -Dscala-2.11
 ```
 
 ### Bringing up Demo Cluster


### PR DESCRIPTION
Adding -Dscala-2.11 argument to `mvn clean package` to ensure that the supported Scala Version 2.11 is used and to avoid errors like https://github.com/apache/hudi/issues/10262

### Change Logs

Documentation Update to include the `-Dscala-2.11` command line argument after `mvn clean package -Pintegration-tests -DskipTests`, which tells the build to use Scala version 2.11, the supported Version for Hudi, as the build would fail using other Scala versions.

### Impact

Less support requests due to "wrong" Scala versions used for the demo build.

### Risk level (write none, low medium or high below)

None

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
