### PR TITLE
[MINOR] Populate the log record with file name instead of file id

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -329,7 +329,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     if (config.populateMetaFields()) {
       String seqId =
           HoodieRecord.generateSequenceId(instantTime, getPartitionId(), RECORD_COUNTER.getAndIncrement());
-      metadataValues.setFileName(fileId);
+      metadataValues.setFileName(writer.getLogFile().getFileName());
       metadataValues.setPartitionPath(partitionPath);
       metadataValues.setRecordKey(hoodieRecord.getRecordKey());
       if (!this.isLogCompaction) {


### PR DESCRIPTION
The `_hoodie_file_name` field in log record is currently populated with the file id, which does not match the intended meaning of the field, so the actual file name is used.

### Change Logs
1. populate the log record with file name instead of file id
_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none
### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
