### PR TITLE
[HUDI-8648] Fix a bug for secondary index deletion

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1189,8 +1189,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
         dataMetaClient,
         getEngineType(),
         indexDefinition)
-        .union(deletedRecords)
-        .distinctWithKey(HoodieRecord::getKey, parallelism);
+        .union(deletedRecords);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
@@ -371,7 +371,7 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
   @Test
   void testReverseLookupSecondaryKeysInternalWithOnlyBaseFileRecord() {
     String recordKey = "recordKey";
-    List<String> recordKeys = Collections.singletonList(recordKey);
+    Set<String> recordKeys = Collections.singleton(recordKey);
     Map<String, HoodieRecord<HoodieMetadataPayload>> baseFileRecords = new HashMap<>();
     HoodieMetadataLogRecordReader logRecordReader = mock(HoodieMetadataLogRecordReader.class);
     List<HoodieRecord<HoodieMetadataPayload>> logRecords = new ArrayList<>();
@@ -391,7 +391,7 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
   @Test
   void testReverseLookupSecondaryKeysInternalWithOnlyLogRecords() {
     String recordKey = "recordKey";
-    List<String> recordKeys = Collections.singletonList(recordKey);
+    Set<String> recordKeys = Collections.singleton(recordKey);
     Map<String, HoodieRecord<HoodieMetadataPayload>> baseFileRecords = new HashMap<>();
     HoodieMetadataLogRecordReader logRecordReader = mock(HoodieMetadataLogRecordReader.class);
     List<HoodieRecord<HoodieMetadataPayload>> logRecords = new ArrayList<>();
@@ -427,7 +427,7 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
   @Test
   void testReverseLookupSecondaryKeysInternal() {
     String recordKey = "recordKey";
-    List<String> recordKeys = Collections.singletonList(recordKey);
+    Set<String> recordKeys = Collections.singleton(recordKey);
     Map<String, HoodieRecord<HoodieMetadataPayload>> baseFileRecords = new HashMap<>();
     HoodieMetadataLogRecordReader logRecordReader = mock(HoodieMetadataLogRecordReader.class);
     List<HoodieRecord<HoodieMetadataPayload>> logRecords = new ArrayList<>();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -860,11 +860,13 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
           }
         });
       } else {
-        // Iterate over all provided log-records, merging them into existing records
-        logRecordsMap.forEach((key1, value1) -> baseFileRecords.merge(key1, value1, (oldRecord, newRecord) -> {
-          Option<HoodieRecord<HoodieMetadataPayload>> mergedRecord = HoodieMetadataPayload.combineSecondaryIndexRecord(oldRecord, newRecord);
-          return mergedRecord.orElse(null);
-        }));
+        // Return non-deleted records from the log files.
+        logRecordsMap.forEach((key, value) -> {
+          if (!value.getData().isDeleted()) {
+            recordKeyMap.put(key, SecondaryIndexKeyUtils.getSecondaryKeyFromSecondaryIndexKey(value.getRecordKey()));
+          }
+        });
+        // Return non-deleted records from the base file.
         baseFileRecords.forEach((key, value) -> {
           if (!deletedRecordsFromLogs.contains(key)) {
             recordKeyMap.put(key, SecondaryIndexKeyUtils.getSecondaryKeyFromSecondaryIndexKey(value.getRecordKey()));

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexKeyUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexKeyUtils.java
@@ -39,7 +39,7 @@ public class SecondaryIndexKeyUtils {
     return unescapeSpecialChars(key.substring(0, delimiterIndex));
   }
 
-  static String constructSecondaryIndexKey(String secondaryKey, String recordKey) {
+  public static String constructSecondaryIndexKey(String secondaryKey, String recordKey) {
     return escapeSpecialChars(secondaryKey) + SECONDARY_INDEX_RECORD_KEY_SEPARATOR + escapeSpecialChars(recordKey);
   }
 


### PR DESCRIPTION
### Change Logs

When we try to search for the SI records for a given record key, the way we search for the secondary key could cause some SI records missed, and further cause some SI records are not deleted correctly.

### Impact

Correct SI behavior.

### Risk level (write none, low medium or high below)

Medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
