### PR TITLE
[HUDI-8643] Fix a secondary index related test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -300,7 +300,11 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
         // Step 1: Initial Insertion of Records
         val dataGen = new HoodieTestDataGenerator()
-        val hudiOpts: Map[String, String] = loadInitialBatchAndCreateSecondaryIndex(tableName, basePath, dataGen)
+
+        var hudiOpts: Map[String, String] = loadInitialBatchAndCreateSecondaryIndex(tableName, basePath, dataGen)
+        // Since the same row_key could be generated for different partitions, which may cause troubles for SI,
+        // we use non-partition tables to reduce test flakiness.
+        hudiOpts.-(PARTITIONPATH_FIELD.key)
 
         // Verify initial state of secondary index
         val initialKeys = spark.sql(s"select _row_key from $tableName limit 5").collect().map(_.getString(0))


### PR DESCRIPTION
### Change Logs

The data generation may produce the same row keys with different partitions, which may cause troubles for SI.
When we switch to non-partition tables, the test succeeded with consecutive 100+ times.

Though we could claim we fix it for good, but it definitely reduced one factor of flakiness.

### Impact

More robust CI tests.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
