### PR TITLE
[HUDI-8796] Restrict insert operation with bucket index for Flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -204,6 +204,10 @@ public class Pipelines {
       Configuration conf,
       RowType rowType,
       DataStream<RowData> dataStream) {
+    if (OptionsResolver.isBucketIndexType(conf)) {
+      throw new HoodieNotSupportedException("Bucket index supports only upsert operation. Please, use upsert operation or switch to another index type.");
+    }
+
     WriteOperatorFactory<RowData> operatorFactory = AppendWriteOperator.getFactory(conf, rowType);
 
     return dataStream


### PR DESCRIPTION
### Change Logs

Currently, there is no exception when we try to write data in Flink append mode using bucket index. Data will be written, but in parquet files without bucket IDs. And it would happen silently. This MR propose to throw exception in this case, instead of silent write of unexpected data, which is not compatible with index settings..

### Impact

Simple bucket index is not supported in Flink append mode. Therefore we need to prevent silent unexpected behavior.

### Risk level (write none, low medium or high below)

Low. Corresponding test is added.

### Documentation Update

There is no detailed description in the documentation about how different index types are working in different modes of different engines.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
