### PR TITLE
[MINOR] Fix incorrect configuration name "hoodie.metadata.enabled"  --> "hoodie.metadata.enable"

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
@@ -270,7 +270,7 @@ public class HoodieCopyOnWriteTableInputFormat extends HoodieTableInputFormat {
                 .collect(Collectors.toList())
         );
       } else {
-        // If hoodie.metadata.enabled is set to false and the table doesn't have the metadata,
+        // If hoodie.metadata.enable is set to false and the table doesn't have the metadata,
         // read the table using fs view cache instead of file index.
         // This is because there's no file index in non-metadata table.
         String basePath = tableMetaClient.getBasePath().toString();

--- a/hudi-platform-service/hudi-metaserver/README.md
+++ b/hudi-platform-service/hudi-metaserver/README.md
@@ -78,7 +78,7 @@ hoodie.database.name=default
 hoodie.table.name=test
 hoodie.base.path=${path}
 hoodie.metaserver.enabled=true
-hoodie.metadata.enabled=false
+hoodie.metadata.enable=false
 hoodie.metaserver.uris=thrift://${serverIP}:9090
 ```
 

--- a/packaging/bundle-validation/service/read.scala
+++ b/packaging/bundle-validation/service/read.scala
@@ -21,7 +21,7 @@ val basePath = "file:///tmp/hudi-bundles/tests/" + tableName
 spark.read.format("hudi").
   option("hoodie.table.name", tableName).
   option("hoodie.database.name", "default").
-  option("hoodie.metadata.enabled", "false").
+  option("hoodie.metadata.enable", "false").
   option("hoodie.metaserver.enabled", "true").
   option("hoodie.metaserver.uris", "thrift://localhost:9090").
   load(basePath).coalesce(1).write.csv("/tmp/metaserver-bundle/sparkdatasource/trips/results")

--- a/packaging/bundle-validation/service/write.scala
+++ b/packaging/bundle-validation/service/write.scala
@@ -40,7 +40,7 @@ df.write.format("hudi").
   option("hoodie.database.name", database).
   option("hoodie.datasource.meta.sync.enable", "false").
   option("hoodie.datasource.hive_sync.enable", "false").
-  option("hoodie.metadata.enabled", "false").
+  option("hoodie.metadata.enable", "false").
   option("hoodie.metaserver.enabled", "true").
   option("hoodie.metaserver.uris", "thrift://localhost:9090").
   mode(Overwrite).


### PR DESCRIPTION
### Change Logs

Fix incorrect configuration name "hoodie.metadata.enabled" --> "hoodie.metadata.enable"

### Impact

Low

### Risk level (write none, low medium or high below)

Low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
