### PR TITLE
[HUDI-8798] Validate Metadata Table Enabled during Archival

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -295,7 +295,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
 
     // If metadata table is enabled, do not archive instants which are more recent than the last compaction on the
     // metadata table.
-    if (table.getMetaClient().getTableConfig().isMetadataTableAvailable()) {
+    if (config.isMetadataTableEnabled() && table.getMetaClient().getTableConfig().isMetadataTableAvailable()) {
       try (HoodieTableMetadata tableMetadata = HoodieTableMetadata.create(table.getContext(), table.getStorage(), config.getMetadataConfig(), config.getBasePath())) {
         Option<String> latestCompactionTime = tableMetadata.getLatestCompactionTime();
         if (!latestCompactionTime.isPresent()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
@@ -208,7 +208,7 @@ public class TimelineArchiverV2<T extends HoodieAvroPayload, I, K, O> implements
 
     // 4. If metadata table is enabled, do not archive instants which are more recent than the last compaction on the
     // metadata table.
-    if (table.getMetaClient().getTableConfig().isMetadataTableAvailable()) {
+    if (config.isMetadataTableEnabled() && table.getMetaClient().getTableConfig().isMetadataTableAvailable()) {
       try (HoodieTableMetadata tableMetadata = HoodieTableMetadata.create(
           table.getContext(), table.getStorage(), config.getMetadataConfig(), config.getBasePath())) {
         Option<String> latestCompactionTime = tableMetadata.getLatestCompactionTime();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -295,6 +295,9 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
             getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
             getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000005", "00000006")),
             commitsAfterArchival, false);
+        if (enableMetadata) {
+          disableMetadataTable(writeConfig);
+        }
       } else if (i < 8) {
         assertEquals(originalCommits, commitsAfterArchival);
       } else if (i == 8) {
@@ -1815,6 +1818,11 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
    */
   private Pair<List<HoodieInstant>, List<HoodieInstant>> archiveAndGetCommitsList(HoodieWriteConfig writeConfig) throws IOException {
     return archiveAndGetCommitsList(writeConfig, false);
+  }
+
+  private void disableMetadataTable(HoodieWriteConfig writeConfig) {
+    writeConfig.setValue(HoodieMetadataConfig.ENABLE.key(), "false");
+    writeConfig.getMetadataConfig().setValue(HoodieMetadataConfig.ENABLE.key(), "false");
   }
 
   private Pair<List<HoodieInstant>, List<HoodieInstant>> archiveAndGetCommitsList(


### PR DESCRIPTION
### Change Logs

Add a check in HoodieTimelineArchiver to validate if metadata table is enabled for the table.

### Impact

Only queries metadata table if it's enabled for the table. Previously we're relying on the presence of the file partitions present in the metadata table. If metadata table is disabled for the stream after a while, we'd still have the partitions present. We need this check to validate if metadata table is enabled for the stream.

### Risk level (write none, low medium or high below)

None

Adds extra check to see if metadata table is enabled.

### Documentation Update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
