### PR TITLE
[HUDI-8787] Improve compaction performance by reducing unnecessary disk access

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -154,12 +154,22 @@ public final class BitCaskDiskMap<T extends Serializable, R extends Serializable
   }
 
   /**
-   * Custom iterator to iterate over values written to disk with pushdown predicate.
+   * Custom iterator to iterate over values written to disk.
+   */
+  @Override
+  public Iterator<R> iterator() {
+    ClosableIterator<R> iterator = new LazyFileIterable(filePath, valueMetadataMap, isCompressionEnabled).iterator();
+    this.iterators.add(iterator);
+    return iterator;
+  }
+
+  /**
+   * Custom iterator to iterate over values written to disk with a key filter.
    */
   @Override
   public Iterator<R> iterator(Predicate<T> filter) {
-    Map<T, ValueMetadata> needMetadata = valueMetadataMap.entrySet().stream().filter(e -> filter.test(e.getKey())).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    ClosableIterator<R> iterator = new LazyFileIterable(filePath, needMetadata, isCompressionEnabled).iterator();
+    Map<T, ValueMetadata> filteredValueMetadata = valueMetadataMap.entrySet().stream().filter(e -> filter.test(e.getKey())).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    ClosableIterator<R> iterator = new LazyFileIterable(filePath, filteredValueMetadata, isCompressionEnabled).iterator();
     this.iterators.add(iterator);
     return iterator;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * @param <T> The generic type of the keys
  * @param <R> The generic type of the values
  */
-public abstract class DiskMap<T extends Serializable, R extends Serializable> implements Map<T, R>, PredicatePushdownIterable<T, R> {
+public abstract class DiskMap<T extends Serializable, R extends Serializable> implements Map<T, R>, KeyFilteringIterable<T, R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DiskMap.class);
   private static final String SUBFOLDER_PREFIX = "hudi";

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * @param <T> The generic type of the keys
  * @param <R> The generic type of the values
  */
-public abstract class DiskMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Iterable<R> {
+public abstract class DiskMap<T extends Serializable, R extends Serializable> implements Map<T, R>, PredicatePushdownIterable<T, R> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DiskMap.class);
   private static final String SUBFOLDER_PREFIX = "hudi";

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -55,7 +56,7 @@ import java.util.stream.Stream;
  * frequently and incur unnecessary disk writes.
  */
 @NotThreadSafe
-public class ExternalSpillableMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Serializable, Closeable {
+public class ExternalSpillableMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Serializable, Closeable, PredicatePushdownIterable<T, R> {
 
   // Find the actual estimated payload size after inserting N records
   private static final int NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE = 100;
@@ -130,9 +131,17 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
   /**
    * A custom iterator to wrap over iterating in-memory + disk spilled data.
    */
-  public Iterator<R> iterator() {
+  @Override
+  public Iterator<R> iterator(Predicate<T> filter) {
+    return diskBasedMap == null ? inMemoryIterator(filter) : new IteratorWrapper<>(inMemoryIterator(filter), diskIterator(filter));
+  }
 
-    return diskBasedMap == null ? inMemoryMap.values().iterator() : new IteratorWrapper<>(inMemoryMap.values().iterator(), diskBasedMap.iterator());
+  private Iterator<R> inMemoryIterator(Predicate<T> filter) {
+    return inMemoryMap.entrySet().stream().filter(entry -> filter.test(entry.getKey())).map(Map.Entry::getValue).iterator();
+  }
+
+  private Iterator<R> diskIterator(Predicate<T> filter) {
+    return diskBasedMap.iterator(filter);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/FilterIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/FilterIterator.java
@@ -23,6 +23,10 @@ import org.apache.hudi.common.util.ValidationUtils;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
+/**
+ * An iterator that filters elements from a source iterator based on a predicate.
+ * @param <R> Type of elements in the iterator
+ */
 public class FilterIterator<R> implements Iterator<R> {
 
   private final Iterator<R> source;
@@ -31,29 +35,13 @@ public class FilterIterator<R> implements Iterator<R> {
 
   private R current;
 
-  private boolean init;
-
   public FilterIterator(Iterator<R> source, Predicate<R> filter) {
     this.source = source;
     this.filter = filter;
   }
 
-  private void init() {
-    if (!init) {
-      while (source.hasNext()) {
-        R next = source.next();
-        if (filter.test(next)) {
-          current = next;
-          break;
-        }
-      }
-      init = true;
-    }
-  }
-
   @Override
   public boolean hasNext() {
-    init();
     while (current == null && source.hasNext()) {
       R next = source.next();
       if (filter.test(next)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/FilterIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/FilterIterator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.apache.hudi.common.util.ValidationUtils;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public class FilterIterator<R> implements Iterator<R> {
+
+  private final Iterator<R> source;
+
+  private final Predicate<R> filter;
+
+  private R current;
+
+  private boolean init;
+
+  public FilterIterator(Iterator<R> source, Predicate<R> filter) {
+    this.source = source;
+    this.filter = filter;
+  }
+
+  private void init() {
+    if (!init) {
+      while (source.hasNext()) {
+        R next = source.next();
+        if (filter.test(next)) {
+          current = next;
+          break;
+        }
+      }
+      init = true;
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    init();
+    while (current == null && source.hasNext()) {
+      R next = source.next();
+      if (filter.test(next)) {
+        current = next;
+        break;
+      }
+    }
+    return current != null;
+  }
+
+  @Override
+  public R next() {
+    ValidationUtils.checkArgument(hasNext(), "No more elements to iterate");
+    R next = current;
+    current = null;
+    return next;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/KeyFilteringIterable.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/KeyFilteringIterable.java
@@ -21,19 +21,19 @@ package org.apache.hudi.common.util.collection;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
-public interface PredicatePushdownIterable<K, V> extends Iterable<V> {
-
-  @Override
-  default Iterator<V> iterator() {
-    return iterator(k -> true);
-  }
-
+/**
+ * An iterable that allows filtering on the element keys.
+ *
+ * @param <K> the type of element keys
+ * @param <V> the type of elements returned by the iterator
+ */
+public interface KeyFilteringIterable<K, V> extends Iterable<V> {
   /**
-   * Filter the values based on the given key-filter.
+   * Returns an iterator over elements of type {@code V}.
    *
-   * @param filter The filter to apply
-   * @return The iterator after applying the filter
+   * @param filter The filter on the key of type {@code K}.
+   *
+   * @return an Iterator.
    */
   Iterator<V> iterator(Predicate<K> filter);
-
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/PredicatePushdownIterable.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/PredicatePushdownIterable.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public interface PredicatePushdownIterable<K, V> extends Iterable<V> {
+
+  @Override
+  default Iterator<V> iterator() {
+    return iterator(k -> true);
+  }
+
+  /**
+   * Filter the values based on the given key-filter.
+   *
+   * @param filter The filter to apply
+   * @return The iterator after applying the filter
+   */
+  Iterator<V> iterator(Predicate<K> filter);
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -348,38 +347,6 @@ public class RocksDBDAO {
       byte[] val = getRocksDB().get(managedHandlesMap.get(columnFamilyName), key);
       return val == null ? null : SerializationUtils.deserialize(val);
     } catch (Exception e) {
-      throw new HoodieException(e);
-    }
-  }
-
-  /**
-   * Retrieve values for the given keys in a column family.
-   *
-   * @param columnFamilyName Column Family Name
-   * @param keys Keys to be retrieved
-   * @param <T> Type of object stored.
-   */
-  public <K extends Serializable, T extends Serializable> List<T> multiGetAsList(String columnFamilyName, List<K> keys) {
-    List<byte[]> byteKeys = keys.stream().map(this::getKeyBytes).collect(Collectors.toList());
-    ColumnFamilyHandle handle = managedHandlesMap.get(columnFamilyName);
-    ValidationUtils.checkArgument(handle != null, "Column Family not found :" + columnFamilyName);
-    List<ColumnFamilyHandle> columnFamilyHandles = byteKeys.stream().map(key -> handle).collect(Collectors.toList());
-    return multiGetAsList(columnFamilyHandles, byteKeys);
-  }
-
-  /**
-   * Retrieve values for the given keys in the given column families.
-   *
-   * @param columnFamilyHandles Column Family Handles
-   * @param keys Keys to be retrieved
-   * @param <T> Type of object stored.
-   */
-  private  <T extends Serializable>  List<T> multiGetAsList(List<ColumnFamilyHandle> columnFamilyHandles, List<byte[]> keys) {
-    ValidationUtils.checkArgument(!closed);
-    try {
-      return getRocksDB().multiGetAsList(columnFamilyHandles, keys)
-          .stream().filter(Objects::nonNull).map(val -> (T) SerializationUtils.deserialize(val)).collect(Collectors.toList());
-    } catch (RocksDBException e) {
       throw new HoodieException(e);
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -416,9 +416,10 @@ public class RocksDBDAO {
    * Return Iterator of key-value pairs from RocksIterator.
    *
    * @param columnFamilyName Column Family Name
-   * @param <T>              Type of value stored
+   * @param <T>              Type of key stored
+   * @param <R>              Type of value stored
    */
-  public <T extends Serializable> Iterator<T> iterator(String columnFamilyName) {
+  public <T extends Serializable, R extends Serializable> Iterator<Pair<T, R>> iterator(String columnFamilyName) {
     return new IteratorWrapper<>(getRocksDB().newIterator(managedHandlesMap.get(columnFamilyName)));
   }
 
@@ -548,7 +549,7 @@ public class RocksDBDAO {
   /**
    * {@link Iterator} wrapper for RocksDb Iterator {@link RocksIterator}.
    */
-  private static class IteratorWrapper<R> implements Iterator<R> {
+  private static class IteratorWrapper<T, R> implements Iterator<Pair<T, R>> {
 
     private final RocksIterator iterator;
 
@@ -563,13 +564,14 @@ public class RocksDBDAO {
     }
 
     @Override
-    public R next() {
+    public Pair<T, R> next() {
       if (!hasNext()) {
         throw new IllegalStateException("next() called on rocksDB with no more valid entries");
       }
+      T key = SerializationUtils.deserialize(iterator.key());
       R val = SerializationUtils.deserialize(iterator.value());
       iterator.next();
-      return val;
+      return Pair.of(key, val);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
@@ -30,9 +30,12 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterators;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -139,6 +142,13 @@ public final class RocksDbDiskMap<T extends Serializable, R extends Serializable
   @Override
   public Iterator<R> iterator() {
     return getRocksDb().iterator(ROCKSDB_COL_FAMILY);
+  }
+
+  @Override
+  public Iterator<R> iterator(Predicate<T> filter) {
+    List<T> filteredKeys = keySet.stream().filter(filter).sorted().collect(Collectors.toList());
+    List<R> values = getRocksDb().multiGet(ROCKSDB_COL_FAMILY, filteredKeys);
+    return values.iterator();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
@@ -30,12 +30,10 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -141,7 +139,7 @@ public final class RocksDbDiskMap<T extends Serializable, R extends Serializable
    */
   @Override
   public Iterator<R> iterator() {
-    return getRocksDb().iterator(ROCKSDB_COL_FAMILY);
+    return new MappingIterator<Pair<T, R>, R>(getRocksDb().iterator(ROCKSDB_COL_FAMILY), Pair::getValue);
   }
 
   /**
@@ -149,9 +147,7 @@ public final class RocksDbDiskMap<T extends Serializable, R extends Serializable
    */
   @Override
   public Iterator<R> iterator(Predicate<T> filter) {
-    List<T> filteredKeys = keySet.stream().filter(filter).sorted().collect(Collectors.toList());
-    List<R> values = getRocksDb().multiGetAsList(ROCKSDB_COL_FAMILY, filteredKeys);
-    return values.iterator();
+    return new MappingIterator<Pair<T, R>, R>(new FilterIterator<>(getRocksDb().iterator(ROCKSDB_COL_FAMILY), pair -> filter.test(pair.getKey())), Pair::getValue);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDbDiskMap.java
@@ -144,10 +144,13 @@ public final class RocksDbDiskMap<T extends Serializable, R extends Serializable
     return getRocksDb().iterator(ROCKSDB_COL_FAMILY);
   }
 
+  /**
+   * Custom iterator to iterate over values written to disk with a key filter.
+   */
   @Override
   public Iterator<R> iterator(Predicate<T> filter) {
     List<T> filteredKeys = keySet.stream().filter(filter).sorted().collect(Collectors.toList());
-    List<R> values = getRocksDb().multiGet(ROCKSDB_COL_FAMILY, filteredKeys);
+    List<R> values = getRocksDb().multiGetAsList(ROCKSDB_COL_FAMILY, filteredKeys);
     return values.iterator();
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestFilterIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestFilterIterator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestFilterIterator {
+
+  @Test
+  public void testFilter() {
+    // Create a list of integers
+    List<Integer> list = Arrays.asList(1, 2, 3, 4, 5);
+    // Create a filter that filters out even numbers
+    Predicate<Integer> filter = i -> i % 2 != 0;
+    // Create a filter iterator
+    FilterIterator<Integer> filterIterator = new FilterIterator<>(list.iterator(), filter);
+    // Create a list to store the filtered elements
+    List<Integer> filteredList = new ArrayList<>();
+    // Iterate over the filter iterator
+    while (filterIterator.hasNext()) {
+      filteredList.add(filterIterator.next());
+    }
+    // Assert that the filtered list contains only odd numbers
+    assertEquals(Arrays.asList(1, 3, 5), filteredList);
+  }
+
+  @Test
+  public void testFilterFailed() {
+    Iterator<Integer> i1 = Collections.emptyIterator(); // empty iterator
+
+    FilterIterator<Integer> ci = new FilterIterator<>(i1, i -> true);
+    assertFalse(ci.hasNext());
+    try {
+      ci.next();
+      fail("expected error for empty iterator");
+    } catch (IllegalArgumentException e) {
+      // no-op
+    }
+  }
+
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestBitCaskDiskMap.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestBitCaskDiskMap.java
@@ -119,6 +119,19 @@ public class TestBitCaskDiskMap extends HoodieCommonTestHarness {
       assert recordKeys.contains(rec.getRecordKey());
     }
 
+
+    // test iterator with predicate
+    String firstKey = recordKeys.stream().findFirst().get();
+    recordKeys.remove(firstKey);
+    itr = records.iterator(key -> !key.equals(firstKey));
+    int cntSize = 0;
+    while (itr.hasNext()) {
+      HoodieRecord<? extends HoodieRecordPayload> rec = itr.next();
+      cntSize++;
+      assert recordKeys.contains(rec.getRecordKey());
+    }
+    assertEquals(recordKeys.size(), cntSize);
+
     verifyCleanup(records);
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDbDiskMap.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDbDiskMap.java
@@ -122,6 +122,18 @@ public class TestRocksDbDiskMap extends HoodieCommonTestHarness {
       assert recordKeys.contains(rec.getRecordKey());
     }
     assertEquals(recordKeys.size(), cntSize);
+
+    // test iterator with predicate
+    String firstKey = recordKeys.stream().findFirst().get();
+    recordKeys.remove(firstKey);
+    itr = rocksDBBasedMap.iterator(key -> !key.equals(firstKey));
+    cntSize = 0;
+    while (itr.hasNext()) {
+      HoodieRecord<? extends HoodieRecordPayload> rec = itr.next();
+      cntSize++;
+      assert recordKeys.contains(rec.getRecordKey());
+    }
+    assertEquals(recordKeys.size(), cntSize);
   }
 
   @Test


### PR DESCRIPTION
`HoodieMergeHandle::writeIncomingRecords` will always read all the log records from disk even thought these log records we have previously confirmed that we do not need to insert.
<img width="807" alt="image" src="https://github.com/user-attachments/assets/08e8c5f9-8f12-4f9b-8ab8-3d0295855dfd" />
So we should push down this predicate to `ExternalSpillableMap::iterator` to avoid unnecessary disk access.


### Change Logs

1. improve compaction performance by avoid unnecessary disk visiting
2. support push down predicate to `ExternalSpillableMap`

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
