### PR TITLE
[HUDI-8772] Fix NPE when deserialize cleaner plan

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -126,7 +126,7 @@ public class TimelineUtils {
           try {
             HoodieCleanMetadata cleanMetadata = TimelineMetadataUtils.deserializeHoodieCleanMetadata(cleanerTimeline.getInstantDetails(instant).get());
             cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
-              if (partitionMetadata.getIsPartitionDeleted()) {
+              if (Boolean.TRUE.equals(partitionMetadata.getIsPartitionDeleted())) {
                 partitionToLatestDeleteTimestamp.put(partition, instant.requestedTime());
               }
             });


### PR DESCRIPTION
### Change Logs

Handle `null` value returned from `org.apache.hudi.avro.model.HoodieCleanPartitionMetadata#getIsPartitionDeleted`

### Impact

Meta sync and spark catalog to get the correct partitions. 

- [ ] TODO add more details here

### Risk level (write none, low medium or high below)

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
