### PR TITLE
[HUDI-8676] Improve ValidationUtils performance by lazy appending msg

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
@@ -172,7 +172,7 @@ public abstract class BaseHoodieCompactionPlanGenerator<T extends HoodieRecordPa
     ValidationUtils.checkArgument(
         compactionPlan.getOperations().stream().noneMatch(
             op -> fgIdsInPendingCompactionAndClustering.contains(new HoodieFileGroupId(op.getPartitionPath(), op.getFileId()))),
-        "Bad Compaction Plan. FileId MUST NOT have multiple pending compactions. "
+        () -> "Bad Compaction Plan. FileId MUST NOT have multiple pending compactions. "
             + "Please fix your strategy implementation. FileIdsWithPendingCompactions :" + fgIdsInPendingCompactionAndClustering
             + ", Selected workload :" + compactionPlan);
     if (compactionPlan.getOperations().isEmpty()) {

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
@@ -47,7 +47,9 @@ public class ValidationUtils {
    * Ensures the truth of an expression, throwing the custom errorMessage otherwise.
    */
   public static void checkArgument(final boolean expression, final Supplier<String> errorMessageSupplier) {
-    checkArgument(expression, errorMessageSupplier.get());
+    if (!expression) {
+      throw new IllegalArgumentException(errorMessageSupplier.get());
+    }
   }
 
   /**


### PR DESCRIPTION
When using ValidationUtils to check arguments or states, messages are created immediately regardless of the result of the expression, which can lead to frequent String variable creation in some scenarios or unnecessarily large string variables, resulting in a certain amount of stress on the jvm.
For example, our task was failed because OOM caused by appending String message:
<img width="1546" alt="image" src="https://github.com/user-attachments/assets/18853ab1-afe5-4eab-a98f-439e15e9ace4">


### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
1. improve ValidationUtils performance by lazy appending msg
### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
