### PR TITLE
[HUDI-8673] Simple and Global-Simple Index improvements

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
@@ -107,16 +107,10 @@ public class HoodieSimpleIndex
           .getString(HoodieIndexConfig.SIMPLE_INDEX_INPUT_STORAGE_LEVEL_VALUE));
     }
 
-    int deduceNumParallelism = inputRecords.deduceNumPartitions();
-    int configuredSimpleIndexParallelism = config.getSimpleIndexParallelism();
-    // NOTE: Target parallelism could be overridden by the config
-    int fetchParallelism =
-        configuredSimpleIndexParallelism > 0 ? configuredSimpleIndexParallelism : deduceNumParallelism;
     HoodiePairData<HoodieKey, HoodieRecord<R>> keyedInputRecords =
         inputRecords.mapToPair(record -> new ImmutablePair<>(record.getKey(), record));
     HoodiePairData<HoodieKey, HoodieRecordLocation> existingLocationsOnTable =
-        fetchRecordLocationsForAffectedPartitions(keyedInputRecords.keys(), context, hoodieTable,
-            fetchParallelism);
+        fetchRecordLocationsForAffectedPartitions(keyedInputRecords.keys(), context, hoodieTable);
 
     HoodieData<HoodieRecord<R>> taggedRecords =
         keyedInputRecords.leftOuterJoin(existingLocationsOnTable).map(entry -> {
@@ -137,27 +131,30 @@ public class HoodieSimpleIndex
    * @param hoodieKeys  {@link HoodieData} of {@link HoodieKey}s for which locations are fetched
    * @param context     instance of {@link HoodieEngineContext} to use
    * @param hoodieTable instance of {@link HoodieTable} of interest
-   * @param parallelism parallelism to use
    * @return {@link HoodiePairData} of {@link HoodieKey} and {@link HoodieRecordLocation}
    */
   protected HoodiePairData<HoodieKey, HoodieRecordLocation> fetchRecordLocationsForAffectedPartitions(
-      HoodieData<HoodieKey> hoodieKeys, HoodieEngineContext context, HoodieTable hoodieTable,
-      int parallelism) {
+      HoodieData<HoodieKey> hoodieKeys, HoodieEngineContext context, HoodieTable hoodieTable) {
     List<String> affectedPartitionPathList =
         hoodieKeys.map(HoodieKey::getPartitionPath).distinct(hoodieKeys.deduceNumPartitions()).collectAsList();
     List<Pair<String, HoodieBaseFile>> latestBaseFiles =
         getLatestBaseFilesForAllPartitions(affectedPartitionPathList, context, hoodieTable);
-    return fetchRecordLocations(context, hoodieTable, parallelism, latestBaseFiles);
+    return fetchRecordLocations(context, hoodieTable, latestBaseFiles);
   }
 
   protected HoodiePairData<HoodieKey, HoodieRecordLocation> fetchRecordLocations(
-      HoodieEngineContext context, HoodieTable hoodieTable, int parallelism,
+      HoodieEngineContext context, HoodieTable hoodieTable,
       List<Pair<String, HoodieBaseFile>> baseFiles) {
-    int fetchParallelism = Math.max(1, Math.min(baseFiles.size(), parallelism));
+    int parallelism = getParallelism(config.getSimpleIndexParallelism(), baseFiles.size());
 
-    return context.parallelize(baseFiles, fetchParallelism)
+    return context.parallelize(baseFiles, parallelism)
         .flatMap(partitionPathBaseFile -> new HoodieKeyLocationFetchHandle(config, hoodieTable, partitionPathBaseFile, keyGeneratorOpt)
-            .locations().iterator())
+            .locations())
         .mapToPair(e -> (Pair<HoodieKey, HoodieRecordLocation>) e);
+  }
+
+  protected int getParallelism(int configuredParallelism, int numberOfBaseFiles) {
+    int parallelism = configuredParallelism > 0 && configuredParallelism < numberOfBaseFiles ? configuredParallelism : numberOfBaseFiles;
+    return Math.max(1, parallelism);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLocationFetchHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLocationFetchHandle.java
@@ -24,14 +24,13 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.FileFormatUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.table.HoodieTable;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * {@link HoodieRecordLocation} fetch handle for all records from {@link HoodieBaseFile} of interest.
@@ -50,7 +49,7 @@ public class HoodieKeyLocationFetchHandle<T, I, K, O> extends HoodieReadHandle<T
     this.keyGeneratorOpt = keyGeneratorOpt;
   }
 
-  private List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieBaseFile baseFile) {
+  private ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieBaseFile baseFile) {
     FileFormatUtils fileFormatUtils = HoodieIOFactory.getIOFactory(hoodieTable.getStorage())
         .getFileFormatUtils(baseFile.getStoragePath());
     if (keyGeneratorOpt.isPresent()) {
@@ -60,19 +59,18 @@ public class HoodieKeyLocationFetchHandle<T, I, K, O> extends HoodieReadHandle<T
     }
   }
 
