### PR TITLE
[HUDI-8682] Simplify precombine and ordering field value handling in the file group reader

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -37,6 +37,7 @@ import org.apache.spark.sql.HoodieUnsafeRowUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -128,5 +129,16 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
 
   protected UnaryOperator<InternalRow> getIdentityProjection() {
     return row -> row;
+  }
+
+  @Override
+  public Comparable convertValueToEngineType(Comparable value) {
+    if (value instanceof String) {
+      // Spark reads String field values as UTF8String.
+      // To foster value comparison, if the value is of String type, e.g., from
+      // the delete record, we convert it to UTF8String type.
+      return UTF8String.fromString((String) value);
+    }
+    return value;
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -32,7 +32,6 @@ import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParq
 import org.apache.hudi.storage.{HoodieStorage, StorageConfiguration, StoragePath}
 import org.apache.hudi.util.CloseableInternalRowIterator
 import org.apache.avro.Schema
-import org.apache.avro.Schema.Type
 import org.apache.avro.generic.{GenericRecord, IndexedRecord}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.HoodieInternalRowUtils
@@ -262,46 +261,10 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
     }
   }
 
-  override def castValue(value: Comparable[_], newType: Schema.Type): Comparable[_] = {
-    val valueToCast = if (value == null) 0 else value
-    valueToCast match {
-      case v: Integer => newType match {
-        case Type.INT => v
-        case Type.LONG => v.longValue()
-        case Type.FLOAT => v.floatValue()
-        case Type.DOUBLE => v.doubleValue()
-        case Type.STRING => UTF8String.fromString(v.toString)
-        case Type.FIXED => BigDecimal(v)
-        case x => throw new UnsupportedOperationException(s"Cast from Integer to $x is not supported")
-      }
-      case v: java.lang.Long => newType match {
-        case Type.LONG => v
-        case Type.FLOAT => v.floatValue()
-        case Type.DOUBLE => v.doubleValue()
-        case Type.STRING => UTF8String.fromString(v.toString)
-        case Type.FIXED => BigDecimal(v)
-        case x => throw new UnsupportedOperationException(s"Cast from Long to $x is not supported")
-      }
-      case v: java.lang.Float => newType match {
-        case Type.FLOAT => v
-        case Type.DOUBLE => v.doubleValue()
-        case Type.STRING => UTF8String.fromString(v.toString)
-        case x => throw new UnsupportedOperationException(s"Cast from Float to $x is not supported")
-      }
-      case v: java.lang.Double => newType match {
-        case Type.DOUBLE => v
-        case Type.STRING => UTF8String.fromString(v.toString)
-        case Type.FIXED => BigDecimal(v)
-        case x => throw new UnsupportedOperationException(s"Cast from Double to $x is not supported")
-      }
-      case v: String => newType match {
-        case Type.STRING => UTF8String.fromString(v)
-        case x => throw new UnsupportedOperationException(s"Cast from String to $x is not supported")
-      }
-      case v: UTF8String => newType match {
-        case Type.STRING => v
-        case x => throw new UnsupportedOperationException(s"Cast from String to $x is not supported")
-      }
+  override def convertValueToEngineType(value: Comparable[_]): Comparable[_] = {
+    value match {
+      case v: String => UTF8String.fromString(v)
+      case v => v
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -260,13 +260,6 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
       }.asInstanceOf[ClosableIterator[InternalRow]]
     }
   }
-
-  override def convertValueToEngineType(value: Comparable[_]): Comparable[_] = {
-    value match {
-      case v: String => UTF8String.fromString(v)
-      case v => v
-    }
-  }
 }
 
 object SparkFileFormatInternalRowReaderContext {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
 import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
 
 /**
@@ -233,26 +234,22 @@ public abstract class HoodieReaderContext<T> implements Closeable {
    * @param metadataMap  A map containing the record metadata.
    * @param schema       The Avro schema of the record.
    * @param orderingFieldName name of the ordering field
-   * @param orderingFieldTypeOpt type of the ordering field
-   * @param orderingFieldDefault default value for ordering
    * @return The ordering value.
    */
   public Comparable getOrderingValue(Option<T> recordOption,
                                      Map<String, Object> metadataMap,
                                      Schema schema,
-                                     String orderingFieldName,
-                                     Option<Schema.Type> orderingFieldTypeOpt,
-                                     Comparable orderingFieldDefault) {
+                                     Option<String> orderingFieldName) {
     if (metadataMap.containsKey(INTERNAL_META_ORDERING_FIELD)) {
       return (Comparable) metadataMap.get(INTERNAL_META_ORDERING_FIELD);
     }
 
-    if (!recordOption.isPresent() || !orderingFieldTypeOpt.isPresent()) {
-      return orderingFieldDefault;
+    if (!recordOption.isPresent() || orderingFieldName.isEmpty()) {
+      return COMMIT_TIME_ORDERING_VALUE;
     }
 
-    Object value = getValue(recordOption.get(), schema, orderingFieldName);
-    Comparable finalOrderingVal = value != null ? castValue((Comparable) value, orderingFieldTypeOpt.get()) : orderingFieldDefault;
+    Object value = getValue(recordOption.get(), schema, orderingFieldName.get());
+    Comparable finalOrderingVal = value != null ? (Comparable) value : COMMIT_TIME_ORDERING_VALUE;
     metadataMap.put(INTERNAL_META_ORDERING_FIELD, finalOrderingVal);
     return finalOrderingVal;
   }
@@ -284,11 +281,11 @@ public abstract class HoodieReaderContext<T> implements Closeable {
    * @return A mapping containing the metadata.
    */
   public Map<String, Object> generateMetadataForRecord(
-      String recordKey, String partitionPath, Comparable orderingVal, Option<Schema.Type> orderingFieldType) {
+      String recordKey, String partitionPath, Comparable orderingVal) {
     Map<String, Object> meta = new HashMap<>();
     meta.put(INTERNAL_META_RECORD_KEY, recordKey);
     meta.put(INTERNAL_META_PARTITION_PATH, partitionPath);
-    meta.put(INTERNAL_META_ORDERING_FIELD, orderingFieldType.map(type -> castValue(orderingVal, type)).orElse(orderingVal));
+    meta.put(INTERNAL_META_ORDERING_FIELD, orderingVal);
     return meta;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -359,7 +359,7 @@ public abstract class HoodieReaderContext<T> implements Closeable {
   /**
    * Returns the value to a type representation in a specific engine.
    * <p>
-   * This is overridden by the reader context implementation on a specific engine to handle
+   * This can be overridden by the reader context implementation on a specific engine to handle
    * engine-specific field type system.  For example, Spark uses {@code UTF8String} to represent
    * {@link String} field values, so we need to convert the values to {@code UTF8String} type
    * in Spark for proper value comparison.

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -285,7 +285,7 @@ public abstract class HoodieReaderContext<T> implements Closeable {
     Map<String, Object> meta = new HashMap<>();
     meta.put(INTERNAL_META_RECORD_KEY, recordKey);
     meta.put(INTERNAL_META_PARTITION_PATH, partitionPath);
-    meta.put(INTERNAL_META_ORDERING_FIELD, convertValueToEngineType(orderingVal));
+    meta.put(INTERNAL_META_ORDERING_FIELD, orderingVal);
     return meta;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -43,7 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
 
 /**
@@ -245,11 +245,11 @@ public abstract class HoodieReaderContext<T> implements Closeable {
     }
 
     if (!recordOption.isPresent() || orderingFieldName.isEmpty()) {
-      return COMMIT_TIME_ORDERING_VALUE;
+      return DEFAULT_ORDERING_VALUE;
     }
 
     Object value = getValue(recordOption.get(), schema, orderingFieldName.get());
-    Comparable finalOrderingVal = value != null ? convertValueToEngineType((Comparable) value) : COMMIT_TIME_ORDERING_VALUE;
+    Comparable finalOrderingVal = value != null ? convertValueToEngineType((Comparable) value) : DEFAULT_ORDERING_VALUE;
     metadataMap.put(INTERNAL_META_ORDERING_FIELD, finalOrderingVal);
     return finalOrderingVal;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
@@ -27,6 +27,8 @@ import org.apache.avro.generic.IndexedRecord;
 import java.io.IOException;
 import java.util.Properties;
 
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+
 /**
  * Provides support for seamlessly applying changes captured via Amazon Database Migration Service onto S3.
  *
@@ -50,7 +52,7 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public AWSDmsAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, 0); // natural order
+    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
@@ -27,7 +27,7 @@ import org.apache.avro.generic.IndexedRecord;
 import java.io.IOException;
 import java.util.Properties;
 
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * Provides support for seamlessly applying changes captured via Amazon Database Migration Service onto S3.
@@ -52,7 +52,7 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public AWSDmsAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * Default payload.
@@ -58,7 +58,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public DefaultHoodieRecordPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+
 /**
  * Default payload.
  * {@link HoodieRecordPayload} impl that honors ordering field in both preCombine and combineAndGetUpdateValue.
@@ -56,7 +58,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public DefaultHoodieRecordPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, 0); // natural order
+    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro;
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * The only difference with {@link DefaultHoodieRecordPayload} is that is does not
@@ -42,7 +42,7 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
   }
 
   public EventTimeAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro;
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
 
 /**
  * The only difference with {@link DefaultHoodieRecordPayload} is that is does not
@@ -41,7 +42,7 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
   }
 
   public EventTimeAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, 0); // natural order
+    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -56,7 +56,9 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   public static final String FILENAME_METADATA_FIELD = HoodieMetadataField.FILENAME_METADATA_FIELD.getFieldName();
   public static final String OPERATION_METADATA_FIELD = HoodieMetadataField.OPERATION_METADATA_FIELD.getFieldName();
   public static final String HOODIE_IS_DELETED_FIELD = "_hoodie_is_deleted";
-  public static final int COMMIT_TIME_ORDERING_VALUE = 0;
+  // If the ordering value is not set, this default order value is set and
+  // always treated as the commit time ordering.
+  public static final int DEFAULT_ORDERING_VALUE = 0;
 
   public enum HoodieMetadataField {
     COMMIT_TIME_METADATA_FIELD("_hoodie_commit_time"),

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -56,6 +56,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   public static final String FILENAME_METADATA_FIELD = HoodieMetadataField.FILENAME_METADATA_FIELD.getFieldName();
   public static final String OPERATION_METADATA_FIELD = HoodieMetadataField.OPERATION_METADATA_FIELD.getFieldName();
   public static final String HOODIE_IS_DELETED_FIELD = "_hoodie_is_deleted";
+  public static final int COMMIT_TIME_ORDERING_VALUE = 0;
 
   public enum HoodieMetadataField {
     COMMIT_TIME_METADATA_FIELD("_hoodie_commit_time"),

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -29,7 +29,7 @@ import org.apache.avro.generic.IndexedRecord;
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * <ol>
@@ -45,7 +45,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   public OverwriteWithLatestAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -29,6 +29,8 @@ import org.apache.avro.generic.IndexedRecord;
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+
 /**
  * <ol>
  * <li> preCombine - Picks the latest delta record for a key, based on an ordering field;
@@ -43,7 +45,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   public OverwriteWithLatestAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, 0); // natural order
+    this(record.isPresent() ? record.get() : null, COMMIT_TIME_ORDERING_VALUE); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -560,7 +560,7 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
   }
 
   protected static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
-    return orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
+    return orderingValue == null || orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
   }
 
   protected static Comparable getOrderingValue(HoodieReaderContext readerContext,
@@ -572,7 +572,7 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
 
   private boolean isDeleteRecordWithNaturalOrder(Option<T> rowOption,
                                                  Comparable orderingValue) {
-    return rowOption.isEmpty() && isCommitTimeOrderingValue(orderingValue);
+    return rowOption.isEmpty() && orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
   }
 
   private boolean isDeleteRecord(Option<T> record, Schema schema) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -559,9 +559,20 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
     return Pair.of(transformer, evolvedSchema);
   }
 
+  protected static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
+    return orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
+  }
+
+  protected static Comparable getOrderingValue(HoodieReaderContext readerContext,
+                                               DeleteRecord deleteRecord) {
+    return isCommitTimeOrderingValue(deleteRecord.getOrderingValue())
+        ? COMMIT_TIME_ORDERING_VALUE
+        : readerContext.convertValueToEngineType(deleteRecord.getOrderingValue());
+  }
+
   private boolean isDeleteRecordWithNaturalOrder(Option<T> rowOption,
                                                  Comparable orderingValue) {
-    return rowOption.isEmpty() && orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
+    return rowOption.isEmpty() && isCommitTimeOrderingValue(orderingValue);
   }
 
   private boolean isDeleteRecord(Option<T> record, Schema schema) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -71,7 +71,7 @@ import static org.apache.hudi.common.config.HoodieMemoryConfig.MAX_MEMORY_FOR_ME
 import static org.apache.hudi.common.config.HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH;
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_PARTITION_PATH;
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_RECORD_KEY;
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.model.HoodieRecord.HOODIE_IS_DELETED_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.OPERATION_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID;
@@ -560,19 +560,19 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
   }
 
   static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
-    return orderingValue == null || orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
+    return orderingValue == null || orderingValue.equals(DEFAULT_ORDERING_VALUE);
   }
 
   static Comparable getOrderingValue(HoodieReaderContext readerContext,
                                      DeleteRecord deleteRecord) {
     return isCommitTimeOrderingValue(deleteRecord.getOrderingValue())
-        ? COMMIT_TIME_ORDERING_VALUE
+        ? DEFAULT_ORDERING_VALUE
         : readerContext.convertValueToEngineType(deleteRecord.getOrderingValue());
   }
 
   private boolean isDeleteRecordWithNaturalOrder(Option<T> rowOption,
                                                  Comparable orderingValue) {
-    return rowOption.isEmpty() && orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
+    return rowOption.isEmpty() && orderingValue.equals(DEFAULT_ORDERING_VALUE);
   }
 
   private boolean isDeleteRecord(Option<T> record, Schema schema) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -559,12 +559,12 @@ public abstract class HoodieBaseFileGroupRecordBuffer<T> implements HoodieFileGr
     return Pair.of(transformer, evolvedSchema);
   }
 
-  protected static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
+  static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
     return orderingValue == null || orderingValue.equals(COMMIT_TIME_ORDERING_VALUE);
   }
 
-  protected static Comparable getOrderingValue(HoodieReaderContext readerContext,
-                                               DeleteRecord deleteRecord) {
+  static Comparable getOrderingValue(HoodieReaderContext readerContext,
+                                     DeleteRecord deleteRecord) {
     return isCommitTimeOrderingValue(deleteRecord.getOrderingValue())
         ? COMMIT_TIME_ORDERING_VALUE
         : readerContext.convertValueToEngineType(deleteRecord.getOrderingValue());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieBaseFileGroupRecordBuffer.java
@@ -71,7 +71,6 @@ import static org.apache.hudi.common.config.HoodieMemoryConfig.MAX_MEMORY_FOR_ME
 import static org.apache.hudi.common.config.HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH;
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_PARTITION_PATH;
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_RECORD_KEY;
-import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_SCHEMA_ID;
 import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
 import static org.apache.hudi.common.model.HoodieRecord.HOODIE_IS_DELETED_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.OPERATION_METADATA_FIELD;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
@@ -115,7 +115,8 @@ public class HoodieKeyBasedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
     Option<DeleteRecord> recordOpt = doProcessNextDeletedRecord(deleteRecord, existingRecordMetadataPair);
     if (recordOpt.isPresent()) {
       records.put(recordKey, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-          (String) recordKey, recordOpt.get().getPartitionPath(), recordOpt.get().getOrderingValue())));
+          (String) recordKey, recordOpt.get().getPartitionPath(),
+          getOrderingValue(readerContext, recordOpt.get()))));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieKeyBasedFileGroupRecordBuffer.java
@@ -115,7 +115,7 @@ public class HoodieKeyBasedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
     Option<DeleteRecord> recordOpt = doProcessNextDeletedRecord(deleteRecord, existingRecordMetadataPair);
     if (recordOpt.isPresent()) {
       records.put(recordKey, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-          (String) recordKey, recordOpt.get().getPartitionPath(), recordOpt.get().getOrderingValue(), orderingFieldTypeOpt)));
+          (String) recordKey, recordOpt.get().getPartitionPath(), recordOpt.get().getOrderingValue())));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
@@ -203,7 +203,7 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieKeyBasedF
       String recordKey = recordOpt.get().getRecordKey();
       records.put(recordPosition, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
           recordKey, recordOpt.get().getPartitionPath(),
-          recordOpt.get().getOrderingValue() == null ? COMMIT_TIME_ORDERING_VALUE : recordOpt.get().getOrderingValue())));
+          getOrderingValue(readerContext, recordOpt.get()))));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_RECORD_KEY;
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
 
 /**
  * A buffer that is used to store log records by {@link org.apache.hudi.common.table.log.HoodieMergedLogRecordReader}
@@ -177,7 +178,8 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieKeyBasedF
       case COMMIT_TIME_ORDERING:
         for (Long recordPosition : recordPositions) {
           records.putIfAbsent(recordPosition,
-              Pair.of(Option.empty(), readerContext.generateMetadataForRecord(null, "", orderingFieldDefault, orderingFieldTypeOpt)));
+              Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
+                  null, "", COMMIT_TIME_ORDERING_VALUE)));
         }
         return;
       case EVENT_TIME_ORDERING:
@@ -200,7 +202,8 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieKeyBasedF
     if (recordOpt.isPresent()) {
       String recordKey = recordOpt.get().getRecordKey();
       records.put(recordPosition, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-          recordKey, recordOpt.get().getPartitionPath(), recordOpt.get().getOrderingValue() == null ? orderingFieldDefault : recordOpt.get().getOrderingValue(), orderingFieldTypeOpt)));
+          recordKey, recordOpt.get().getPartitionPath(),
+          recordOpt.get().getOrderingValue() == null ? COMMIT_TIME_ORDERING_VALUE : recordOpt.get().getOrderingValue())));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodiePositionBasedFileGroupRecordBuffer.java
@@ -51,7 +51,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.apache.hudi.common.engine.HoodieReaderContext.INTERNAL_META_RECORD_KEY;
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * A buffer that is used to store log records by {@link org.apache.hudi.common.table.log.HoodieMergedLogRecordReader}
@@ -179,7 +179,7 @@ public class HoodiePositionBasedFileGroupRecordBuffer<T> extends HoodieKeyBasedF
         for (Long recordPosition : recordPositions) {
           records.putIfAbsent(recordPosition,
               Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-                  null, "", COMMIT_TIME_ORDERING_VALUE)));
+                  null, "", DEFAULT_ORDERING_VALUE)));
         }
         return;
       case EVENT_TIME_ORDERING:

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
@@ -127,7 +127,8 @@ public class HoodieUnmergedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
   public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable index) {
     // never used for now
     records.put(index, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-        deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue())));
+        deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(),
+        getOrderingValue(readerContext, deleteRecord))));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieUnmergedFileGroupRecordBuffer.java
@@ -127,7 +127,7 @@ public class HoodieUnmergedFileGroupRecordBuffer<T> extends HoodieBaseFileGroupR
   public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable index) {
     // never used for now
     records.put(index, Pair.of(Option.empty(), readerContext.generateMetadataForRecord(
-        deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue(), orderingFieldTypeOpt)));
+        deleteRecord.getRecordKey(), deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue())));
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -201,7 +201,8 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
                 Pair.of(
                     Option.ofNullable(readerContext.seal(record)),
                     readerContext.generateMetadataForRecord(
-                        recordKey, dataGen.getPartitionPaths()[0], orderingFieldValue)));
+                        recordKey, dataGen.getPartitionPaths()[0],
+                        readerContext.convertValueToEngineType(orderingFieldValue))));
           }
 
           assertEquals(records.size() * 2, spillableMap.size());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -182,7 +182,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       List<T> records = readRecordsFromFileGroup(getStorageConf(), getBasePath(), metaClient,  fileSlice,
           avroSchema, RecordMergeMode.COMMIT_TIME_ORDERING, false);
       HoodieReaderContext<T> readerContext = getHoodieReaderContext(getBasePath(), avroSchema, getStorageConf());
-      Comparable castedOrderingField = readerContext.castValue(100, Schema.Type.STRING);
+      Comparable castedOrderingField = "100";
       for (Boolean isCompressionEnabled : new boolean[] {true, false}) {
         try (ExternalSpillableMap<Serializable, Pair<Option<T>, Map<String, Object>>> spillableMap =
                  new ExternalSpillableMap<>(16L, baseMapPath, new DefaultSizeEstimator(),
@@ -200,8 +200,8 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
             spillableMap.put(position++,
                 Pair.of(
                     Option.ofNullable(readerContext.seal(record)),
-                    readerContext.generateMetadataForRecord(recordKey,
-                        dataGen.getPartitionPaths()[0], 100, orderingFieldType)));
+                    readerContext.generateMetadataForRecord(
+                        recordKey, dataGen.getPartitionPaths()[0], "100")));
           }
 
           assertEquals(records.size() * 2, spillableMap.size());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -182,7 +182,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       List<T> records = readRecordsFromFileGroup(getStorageConf(), getBasePath(), metaClient,  fileSlice,
           avroSchema, RecordMergeMode.COMMIT_TIME_ORDERING, false);
       HoodieReaderContext<T> readerContext = getHoodieReaderContext(getBasePath(), avroSchema, getStorageConf());
-      Comparable castedOrderingField = "100";
+      Comparable orderingFieldValue = "100";
       for (Boolean isCompressionEnabled : new boolean[] {true, false}) {
         try (ExternalSpillableMap<Serializable, Pair<Option<T>, Map<String, Object>>> spillableMap =
                  new ExternalSpillableMap<>(16L, baseMapPath, new DefaultSizeEstimator(),
@@ -201,7 +201,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
                 Pair.of(
                     Option.ofNullable(readerContext.seal(record)),
                     readerContext.generateMetadataForRecord(
-                        recordKey, dataGen.getPartitionPaths()[0], "100")));
+                        recordKey, dataGen.getPartitionPaths()[0], orderingFieldValue)));
           }
 
           assertEquals(records.size() * 2, spillableMap.size());
@@ -219,7 +219,8 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
             assertEquals(positionBased.getRight().get(INTERNAL_META_RECORD_KEY), recordKey);
             assertEquals(avroSchema, readerContext.getSchemaFromMetadata(keyBased.getRight()));
             assertEquals(dataGen.getPartitionPaths()[0], positionBased.getRight().get(INTERNAL_META_PARTITION_PATH));
-            assertEquals(castedOrderingField, positionBased.getRight().get(INTERNAL_META_ORDERING_FIELD));
+            assertEquals(readerContext.convertValueToEngineType(orderingFieldValue),
+                positionBased.getRight().get(INTERNAL_META_ORDERING_FIELD));
           }
 
         }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupRecordBuffer.java
@@ -24,7 +24,7 @@ import org.apache.hudi.common.model.DeleteRecord;
 
 import org.junit.jupiter.api.Test;
 
-import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.table.read.HoodieBaseFileGroupRecordBuffer.getOrderingValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -39,9 +39,9 @@ public class TestHoodieFileGroupRecordBuffer {
     HoodieReaderContext readerContext = mock(HoodieReaderContext.class);
     DeleteRecord deleteRecord = mock(DeleteRecord.class);
     mockDeleteRecord(deleteRecord, null);
-    assertEquals(COMMIT_TIME_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
-    mockDeleteRecord(deleteRecord, COMMIT_TIME_ORDERING_VALUE);
-    assertEquals(COMMIT_TIME_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
+    assertEquals(DEFAULT_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
+    mockDeleteRecord(deleteRecord, DEFAULT_ORDERING_VALUE);
+    assertEquals(DEFAULT_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
     String orderingValue = "xyz";
     String convertedValue = "_xyz";
     mockDeleteRecord(deleteRecord, orderingValue);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupRecordBuffer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.DeleteRecord;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE;
+import static org.apache.hudi.common.table.read.HoodieBaseFileGroupRecordBuffer.getOrderingValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link HoodieBaseFileGroupRecordBuffer}
+ */
+public class TestHoodieFileGroupRecordBuffer {
+  @Test
+  void testGetOrderingValueFromDeleteRecord() {
+    HoodieReaderContext readerContext = mock(HoodieReaderContext.class);
+    DeleteRecord deleteRecord = mock(DeleteRecord.class);
+    mockDeleteRecord(deleteRecord, null);
+    assertEquals(COMMIT_TIME_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
+    mockDeleteRecord(deleteRecord, COMMIT_TIME_ORDERING_VALUE);
+    assertEquals(COMMIT_TIME_ORDERING_VALUE, getOrderingValue(readerContext, deleteRecord));
+    String orderingValue = "xyz";
+    String convertedValue = "_xyz";
+    mockDeleteRecord(deleteRecord, orderingValue);
+    when(readerContext.convertValueToEngineType(orderingValue)).thenReturn(convertedValue);
+    assertEquals(convertedValue, getOrderingValue(readerContext, deleteRecord));
+  }
+
+  private void mockDeleteRecord(DeleteRecord deleteRecord,
+                                Comparable orderingValue) {
+    when(deleteRecord.getOrderingValue()).thenReturn(orderingValue);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieTestReaderContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieTestReaderContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.hudi.common.testutils.reader;
 
-import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.engine.HoodieReaderContext;
@@ -184,26 +183,6 @@ public class HoodieTestReaderContext extends HoodieReaderContext<IndexedRecord> 
       }
       return outputRecord;
     };
-  }
-
-  @Override
-  public Comparable castValue(Comparable value, Schema.Type newType) {
-    Schema newSchema = Schema.create(newType);
-    Schema oldType;
-    if (value instanceof Integer) {
-      oldType = Schema.create(Schema.Type.INT);
-    } else if (value instanceof Long) {
-      oldType = Schema.create(Schema.Type.LONG);
-    } else if (value instanceof Float) {
-      oldType = Schema.create(Schema.Type.FLOAT);
-    } else if (value instanceof Double) {
-      oldType = Schema.create(Schema.Type.DOUBLE);
-    } else if (value instanceof String) {
-      oldType = Schema.create(Schema.Type.STRING);
-    } else {
-      throw new UnsupportedOperationException("Cast from " + value.getClass() + " to " + newType + " is not supported");
-    }
-    return (Comparable) HoodieAvroUtils.rewritePrimaryType(value, oldType, newSchema);
   }
 
   private Object getFieldValueFromIndexedRecord(

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
@@ -261,15 +260,6 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
       throw new IllegalStateException("Schema evolution is not supported in the filegroup reader for Hive currently");
     }
     return HoodieArrayWritableAvroUtils.projectRecord(from, to);
-  }
-
-  @Override
-  public Comparable castValue(Comparable value, Schema.Type newType) {
-    //TODO: [HUDI-8261] actually do casting here
-    if (value instanceof WritableComparable) {
-      return value;
-    }
-    return (WritableComparable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(value, Schema.create(newType));
   }
 
   public UnaryOperator<ArrayWritable> reverseProjectRecord(Schema from, Schema to) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -49,10 +49,17 @@ import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
@@ -260,6 +267,30 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
       throw new IllegalStateException("Schema evolution is not supported in the filegroup reader for Hive currently");
     }
     return HoodieArrayWritableAvroUtils.projectRecord(from, to);
+  }
+
+  @Override
+  public Comparable convertValueToEngineType(Comparable value) {
+    if (value instanceof WritableComparable) {
+      return value;
+    }
+    //TODO: [HUDI-8261] cover more types
+    if (value == null) {
+      return null;
+    } else if (value instanceof String) {
+      return new Text((String) value);
+    } else if (value instanceof Integer) {
+      return new IntWritable((int) value);
+    } else if (value instanceof Long) {
+      return new LongWritable((long) value);
+    } else if (value instanceof Float) {
+      return new FloatWritable((float) value);
+    } else if (value instanceof Double) {
+      return new DoubleWritable((double) value);
+    } else if (value instanceof Boolean) {
+      return new BooleanWritable((boolean) value);
+    }
+    return value;
   }
 
   public UnaryOperator<ArrayWritable> reverseProjectRecord(Schema from, Schema to) {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.JobConf;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -95,16 +94,19 @@ public class TestHoodieArrayWritableAvroUtils {
     return  (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, record.getSchema(), false);
   }
 
-  // TODO(yihua)
-  @Disabled
   @Test
   public void testCastOrderingField() {
     HiveHoodieReaderContext readerContext = Mockito.mock(HiveHoodieReaderContext.class, Mockito.CALLS_REAL_METHODS);
+    assertEquals(new Text("ASDF"), readerContext.convertValueToEngineType(new Text("ASDF")));
     assertEquals(new Text("ASDF"), readerContext.convertValueToEngineType("ASDF"));
+    assertEquals(new IntWritable(0), readerContext.convertValueToEngineType(new IntWritable(0)));
     assertEquals(new IntWritable(0), readerContext.convertValueToEngineType(0));
-    assertEquals(new LongWritable(1000000000), readerContext.convertValueToEngineType(1000000000));
-    assertEquals(new FloatWritable(20.24f), readerContext.convertValueToEngineType(20.24));
-    assertEquals(new DoubleWritable(21.12d), readerContext.convertValueToEngineType(21.12));
+    assertEquals(new LongWritable(Long.MAX_VALUE / 2L), readerContext.convertValueToEngineType(new LongWritable(Long.MAX_VALUE / 2L)));
+    assertEquals(new LongWritable(Long.MAX_VALUE / 2L), readerContext.convertValueToEngineType(Long.MAX_VALUE / 2L));
+    assertEquals(new FloatWritable(20.24f), readerContext.convertValueToEngineType(new FloatWritable(20.24f)));
+    assertEquals(new FloatWritable(20.24f), readerContext.convertValueToEngineType(20.24f));
+    assertEquals(new DoubleWritable(21.12d), readerContext.convertValueToEngineType(new DoubleWritable(21.12d)));
+    assertEquals(new DoubleWritable(21.12d), readerContext.convertValueToEngineType(21.12d));
 
     // make sure that if input is a writeable, then it still works
     WritableComparable reflexive = new IntWritable(8675309);

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
@@ -99,8 +99,8 @@ public class TestHoodieArrayWritableAvroUtils {
     HiveHoodieReaderContext readerContext = Mockito.mock(HiveHoodieReaderContext.class, Mockito.CALLS_REAL_METHODS);
     assertEquals(new Text("ASDF"), readerContext.convertValueToEngineType(new Text("ASDF")));
     assertEquals(new Text("ASDF"), readerContext.convertValueToEngineType("ASDF"));
-    assertEquals(new IntWritable(0), readerContext.convertValueToEngineType(new IntWritable(0)));
-    assertEquals(new IntWritable(0), readerContext.convertValueToEngineType(0));
+    assertEquals(new IntWritable(8), readerContext.convertValueToEngineType(new IntWritable(8)));
+    assertEquals(new IntWritable(8), readerContext.convertValueToEngineType(8));
     assertEquals(new LongWritable(Long.MAX_VALUE / 2L), readerContext.convertValueToEngineType(new LongWritable(Long.MAX_VALUE / 2L)));
     assertEquals(new LongWritable(Long.MAX_VALUE / 2L), readerContext.convertValueToEngineType(Long.MAX_VALUE / 2L));
     assertEquals(new FloatWritable(20.24f), readerContext.convertValueToEngineType(new FloatWritable(20.24f)));

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableAvroUtils.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.JobConf;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -94,17 +95,19 @@ public class TestHoodieArrayWritableAvroUtils {
     return  (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, record.getSchema(), false);
   }
 
+  // TODO(yihua)
+  @Disabled
   @Test
   public void testCastOrderingField() {
     HiveHoodieReaderContext readerContext = Mockito.mock(HiveHoodieReaderContext.class, Mockito.CALLS_REAL_METHODS);
-    assertEquals(new Text("ASDF"), readerContext.castValue("ASDF", Schema.Type.STRING));
-    assertEquals(new IntWritable(0),readerContext.castValue(0, Schema.Type.INT));
-    assertEquals(new LongWritable(1000000000),readerContext.castValue(1000000000, Schema.Type.LONG));
-    assertEquals(new FloatWritable(20.24f),readerContext.castValue(20.24, Schema.Type.FLOAT));
-    assertEquals(new DoubleWritable(21.12d),readerContext.castValue(21.12, Schema.Type.DOUBLE));
+    assertEquals(new Text("ASDF"), readerContext.convertValueToEngineType("ASDF"));
+    assertEquals(new IntWritable(0), readerContext.convertValueToEngineType(0));
+    assertEquals(new LongWritable(1000000000), readerContext.convertValueToEngineType(1000000000));
+    assertEquals(new FloatWritable(20.24f), readerContext.convertValueToEngineType(20.24));
+    assertEquals(new DoubleWritable(21.12d), readerContext.convertValueToEngineType(21.12));
 
     // make sure that if input is a writeable, then it still works
     WritableComparable reflexive = new IntWritable(8675309);
-    assertEquals(reflexive, readerContext.castValue(reflexive, Schema.Type.INT));
+    assertEquals(reflexive, readerContext.convertValueToEngineType(reflexive));
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
@@ -24,10 +24,14 @@ import org.apache.hudi.SparkFileFormatInternalRowReaderContext.filterIsSafeForBo
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.read.HoodiePositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
+import org.apache.spark.sql.execution.datasources.parquet.SparkParquetReader
 import org.apache.spark.sql.sources.{And, IsNotNull, Or}
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 
 class TestSparkFileFormatInternalRowReaderContext extends SparkClientFunctionalTestHarness {
 
@@ -68,5 +72,20 @@ class TestSparkFileFormatInternalRowReaderContext extends SparkClientFunctionalT
       requiredSchema, true)
     assertEquals(3, appliedSchema.fields.length)
     assertTrue(appliedSchema.fields.map(f => f.name).contains(ROW_INDEX_TEMPORARY_COLUMN_NAME))
+  }
+
+  @Test
+  def testConvertValueToEngineType(): Unit = {
+    val reader = Mockito.mock(classOf[SparkParquetReader])
+    val stringValue = "string_value"
+    val sparkReaderContext = new SparkFileFormatInternalRowReaderContext(reader, Seq.empty, Seq.empty)
+    assertEquals(1, sparkReaderContext.convertValueToEngineType(1))
+    assertEquals(1L, sparkReaderContext.convertValueToEngineType(1L))
+    assertEquals(1.1f, sparkReaderContext.convertValueToEngineType(1.1f))
+    assertEquals(1.1, sparkReaderContext.convertValueToEngineType(1.1))
+    assertEquals(UTF8String.fromString(stringValue),
+      sparkReaderContext.convertValueToEngineType(stringValue))
+    assertEquals(UTF8String.fromString(stringValue),
+      sparkReaderContext.convertValueToEngineType(UTF8String.fromString(stringValue)))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
@@ -82,7 +82,7 @@ class TestSparkFileFormatInternalRowReaderContext extends SparkClientFunctionalT
     assertEquals(1, sparkReaderContext.convertValueToEngineType(1))
     assertEquals(1L, sparkReaderContext.convertValueToEngineType(1L))
     assertEquals(1.1f, sparkReaderContext.convertValueToEngineType(1.1f))
-    assertEquals(1.1, sparkReaderContext.convertValueToEngineType(1.1))
+    assertEquals(1.1d, sparkReaderContext.convertValueToEngineType(1.1d))
     assertEquals(UTF8String.fromString(stringValue),
       sparkReaderContext.convertValueToEngineType(stringValue))
     assertEquals(UTF8String.fromString(stringValue),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -24,14 +24,15 @@ import org.apache.hudi.avro.AvroSchemaUtils.{isNullable, resolveNullableSchema}
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodiePayloadProps, HoodieRecord}
-import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.{BinaryUtil, ConfigUtils, StringUtils, ValidationUtils, Option => HOption}
+import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieException
 
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord, IndexedRecord}
+import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.{KryoSerializer, SerializerInstance}
 import org.apache.spark.sql.avro.{HoodieAvroDeserializer, HoodieAvroSerializer}
@@ -39,11 +40,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, Projection, SafeProjection}
 import org.apache.spark.sql.hudi.command.payload.ExpressionPayload._
 import org.apache.spark.sql.types.{BooleanType, StructType}
-import org.apache.spark.{SparkConf, SparkEnv}
 
 import java.nio.ByteBuffer
-import java.util.function.{Function, Supplier}
 import java.util.{Base64, Objects, Properties}
+import java.util.function.{Function, Supplier}
 
 import scala.collection.JavaConverters._
 
@@ -65,7 +65,7 @@ class ExpressionPayload(@transient record: GenericRecord,
   extends DefaultHoodieRecordPayload(record, orderingVal) with Logging {
 
   def this(recordOpt: HOption[GenericRecord]) {
-    this(recordOpt.orElse(null), 0)
+    this(recordOpt.orElse(null), HoodieRecord.COMMIT_TIME_ORDERING_VALUE)
   }
 
   override def combineAndGetUpdateValue(currentValue: IndexedRecord,

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -65,7 +65,7 @@ class ExpressionPayload(@transient record: GenericRecord,
   extends DefaultHoodieRecordPayload(record, orderingVal) with Logging {
 
   def this(recordOpt: HOption[GenericRecord]) {
-    this(recordOpt.orElse(null), HoodieRecord.COMMIT_TIME_ORDERING_VALUE)
+    this(recordOpt.orElse(null), HoodieRecord.DEFAULT_ORDERING_VALUE)
   }
 
   override def combineAndGetUpdateValue(currentValue: IndexedRecord,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -195,7 +196,9 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
   public void testRecordGenerationAPIsForMOR() throws IOException {
     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
     cleanupClients();
-    initMetaClient(tableType);
+    Properties props = new Properties();
+    props.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+    initMetaClient(tableType, props);
     cleanupTimelineService();
     initTimelineService();
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -65,7 +65,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -196,9 +195,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
   public void testRecordGenerationAPIsForMOR() throws IOException {
     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
     cleanupClients();
-    Properties props = new Properties();
-    props.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
-    initMetaClient(tableType, props);
+    initMetaClient(tableType);
     cleanupTimelineService();
     initTimelineService();
 

--- a/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
+++ b/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
@@ -205,7 +205,7 @@ select id, name, price, ts, dt from h1_p order by id;
 
 merge into h1_p t0
 using (
-  select 5 as _id, 'a5' as _name, 10 as _price, 1000 as _ts, '2021-05-08' as dt
+  select 5 as _id, 'a5' as _name, 10 as _price, 1000L as _ts, '2021-05-08' as dt
 ) s0
 on s0._id = t0.id
 when matched then update set id = _id, name = _name, price = _price, ts = _ts, dt = s0.dt
@@ -224,11 +224,11 @@ select id, name, price, ts, dt from h1_p order by id;
 
 merge into h1_p t0
 using (
-  select 1 as id, '_delete' as name, 10 as price, 1000 as ts, '2021-05-07' as dt
+  select 1 as id, '_delete' as name, 10 as price, 1000L as ts, '2021-05-07' as dt
   union
-  select 2 as id, '_update' as name, 12 as price, 1001 as ts, '2021-05-07' as dt
+  select 2 as id, '_update' as name, 12 as price, 1001L as ts, '2021-05-07' as dt
   union
-  select 6 as id, '_insert' as name, 10 as price, 1000 as ts, '2021-05-08' as dt
+  select 6 as id, '_insert' as name, 10 as price, 1000L as ts, '2021-05-08' as dt
 ) s0
 on s0.id = t0.id
 when matched and s0.name = '_update'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -19,23 +19,28 @@
 
 package org.apache.hudi.common.table.read
 
+import org.apache.hudi.{SparkAdapterSupport, SparkFileFormatInternalRowReaderContext}
 import org.apache.hudi.common.config.HoodieReaderConfig
 import org.apache.hudi.common.config.HoodieReaderConfig.FILE_GROUP_READER_ENABLED
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord, WriteOperationType}
+import org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE
 import org.apache.hudi.common.testutils.{HoodieTestUtils, RawTripTestPayload}
+import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.storage.StorageConfiguration
-import org.apache.hudi.{SparkAdapterSupport, SparkFileFormatInternalRowReaderContext}
 
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.{HoodieSparkKryoRegistrar, SparkConf}
+import org.apache.spark.sql.{Dataset, HoodieInternalRowUtils, HoodieUnsafeUtils, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.parquet.SparkParquetReader
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{Dataset, HoodieInternalRowUtils, HoodieUnsafeUtils, Row, SaveMode, SparkSession}
-import org.apache.spark.{HoodieSparkKryoRegistrar, SparkConf}
+import org.apache.spark.unsafe.types.UTF8String
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.{AfterEach, BeforeEach}
+import org.mockito.Mockito
 
 import java.util
 
@@ -130,5 +135,45 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     expected.toSeq(expectedStruct).zip(actual.toSeq(expectedStruct)).foreach( converted => {
       assertEquals(converted._1, converted._2)
     })
+  }
+
+  @Test
+  def testGetOrderingValue(): Unit = {
+    val reader = Mockito.mock(classOf[SparkParquetReader])
+    val sparkReaderContext = new SparkFileFormatInternalRowReaderContext(reader, Seq.empty, Seq.empty)
+    val orderingFieldName = "col2"
+    val avroSchema = new Schema.Parser().parse(
+      "{\"type\": \"record\",\"name\": \"test\",\"namespace\": \"org.apache.hudi\",\"fields\": ["
+        + "{\"name\": \"col1\", \"type\": \"string\" },"
+        + "{\"name\": \"col2\", \"type\": \"long\" },"
+        + "{ \"name\": \"col3\", \"type\": [\"null\", \"string\"], \"default\": null}]}")
+    val row = InternalRow("item", 1000L, "blue")
+    val metadataMap = Map(HoodieReaderContext.INTERNAL_META_ORDERING_FIELD -> 100L)
+    assertEquals(100L, sparkReaderContext.getOrderingValue(
+      HOption.empty(), metadataMap.asJava.asInstanceOf[java.util.Map[String, Object]],
+      avroSchema, HOption.of(orderingFieldName)))
+    assertEquals(COMMIT_TIME_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
+      HOption.empty(), Map().asJava.asInstanceOf[java.util.Map[String, Object]],
+      avroSchema, HOption.of(orderingFieldName)))
+    assertEquals(COMMIT_TIME_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
+      HOption.of(row), Map().asJava.asInstanceOf[java.util.Map[String, Object]],
+      avroSchema, HOption.empty()))
+    testGetOrderingValue(sparkReaderContext, row, avroSchema, orderingFieldName, 1000L)
+    testGetOrderingValue(
+      sparkReaderContext, row, avroSchema, "col3", UTF8String.fromString("blue"))
+    testGetOrderingValue(
+      sparkReaderContext, row, avroSchema, "non_existent_col", COMMIT_TIME_ORDERING_VALUE)
+  }
+
+  private def testGetOrderingValue(sparkReaderContext: HoodieReaderContext[InternalRow],
+                                   row: InternalRow,
+                                   avroSchema: Schema,
+                                   orderingColumn: String,
+                                   expectedOrderingValue: Comparable[_]): Unit = {
+    val metadataMap = new util.HashMap[String, Object]()
+    assertEquals(expectedOrderingValue, sparkReaderContext.getOrderingValue(
+      HOption.of(row), metadataMap, avroSchema, HOption.of(orderingColumn)))
+    assertEquals(expectedOrderingValue,
+      metadataMap.get(HoodieReaderContext.INTERNAL_META_ORDERING_FIELD))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.common.config.HoodieReaderConfig
 import org.apache.hudi.common.config.HoodieReaderConfig.FILE_GROUP_READER_ENABLED
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord, WriteOperationType}
-import org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_ORDERING_VALUE
+import org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE
 import org.apache.hudi.common.testutils.{HoodieTestUtils, RawTripTestPayload}
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.storage.StorageConfiguration
@@ -152,17 +152,17 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     assertEquals(100L, sparkReaderContext.getOrderingValue(
       HOption.empty(), metadataMap.asJava.asInstanceOf[java.util.Map[String, Object]],
       avroSchema, HOption.of(orderingFieldName)))
-    assertEquals(COMMIT_TIME_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
+    assertEquals(DEFAULT_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
       HOption.empty(), Map().asJava.asInstanceOf[java.util.Map[String, Object]],
       avroSchema, HOption.of(orderingFieldName)))
-    assertEquals(COMMIT_TIME_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
+    assertEquals(DEFAULT_ORDERING_VALUE, sparkReaderContext.getOrderingValue(
       HOption.of(row), Map().asJava.asInstanceOf[java.util.Map[String, Object]],
       avroSchema, HOption.empty()))
     testGetOrderingValue(sparkReaderContext, row, avroSchema, orderingFieldName, 1000L)
     testGetOrderingValue(
       sparkReaderContext, row, avroSchema, "col3", UTF8String.fromString("blue"))
     testGetOrderingValue(
-      sparkReaderContext, row, avroSchema, "non_existent_col", COMMIT_TIME_ORDERING_VALUE)
+      sparkReaderContext, row, avroSchema, "non_existent_col", DEFAULT_ORDERING_VALUE)
   }
 
   private def testGetOrderingValue(sparkReaderContext: HoodieReaderContext[InternalRow],

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -431,7 +431,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
     }
   }
 
-  test("Test MergeInto for MOR table ") {
+  test("Test MergeInto for MOR table") {
     spark.sql(s"set ${MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key} = 0")
     withTempDir { tmp =>
       spark.sql("set hoodie.payload.combined.schema.validate = true")
@@ -466,7 +466,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 10 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when not matched and s0.id % 2 = 1 then insert *
@@ -481,7 +481,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as _id, 'a1' as name, 12 as _price, 1001 as _ts, '2021-03-21' as dt
+           |  select 1 as _id, 'a1' as name, 12 as _price, 1001L as _ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0._id
            | when matched and s0._id % 2 = 0 then update set
@@ -497,7 +497,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as _id, 'a1' as name, 12 as _price, 1001 as _ts, '2021-03-21' as dt
+           |  select 1 as _id, 'a1' as name, 12 as _price, 1001L as _ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0._id
            | when matched and s0._id % 2 = 1 then update set
@@ -513,7 +513,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 2 as id, 'a2' as name, 10 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 2 as id, 'a2' as name, 10 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when not matched and s0.id % 2 = 0 then insert *
@@ -528,7 +528,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName t0
            | using (
-           |  select 2 as s_id, 'a2' as s_name, 15 as s_price, 1001 as s_ts, '2021-03-21' as dt
+           |  select 2 as s_id, 'a2' as s_name, 15 as s_price, 1001L as s_ts, '2021-03-21' as dt
            | ) s0
            | on t0.id = s0.s_id
            | when matched and s_ts = 1001
@@ -548,7 +548,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName t0
            | using (
-           |  select 1 as s_id, 'a2' as s_name, 15 as s_price, 1001 as s_ts, '2021-03-21' as dt
+           |  select 1 as s_id, 'a2' as s_name, 15 as s_price, 1001L as s_ts, '2021-03-21' as dt
            | ) s0
            | on t0.id = s0.s_id + 1
            | when matched and s_ts = 1001 then delete
@@ -559,7 +559,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         s"""
            | merge into $tableName t0
            | using (
-           |  select 2 as s_id, 'a2' as s_name, 15 as s_price, 1001 as ts, '2021-03-21' as dt
+           |  select 2 as s_id, 'a2' as s_name, 15 as s_price, 1001L as ts, '2021-03-21' as dt
            | ) s0
            | on t0.id = s0.s_id
            | when matched and s0.ts = 1001 then delete

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -58,7 +58,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 10 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when not matched and s0.id % 2 = 1 then insert *
@@ -73,7 +73,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 2 as id, 'a2' as name, 10 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 2 as id, 'a2' as name, 10 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when not matched and s0.id % 2 = 1 then insert *
@@ -88,7 +88,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 11 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 11 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when matched and s0.id % 2 = 0 then update set *
@@ -105,7 +105,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 11 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 11 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when matched and s0.id % 2 = 1 then update set id = s0.id, name = s0.name,
@@ -122,7 +122,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 11 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 11 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when matched and s0.id % 2 = 0 then update set id = s0.id, name = s0.name,
@@ -139,7 +139,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         s"""
            | merge into $tableName as t0
            | using (
-           |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, '2021-03-21' as dt
+           |  select 1 as id, 'a1' as name, 10 as price, 1000L as ts, '2021-03-21' as dt
            | ) as s0
            | on t0.id = s0.id
            | when matched and s0.id % 2 = 1 then update set id = s0.id, name = s0.name,


### PR DESCRIPTION
### Change Logs

This PR simplifies precombine and ordering field value handling in the file group reader by assuming that the precombine field should not be changed after table creation, i.e., both the field name and type should not be changed.  All the type cast logic specifically for ordering value is removed.

If the user does want to change the precombine or ordering field in rare cases, we should advise them to compact the table fully first, and then change the table config through a special process through Hudi CLI for example.  After this PR, such a process can still work as the precombine and ordering value comparison only happens when merging records from base and log files.

### Impact

Simplify precombine and ordering field value handling in the file group reader and avoids hidden mishandling of precombine and ordering value comparion.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
