### PR TITLE
[HUDI-8748] Fix check for whether legacy mode is enabled for file

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/HoodieAvroReadSupport.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/HoodieAvroReadSupport.java
@@ -102,25 +102,23 @@ public class HoodieAvroReadSupport<T> extends AvroReadSupport<T> {
    *      }
    *    }
    */
-  private boolean checkLegacyMode(List<Type> parquetFields) {
-    for (Type type : parquetFields) {
+  private static boolean checkLegacyMode(List<Type> parquetFields) {
+    return parquetFields.stream().anyMatch(type -> {
       if (!type.isPrimitive()) {
         GroupType groupType = type.asGroupType();
         OriginalType originalType = groupType.getOriginalType();
         if (originalType == OriginalType.MAP
-            && groupType.getFields().get(0).getOriginalType() != OriginalType.MAP_KEY_VALUE) {
-          return false;
+            && !groupType.getFields().get(0).getName().equals("key_value")) {
+          return true;
         }
         if (originalType == OriginalType.LIST
-            && !groupType.getType(0).getName().equals("array")) {
-          return false;
+            && !groupType.getType(0).getName().equals("list")) {
+          return true;
         }
-        if (!checkLegacyMode(groupType.getFields())) {
-          return false;
-        }
+        return checkLegacyMode(groupType.getFields());
       }
-    }
-    return true;
+      return false;
+    });
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/parquet/avro/TestHoodieAvroReadSupport.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/parquet/avro/TestHoodieAvroReadSupport.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.parquet.avro;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.schema.ConversionPatterns;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestHoodieAvroReadSupport {
+  private final Type legacyListType = ConversionPatterns.listType(Type.Repetition.REQUIRED, "legacyList",
+      Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REPEATED).named("double_field"));
+  private final Type listType = ConversionPatterns.listOfElements(Type.Repetition.REQUIRED, "newList",
+      Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REPEATED).named("element"));
+  private final Type integerField = Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, Type.Repetition.REQUIRED).named("int_field");
+  private final Type legacyMapType = new GroupType(Type.Repetition.OPTIONAL, "my_map", OriginalType.MAP, new GroupType(Type.Repetition.REPEATED, "map",
+      Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED).named("key"),
+      Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED).named("value")));
+  private final Type mapType = ConversionPatterns.stringKeyMapType(Type.Repetition.OPTIONAL, "newMap",
+      Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED).named("value"));
+  private final Configuration configuration = mock(Configuration.class);
+
+  @Test
+  void fileContainsLegacyList() {
+    when(configuration.getBoolean(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE_DEFAULT)).thenReturn(false);
+    MessageType messageType = new MessageType("LegacyList", integerField, legacyListType, mapType);
+    new HoodieAvroReadSupport<>().init(configuration, Collections.emptyMap(), messageType);
+    verify(configuration).set(eq(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE), eq("true"), anyString());
+  }
+
+  @Test
+  void fileContainsLegacyMap() {
+    when(configuration.getBoolean(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE_DEFAULT)).thenReturn(false);
+    MessageType messageType = new MessageType("LegacyList", integerField, legacyMapType, listType);
+    new HoodieAvroReadSupport<>().init(configuration, Collections.emptyMap(), messageType);
+    verify(configuration).set(eq(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE), eq("true"), anyString());
+  }
+
+  @Test
+  void fileContainsNewListAndMap() {
+    when(configuration.get(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE)).thenReturn(null);
+    MessageType messageType = new MessageType("newFieldTypes", listType, mapType, integerField);
+    new HoodieAvroReadSupport<>().init(configuration, Collections.emptyMap(), messageType);
+    verify(configuration).set(eq(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE), eq("false"), anyString());
+  }
+
+  @Test
+  void fileContainsNoListOrMap() {
+    MessageType messageType = new MessageType("noListOrMap", integerField);
+    new HoodieAvroReadSupport<>().init(configuration, Collections.emptyMap(), messageType);
+    verify(configuration, never()).set(anyString(), anyString());
+  }
+}


### PR DESCRIPTION
### Change Logs

- Update check to see if there are any fields matching the legacy format. The legacy list format can be present with the proper map format causing an inaccurate result in the current implementation.

### Impact

Fixes issue that prevents user from being able to read certain files

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
