### PR TITLE
[HUDI-8794] Make sure the log file has been closed and then remove the shutdown hook

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -231,10 +231,11 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
 
   @Override
   public void close() throws IOException {
+    closeStream();
+    // remove the shutdown hook after closing the stream to avoid memory leaks
     if (null != shutdownThread) {
       Runtime.getRuntime().removeShutdownHook(shutdownThread);
     }
-    closeStream();
   }
 
   private void closeStream() throws IOException {
@@ -275,12 +276,10 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     shutdownThread = new Thread() {
       public void run() {
         try {
-          LOG.warn("running logformatwriter hook");
-          if (output != null) {
-            closeStream();
-          }
+          LOG.warn("running HoodieLogFormatWriter shutdown hook to close output stream for log file: {}", logFile);
+          closeStream();
         } catch (Exception e) {
-          LOG.warn(String.format("unable to close output stream for log file %s", logFile), e);
+          LOG.warn("unable to close output stream for log file: {}", logFile, e);
           // fail silently for any sort of exception
         }
       }


### PR DESCRIPTION
In our actual production, we encountered an exception because the log file was not closed and then subsequent tasks to read the file.

Consider the following scenario: A speculative task has finished writing all the data, but the original task has been successfully executed, resulting in the need to kill the task. In the exit logic, we find that the code will remove the shutdown hook and then execute the close. If a jvm exits between the shutdown removal and the close completion, the log file will not be closed properly, resulting in a downstream read error.

org.apache.hudi.common.table.log.HoodieLogFormatWriter#close
<img width="553" alt="image" src="https://github.com/user-attachments/assets/ea0b1ab9-d72b-4918-b453-a0aa75f16bc3" />



### Change Logs

1. make sure log file has been closed and then remove the shutdown hook

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
