### PR TITLE
[MINOR] Reduce logs from marker creation

### DIFF
--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
@@ -245,7 +245,7 @@ public class MarkerHandler extends Handler {
 
   private MarkerCreationFuture addMarkerCreationRequestForAsyncProcessing(
       Context context, String markerDir, String markerName) {
-    LOG.info("Request: create marker: " + markerName);
+    LOG.debug("Request: create marker: {}", markerName);
     MarkerCreationFuture future = new MarkerCreationFuture(context, markerDir, markerName);
     // Add the future to the list
     MarkerDirState markerDirState = getMarkerDirState(markerDir);


### PR DESCRIPTION
### Change Logs

This PR changes the level of marker creation logs from `INFO` to `DEBUG` at the timeline server to avoid large volume of logs from a large number of files created.

### Impact

Reduces logging burden.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
