### PR TITLE
[MINOR] Improve config docs to avoid build errors

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -117,7 +117,7 @@ public class CloudSourceConfig extends HoodieConfig {
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.datasource.options")
       .markAdvanced()
       .withDocumentation("A JSON string passed to the Spark DataFrameReader while loading the dataset. "
-          + "Example: hoodie.streamer.gcp.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}\n");
+          + "Example: `hoodie.streamer.gcp.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}`\n");
 
   public static final ConfigProperty<String> CLOUD_DATAFILE_EXTENSION = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.select.file.extension")
@@ -146,9 +146,11 @@ public class CloudSourceConfig extends HoodieConfig {
       .defaultValue(false)
       .markAdvanced()
       .sinceVersion("0.14.1")
-      .withDocumentation("Boolean value for specifying path format in load args of spark.read.format(\"..\").load(\"a.xml,b.xml,c.xml\"),\n"
-          + "   * set true if path format needs to be comma separated string value, if false it's passed as array of strings like\n"
-          + "   * spark.read.format(\"..\").load(new String[]{a.xml,b.xml,c.xml})");
+      .withDocumentation("Boolean value for specifying path format in load args of "
+          + "`spark.read.format(\"..\").load(\"a.xml,b.xml,c.xml\")`. "
+          + "Set true if path format needs to be comma separated string value; "
+          + "false if it's passed as array of strings like"
+          + "`spark.read.format(\"..\").load(new String[]{a.xml,b.xml,c.xml})`");
 
   public static final ConfigProperty<String> SOURCE_MAX_BYTES_PER_PARTITION = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.partition.max.size")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3EventsHoodieIncrSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3EventsHoodieIncrSourceConfig.java
@@ -89,6 +89,6 @@ public class S3EventsHoodieIncrSourceConfig extends HoodieConfig {
       .noDefaultValue()
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.s3incr.spark.datasource.options")
       .markAdvanced()
-      .withDocumentation("Json string, passed to the reader while loading dataset. Example Hudi Streamer conf \n"
-          + " --hoodie-conf hoodie.streamer.source.s3incr.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}");
+      .withDocumentation("Json string, passed to the reader while loading dataset. Example Hudi Streamer conf "
+          + "`--hoodie-conf hoodie.streamer.source.s3incr.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}`");
 }


### PR DESCRIPTION
### Change Logs

When updating the configuration docs based on `release-1.0.0` branch, we have to make changes in https://github.com/apache/hudi/pull/12439/commits/2ea3bf75c71a9932983a9834410781722b61fb02 to make the website compile.  This PR fixes the configs docs in the source code, i.e., making sure code examples are wrapped with backticks.

### Impact

Improve config docs to avoid build errors

### Risk level

none

### Documentation Update

As above

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