-  public Stream<Pair<HoodieKey, HoodieRecordLocation>> locations() {
+  public ClosableIterator<Pair<HoodieKey, HoodieRecordLocation>> locations() {
     HoodieBaseFile baseFile = partitionPathBaseFilePair.getRight();
     String commitTime = baseFile.getCommitTime();
     String fileId = baseFile.getFileId();
-    return fetchRecordKeysWithPositions(baseFile).stream()
-        .map(entry -> Pair.of(entry.getLeft(),
-            new HoodieRecordLocation(commitTime, fileId, entry.getRight())));
+    return new CloseableMappingIterator<>(fetchRecordKeysWithPositions(baseFile),
+        entry -> Pair.of(entry.getLeft(), new HoodieRecordLocation(commitTime, fileId, entry.getRight())));
   }
 
-  public Stream<Pair<String, HoodieRecordGlobalLocation>> globalLocations() {
+  public ClosableIterator<Pair<String, HoodieRecordGlobalLocation>> globalLocations() {
     HoodieBaseFile baseFile = partitionPathBaseFilePair.getRight();
-    return fetchRecordKeysWithPositions(baseFile).stream()
-        .map(entry -> Pair.of(entry.getLeft().getRecordKey(),
+    return new CloseableMappingIterator<>(fetchRecordKeysWithPositions(baseFile),
+        entry -> Pair.of(entry.getLeft().getRecordKey(),
             new HoodieRecordGlobalLocation(
                 entry.getLeft().getPartitionPath(), baseFile.getCommitTime(),
                 baseFile.getFileId(), entry.getRight())));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/simple/TestGlobalSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/simple/TestGlobalSimpleIndex.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.simple;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.RawTripTestPayload;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.HoodieWriteableTestTable;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestGlobalSimpleIndex extends HoodieCommonTestHarness {
+  private static final Schema SCHEMA = getSchemaFromResource(TestGlobalSimpleIndex.class, "/exampleSchema.avsc", true);
+
+  @BeforeEach
+  void setUp() throws Exception {
+    initPath();
+    initMetaClient();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testTagLocation(boolean manuallySetPartitions) throws Exception {
+    String partition1 = "2016/01/31";
+    String partition2 = "2016/01/26";
+    String rowKey1 = UUID.randomUUID().toString();
+    String rowKey2 = UUID.randomUUID().toString();
+    String rowKey3 = UUID.randomUUID().toString();
+    String rowKey4 = UUID.randomUUID().toString();
+    String recordStr1 = "{\"_row_key\":\"" + rowKey1 + "\",\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
+    String recordStr2 = "{\"_row_key\":\"" + rowKey2 + "\",\"time\":\"2016-01-31T03:20:41.415Z\",\"number\":100}";
+    String recordStr3 = "{\"_row_key\":\"" + rowKey3 + "\",\"time\":\"2016-01-26T03:16:41.415Z\",\"number\":15}";
+    String recordStr4 = "{\"_row_key\":\"" + rowKey4 + "\",\"time\":\"2015-01-31T03:16:41.415Z\",\"number\":32}";
+    RawTripTestPayload payload1 = new RawTripTestPayload(recordStr1);
+    HoodieRecord record1 = new HoodieAvroRecord(
+        new HoodieKey(payload1.getRowKey(), payload1.getPartitionPath()), payload1);
+    RawTripTestPayload payload2 = new RawTripTestPayload(recordStr2);
+    HoodieRecord record2 = new HoodieAvroRecord(
+        new HoodieKey(payload2.getRowKey(), payload2.getPartitionPath()), payload2);
+    RawTripTestPayload payload3 = new RawTripTestPayload(recordStr3);
+    HoodieRecord record3 = new HoodieAvroRecord(
+        new HoodieKey(payload3.getRowKey(), payload3.getPartitionPath()), payload3);
+    HoodieRecord record3WithNewPartition = new HoodieAvroRecord(
+        new HoodieKey(payload3.getRowKey(), partition1), payload3);
+    RawTripTestPayload payload4 = new RawTripTestPayload(recordStr4);
+    HoodieAvroRecord record4 = new HoodieAvroRecord(
+        new HoodieKey(payload4.getRowKey(), payload4.getPartitionPath()), payload4);
+    HoodieData<HoodieRecord<HoodieAvroRecord>> records = HoodieListData.eager(Arrays.asList(record1, record2, record3WithNewPartition, record4));
+
+    HoodieWriteConfig config = makeConfig(manuallySetPartitions);
+    Configuration conf = new Configuration(false);
+    HoodieEngineContext context = new HoodieLocalEngineContext(metaClient.getStorageConf());
+    HoodieTable table = mock(HoodieTable.class, RETURNS_DEEP_STUBS);
+    when(table.getConfig()).thenReturn(config);
+    when(table.getMetaClient()).thenReturn(metaClient);
+    when(table.getStorage()).thenReturn(metaClient.getStorage());
+    HoodieGlobalSimpleIndex globalSimpleIndex = new HoodieGlobalSimpleIndex(config, Option.empty());
+    HoodieData<HoodieRecord<HoodieAvroRecord>> taggedRecordRDD = globalSimpleIndex.tagLocation(records, context, table);
+    assertFalse(taggedRecordRDD.collectAsList().stream().anyMatch(HoodieRecord::isCurrentLocationKnown));
+
+    HoodieStorage hoodieStorage = new HoodieHadoopStorage(basePath, conf);
+    HoodieWriteableTestTable testTable = new HoodieWriteableTestTable(basePath, hoodieStorage, metaClient, SCHEMA, null, null, Option.of(context));
+
+    String fileId1 = UUID.randomUUID().toString();
+    String fileId2 = UUID.randomUUID().toString();
+    String fileId3 = UUID.randomUUID().toString();
+    TaskContextSupplier localTaskContextSupplier = new LocalTaskContextSupplier();
+    StoragePath filePath1 = testTable.addCommit("001").withInserts(partition1, fileId1, Collections.singletonList(record1), localTaskContextSupplier);
+    StoragePath filePath2 = testTable.addCommit("002").withInserts(partition1, fileId2, Collections.singletonList(record2), localTaskContextSupplier);
+    StoragePath filePath3 = testTable.addCommit("003").withInserts(partition2, fileId3, Collections.singletonList(record3), localTaskContextSupplier);
+
+    String timestamp = metaClient.reloadActiveTimeline().lastInstant().get().requestedTime();
+    when(table.getBaseFileOnlyView().getLatestBaseFilesBeforeOrOn(partition1, timestamp))
+        .thenReturn(Stream.of(new HoodieBaseFile(hoodieStorage.getPathInfo(filePath1)), new HoodieBaseFile(hoodieStorage.getPathInfo(filePath2))));
+    when(table.getBaseFileOnlyView().getLatestBaseFilesBeforeOrOn(partition2, timestamp))
+        .thenReturn(Stream.of(new HoodieBaseFile(hoodieStorage.getPathInfo(filePath3))));
+
+    taggedRecordRDD = globalSimpleIndex.tagLocation(records, context, table);
+    Map<String, Option<String>> expectedRecordKeyToFileId = new HashMap<>();
+    expectedRecordKeyToFileId.put(rowKey1, Option.of(fileId1));
+    expectedRecordKeyToFileId.put(rowKey2, Option.of(fileId2));
+    expectedRecordKeyToFileId.put(rowKey3, Option.of(fileId3));
+    expectedRecordKeyToFileId.put(rowKey4, Option.empty());
+    Map<String, Option<String>> actualRecordKeyToFileId = taggedRecordRDD.collectAsList().stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, record -> record.isCurrentLocationKnown() ? Option.of(record.getCurrentLocation().getFileId()) : Option.empty()));
+    assertEquals(expectedRecordKeyToFileId, actualRecordKeyToFileId);
+  }
+
+  private HoodieWriteConfig makeConfig(boolean manuallySetPartitions) {
+    Properties props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    return HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .fromProperties(props)
+            .withIndexType(HoodieIndex.IndexType.GLOBAL_SIMPLE)
+            .withGlobalSimpleIndexParallelism(manuallySetPartitions ? 1 : 0)
+            .build())
+        .build();
+  }
+}
+

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/simple/TestSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/index/simple/TestSimpleIndex.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.simple;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.RawTripTestPayload;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.HoodieWriteableTestTable;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestSimpleIndex extends HoodieCommonTestHarness {
+  private static final Schema SCHEMA = getSchemaFromResource(TestSimpleIndex.class, "/exampleSchema.avsc", true);
+
+  @BeforeEach
+  void setUp() throws Exception {
+    initPath();
+    initMetaClient();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testTagLocation(boolean manuallySetPartitions) throws Exception {
+    String partition1 = "2016/01/31";
+    String partition2 = "2016/01/26";
+    String rowKey1 = UUID.randomUUID().toString();
+    String rowKey2 = UUID.randomUUID().toString();
+    String rowKey3 = UUID.randomUUID().toString();
+    String rowKey4 = UUID.randomUUID().toString();
+    String recordStr1 = "{\"_row_key\":\"" + rowKey1 + "\",\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
+    String recordStr2 = "{\"_row_key\":\"" + rowKey2 + "\",\"time\":\"2016-01-31T03:20:41.415Z\",\"number\":100}";
+    String recordStr3 = "{\"_row_key\":\"" + rowKey3 + "\",\"time\":\"2016-01-26T03:16:41.415Z\",\"number\":15}";
+    String recordStr4 = "{\"_row_key\":\"" + rowKey4 + "\",\"time\":\"2015-01-31T03:16:41.415Z\",\"number\":32}";
+    RawTripTestPayload payload1 = new RawTripTestPayload(recordStr1);
+    HoodieRecord record1 = new HoodieAvroRecord(
+        new HoodieKey(payload1.getRowKey(), payload1.getPartitionPath()), payload1);
+    RawTripTestPayload payload2 = new RawTripTestPayload(recordStr2);
+    HoodieRecord record2 = new HoodieAvroRecord(
+        new HoodieKey(payload2.getRowKey(), payload2.getPartitionPath()), payload2);
+    RawTripTestPayload payload3 = new RawTripTestPayload(recordStr3);
+    HoodieRecord record3 = new HoodieAvroRecord(
+        new HoodieKey(payload3.getRowKey(), payload3.getPartitionPath()), payload3);
+    HoodieRecord record3WithNewPartition = new HoodieAvroRecord(
+        new HoodieKey(payload3.getRowKey(), partition1), payload3);
+    RawTripTestPayload payload4 = new RawTripTestPayload(recordStr4);
+    HoodieAvroRecord record4 = new HoodieAvroRecord(
+        new HoodieKey(payload4.getRowKey(), payload4.getPartitionPath()), payload4);
+    HoodieData<HoodieRecord<HoodieAvroRecord>> records = HoodieListData.eager(Arrays.asList(record1, record2, record3WithNewPartition, record4));
+
+    HoodieWriteConfig config = makeConfig(manuallySetPartitions);
+    Configuration conf = new Configuration(false);
+
+    HoodieEngineContext context = new HoodieLocalEngineContext(metaClient.getStorageConf());
+    HoodieTable table = mock(HoodieTable.class, RETURNS_DEEP_STUBS);
+    when(table.getConfig()).thenReturn(config);
+    when(table.getMetaClient()).thenReturn(metaClient);
+    when(table.getStorage()).thenReturn(metaClient.getStorage());
+    HoodieSimpleIndex simpleIndex = new HoodieSimpleIndex(config, Option.empty());
+    HoodieData<HoodieRecord<HoodieAvroRecord>> taggedRecordRDD = simpleIndex.tagLocation(records, context, table);
+    assertFalse(taggedRecordRDD.collectAsList().stream().anyMatch(HoodieRecord::isCurrentLocationKnown));
+
+    HoodieStorage hoodieStorage = new HoodieHadoopStorage(basePath, conf);
+    HoodieWriteableTestTable testTable = new HoodieWriteableTestTable(basePath, hoodieStorage, metaClient, SCHEMA, null, null, Option.of(context));
+
+    String fileId1 = UUID.randomUUID().toString();
+    String fileId2 = UUID.randomUUID().toString();
+    String fileId3 = UUID.randomUUID().toString();
+    TaskContextSupplier localTaskContextSupplier = new LocalTaskContextSupplier();
+    StoragePath filePath1 = testTable.addCommit("001").withInserts(partition1, fileId1, Collections.singletonList(record1), localTaskContextSupplier);
+    StoragePath filePath2 = testTable.addCommit("002").withInserts(partition1, fileId2, Collections.singletonList(record2), localTaskContextSupplier);
+    testTable.addCommit("003").withInserts(partition2, fileId3, Collections.singletonList(record3), localTaskContextSupplier);
+
+    String timestamp = metaClient.reloadActiveTimeline().lastInstant().get().requestedTime();
+    when(table.getBaseFileOnlyView().getLatestBaseFilesBeforeOrOn(partition1, timestamp))
+        .thenReturn(Stream.of(new HoodieBaseFile(hoodieStorage.getPathInfo(filePath1)), new HoodieBaseFile(hoodieStorage.getPathInfo(filePath2))));
+    when(table.getBaseFileOnlyView().getLatestBaseFilesBeforeOrOn("2015/01/31", timestamp))
+        .thenReturn(Stream.empty());
+
+    taggedRecordRDD = simpleIndex.tagLocation(records, context, table);
+    Map<String, Option<String>> expectedRecordKeyToFileId = new HashMap<>();
+    expectedRecordKeyToFileId.put(rowKey1, Option.of(fileId1));
+    expectedRecordKeyToFileId.put(rowKey2, Option.of(fileId2));
+    // record3 has a new partition so will not be tagged
+    expectedRecordKeyToFileId.put(rowKey3, Option.empty());
+    expectedRecordKeyToFileId.put(rowKey4, Option.empty());
+    Map<String, Option<String>> actualRecordKeyToFileId = taggedRecordRDD.collectAsList().stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, record -> record.isCurrentLocationKnown() ? Option.of(record.getCurrentLocation().getFileId()) : Option.empty()));
+    assertEquals(expectedRecordKeyToFileId, actualRecordKeyToFileId);
+  }
+
+  private HoodieWriteConfig makeConfig(boolean manuallySetPartitions) {
+    Properties props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    return HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .fromProperties(props)
+            .withIndexType(HoodieIndex.IndexType.SIMPLE)
+            .withSimpleIndexParallelism(manuallySetPartitions ? 1 : 0)
+            .build())
+        .build();
+  }
+}
+

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -187,7 +188,7 @@ public abstract class FileFormatUtils {
    * @param filePath the data file path.
    * @return {@link List} of pairs of {@link HoodieKey} and position fetched from the data file.
    */
-  public abstract List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath);
+  public abstract ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath);
 
   /**
    * Provides a closable iterator for reading the given data file.
@@ -216,11 +217,11 @@ public abstract class FileFormatUtils {
    * @param storage         {@link HoodieStorage} instance.
    * @param filePath        the data file path.
    * @param keyGeneratorOpt instance of KeyGenerator.
-   * @return {@link List} of pairs of {@link HoodieKey} and position fetched from the data file.
+   * @return {@link Iterator} of pairs of {@link HoodieKey} and position fetched from the data file.
    */
