### PR TITLE
[MINOR] Removed confusing warnings from not applicable to metadata table checks

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -462,7 +462,10 @@ case class HoodieFileIndex(spark: SparkSession,
   private def isIndexAvailable: Boolean = indicesSupport.exists(idx => idx.isIndexAvailable)
 
   private def validateConfig(): Unit = {
-    if (isDataSkippingEnabled && (!isMetadataTableEnabled || !isIndexAvailable)) {
+    // no need to validate config for metadata table
+    if (!metaClient.isInstanceOf[HoodieTableMetaClient]
+      && isDataSkippingEnabled
+      && (!isMetadataTableEnabled || !isIndexAvailable)) {
       logWarning("Data skipping requires Metadata Table and at least one of the indices to be enabled! "
         + s"(isMetadataTableEnabled = $isMetadataTableEnabled, isColumnStatsIndexEnabled = $isColumnStatsIndexEnabled"
         + s", isRecordIndexApplicable = $isRecordIndexEnabled, isExpressionIndexEnabled = $isExpressionIndexEnabled, " +

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -149,10 +149,13 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
         }
       }
     } else {
-      // If the partition columns have not stored in hoodie.properties(the table that was
-      // created earlier), we trait it as a non-partitioned table.
-      logWarning("No partition columns available from hoodie.properties." +
-        " Partition pruning will not work")
+      // no warning for metadata table
+      if (!metaClient.isInstanceOf[HoodieTableMetaClient]) {
+        // If the partition columns have not stored in hoodie.properties(the table that was
+        // created earlier), we trait it as a non-partitioned table.
+        logWarning("No partition columns available from hoodie.properties." +
+          " Partition pruning will not work")
+      }
       new StructType()
     }
   }


### PR DESCRIPTION
### Change Logs

There are confusing warnings in logs:
```Text
[ScalaTest-main-running-TestPartitionStatsIndexWithSql] WARN  org.apache.hudi.HoodieFileIndex [] - No partition columns available from hoodie.properties. Partition pruning will not work
[ScalaTest-main-running-TestPartitionStatsIndexWithSql] WARN  org.apache.hudi.HoodieFileIndex [] - Data skipping requires Metadata Table and at least one of the indices to be enabled! (isMetadataTableEnabled = false, isColumnStatsIndexEnabled = false, isRecordIndexApplicable = false, isExpressionIndexEnabled = false, isBucketIndexEnable = false, isPartitionStatsIndexEnabled = false), isBloomFiltersIndexEnabled = false)
```
during reading of metadata table, for instance, in `TestSecondaryIndex @Test Secondary Index With Updates Compaction Clustering Deletes`.

But there is no partitioning for metadata table, and we shouldn't do those checks for metadata table. This PR fixes this logging logic.

### Impact
No

### Risk level (write none, low medium or high below)
No

### Documentation Update
No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
