### PR TITLE
[HUDI-8771] Fix Incorrect classification of input paths in InputPathHandler and HoodieInputFormatUtils

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
@@ -94,8 +94,10 @@ public class InputPathHandler {
       throws IOException {
     for (Path inputPath : inputPaths) {
       boolean basePathKnown = false;
+      String inputPathStr = inputPath.toString();
       for (HoodieTableMetaClient metaClient : tableMetaClientMap.values()) {
-        if (inputPath.toString().contains(metaClient.getBasePath().toString())) {
+        String basePathStr = metaClient.getBasePath().toString();
+        if (inputPathStr.equals(basePathStr) || inputPathStr.startsWith(basePathStr + "/")) {
           // We already know the base path for this inputPath.
           basePathKnown = true;
           // Check if this is for a snapshot query

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestInputPathHandler.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestInputPathHandler.java
@@ -54,6 +54,7 @@ public class TestInputPathHandler {
 
   // snapshot Table
   public static final String ETL_TRIPS_TEST_NAME = "etl_trips";
+  public static final String MODEL_TRIPS_COW_TEST_NAME = "model_trips_cow";
 
   // non Hoodie table
   public static final String TRIPS_STATS_TEST_NAME = "trips_stats";
@@ -77,6 +78,7 @@ public class TestInputPathHandler {
   private static String basePathTable4 = null; // non hoodie Path
   private static String basePathTable5 = null;
   private static String basePathTable6 = null;
+  private static String basePathTable7 = null;
   private static List<String> incrementalTables;
   private static List<Path> incrementalPaths;
   private static List<Path> snapshotPaths;
@@ -123,6 +125,7 @@ public class TestInputPathHandler {
     String tempPath = "/tmp/";
     basePathTable5 = tempPath + EMPTY_SNAPSHOT_TEST_NAME;
     basePathTable6 = tempPath + EMPTY_INCREMENTAL_TEST_NAME;
+    basePathTable7 = parentPath.resolve(MODEL_TRIPS_COW_TEST_NAME).toAbsolutePath().toString();
 
     dfs.mkdirs(new Path(basePathTable1));
     initTableType(dfs.getConf(), basePathTable1, RAW_TRIPS_TEST_NAME, HoodieTableType.MERGE_ON_READ);
@@ -144,6 +147,10 @@ public class TestInputPathHandler {
 
     initTableType(dfs.getConf(), basePathTable6, EMPTY_INCREMENTAL_TEST_NAME, HoodieTableType.MERGE_ON_READ);
     incrementalPaths.add(new Path(basePathTable6));
+
+    dfs.mkdirs(new Path(basePathTable7));
+    initTableType(dfs.getConf(), basePathTable7, MODEL_TRIPS_COW_TEST_NAME, HoodieTableType.COPY_ON_WRITE);
+    snapshotPaths.addAll(generatePartitions(dfs, basePathTable7));
 
     inputPaths.addAll(incrementalPaths);
     inputPaths.addAll(snapshotPaths);


### PR DESCRIPTION
### Change Logs

- Fix Incorrect classification of input paths in `InputPathHandler` and `HoodieInputFormatUtils`
- `HoodieInputFormatUtils.groupSnapshotPathsByMetaClient()` was not strict enough and allowed multiple ownership of paths. `forEach()` usage could potentially make multiple `metaClient` associations for a single path.
- Remove not used `HoodieInputFormatUtils.groupFileStatusForSnapshotPaths()` since the logic that called this method were refactored in [HUDI-3094](https://github.com/apache/hudi/pull/4417) and this responsibility moved to `InputPathHandler`

### Impact

Reduce ambiguity of input paths classification  

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