-  public abstract List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage,
-                                                                           StoragePath filePath,
-                                                                           Option<BaseKeyGenerator> keyGeneratorOpt);
+  public abstract ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage,
+                                                                                       StoragePath filePath,
+                                                                                       Option<BaseKeyGenerator> keyGeneratorOpt);
 
   /**
    * Read the Avro schema of the data file.

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -109,7 +109,7 @@ public class HFileUtils extends FileFormatUtils {
   }
 
   @Override
-  public List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
     throw new UnsupportedOperationException("HFileUtils does not support fetchRecordKeysWithPositions");
   }
 
@@ -124,7 +124,7 @@ public class HFileUtils extends FileFormatUtils {
   }
 
   @Override
-  public List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt) {
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt) {
     throw new UnsupportedOperationException("HFileUtils does not support fetchRecordKeysWithPositions");
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -58,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.BinaryUtil.toBytes;
@@ -89,28 +91,21 @@ public class OrcUtils extends FileFormatUtils {
    * @return {@link List} of {@link HoodieKey}s fetched from the ORC file
    */
   @Override
-  public List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
     return fetchRecordKeysWithPositions(storage, filePath, Option.empty());
   }
 
   @Override
-  public List<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt) {
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt) {
     try {
       if (!storage.exists(filePath)) {
-        return Collections.emptyList();
+        return ClosableIterator.wrap(Collections.emptyIterator());
       }
     } catch (IOException e) {
       throw new HoodieIOException("Failed to read from ORC file:" + filePath, e);
     }
-    List<Pair<HoodieKey, Long>> hoodieKeysAndPositions = new ArrayList<>();
-    long position = 0;
-    try (ClosableIterator<HoodieKey> iterator = getHoodieKeyIterator(storage, filePath, keyGeneratorOpt)) {
-      while (iterator.hasNext()) {
-        hoodieKeysAndPositions.add(Pair.of(iterator.next(), position));
-        position++;
-      }
-    }
-    return hoodieKeysAndPositions;
+    AtomicLong position = new AtomicLong(0);
+    return new CloseableMappingIterator<>(getHoodieKeyIterator(storage, filePath, keyGeneratorOpt), key -> Pair.of(key, position.getAndIncrement()));
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.storage.StoragePath;
@@ -154,8 +155,13 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     writeParquetFile(typeCode, filePath, rowKeys, schema, true, partitionPath);
 
     // Read and verify
-    List<Pair<HoodieKey, Long>> fetchedRows = parquetUtils.fetchRecordKeysWithPositions(
-        HoodieTestUtils.getStorage(filePath), new StoragePath(filePath));
+    List<Pair<HoodieKey, Long>> fetchedRows = new ArrayList<>();
+    try (ClosableIterator<Pair<HoodieKey, Long>> iter = parquetUtils.fetchRecordKeysWithPositions(
+        HoodieTestUtils.getStorage(filePath), new StoragePath(filePath))) {
+      while (iter.hasNext()) {
+        fetchedRows.add(iter.next());
+      }
+    }
     assertEquals(rowKeys.size(), fetchedRows.size(), "Total count does not match");
 
     for (Pair<HoodieKey, Long> entry : fetchedRows) {
@@ -180,9 +186,14 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         false, "abc", "def");
 
     // Read and verify
-    List<Pair<HoodieKey, Long>> fetchedRows = parquetUtils.fetchRecordKeysWithPositions(
+    List<Pair<HoodieKey, Long>> fetchedRows = new ArrayList<>();
+    try (ClosableIterator<Pair<HoodieKey, Long>> iter = parquetUtils.fetchRecordKeysWithPositions(
         HoodieTestUtils.getStorage(filePath), new StoragePath(filePath),
-        Option.of(new TestBaseKeyGen("abc", "def")));
+        Option.of(new TestBaseKeyGen("abc", "def")))) {
+      while (iter.hasNext()) {
+        fetchedRows.add(iter.next());
+      }
+    }
     assertEquals(rowKeys.size(), fetchedRows.size(), "Total count does not match");
 
     for (Pair<HoodieKey, Long> entry : fetchedRows) {


### PR DESCRIPTION
### Change Logs

- Update the default parallelism to be based off of the base files that will be read instead of input data partitions
- Update the key lookup to use iterators instead of materializing a full list first
- Added unit tests

### Impact

- Small updates against a large table will struggle with the current defaults since the number of input partitions is small relative to the total number of files that need to be inspected.
- We use iterators now instead of creating an intermediate list object which is preferred in spark

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
