### PR TITLE
[HUDI-8619] fix a bug for checkpoint translation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
@@ -56,6 +57,9 @@ public class CheckpointUtils {
   // instant or completion time
   public static StreamerCheckpointV2 convertToCheckpointV2ForCommitTime(
       Checkpoint checkpoint, HoodieTableMetaClient metaClient) {
+    if (checkpoint.checkpointKey.equals(HoodieTimeline.INIT_INSTANT_TS)) {
+      return new StreamerCheckpointV2(HoodieTimeline.INIT_INSTANT_TS);
+    }
     if (checkpoint instanceof StreamerCheckpointV2) {
       return (StreamerCheckpointV2) checkpoint;
     }
@@ -81,6 +85,9 @@ public class CheckpointUtils {
 
   public static StreamerCheckpointV1 convertToCheckpointV1ForCommitTime(
       Checkpoint checkpoint, HoodieTableMetaClient metaClient) {
+    if (checkpoint.checkpointKey.equals(HoodieTimeline.INIT_INSTANT_TS)) {
+      return new StreamerCheckpointV1(HoodieTimeline.INIT_INSTANT_TS);
+    }
     if (checkpoint instanceof StreamerCheckpointV1) {
       return (StreamerCheckpointV1) checkpoint;
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/checkpoint/TestCheckpointUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/checkpoint/TestCheckpointUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.exception.HoodieException;
@@ -156,5 +157,18 @@ public class TestCheckpointUtils {
     Exception exception = assertThrows(UnsupportedOperationException.class,
         () -> CheckpointUtils.convertToCheckpointV2ForCommitTime(checkpoint, metaClient));
     assertTrue(exception.getMessage().contains("Unable to find completion time"));
+  }
+
+  @Test
+  public void testConvertCheckpointWithInitTimestamp() {
+    String instantTime = HoodieTimeline.INIT_INSTANT_TS;
+
+    Checkpoint checkpoint = new StreamerCheckpointV1(instantTime);
+    Checkpoint translated = CheckpointUtils.convertToCheckpointV1ForCommitTime(checkpoint, metaClient);
+    assertEquals(HoodieTimeline.INIT_INSTANT_TS, translated.getCheckpointKey());
+
+    checkpoint = new StreamerCheckpointV2(instantTime);
+    translated = CheckpointUtils.convertToCheckpointV2ForCommitTime(checkpoint, metaClient);
+    assertEquals(HoodieTimeline.INIT_INSTANT_TS, translated.getCheckpointKey());
   }
 }


### PR DESCRIPTION
### Change Logs

When the checkpoint is not given, the initial one is created with default start time: "00000000000000".
Since there is no completion time for it, the translation fails.

When we meet this kind of checkpoint, we should just return the correct checkpoint with the same time.

### Impact

Fix a bug.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
