### PR TITLE
[HUDI-8704] Instant time to completion time state upgrade migration for Flink StreamReadMonitoringFunction

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -154,7 +154,7 @@ public class StreamReadMonitoringFunction
 
       // Handle state upgrades
       StateUpgrader<String> stateUpgrader = new StreamReadMonitoringStateUpgrader(metaClient, issuedInstant);
-      new StateUpgradeHelper<>(instantState, stateUpgrader, StateVersion.V2).upgradeState();
+      new StateUpgradeHelper<>(instantState, stateUpgrader, StateVersion.V1).upgradeState();
 
       List<String> retrievedStates = new ArrayList<>();
       for (String entry : this.instantState.get()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
@@ -50,6 +50,13 @@ public class StateUpgradeHelper<T> {
   }
 
   private StateVersion detectVersion(List<T> state) {
-    return state.size() == 1 ? StateVersion.V1 : StateVersion.V2;
+    switch (state.size()) {
+      case 1:
+        return StateVersion.V0;
+      case 2:
+        return StateVersion.V1;
+      default:
+        throw new IllegalStateException("Unknown state size when detecting version, size: " + state.size());
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
@@ -41,22 +41,11 @@ public class StateUpgradeHelper<T> {
         .stream(state.get().spliterator(), false)
         .collect(Collectors.toList());
 
-    StateVersion detectedVersion = detectVersion(currentState);
+    StateVersion detectedVersion = upgrader.detectVersion(currentState);
     if (upgrader.canUpgrade(detectedVersion, currentVersion)) {
       List<T> upgradedState = upgrader.upgrade(currentState, detectedVersion, currentVersion);
       state.clear();
       state.addAll(upgradedState);
-    }
-  }
-
-  private StateVersion detectVersion(List<T> state) {
-    switch (state.size()) {
-      case 1:
-        return StateVersion.V0;
-      case 2:
-        return StateVersion.V1;
-      default:
-        throw new IllegalStateException("Unknown state size when detecting version, size: " + state.size());
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
@@ -28,12 +28,12 @@ public class StateUpgradeHelper<T> {
 
   private final ListState<T> state;
   private final StateUpgrader<T> upgrader;
-  private final StateVersion currentVersion;
+  private final StateVersion targetVersion;
 
-  public StateUpgradeHelper(ListState<T> state, StateUpgrader<T> upgrader, StateVersion currentVersion) {
+  public StateUpgradeHelper(ListState<T> state, StateUpgrader<T> upgrader, StateVersion targetVersion) {
     this.state = state;
     this.upgrader = upgrader;
-    this.currentVersion = currentVersion;
+    this.targetVersion = targetVersion;
   }
 
   public void upgradeState() throws Exception {
@@ -42,8 +42,8 @@ public class StateUpgradeHelper<T> {
         .collect(Collectors.toList());
 
     StateVersion detectedVersion = upgrader.detectVersion(currentState);
-    if (upgrader.canUpgrade(detectedVersion, currentVersion)) {
-      List<T> upgradedState = upgrader.upgrade(currentState, detectedVersion, currentVersion);
+    if (upgrader.canUpgrade(detectedVersion, targetVersion)) {
+      List<T> upgradedState = upgrader.upgrade(currentState, detectedVersion, targetVersion);
       state.clear();
       state.addAll(upgradedState);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgradeHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.state.upgrade;
+
+import org.apache.flink.api.common.state.ListState;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class StateUpgradeHelper<T> {
+
+  private final ListState<T> state;
+  private final StateUpgrader<T> upgrader;
+  private final StateVersion currentVersion;
+
+  public StateUpgradeHelper(ListState<T> state, StateUpgrader<T> upgrader, StateVersion currentVersion) {
+    this.state = state;
+    this.upgrader = upgrader;
+    this.currentVersion = currentVersion;
+  }
+
+  public void upgradeState() throws Exception {
+    List<T> currentState = StreamSupport
+        .stream(state.get().spliterator(), false)
+        .collect(Collectors.toList());
+
+    StateVersion detectedVersion = detectVersion(currentState);
+    if (upgrader.canUpgrade(detectedVersion, currentVersion)) {
+      List<T> upgradedState = upgrader.upgrade(currentState, detectedVersion, currentVersion);
+      state.clear();
+      state.addAll(upgradedState);
+    }
+  }
+
+  private StateVersion detectVersion(List<T> state) {
+    return state.size() == 1 ? StateVersion.V1 : StateVersion.V2;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
@@ -24,4 +24,6 @@ public interface StateUpgrader<T> {
   List<T> upgrade(List<T> oldState, StateVersion fromVersion, StateVersion toVersion);
   
   boolean canUpgrade(StateVersion fromVersion, StateVersion toVersion);
+
+  StateVersion detectVersion(List<T> oldState);
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
@@ -22,5 +22,6 @@ import java.util.List;
 
 public interface StateUpgrader<T> {
   List<T> upgrade(List<T> oldState, StateVersion fromVersion, StateVersion toVersion);
+  
   boolean canUpgrade(StateVersion fromVersion, StateVersion toVersion);
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateUpgrader.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.state.upgrade;
+
+import java.util.List;
+
+public interface StateUpgrader<T> {
+  List<T> upgrade(List<T> oldState, StateVersion fromVersion, StateVersion toVersion);
+  boolean canUpgrade(StateVersion fromVersion, StateVersion toVersion);
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
@@ -18,10 +18,9 @@
 
 package org.apache.hudi.state.upgrade;
 
-// StateVersion.java
 public enum StateVersion {
-  V1(1),
-  V2(2);
+  V0(0),
+  V1(1);
 
   private final int version;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
@@ -20,7 +20,8 @@ package org.apache.hudi.state.upgrade;
 
 public enum StateVersion {
   V0(0),
-  V1(1);
+  V1(1),
+  UNKNOWN(-1);
 
   private final int version;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/StateVersion.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.state.upgrade;
+
+// StateVersion.java
+public enum StateVersion {
+  V1(1),
+  V2(2);
+
+  private final int version;
+
+  StateVersion(int version) {
+    this.version = version;
+  }
+
+  public int getValue() {
+    return version;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
 import org.apache.hudi.state.upgrade.StateUpgrader;
 import org.apache.hudi.state.upgrade.StateVersion;
 
@@ -49,15 +50,15 @@ public class StreamReadMonitoringStateUpgrader implements StateUpgrader<String> 
   public List<String> upgrade(List<String> oldState, StateVersion fromVersion, StateVersion toVersion) {
     switch (fromVersion) {
       case V0:
-        if (toVersion == StateVersion.V0) {
+        if (toVersion == StateVersion.V1) {
           return upgradeV0ToV1(oldState);
         }
-        throw new IllegalStateException("Unsupported version upgrade path");
+        throw new HoodieUpgradeDowngradeException("Unsupported version upgrade path :" + fromVersion + " -> " + toVersion);
       case V1:
         // Do nothing
         return oldState;
       default:
-        throw new IllegalStateException("Unsupported version upgrade path");
+        throw new HoodieUpgradeDowngradeException("Unsupported version upgrade path :" + fromVersion + " -> " + toVersion);
     }
   }
 
@@ -100,7 +101,7 @@ public class StreamReadMonitoringStateUpgrader implements StateUpgrader<String> 
     }
 
     if (filteredTimeline.firstInstant().isEmpty()) {
-      LOG.error("Unable to find instant {} in [isArchived: {}] timeline: {}", issuedInstant, isReadArchivedTimeline, filteredTimeline);
+      LOG.error("Unable to find instant {} in [isArchived: {}] timeline: {}", issuedInstant, isReadArchivedTimeline, filteredTimeline.getInstants());
       throw new HoodieException("Unable to find completionTime in timeline for instant: " + issuedInstant);
     }
     String issuedOffset = filteredTimeline.firstInstant().get().getCompletionTime();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.state.upgrade.source;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.state.upgrade.StateUpgrader;
+import org.apache.hudi.state.upgrade.StateVersion;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StreamReadMonitoringStateUpgrader implements StateUpgrader<String> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamReadMonitoringStateUpgrader.class);
+
+  private final HoodieTableMetaClient metaClient;
+  private final String issuedInstant;
+
+  public StreamReadMonitoringStateUpgrader(HoodieTableMetaClient metaClient, String issuedInstant) {
+    this.metaClient = metaClient;
+    this.issuedInstant = issuedInstant;
+  }
+
+  @Override
+  public List<String> upgrade(List<String> oldState, StateVersion fromVersion, StateVersion toVersion) {
+    switch (fromVersion) {
+      case V1:
+        if (toVersion == StateVersion.V2) {
+          return upgradeV1ToV2(oldState);
+        }
+      case V2:
+        // Do nothing
+        return oldState;
+      default:
+        throw new IllegalStateException("Unsupported version upgrade path");
+    }
+  }
+
+  @Override
+  public boolean canUpgrade(StateVersion fromVersion, StateVersion toVersion) {
+    return fromVersion.getValue() < toVersion.getValue();
+  }
+
+  private List<String> upgradeV1ToV2(List<String> oldState) {
+    ValidationUtils.checkState(oldState.size() == 1, "Retrieved state must have a size of 1");
+
+    // this is the case where we have both legacy and new state.
+    // the two should be mutually exclusive for the operator, thus we throw the exception.
+    ValidationUtils.checkState(this.issuedInstant != null,
+        "The " + getClass().getSimpleName() + " has already restored from a previous Flink version.");
+
+    String issuedInstant = oldState.get(0);
+
+    // TODO 1: Find issuedOffset by querying for completion time using metaClient's active offset
+    // TODO 2: If issuedInstant (requestInstant) is in archive timeline, how do we handle that, should we throw an error?
+    String issuedOffset = "";
+    return Arrays.asList(issuedInstant, issuedOffset);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
@@ -48,6 +48,7 @@ public class StreamReadMonitoringStateUpgrader implements StateUpgrader<String> 
         if (toVersion == StateVersion.V2) {
           return upgradeV1ToV2(oldState);
         }
+        throw new IllegalStateException("Unsupported version upgrade path");
       case V2:
         // Do nothing
         return oldState;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/state/upgrade/source/StreamReadMonitoringStateUpgrader.java
@@ -66,6 +66,18 @@ public class StreamReadMonitoringStateUpgrader implements StateUpgrader<String> 
     return fromVersion.getValue() < toVersion.getValue();
   }
 
+  @Override
+  public StateVersion detectVersion(List<String> state) {
+    switch (state.size()) {
+      case 1:
+        return StateVersion.V0;
+      case 2:
+        return StateVersion.V1;
+      default:
+        throw new IllegalStateException("Unknown state size when detecting version, size: " + state.size());
+    }
+  }
+
   private List<String> upgradeV0ToV1(List<String> oldState) {
     ValidationUtils.checkState(oldState.size() == 1, "Retrieved state must have a size of 1");
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/state/upgrade/TestStreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/state/upgrade/TestStreamReadMonitoringStateUpgrader.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.state.upgrade;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineFactory;
+import org.apache.hudi.common.table.timeline.versioning.DefaultTimelineFactory;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
+import org.apache.hudi.state.upgrade.source.StreamReadMonitoringStateUpgrader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.table.timeline.HoodieInstant.State.COMPLETED;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestStreamReadMonitoringStateUpgrader {
+
+  private final static TimelineFactory TIMELINE_FACTORY = new DefaultTimelineFactory();
+
+  @Mock
+  private HoodieTableMetaClient metaClient;
+
+  @Mock
+  private HoodieActiveTimeline activeTimeline;
+
+  @Mock
+  private HoodieArchivedTimeline archivedTimeline;
+
+  private StreamReadMonitoringStateUpgrader upgrader;
+
+  // issuedInstant
+  private final String requestTimeTs = "20250203000000000";
+  // issuedOffset
+  private final String completionTimeTs = "20250203000000900";
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    upgrader = new StreamReadMonitoringStateUpgrader(metaClient, requestTimeTs);
+  }
+
+  @Test
+  void testDetectVersion_V0State() {
+    List<String> v0State = Collections.singletonList(requestTimeTs);
+    assertEquals(StateVersion.V0, upgrader.detectVersion(v0State));
+  }
+
+  @Test
+  void testDetectVersion_V1State() {
+    List<String> v1State = Arrays.asList(requestTimeTs, completionTimeTs);
+    assertEquals(StateVersion.V1, upgrader.detectVersion(v1State));
+  }
+
+  @Test
+  void testDetectVersion_InvalidState() {
+    List<String> invalidState = Arrays.asList(requestTimeTs, completionTimeTs, "3");
+    assertThrows(IllegalStateException.class, () -> upgrader.detectVersion(invalidState));
+  }
+
+  @Test
+  void testCanUpgrade() {
+    assertFalse(upgrader.canUpgrade(StateVersion.V0, StateVersion.V0));
+    assertTrue(upgrader.canUpgrade(StateVersion.V0, StateVersion.V1));
+    assertFalse(upgrader.canUpgrade(StateVersion.V1, StateVersion.V0));
+    assertFalse(upgrader.canUpgrade(StateVersion.V1, StateVersion.V1));
+  }
+
+  @Test
+  void testUpgrade_V0ToV1_ActiveTimeline() {
+    List<String> oldState = Collections.singletonList(requestTimeTs);
+    HoodieInstant activeInstant = new HoodieInstant(COMPLETED, COMMIT_ACTION, completionTimeTs, completionTimeTs, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+
+    when(activeTimeline.isBeforeTimelineStarts(requestTimeTs)).thenReturn(false);
+    when(activeTimeline.findInstantsAfterOrEquals(requestTimeTs, 3))
+        .thenReturn(TIMELINE_FACTORY.createDefaultTimeline(Stream.of(activeInstant), null));
+
+    List<String> result = upgrader.upgrade(oldState, StateVersion.V0, StateVersion.V1);
+
+    assertEquals(2, result.size());
+    assertEquals(requestTimeTs, result.get(0));
+    assertEquals(completionTimeTs, result.get(1));
+    // verify that #getArchivedTimelien was NEVER invoked during test
+    verify(metaClient, never()).getArchivedTimeline(any(), anyBoolean());
+  }
+
+  @Test
+  void testUpgrade_V0ToV1_ArchivedTimeline() {
+    List<String> oldState = Collections.singletonList(requestTimeTs);
+    HoodieInstant archivedInstant = new HoodieInstant(COMPLETED, COMMIT_ACTION, completionTimeTs, completionTimeTs, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+
+    when(activeTimeline.isBeforeTimelineStarts(requestTimeTs)).thenReturn(true);
+    when(metaClient.getArchivedTimeline(StringUtils.EMPTY_STRING, false)).thenReturn(archivedTimeline);
+    when(archivedTimeline.findInstantsAfterOrEquals(requestTimeTs, 3))
+        .thenReturn(TIMELINE_FACTORY.createDefaultTimeline(Stream.of(archivedInstant), null));
+
+    List<String> result = upgrader.upgrade(oldState, StateVersion.V0, StateVersion.V1);
+
+    assertEquals(2, result.size());
+    assertEquals(requestTimeTs, result.get(0));
+    assertEquals(completionTimeTs, result.get(1));
+    // verify that #getArchivedTimelien was invoked during test
+    verify(metaClient).getArchivedTimeline(StringUtils.EMPTY_STRING, false);
+  }
+
+  @Test
+  void testUpgrade_V0ToV1_NoInstantFound() {
+    List<String> oldState = Collections.singletonList(requestTimeTs);
+
+    // Mock timeline to not return any instants
+    when(activeTimeline.isBeforeTimelineStarts(requestTimeTs)).thenReturn(false);
+    when(activeTimeline.findInstantsAfterOrEquals(requestTimeTs, 3))
+        .thenReturn(TIMELINE_FACTORY.createDefaultTimeline(Stream.of(), null));
+
+    assertThrows(HoodieException.class, () ->
+        upgrader.upgrade(oldState, StateVersion.V0, StateVersion.V1));
+  }
+
+  @Test
+  void testUpgrade_V1ToV1_NoChange() {
+    List<String> v1State = Arrays.asList(requestTimeTs, completionTimeTs);
+    List<String> result = upgrader.upgrade(v1State, StateVersion.V1, StateVersion.V1);
+    assertEquals(v1State, result);
+  }
+
+  @Test
+  void testUpgrade_UnsupportedPath() {
+    List<String> state = Collections.singletonList(requestTimeTs);
+    assertThrows(HoodieUpgradeDowngradeException.class, () ->
+        upgrader.upgrade(state, StateVersion.V0, StateVersion.UNKNOWN));
+  }
+
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/state/upgrade/TestStreamReadMonitoringStateUpgrader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/state/upgrade/TestStreamReadMonitoringStateUpgrader.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 
 public class TestStreamReadMonitoringStateUpgrader {
 
-  private final static TimelineFactory TIMELINE_FACTORY = new DefaultTimelineFactory();
+  private static final TimelineFactory TIMELINE_FACTORY = new DefaultTimelineFactory();
 
   @Mock
   private HoodieTableMetaClient metaClient;


### PR DESCRIPTION
### Change Logs

Instant time to completion time state upgrade migration for Flink StreamReadMonitoringFunction. 

When performing a version upgrade, users are required to stop their job with savepoint, then restart their job with a newer Hudi-Flink-Bundle. To ensure forward compatibility, we added a state upgrader interface for StreamReadMonitoring function to allow forward compatibility for readers.

1. Added an interface to handle state upgrades.
2. Implemented `StreamReadMonitoringStateUpgrader` to handle issuedInstant (requestInstant) -> issuedInstant + issuedOffset (completionTime) upgrade
3. Moved outdated legacy validation logic into `StreamReadMonitoringStateUpgrader` to avoid confusion.


### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
