### PR TITLE
[HUDI-8674] Fix Flink build in CI to be consistent with release script

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -405,12 +405,19 @@ jobs:
       matrix:
         include:
           - flinkProfile: "flink1.14"
+            flinkAvroVersion: "1.10.0"
           - flinkProfile: "flink1.15"
+            flinkAvroVersion: "1.10.0"
           - flinkProfile: "flink1.16"
+            flinkAvroVersion: "1.11.1"
           - flinkProfile: "flink1.17"
+            flinkAvroVersion: "1.11.1"
           - flinkProfile: "flink1.18"
+            flinkAvroVersion: "1.11.1"
           - flinkProfile: "flink1.19"
+            flinkAvroVersion: "1.11.1"
           - flinkProfile: "flink1.20"
+            flinkAvroVersion: "1.11.3"
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
@@ -423,22 +430,25 @@ jobs:
         env:
           SCALA_PROFILE: 'scala-2.12'
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
+          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version=1.10.0 -DskipTests=true $MVN_ARGS
+          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: 'scala-2.12'
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
+          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="FLINK_AVRO_VERSION" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
       - name: Integration Test
         env:
           SCALA_PROFILE: 'scala-2.12'
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
+          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         if: ${{ endsWith(env.FLINK_PROFILE, '1.20') }}
         run: |
-          mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version=1.10.0 -DskipTests=true $MVN_ARGS
-          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
+          mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version="FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
+          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="FLINK_AVRO_VERSION" -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
 
   docker-java17-test:
     runs-on: ubuntu-latest
@@ -484,30 +494,37 @@ jobs:
         include:
           - scalaProfile: 'scala-2.13'
             flinkProfile: 'flink1.20'
+            flinkAvroVersion: '1.11.3'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
           - scalaProfile: 'scala-2.13'
             flinkProfile: 'flink1.19'
+            flinkAvroVersion: '1.11.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
           - scalaProfile: 'scala-2.13'
             flinkProfile: 'flink1.18'
+            flinkAvroVersion: '1.11.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.17'
+            flinkAvroVersion: '1.11.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.16'
+            flinkAvroVersion: '1.11.1'
             sparkProfile: 'spark3.4'
             sparkRuntime: 'spark3.4.3'
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.15'
+            flinkAvroVersion: '1.10.0'
             sparkProfile: 'spark3.3'
             sparkRuntime: 'spark3.3.4'
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink1.14'
+            flinkAvroVersion: '1.10.0'
             sparkProfile: 'spark3.3'
             sparkRuntime: 'spark3.3.4'
     steps:
@@ -523,6 +540,7 @@ jobs:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
+          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run: |
           if [ "$SCALA_PROFILE" == "scala-2.13" ]; then
             mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DdeployArtifacts=true -DskipTests=true $MVN_ARGS -pl packaging/hudi-hadoop-mr-bundle,packaging/hudi-spark-bundle,packaging/hudi-utilities-bundle,packaging/hudi-utilities-slim-bundle,packaging/hudi-cli-bundle -am
@@ -530,7 +548,7 @@ jobs:
             mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DdeployArtifacts=true -DskipTests=true $MVN_ARGS
             # TODO remove the sudo below. It's a needed workaround as detailed in HUDI-5708.
             sudo chown -R "$USER:$(id -g -n)" hudi-platform-service/hudi-metaserver/target/generated-sources
-            mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -DdeployArtifacts=true -DskipTests=true $MVN_ARGS -pl packaging/hudi-flink-bundle -am -Davro.version=1.10.0
+            mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -DdeployArtifacts=true -DskipTests=true $MVN_ARGS -pl packaging/hudi-flink-bundle -am -Davro.version="$FLINK_AVRO_VERSION"
           fi
       - name: IT - Bundle Validation - OpenJDK 8
         env:
@@ -709,7 +727,7 @@ jobs:
         include:
           - scalaProfile: "scala-2.12"
             flinkProfile: "flink1.20"
-
+            flinkAvroVersion: '1.11.3'
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -722,8 +740,9 @@ jobs:
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
+          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run:
-          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version=1.10.0 -DskipTests=true $MVN_ARGS
+          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="$FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -432,14 +432,14 @@ jobs:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
           FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
+          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="$FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: 'scala-2.12'
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
           FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="FLINK_AVRO_VERSION" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
       - name: Integration Test
         env:
           SCALA_PROFILE: 'scala-2.12'
@@ -447,8 +447,8 @@ jobs:
           FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
         if: ${{ endsWith(env.FLINK_PROFILE, '1.20') }}
         run: |
-          mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version="FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
-          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="FLINK_AVRO_VERSION" -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
+          mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version="$FLINK_AVRO_VERSION" -DskipTests=true $MVN_ARGS
+          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
 
   docker-java17-test:
     runs-on: ubuntu-latest

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -83,7 +83,7 @@
             <import>${basedir}/src/main/avro/HoodiePath.avsc</import>
             <import>${basedir}/src/main/avro/HoodieFSPermission.avsc</import>
             <import>${basedir}/src/main/avro/HoodieFileStatus.avsc</import>
-            <import>${basedir}/src/main/avro/HoodieBootstrapFilePartitionInfo.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieBootstrapSourceFilePartitionInfo.avsc</import>
             <import>${basedir}/src/main/avro/HoodieBootstrapIndexInfo.avsc</import>
             <import>${basedir}/src/main/avro/HoodieBootstrapPartitionMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieSliceInfo.avsc</import>

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -83,7 +83,7 @@
             <import>${basedir}/src/main/avro/HoodiePath.avsc</import>
             <import>${basedir}/src/main/avro/HoodieFSPermission.avsc</import>
             <import>${basedir}/src/main/avro/HoodieFileStatus.avsc</import>
-            <import>${basedir}/src/main/avro/HoodieBootstrapSourceFilePartitionInfo.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieBootstrapFilePartitionInfo.avsc</import>
             <import>${basedir}/src/main/avro/HoodieBootstrapIndexInfo.avsc</import>
             <import>${basedir}/src/main/avro/HoodieBootstrapPartitionMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieSliceInfo.avsc</import>


### PR DESCRIPTION
### Change Logs

We made a fix to an issue that fails Flink 1.20 bundle build in the release script which was not caught by CI: #12432 .  The root cause is that CI build is not consistent with the release script, specifically the `avro.version` set.  This PR fixes the GH CI to be consistent with the release script by setting the `avro.version` per supported Flink version.

After fixing the build command CI and testing against the POM before the fix, now CI throws build error as expected:
<img width="1823" alt="Screenshot 2024-12-06 at 21 20 06" src="https://github.com/user-attachments/assets/824ac3cc-ee82-42a9-a117-4c44dbd772d0">


### Impact

Improves CI on Hudi Flink.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
