### PR TITLE
[HUDI-8787] Improve compaction performance by reducing unnecessary memory usage and unnecessary disk access

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
@@ -62,7 +62,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -117,7 +116,6 @@ public class HoodieSparkFileGroupReaderBasedMergeHandle<T, I, K, O> extends Hood
   private void init(CompactionOperation operation, String partitionPath, Option<HoodieBaseFile> baseFileToMerge) {
     LOG.info("partitionPath:" + partitionPath + ", fileId to be merged:" + fileId);
     this.baseFileToMerge = baseFileToMerge.orElse(null);
-    this.writtenRecordKeys = new HashSet<>();
     writeStatus.setStat(new HoodieWriteStat());
     writeStatus.getStat().setTotalLogSizeCompacted(
         operation.getMetrics().get(CompactionStrategy.TOTAL_LOG_FILE_SIZE).longValue());

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -61,7 +61,7 @@ public class HoodieReaderConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> FILE_GROUP_READER_ENABLED = ConfigProperty
       .key("hoodie.file.group.reader.enabled")
-      .defaultValue(true)
+      .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("Use engine agnostic file group reader if enabled");


### PR DESCRIPTION
In the current merge process, after judging whether the current log record can be merged or discarded, `writtenRecordKeys` only marks that the key has been deleted, rather than deleting it from the `keyToNewRecords`. This results in the following two problems:
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/2a560439-e236-4fdd-8c46-a0af394fe327" />

> unnecessary memory usage 

`keyToNewRecords` will only be used in `HoodieMergeHandle` one time, therefore, this log record can be deleted after determining it. As there is no actual deletion at present, the memory of this log record in `ExternalSpillableMap::inMemoryMap` has not been released until `close`

> unnecessary disk access

`HoodieMergeHandle::writeIncomingRecords` will always read all the log records from disk even thought hese log records we have previously confirmed that we do not need to insert.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/00168faf-96ba-4664-a6dd-f39ef5a8f347" />


### Change Logs
1. remove log record from `ExternalSpillableMap` after merging/deleting
2. save unnecessary memory usage in `ExternalSpillableMap::inMemoryMap` due to the current logic not deleting these log records in time
3. avoid unnecessary disk reading due to `HoodieMergeHandle::writeIncomingRecords` will always visit all log records even though these log records we have previously confirmed that we do not need to insert

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none
### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
