### PR TITLE
[MINOR] refactor: extract the common logic for the bucket-type bulk insert partitioner

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
+
+/**
+ * Bucket-Index based Bulk Insert Partitioner and provides the unified sorting logic
+ */
+public abstract class BucketSortBulkInsertPartitioner<T> implements BulkInsertPartitioner<T> {
+
+  protected final String[] sortColumnNames;
+
+  protected final HoodieTable table;
+
+  public BucketSortBulkInsertPartitioner(HoodieTable table, String sortString) {
+    this.table = table;
+    if (!StringUtils.isNullOrEmpty(sortString)) {
+      this.sortColumnNames = sortString.split(",");
+    } else {
+      this.sortColumnNames = null;
+    }
+  }
+
+  /**
+   * Check if the records can be sorted by custom columns
+   */
+  protected boolean isCustomSorted() {
+    return sortColumnNames != null && sortColumnNames.length > 0;
+  }
+
+  /**
+   * Check if the records can be sorted by record key
+   */
+  protected boolean isRecordKeySorted() {
+    return table.requireSortedRecords() || table.getConfig().getBulkInsertSortMode() != BulkInsertSortMode.NONE;
+  }
+
+  @Override
+  public boolean arePartitionRecordsSorted() {
+    return isCustomSorted() || isRecordKeySorted();
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/ConsistentBucketIndexBulkInsertPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/ConsistentBucketIndexBulkInsertPartitionerWithRows.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
@@ -31,7 +30,7 @@ import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
 import org.apache.hudi.index.bucket.HoodieSparkConsistentBucketIndex;
 import org.apache.hudi.keygen.BuiltinKeyGenerator;
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
-import org.apache.hudi.table.BulkInsertPartitioner;
+import org.apache.hudi.table.BucketSortBulkInsertPartitioner;
 import org.apache.hudi.table.ConsistentHashingBucketInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
 
@@ -56,13 +55,9 @@ import static org.apache.hudi.config.HoodieClusteringConfig.PLAN_STRATEGY_SORT_C
  * Bulk_insert partitioner of Spark row using consistent hashing bucket index.
  */
 public class ConsistentBucketIndexBulkInsertPartitionerWithRows
-    implements BulkInsertPartitioner<Dataset<Row>>, ConsistentHashingBucketInsertPartitioner {
-
-  private final HoodieTable table;
+    extends BucketSortBulkInsertPartitioner<Dataset<Row>> implements ConsistentHashingBucketInsertPartitioner {
 
   private final String indexKeyFields;
-
-  private final String[] sortColumnNames;
 
   private final List<String> fileIdPfxList = new ArrayList<>();
 
@@ -81,20 +76,14 @@ public class ConsistentBucketIndexBulkInsertPartitionerWithRows
   public ConsistentBucketIndexBulkInsertPartitionerWithRows(HoodieTable table,
                                                             Map<String, String> strategyParams,
                                                             boolean populateMetaFields) {
+    super(table, strategyParams.getOrDefault(PLAN_STRATEGY_SORT_COLUMNS.key(), ""));
     this.indexKeyFields = table.getConfig().getBucketIndexHashField();
-    this.table = table;
     this.hashingChildrenNodes = new HashMap<>();
     this.populateMetaFields = populateMetaFields;
     if (!populateMetaFields) {
       this.keyGeneratorOpt = HoodieSparkKeyGeneratorFactory.getKeyGenerator(table.getConfig().getProps());
     } else {
       this.keyGeneratorOpt = Option.empty();
-    }
-    String sortString = strategyParams.getOrDefault(PLAN_STRATEGY_SORT_COLUMNS.key(), "");
-    if (!StringUtils.isNullOrEmpty(sortString)) {
-      this.sortColumnNames = sortString.split(",");
-    } else {
-      this.sortColumnNames = null;
     }
     this.extractor = RowRecordKeyExtractor.getRowRecordKeyExtractor(populateMetaFields, keyGeneratorOpt);
     ValidationUtils.checkArgument(table.getMetaClient().getTableType().equals(HoodieTableType.MERGE_ON_READ),
@@ -131,10 +120,10 @@ public class ConsistentBucketIndexBulkInsertPartitionerWithRows
         })
         .values(), rows.schema());
 
-    if (sortColumnNames != null && sortColumnNames.length > 0) {
+    if (isCustomSorted()) {
       partitionedRows = partitionedRows
           .sortWithinPartitions(Arrays.stream(sortColumnNames).map(Column::new).toArray(Column[]::new));
-    } else if (table.requireSortedRecords() || table.getConfig().getBulkInsertSortMode() != BulkInsertSortMode.NONE) {
+    } else if (isRecordKeySorted()) {
       if (populateMetaFields) {
         partitionedRows = partitionedRows.sortWithinPartitions(HoodieRecord.RECORD_KEY_METADATA_FIELD);
       } else {
@@ -172,12 +161,6 @@ public class ConsistentBucketIndexBulkInsertPartitionerWithRows
     ValidationUtils.checkState(nodes.stream().noneMatch(n -> n.getTag() == ConsistentHashingNode.NodeTag.NORMAL),
         "children nodes should not be tagged as NORMAL");
     hashingChildrenNodes.put(partition, nodes);
-  }
-
-  @Override
-  public boolean arePartitionRecordsSorted() {
-    return (sortColumnNames != null && sortColumnNames.length > 0)
-        || table.requireSortedRecords() || table.getConfig().getBulkInsertSortMode() != BulkInsertSortMode.NONE;
   }
 
   private int getBucketId(Row row) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
@@ -62,9 +62,9 @@ public abstract class RDDBucketIndexPartitioner<T> extends BucketIndexBulkInsert
    */
 
   public JavaRDD<HoodieRecord<T>> doPartition(JavaRDD<HoodieRecord<T>> records, Partitioner partitioner) {
-    if (sortColumnNames != null && sortColumnNames.length > 0) {
+    if (isCustomSorted()) {
       return doPartitionAndCustomColumnSort(records, partitioner);
-    } else if (table.requireSortedRecords() || table.getConfig().getBulkInsertSortMode() != BulkInsertSortMode.NONE) {
+    } else if (isRecordKeySorted()) {
       return doPartitionAndSortByRecordKey(records, partitioner);
     } else {
       // By default, do partition only


### PR DESCRIPTION
Currently there are some common code logic in the partitioner of type bucket, refactor these code into a common parent class for better code maintainability and readability.

### Change Logs
1. extract the public logic for the bucket-type bulk insert partitioner
_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none
### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
