### PR TITLE
[HUDI-8639] Support filter by partitions in ShowInvalidParquetProcedure

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext
-import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage
-
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.spark.api.java.JavaRDD
@@ -30,12 +30,14 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util.function.Supplier
+import collection.JavaConverters._
 
 class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
     ProcedureParameter.required(0, "path", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 100),
-    ProcedureParameter.optional(2, "needDelete", DataTypes.BooleanType, false)
+    ProcedureParameter.optional(2, "needDelete", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(3, "partitions", DataTypes.StringType, "")
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -52,11 +54,14 @@ class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
     val srcPath = getArgValueOrDefault(args, PARAMETERS(0)).get.asInstanceOf[String]
     val limit = getArgValueOrDefault(args, PARAMETERS(1))
     val needDelete = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[Boolean]
+    val partitions = getArgValueOrDefault(args, PARAMETERS(3)).map(_.toString).getOrElse("")
     val storageConf = HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration())
     val storage = new HoodieHadoopStorage(srcPath, storageConf)
-    val partitionPaths: java.util.List[String] = FSUtils.getAllPartitionPaths(
-      new HoodieSparkEngineContext(jsc), storage, srcPath, false)
-    val javaRdd: JavaRDD[String] = jsc.parallelize(partitionPaths, partitionPaths.size())
+    val metadataConfig = HoodieMetadataConfig.newBuilder.enable(false).build
+    val metadata = HoodieTableMetadata.create(new HoodieSparkEngineContext(jsc), storage, metadataConfig, srcPath)
+    val partitionPaths: java.util.List[String] = metadata.getPartitionPathWithPathPrefixes(partitions.split(",").toList.asJava)
+    val partitionPathsSize = if (partitionPaths.size() == 0) 1 else partitionPaths.size()
+    val javaRdd: JavaRDD[String] = jsc.parallelize(partitionPaths, partitionPathsSize)
     val parquetRdd = javaRdd.rdd.map(part => {
         val fs = HadoopFSUtils.getFs(new Path(srcPath), storageConf.unwrap())
         HadoopFSUtils.getAllDataFilesInPartition(fs, HadoopFSUtils.constructAbsolutePathInHadoopPath(srcPath, part))
@@ -87,7 +92,6 @@ class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
     } else {
       parquetRdd.collect()
     }
-
   }
 
   override def build = new ShowInvalidParquetProcedure()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
@@ -119,4 +119,85 @@ class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
       }
     }
   }
+
+  test("Test Call show_invalid_parquet Procedure and Specify Partitions") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      // create table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  year string,
+           |  month string,
+           |  day string
+           |) using hudi
+           | partitioned by (year, month, day)
+           | location '$basePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+      // insert data to table
+      spark.sql(s"insert into $tableName select 1, 'a1', 10, 1001, '2022', '08', '30'")
+      spark.sql(s"insert into $tableName select 2, 'a2', 20, 1002, '2022', '08', '31'")
+      spark.sql(s"insert into $tableName select 3, 'a3', 10, 1003, '2022', '07', '03'")
+      spark.sql(s"insert into $tableName select 4, 'a4', 20, 1004, '2022', '07', '04'")
+
+      // Check required fields
+      checkExceptionContain(s"""call show_invalid_parquet(limit => 10)""")(
+        s"Argument: path is required")
+
+      val fs = HadoopFSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
+      val invalidPath1 = new Path(basePath, "year=2022/month=08/day=30/1.parquet")
+      val out1 = fs.create(invalidPath1)
+      out1.write(1)
+      out1.close()
+
+      val invalidPath2 = new Path(basePath, "year=2022/month=08/day=31/2.parquet")
+      val out2 = fs.create(invalidPath2)
+      out2.write(1)
+      out2.close()
+
+      val invalidPath3 = new Path(basePath, "year=2022/month=07/day=03/3.parquet")
+      val out3 = fs.create(invalidPath3)
+      out3.write(1)
+      out3.close()
+
+      val invalidPath4 = new Path(basePath, "year=2022/month=07/day=04/4.parquet")
+      val out4 = fs.create(invalidPath4)
+      out4.write(1)
+      out4.close()
+
+      // collect result for table
+      var result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath')""".stripMargin).collect()
+      assertResult(4) {
+        result.length
+      }
+
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', partitions => 'year=2022')""".stripMargin).collect()
+      assertResult(4) {
+        result.length
+      }
+
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', partitions => 'year=2022/month=07')""".stripMargin).collect()
+      assertResult(2) {
+        result.length
+      }
+
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', partitions => 'year=2022/month=08/day=30,year=2022/month=08/day=31')""".stripMargin).collect()
+      assertResult(2) {
+        result.length
+      }
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
@@ -198,6 +198,13 @@ class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
       assertResult(2) {
         result.length
       }
+
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', partitions => 'year=2023')""".stripMargin).collect()
+      assertResult(0) {
+        result.length
+      }
+
     }
   }
 }


### PR DESCRIPTION
### Change Logs

add new parameter in ShowInvalidParquetProcedure, support specifying 'partitions' and filter invalid parquet files by partitions.

### Impact

hudi-spark-datasource

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
