### PR TITLE
[MINOR] Fix README and CI fir min Spark 3.3 patch version support

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -509,7 +509,7 @@ jobs:
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.14'
             sparkProfile: 'spark3.3'
-            sparkRuntime: 'spark3.3.1'
+            sparkRuntime: 'spark3.3.2'
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -509,7 +509,7 @@ jobs:
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.14'
             sparkProfile: 'spark3.3'
-            sparkRuntime: 'spark3.3.2'
+            sparkRuntime: 'spark3.3.4'
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Refer to the table below for building with different Spark and Scala versions.
 | Maven build options       | Expected Spark bundle jar name               | Notes                                            |
 |:--------------------------|:---------------------------------------------|:-------------------------------------------------|
 | (empty)                   | hudi-spark3.5-bundle_2.12                    | For Spark 3.5.x and Scala 2.12 (default options) |
-| `-Dspark3.3`              | hudi-spark3.3-bundle_2.12                    | For Spark 3.3.x and Scala 2.12                   |
+| `-Dspark3.3`              | hudi-spark3.3-bundle_2.12                    | For Spark 3.3.2+ and Scala 2.12                  |
 | `-Dspark3.4`              | hudi-spark3.4-bundle_2.12                    | For Spark 3.4.x and Scala 2.12                   |
 | `-Dspark3.5 -Dscala-2.12` | hudi-spark3.5-bundle_2.12                    | For Spark 3.5.x and Scala 2.12 (same as default) |
 | `-Dspark3.5 -Dscala-2.13` | hudi-spark3.5-bundle_2.13                    | For Spark 3.5.x and Scala 2.13                   |

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -313,6 +313,8 @@ mvn -Prelease clean install -Dspark3
 - There are no release blocking JIRA issues.
 - Release branch has been created.
 - Release Notes  have been audited and added to RELEASE_NOTES.md.
+- Thrift is installed locally, if not then please follow the instructions [here](https://thrift.apache.org/docs/install/).
+- A docker daemon is running (or Docker Desktop is running). This is required to build `hudi-metaserver-server` module.
 
 # Build a release candidate
 
@@ -412,6 +414,7 @@ Set up a few environment variables to simplify Maven commands that follow. This 
       2. make sure your IP is not changing while uploading, otherwise it creates a different staging repo
       3. Use a VPN if you can't prevent your IP from switching
       4. after uploading, inspect the log to make sure all maven tasks said "BUILD SUCCESS"
+      5. In case you faced any issue while building `hudi-platform-service` or `hudi-metaserver-server` module, please ensire that you have docker daemon running. This is required to build `hudi-metaserver-server` module. See [checklist](#checklist-to-proceed-to-the-next-step). 
    5. Review all staged artifacts by logging into Apache Nexus and clicking on "Staging Repositories" link on left pane. Then find a "open" entry for apachehudi
    6. Ensure it contains all 2 (2.12 and 2.13) artifacts, mainly hudi-spark-bundle-2.12/2.13, hudi-spark3-bundle-2.12/2.13, hudi-spark-2.12/2.13, hudi-spark3-2.12/2.13, hudi-utilities-bundle_2.12/2.13 and hudi-utilities_2.12/2.13.
       > With 0.10.1, we had 4 bundles. spark2 with scala11, spark2 with scala12, spark3.0.x bundles and spark3.1.x bundles. Ensure each spark bundle reflects the version correctly. hudi-spark3.1.2-bundle_2.12-0.10.1.jar and hudi-spark3.0.3-bundle_2.12-0.10.1.jar are the respective bundle names for spark3 bundles.

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -414,7 +414,7 @@ Set up a few environment variables to simplify Maven commands that follow. This 
       2. make sure your IP is not changing while uploading, otherwise it creates a different staging repo
       3. Use a VPN if you can't prevent your IP from switching
       4. after uploading, inspect the log to make sure all maven tasks said "BUILD SUCCESS"
-      5. In case you faced any issue while building `hudi-platform-service` or `hudi-metaserver-server` module, please ensire that you have docker daemon running. This is required to build `hudi-metaserver-server` module. See [checklist](#checklist-to-proceed-to-the-next-step). 
+      5. In case you faced any issue while building `hudi-platform-service` or `hudi-metaserver-server` module, please ensure that you have docker daemon running. This is required to build `hudi-metaserver-server` module. See [checklist](#checklist-to-proceed-to-the-next-step). 
    5. Review all staged artifacts by logging into Apache Nexus and clicking on "Staging Repositories" link on left pane. Then find a "open" entry for apachehudi
    6. Ensure it contains all 2 (2.12 and 2.13) artifacts, mainly hudi-spark-bundle-2.12/2.13, hudi-spark3-bundle-2.12/2.13, hudi-spark-2.12/2.13, hudi-spark3-2.12/2.13, hudi-utilities-bundle_2.12/2.13 and hudi-utilities_2.12/2.13.
       > With 0.10.1, we had 4 bundles. spark2 with scala11, spark2 with scala12, spark3.0.x bundles and spark3.1.x bundles. Ensure each spark bundle reflects the version correctly. hudi-spark3.1.2-bundle_2.12-0.10.1.jar and hudi-spark3.0.3-bundle_2.12-0.10.1.jar are the respective bundle names for spark3 bundles.


### PR DESCRIPTION
### Change Logs

This is in context of https://github.com/apache/hudi/pull/12426#issuecomment-2520197590
We are going to use only Spark 3.3.2+ for spark 3.3 versions.

### Impact

Spark patch version support update.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
