### PR TITLE
[HUDI-8789] Dropping hbase deps from presto/trino bundle

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -211,26 +211,8 @@
       <scope>compile</scope>
     </dependency>
 
-    <!--Guava needs to be shaded because HBase 1.2.3 depends on an earlier guava version i.e 12.0.1 and hits runtime
-    issues with the guava version present in Presto runtime-->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>12.0.1</version>
-      <scope>${presto.bundle.bootstrap.scope}</scope>
-    </dependency>
-
-    <!--commons-lang needs to be shaded because HBase 1.2.3 needs it at runtime, but Presto runtime does not have this
-    dependency-->
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>${presto.bundle.bootstrap.scope}</scope>
-    </dependency>
-
-    <!--protobuf needs to be shaded because HBase 1.2.3 needs it at runtime, but Presto runtime does not have this
-    dependency-->
+    <!--protobuf needs to be shaded because HBase 1.2.3 and our native reader needs it at runtime,
+    but Presto runtime does not have this dependency-->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>

--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -81,9 +81,7 @@
                   <include>org.codehaus.jackson:*</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>com.yammer.metrics:metrics-core</include>
-                  <include>com.google.guava:guava</include>
                   <include>commons-io:commons-io</include>
-                  <include>commons-lang:commons-lang</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>org.openjdk.jol:jol-core</include>
                 </includes>

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -217,26 +217,8 @@
       <scope>compile</scope>
     </dependency>
 
-    <!--Guava needs to be shaded because HBase 1.2.3 depends on an earlier guava version i.e 12.0.1 and hits runtime
-    issues with the guava version present in Trino runtime-->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>12.0.1</version>
-      <scope>${trino.bundle.bootstrap.scope}</scope>
-    </dependency>
-
-    <!--commons-lang needs to be shaded because HBase 1.2.3 needs it at runtime, but Trino runtime does not have this
-    dependency-->
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>${trino.bundle.bootstrap.scope}</scope>
-    </dependency>
-
-    <!--protobuf needs to be shaded because HBase 1.2.3 needs it at runtime, but Trino runtime does not have this
-    dependency-->
+    <!--protobuf needs to be shaded because HBase 1.2.3 + native HFile reader needs it at runtime,
+    but Trino runtime does not have this dependency-->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -83,8 +83,6 @@
                   <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.codehaus.jackson:*</include>
                   <include>com.yammer.metrics:metrics-core</include>
-                  <include>com.google.guava:guava</include>
-                  <include>commons-lang:commons-lang</include>
                   <include>commons-io:commons-io</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>org.openjdk.jol:jol-core</include>


### PR DESCRIPTION
### Change Logs

- Removed guava, commons-lang 

### Impact

Presto, Trino bundles need to rely on native HFile reader going forward. 

### Risk level (write none, low medium or high below)

medium: need to be ultimately tested on trino/presto side. 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
