### PR TITLE
[MINOR] Search for reason of test flakiness from `TestSecondaryIndex`

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -544,7 +544,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
 
       // Ensure secondary keys are correctly present or deleted
       if (hasDeleteKeys) {
-        assertTrue(secondaryKeys.isEmpty)
+        assertTrue(secondaryKeys.isEmpty, s"Secondary index should be deleted for key: $key")
       } else {
         assertTrue(secondaryKeys.nonEmpty, s"Secondary index entry missing for key: $key")
         secondaryKeys.foreach { secKey =>


### PR DESCRIPTION
### Change Logs

Extended log info for deleted key.

### Impact

No

### Risk level (write none, low medium or high below)

No

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
