### PR TITLE
[HUDI-8775] Expression index on a column should get tracked at partition level if partition stats index is turned on

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -27,11 +27,13 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
@@ -105,10 +107,12 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeIndexPlan;
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createMetadataWriteConfig;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.DirectoryInfo;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToPartitionStatsColumnRangeMetadata;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionLatestFileSlicesIncludingInflight;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
@@ -539,12 +543,25 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     return Pair.of(fileGroupCount, records);
   }
 
+  /**
+   * Generates expression index records
+   * @param partitionFilePathAndSizeTriplet Triplet of file path, file size and partition name to which file belongs
+   * @param indexDefinition Hoodie Index Definition for the expression index for which records need to be generated
+   * @param metaClient Hoodie Table Meta Client
+   * @param parallelism Parallelism to use for engine operations
+   * @param readerSchema Schema of reader
+   * @param storageConf Storage Config
+   * @param instantTime Instant time
+   * @param shouldGeneratePartitionStatRecords Whether partition stat records need to be generated along with the file level expression index
+   *                                           records. Partition stat records need to be generated when bootstrapping the index
+   * @return HoodieData wrapper of expression index HoodieRecords
+   */
   protected abstract HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet,
                                                                         HoodieIndexDefinition indexDefinition,
                                                                         HoodieTableMetaClient metaClient,
                                                                         int parallelism, Schema readerSchema,
                                                                         StorageConfiguration<?> storageConf,
-                                                                        String instantTime);
+                                                                        String instantTime, boolean shouldGeneratePartitionStatRecords);
 
   protected abstract EngineType getEngineType();
 
@@ -573,10 +590,10 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     int fileGroupCount = dataWriteConfig.getMetadataConfig().getExpressionIndexFileGroupCount();
     int parallelism = Math.min(partitionFilePathSizeTriplet.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
     Schema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient);
-    return Pair.of(fileGroupCount, getExpressionIndexRecords(partitionFilePathSizeTriplet, indexDefinition, dataMetaClient, parallelism, readerSchema, storageConf, instantTime));
+    return Pair.of(fileGroupCount, getExpressionIndexRecords(partitionFilePathSizeTriplet, indexDefinition, dataMetaClient, parallelism, readerSchema, storageConf, instantTime, true));
   }
 
-  private HoodieIndexDefinition getIndexDefinition(String indexName) {
+  HoodieIndexDefinition getIndexDefinition(String indexName) {
     Option<HoodieIndexMetadata> expressionIndexMetadata = dataMetaClient.getIndexMetadata();
     if (expressionIndexMetadata.isPresent()) {
       return expressionIndexMetadata.get().getIndexDefinitions().get(indexName);
@@ -1064,13 +1081,24 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
               enabledPartitionTypes, dataWriteConfig.getBloomFilterType(),
               dataWriteConfig.getBloomIndexParallelism(), dataWriteConfig.getWritesFileIdEncoding());
 
+      Option<HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>>> partitionRangeMetadataPartitionPairOpt = Option.empty();
+      if (enabledPartitionTypes.contains(MetadataPartitionType.PARTITION_STATS)) {
+        checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient),
+            "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
+        partitionRangeMetadataPartitionPairOpt = Option.of(convertMetadataToPartitionStatsColumnRangeMetadata(commitMetadata, engineContext, dataMetaClient, dataWriteConfig.getMetadataConfig()));
+        final HoodieData<HoodieRecord> partitionStatsRDD = HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords(partitionRangeMetadataPartitionPairOpt.get(),
+            dataMetaClient);
+        partitionToRecordMap.put(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), partitionStatsRDD);
+      }
+
       // Updates for record index are created by parsing the WriteStatus which is a hudi-client object. Hence, we cannot yet move this code
       // to the HoodieTableMetadataUtil class in hudi-common.
       if (dataWriteConfig.isRecordIndexEnabled()) {
         HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(partitionToRecordMap.get(MetadataPartitionType.RECORD_INDEX.getPartitionPath()), commitMetadata);
         partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), partitionToRecordMap.get(MetadataPartitionType.RECORD_INDEX.getPartitionPath()).union(additionalUpdates));
       }
-      updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionToRecordMap);
+      // TODO: ABCDEFGHI Cache partitionRangeMetadataPartitionPairOpt
+      updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionRangeMetadataPartitionPairOpt, partitionToRecordMap);
       updateSecondaryIndexIfPresent(commitMetadata, partitionToRecordMap, instantTime);
       return partitionToRecordMap;
     });
@@ -1085,8 +1113,19 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
               engineContext, dataWriteConfig, commitMetadata, instantTime, dataMetaClient, dataWriteConfig.getMetadataConfig(),
               enabledPartitionTypes, dataWriteConfig.getBloomFilterType(), dataWriteConfig.getBloomIndexParallelism(), dataWriteConfig.getWritesFileIdEncoding());
       HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(records, commitMetadata);
+
+      Option<HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>>> partitionRangeMetadataPartitionPairOpt = Option.empty();
+      if (enabledPartitionTypes.contains(MetadataPartitionType.PARTITION_STATS)) {
+        checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient),
+            "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
+        partitionRangeMetadataPartitionPairOpt = Option.of(convertMetadataToPartitionStatsColumnRangeMetadata(commitMetadata, engineContext, dataMetaClient, dataWriteConfig.getMetadataConfig()));
+        final HoodieData<HoodieRecord> partitionStatsRDD = HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords(partitionRangeMetadataPartitionPairOpt.get(),
+            dataMetaClient);
+        partitionToRecordMap.put(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), partitionStatsRDD);
+      }
+
       partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), records.union(additionalUpdates));
-      updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionToRecordMap);
+      updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionRangeMetadataPartitionPairOpt, partitionToRecordMap);
       return partitionToRecordMap;
     });
     closeInternal();
@@ -1095,7 +1134,9 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   /**
    * Update expression index from {@link HoodieCommitMetadata}.
    */
-  private void updateExpressionIndexIfPresent(HoodieCommitMetadata commitMetadata, String instantTime, Map<String, HoodieData<HoodieRecord>> partitionToRecordMap) {
+  private void updateExpressionIndexIfPresent(HoodieCommitMetadata commitMetadata, String instantTime,
+                                              Option<HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>>> partitionRangeMetadataPartitionPairOpt,
+                                              Map<String, HoodieData<HoodieRecord>> partitionToRecordMap) {
     if (!MetadataPartitionType.EXPRESSION_INDEX.isMetadataPartitionAvailable(dataMetaClient)) {
       return;
     }
@@ -1105,7 +1146,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
         .forEach(partition -> {
           HoodieData<HoodieRecord> expressionIndexRecords;
           try {
-            expressionIndexRecords = getExpressionIndexUpdates(commitMetadata, partition, instantTime);
+            expressionIndexRecords = getExpressionIndexUpdates(partitionRangeMetadataPartitionPairOpt, commitMetadata, partition, instantTime);
           } catch (Exception e) {
             throw new HoodieMetadataException(String.format("Failed to get expression index updates for partition %s", partition), e);
           }
@@ -1116,18 +1157,14 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   /**
    * Loads the file slices touched by the commit due to given instant time and returns the records for the expression index.
    *
+   * @param partitionRangeMetadataPartitionPairOpt Optional value of HoodiePairData containing pair of partition name and updated column range metadata for that partition
    * @param commitMetadata {@code HoodieCommitMetadata}
    * @param indexPartition partition name of the expression index
    * @param instantTime    timestamp at of the current update commit
    */
-  private HoodieData<HoodieRecord> getExpressionIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
-    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexPartition);
-    List<Pair<String, Pair<String, Long>>> partitionFilePathPairs = new ArrayList<>();
-    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> partitionFilePathPairs.add(
-        Pair.of(writeStat.getPartitionPath(), Pair.of(new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes())))));
-    int parallelism = Math.min(partitionFilePathPairs.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
-    Schema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient);
-    return getExpressionIndexRecords(partitionFilePathPairs, indexDefinition, dataMetaClient, parallelism, readerSchema, storageConf, instantTime);
+  protected HoodieData<HoodieRecord> getExpressionIndexUpdates(Option<HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>>> partitionRangeMetadataPartitionPairOpt,
+                                                               HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
+    throw new UnsupportedOperationException("");
   }
 
   private void updateSecondaryIndexIfPresent(HoodieCommitMetadata commitMetadata, Map<String, HoodieData<HoodieRecord>> partitionToRecordMap,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -190,7 +190,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
                                                                HoodieTableMetaClient metaClient, int parallelism, Schema readerSchema, StorageConfiguration<?> storageConf,
-                                                               String instantTime) {
+                                                               String instantTime, boolean shouldGeneratePartitionStatRecords) {
     throw new HoodieNotSupportedException("Flink metadata table does not support expression index yet.");
   }
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -125,7 +125,7 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   @Override
   protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
                                                                HoodieTableMetaClient metaClient, int parallelism, Schema readerSchema, StorageConfiguration<?> storageConf,
-                                                               String instantTime) {
+                                                               String instantTime, boolean shouldGeneratePartitionStatRecords) {
     throw new HoodieNotSupportedException("Expression index not supported for Java metadata table writer yet.");
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/data/HoodieJavaPairRDD.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/data/HoodieJavaPairRDD.java
@@ -34,6 +34,7 @@ import org.apache.spark.api.java.Optional;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.storage.StorageLevel;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -127,6 +128,10 @@ public class HoodieJavaPairRDD<K, V> implements HoodiePairData<K, V> {
   @Override
   public <W> HoodiePairData<K, W> mapValues(SerializableFunction<V, W> func) {
     return HoodieJavaPairRDD.of(pairRDDData.mapValues(func::apply));
+  }
+
+  public <W> HoodiePairData<K, W> flatMapValues(SerializableFunction<V, Iterator<W>> func) {
+    return HoodieJavaPairRDD.of(pairRDDData.flatMapValues(func::apply));
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -19,6 +19,10 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.data.HoodieJavaPairRDD;
 import org.apache.hudi.index.expression.HoodieSparkExpressionIndex;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
@@ -49,6 +53,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Column;
@@ -63,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -73,6 +79,7 @@ import static org.apache.hudi.client.utils.SparkMetadataWriterUtils.readRecordsA
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
 
 public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetadataWriter<JavaRDD<HoodieRecord>> {
 
@@ -169,11 +176,77 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
+  protected HoodieData<HoodieRecord> getExpressionIndexUpdates(Option<HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>>> partitionRangeMetadataPairOpt,
+                                                               HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
+    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexPartition);
+//    RDD<HoodieColumnRangeMetadata<Comparable>> rdd = HoodieJavaPairRDD.getJavaPairRDD(partitionRangeMetadataPair).values().flatMap(list -> list.stream().flatMap(
+//        Collection::stream).iterator()).rdd();
+//
+//    Encoder<HoodieColumnRangeMetadata<Comparable>> encoder = (Encoder<HoodieColumnRangeMetadata<Comparable>>) Encoders.kryo(rdd.first().getClass());
+//    Dataset<HoodieColumnRangeMetadata<Comparable>> dataset = ((HoodieSparkEngineContext) engineContext).getSqlContext().createDataset(rdd, encoder);
+
+    Option<HoodieData<HoodieRecord>> partitionStatsRDDOpt = Option.empty();
+    if (partitionRangeMetadataPairOpt.isPresent()) {
+      HoodieExpressionIndex<Column, Column> expressionIndex =
+          new HoodieSparkExpressionIndex(indexDefinition.getIndexName(), indexDefinition.getIndexFunction(), indexDefinition.getSourceFields(), indexDefinition.getIndexOptions());
+      ObjectMapper objectMapper = new ObjectMapper();
+      JavaRDD<String> rangeMetadataJson = HoodieJavaPairRDD.getJavaPairRDD(partitionRangeMetadataPairOpt.get())
+          .flatMapValues(list -> list.stream()
+              .flatMap(Collection::stream)
+              .iterator()
+          ).map(rangeMetadata -> objectMapper.writeValueAsString(rangeMetadata));
+//    JavaRDD<String> rangeMetadataJson = HoodieJavaPairRDD.getJavaPairRDD(partitionRangeMetadataPartitionPair).values().flatMap(list -> list.stream().flatMap(
+//        Collection::stream).iterator()).map(rangeMetadata -> objectMapper.writeValueAsString(rangeMetadata));
+      Dataset<Row> rowDataset = ((HoodieSparkEngineContext) engineContext).getSqlContext().read().json(rangeMetadataJson);
+      rowDataset = rowDataset.filter(String.format("_2.columnName == '%s'", indexDefinition.getSourceFields().get(0)));
+      Column minValueCol = expressionIndex.apply(Collections.singletonList(rowDataset.col("_2.minValue")));
+      Column maxValueCol = expressionIndex.apply(Collections.singletonList(rowDataset.col("_2.maxValue")));
+      Dataset<Row> transformedDataset = rowDataset.withColumn("transformedMinValue", minValueCol);
+      transformedDataset = transformedDataset.withColumn("transformedMaxValue", maxValueCol);
+      HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>> finalDataset = HoodieJavaRDD.of(transformedDataset.javaRDD()).mapToPair(row -> {
+        Row rangeMetadataRow = row.getAs("_2");
+        HoodieColumnRangeMetadata rangeMetadata = HoodieColumnRangeMetadata.create(rangeMetadataRow.getAs("filePath"),
+            rangeMetadataRow.getAs("columnName"), row.getAs("transformedMinValue"), row.getAs("transformedMaxValue"),
+            rangeMetadataRow.getAs("nullCount"), rangeMetadataRow.getAs("valueCount"), rangeMetadataRow.getAs("totalSize"),
+            rangeMetadataRow.getAs("totalUncompressedSize"));
+        String partitionName = row.getAs("_1");
+        return Pair.of(partitionName, rangeMetadata);
+      });
+      partitionStatsRDDOpt = Option.of(HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords(finalDataset,
+          dataMetaClient, Option.of(indexPartition)));
+    }
+
+//    HoodieData<List<HoodieColumnRangeMetadata<Comparable>>> transformedColumnRangeMetadatas =
+//        partitionRangeMetadataPartitionPair.mapValues(rangeMetadatas ->
+//            rangeMetadatas.stream().map(rangeMetadata -> {
+//              HoodieExpressionIndex<Column, Column> expressionIndex =
+//                  new HoodieSparkExpressionIndex(indexDefinition.getIndexName(), indexDefinition.getIndexFunction(), indexDefinition.getSourceFields(), indexDefinition.getIndexOptions());
+//              Dataset<Row> dataset = ((HoodieSparkEngineContext) engineContext).getSqlContext().emptyDataFrame();
+//              Column minValueCol = expressionIndex.apply(Collections.singletonList(functions.lit(rangeMetadata.getMinValue())));
+//              Column maxValueCol = expressionIndex.apply(Collections.singletonList(functions.lit(rangeMetadata.getMaxValue())));
+//              dataset.withColumn("minValue", minValueCol);
+//              dataset.withColumn("maxValue", maxValueCol);
+//              Row transformedRangeRow = dataset.collect()[0];
+//              Comparable minValue = (Comparable) transformedRangeRow.get(0);
+//              Comparable maxValue = (Comparable) transformedRangeRow.get(1);
+//              return HoodieColumnRangeMetadata.create(rangeMetadata.getFilePath(), rangeMetadata.getColumnName(), minValue, maxValue, rangeMetadata.getNullCount(),
+//                  rangeMetadata.getValueCount(), rangeMetadata.getTotalSize(), rangeMetadata.getTotalUncompressedSize());
+//            }).collect(Collectors.toList()));
+    List<Pair<String, Pair<String, Long>>> partitionFilePathPairs = new ArrayList<>();
+    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> partitionFilePathPairs.add(
+        Pair.of(writeStat.getPartitionPath(), Pair.of(new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes())))));
+    int parallelism = Math.min(partitionFilePathPairs.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
+    Schema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient);
+    HoodieData<HoodieRecord> expressionIndexRecords = getExpressionIndexRecords(partitionFilePathPairs, indexDefinition, dataMetaClient, parallelism, readerSchema, storageConf, instantTime, false);
+    return partitionStatsRDDOpt.isPresent() ? expressionIndexRecords.union(partitionStatsRDDOpt.get()) : expressionIndexRecords;
+  }
+
+  @Override
   protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet,
                                                                HoodieIndexDefinition indexDefinition,
                                                                HoodieTableMetaClient metaClient, int parallelism,
                                                                Schema readerSchema, StorageConfiguration<?> storageConf,
-                                                               String instantTime) {
+                                                               String instantTime, boolean shouldGeneratePartitionStatRecords) {
     HoodieSparkEngineContext sparkEngineContext = (HoodieSparkEngineContext) engineContext;
     if (indexDefinition.getSourceFields().isEmpty()) {
       // In case there are no columns to index, bail
@@ -214,7 +287,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     // Generate expression index records
     if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_COLUMN_STATS)) {
-      return SparkMetadataWriterUtils.getExpressionIndexRecordsUsingColumnStats(rowDataset, expressionIndex, columnToIndex);
+      return SparkMetadataWriterUtils.getExpressionIndexRecordsUsingColumnStats(rowDataset, expressionIndex, indexDefinition, columnToIndex, shouldGeneratePartitionStatRecords);
     } else if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_BLOOM_FILTERS)) {
       return SparkMetadataWriterUtils.getExpressionIndexRecordsUsingBloomFilter(rowDataset, columnToIndex, metadataWriteConfig, instantTime, indexDefinition.getIndexName());
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListPairData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListPairData.java
@@ -147,6 +147,7 @@ public class HoodieListPairData<K, V> extends HoodieBaseListData<Pair<K, V>> imp
     return new HoodieListPairData<>(asStream().map(p -> Pair.of(p.getKey(), uncheckedMapper.apply(p.getValue()))), lazy);
   }
 
+  @Override
   public <W> HoodiePairData<K, W> flatMapValues(SerializableFunction<V, Iterator<W>> func) {
     Function<V, Iterator<W>> uncheckedMapper = throwingMapWrapper(func);
     return new HoodieListPairData<>(asStream().flatMap(p -> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodiePairData.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import java.io.Serializable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -100,6 +101,11 @@ public interface HoodiePairData<K, V> extends Serializable {
    * Maps values of this {@link HoodiePairData} container leveraging provided mapper
    */
   <W> HoodiePairData<K, W> mapValues(SerializableFunction<V, W> func);
+
+  /**
+   * Maps values of this {@link HoodiePairData} container leveraging provided mapper
+   */
+  <W> HoodiePairData<K, W> flatMapValues(SerializableFunction<V, Iterator<W>> func);
 
   /**
    * @param mapToPairFunc serializable map function to generate another pair.

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
@@ -176,6 +176,10 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
   public static <T extends Comparable<T>> HoodieColumnRangeMetadata<T> merge(
       HoodieColumnRangeMetadata<T> left,
       HoodieColumnRangeMetadata<T> right) {
+    if (left == null || right == null) {
+      return left == null ? right : left;
+    }
+
     ValidationUtils.checkArgument(left.getColumnName().equals(right.getColumnName()),
         "Column names should be the same for merging column ranges");
     String filePath = left.getFilePath();

--- a/hudi-common/src/main/java/org/apache/hudi/index/expression/HoodieExpressionIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/expression/HoodieExpressionIndex.java
@@ -35,6 +35,8 @@ public interface HoodieExpressionIndex<S, T> extends Serializable {
   String HOODIE_EXPRESSION_INDEX_PARTITION = "_hoodie_expression_index_partition";
   String HOODIE_EXPRESSION_INDEX_FILE_SIZE = "_hoodie_expression_index_file_size";
 
+  String HOODIE_EXPRESSION_INDEX_PARTITION_STAT_PREFIX = "_partition_stat_";
+
   String EXPRESSION_OPTION = "expr";
   String TRIM_STRING_OPTION = "trimString";
   String REGEX_GROUP_INDEX_OPTION = "idx";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -43,6 +43,7 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieAccumulator;
 import org.apache.hudi.common.data.HoodieAtomicLongAccumulator;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -393,12 +394,6 @@ public class HoodieTableMetadataUtil {
       final HoodieData<HoodieRecord> metadataColumnStatsRDD = convertMetadataToColumnStatsRecords(commitMetadata, context,
           dataMetaClient, metadataConfig);
       partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), metadataColumnStatsRDD);
-    }
-    if (enabledPartitionTypes.contains(MetadataPartitionType.PARTITION_STATS)) {
-      checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient),
-          "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
-      final HoodieData<HoodieRecord> partitionStatsRDD = convertMetadataToPartitionStatsRecords(commitMetadata, context, dataMetaClient, metadataConfig);
-      partitionToRecordsMap.put(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), partitionStatsRDD);
     }
     if (enabledPartitionTypes.contains(MetadataPartitionType.RECORD_INDEX)) {
       partitionToRecordsMap.put(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), convertMetadataToRecordIndexRecords(context, commitMetadata, metadataConfig,
@@ -2425,18 +2420,52 @@ public class HoodieTableMetadataUtil {
   private static Stream<HoodieRecord> collectAndProcessColumnMetadata(
           List<List<HoodieColumnRangeMetadata<Comparable>>> fileColumnMetadata,
           String partitionPath, boolean isTightBound) {
+    return collectAndProcessColumnMetadata(partitionPath, isTightBound, Option.empty(), fileColumnMetadata.stream().flatMap(List::stream));
+  }
 
+  private static Stream<HoodieRecord> collectAndProcessColumnMetadata(Iterable<HoodieColumnRangeMetadata<Comparable>> fileColumnMetadataIterable, String partitionPath,
+                                                                      boolean isTightBound, Option<String> indexPartitionOpt) {
+
+    List<HoodieColumnRangeMetadata<Comparable>> fileColumnMetadata = new ArrayList<>();
+    fileColumnMetadataIterable.forEach(fileColumnMetadata::add);
     // Step 1: Flatten and Group by Column Name
-    Map<String, List<HoodieColumnRangeMetadata<Comparable>>> columnMetadataMap = fileColumnMetadata.stream()
-            .flatMap(List::stream)
-            .collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, Collectors.toList()));
+    return collectAndProcessColumnMetadata(partitionPath, isTightBound, indexPartitionOpt, fileColumnMetadata.stream());
+  }
+
+  private static Stream<HoodieRecord> collectAndProcessColumnMetadata(String partitionPath, boolean isTightBound, Option<String> indexPartitionOpt,
+                                                                      Stream<HoodieColumnRangeMetadata<Comparable>> fileColumnMetadata) {
+    Map<String, List<HoodieColumnRangeMetadata<Comparable>>> columnMetadataMap =
+        fileColumnMetadata.collect(Collectors.groupingBy(HoodieColumnRangeMetadata::getColumnName, Collectors.toList()));
 
     // Step 2: Aggregate Column Ranges
     Stream<HoodieColumnRangeMetadata<Comparable>> partitionStatsRangeMetadata = columnMetadataMap.entrySet().stream()
-            .map(entry -> FileFormatUtils.getColumnRangeInPartition(partitionPath, entry.getValue()));
+        .map(entry -> FileFormatUtils.getColumnRangeInPartition(partitionPath, entry.getValue()));
 
     // Create Partition Stats Records
-    return HoodieMetadataPayload.createPartitionStatsRecords(partitionPath, partitionStatsRangeMetadata.collect(Collectors.toList()), false, isTightBound);
+    return HoodieMetadataPayload.createPartitionStatsRecords(partitionPath, partitionStatsRangeMetadata.collect(Collectors.toList()), false, isTightBound, indexPartitionOpt);
+  }
+
+  public static HoodieData<HoodieRecord> collectAndProcessColumnMetadata(
+      HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>> fileColumnMetadata, boolean isTightBound, Option<String> indexPartitionOpt) {
+
+    // Step 1: Group by partition name
+    HoodiePairData<String, Iterable<HoodieColumnRangeMetadata<Comparable>>> columnMetadataMap = fileColumnMetadata.groupByKey();
+
+    // Step 2: Aggregate Column Ranges
+    return columnMetadataMap.map(entry -> {
+      String partitionName = entry.getKey();
+      Iterable<HoodieColumnRangeMetadata<Comparable>> iterable = entry.getValue();
+      final HoodieColumnRangeMetadata<Comparable>[] finalMetadata = new HoodieColumnRangeMetadata[] {null};
+      iterable.forEach(e -> {
+        HoodieColumnRangeMetadata<Comparable> rangeMetadata = HoodieColumnRangeMetadata.create(
+            partitionName, e.getColumnName(), e.getMinValue(), e.getMaxValue(),
+            e.getNullCount(), e.getValueCount(), e.getTotalSize(), e.getTotalUncompressedSize());
+        finalMetadata[0] = HoodieColumnRangeMetadata.merge(finalMetadata[0], rangeMetadata);
+      });
+      return HoodieMetadataPayload.createPartitionStatsRecords(partitionName,
+              Collections.singletonList(finalMetadata[0]), false, isTightBound, indexPartitionOpt)
+          .collect(Collectors.toList());
+    }).flatMap(records -> records.iterator());
   }
 
   public static HoodieData<HoodieRecord> convertFilesToPartitionStatsRecords(HoodieEngineContext engineContext,
@@ -2501,14 +2530,35 @@ public class HoodieTableMetadataUtil {
     return readColumnRangeMetadataFrom(partitionPath, fileName, datasetMetaClient, columnsToIndex, maxBufferSize);
   }
 
-  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatsRecords(HoodieCommitMetadata commitMetadata,
-                                                                                HoodieEngineContext engineContext,
-                                                                                HoodieTableMetaClient dataMetaClient,
-                                                                                HoodieMetadataConfig metadataConfig) {
+  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatsRecords(HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>> partitionRangeMetadataPartitionPair,
+                                                                                HoodieTableMetaClient dataMetaClient) {
+    return convertMetadataToPartitionStatsRecords(partitionRangeMetadataPartitionPair.flatMapValues(list -> list.stream().flatMap(List::stream).iterator()), dataMetaClient, Option.empty());
+  }
+
+  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatsRecords(HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>> partitionRangeMetadataPartitionPair,
+                                                                                HoodieTableMetaClient dataMetaClient, Option<String> indexPartitionOpt) {
+    try {
+      return partitionRangeMetadataPartitionPair
+          .groupByKey()
+          .map(pair -> {
+            final String partitionName = pair.getLeft();
+            boolean shouldScanColStatsForTightBound = isShouldScanColStatsForTightBound(dataMetaClient);
+            return collectAndProcessColumnMetadata(pair.getRight(), partitionName, shouldScanColStatsForTightBound, indexPartitionOpt);
+          })
+          .flatMap(recordStream -> recordStream.iterator());
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate column stats records for metadata table", e);
+    }
+  }
+
+  public static HoodiePairData<String, List<List<HoodieColumnRangeMetadata<Comparable>>>> convertMetadataToPartitionStatsColumnRangeMetadata(HoodieCommitMetadata commitMetadata,
+                                                                                                                                             HoodieEngineContext engineContext,
+                                                                                                                                             HoodieTableMetaClient dataMetaClient,
+                                                                                                                                             HoodieMetadataConfig metadataConfig) {
     List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
         .flatMap(Collection::stream).collect(Collectors.toList());
     if (allWriteStats.isEmpty()) {
-      return engineContext.emptyHoodieData();
+      return engineContext.emptyHoodieData().mapToPair(o -> Pair.of("", new ArrayList<>()));
     }
 
     try {
@@ -2523,7 +2573,7 @@ public class HoodieTableMetadataUtil {
       Lazy<Option<Schema>> writerSchemaOpt = Lazy.eagerly(tableSchema);
       List<String> columnsToIndex = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig, writerSchemaOpt);
       if (columnsToIndex.isEmpty()) {
-        return engineContext.emptyHoodieData();
+        return engineContext.emptyHoodieData().mapToPair(o -> Pair.of("", new ArrayList<>()));
       }
       // filter columns with only supported types
       final List<String> validColumnsToIndex = columnsToIndex.stream()
@@ -2539,7 +2589,7 @@ public class HoodieTableMetadataUtil {
           .collect(Collectors.toList());
 
       int parallelism = Math.max(Math.min(partitionedWriteStats.size(), metadataConfig.getPartitionStatsIndexParallelism()), 1);
-      boolean shouldScanColStatsForTightBound = MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient);
+      boolean shouldScanColStatsForTightBound = isShouldScanColStatsForTightBound(dataMetaClient);
 
       HoodieTableMetadata tableMetadata;
       if (shouldScanColStatsForTightBound) {
@@ -2547,7 +2597,7 @@ public class HoodieTableMetadataUtil {
       } else {
         tableMetadata = null;
       }
-      return engineContext.parallelize(partitionedWriteStats, parallelism).flatMap(partitionedWriteStat -> {
+      return engineContext.parallelize(partitionedWriteStats, parallelism).mapToPair(partitionedWriteStat -> {
         final String partitionName = partitionedWriteStat.get(0).getPartitionPath();
         // Step 1: Collect Column Metadata for Each File part of current commit metadata
         List<List<HoodieColumnRangeMetadata<Comparable>>> fileColumnMetadata = partitionedWriteStat.stream()
@@ -2578,11 +2628,17 @@ public class HoodieTableMetadataUtil {
           fileColumnMetadata.add(partitionColumnMetadata);
         }
 
-        return collectAndProcessColumnMetadata(fileColumnMetadata, partitionName, shouldScanColStatsForTightBound).iterator();
+        return Pair.of(partitionName, fileColumnMetadata);
       });
+
     } catch (Exception e) {
       throw new HoodieException("Failed to generate column stats records for metadata table", e);
     }
+  }
+
+  private static boolean isShouldScanColStatsForTightBound(HoodieTableMetaClient dataMetaClient) {
+    boolean shouldScanColStatsForTightBound = MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient);
+    return shouldScanColStatsForTightBound;
   }
 
   /**
@@ -2641,6 +2697,14 @@ public class HoodieTableMetadataUtil {
     final PartitionIndexID partitionIndexID = new PartitionIndexID(getColumnStatsIndexPartitionIdentifier(partitionPath));
     final ColumnIndexID columnIndexID = new ColumnIndexID(columnName);
     return columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString());
+  }
+
+  public static String getPartitionStatsIndexKey(String partitionPathPrefix, String partitionPath, String columnName) {
+    final PartitionIndexID partitionPrefixID = new PartitionIndexID(getColumnStatsIndexPartitionIdentifier(partitionPathPrefix));
+    final PartitionIndexID partitionIndexID = new PartitionIndexID(getColumnStatsIndexPartitionIdentifier(partitionPath));
+    final ColumnIndexID columnIndexID = new ColumnIndexID(columnName);
+    String partitionID = partitionPrefixID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString());
+    return columnIndexID.asBase64EncodedString().concat(partitionID);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataPayload.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataPayload.java
@@ -255,17 +255,17 @@ public class TestHoodieMetadataPayload extends HoodieCommonTestHarness {
     HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 1, 5, 0, 10, 100, 200);
     HoodieRecord<HoodieMetadataPayload> firstPartitionStatsRecord =
-        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange1), false, false).findFirst().get();
+        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange1), false, false, Option.empty()).findFirst().get();
     HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 3, 8, 1, 15, 120, 250);
     HoodieRecord<HoodieMetadataPayload> updatedPartitionStatsRecord =
-        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange2), false, false).findFirst().get();
+        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange2), false, false, Option.empty()).findFirst().get();
     HoodieMetadataPayload combinedPartitionStatsRecordPayload =
         updatedPartitionStatsRecord.getData().preCombine(firstPartitionStatsRecord.getData());
     HoodieColumnRangeMetadata<Comparable> expectedColumnRange = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 1, 8, 1, 25, 220, 450);
     HoodieMetadataPayload expectedColumnRangeMetadata = (HoodieMetadataPayload) HoodieMetadataPayload.createPartitionStatsRecords(
-        PARTITION_NAME, Collections.singletonList(expectedColumnRange), false, false).findFirst().get().getData();
+        PARTITION_NAME, Collections.singletonList(expectedColumnRange), false, false, Option.empty()).findFirst().get().getData();
     assertEquals(expectedColumnRangeMetadata, combinedPartitionStatsRecordPayload);
   }
 
@@ -274,19 +274,19 @@ public class TestHoodieMetadataPayload extends HoodieCommonTestHarness {
     HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 1, 5, 0, 10, 100, 200);
     HoodieRecord<HoodieMetadataPayload> firstPartitionStatsRecord =
-        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange1), false, false).findFirst().get();
+        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange1), false, false, Option.empty()).findFirst().get();
     HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 3, 8, 1, 15, 120, 250);
     // create delete payload
     HoodieRecord<HoodieMetadataPayload> deletedPartitionStatsRecord =
-        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange2), true, false).findFirst().get();
+        HoodieMetadataPayload.createPartitionStatsRecords(PARTITION_NAME, Collections.singletonList(fileColumnRange2), true, false, Option.empty()).findFirst().get();
     // deleted (or tombstone) record will be therefore deleting previous state of the record
     HoodieMetadataPayload combinedPartitionStatsRecordPayload =
         deletedPartitionStatsRecord.getData().preCombine(firstPartitionStatsRecord.getData());
     HoodieColumnRangeMetadata<Comparable> expectedColumnRange = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file", "columnName", 3, 8, 1, 15, 120, 250);
     HoodieMetadataPayload expectedColumnRangeMetadata = (HoodieMetadataPayload) HoodieMetadataPayload.createPartitionStatsRecords(
-        PARTITION_NAME, Collections.singletonList(expectedColumnRange), true, false).findFirst().get().getData();
+        PARTITION_NAME, Collections.singletonList(expectedColumnRange), true, false, Option.empty()).findFirst().get().getData();
     assertEquals(expectedColumnRangeMetadata, combinedPartitionStatsRecordPayload);
 
     // another update for the same key should overwrite the delete record

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ExpressionIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ExpressionIndexSupport.scala
@@ -33,15 +33,18 @@ import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.hash.{ColumnIndexID, PartitionIndexID}
 import org.apache.hudi.common.util.{StringUtils, collection}
 import org.apache.hudi.data.HoodieJavaRDD
+import org.apache.hudi.index.expression.HoodieExpressionIndex
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionStatsIndexKey
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil, MetadataPartitionType}
 import org.apache.hudi.util.JFunction
 import org.apache.spark.sql.HoodieUnsafeUtils.{createDataFrameFromInternalRows, createDataFrameFromRDD, createDataFrameFromRows}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{DateAdd, DateFormatClass, DateSub, EqualTo, Expression, FromUnixTime, In, Literal, ParseToDate, ParseToTimestamp, RegExpExtract, RegExpReplace, StringSplit, StringTrim, StringTrimLeft, StringTrimRight, Substring, UnaryExpression, UnixTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{And, DateAdd, DateFormatClass, DateSub, EqualTo, Expression, FromUnixTime, In, Literal, ParseToDate, ParseToTimestamp, RegExpExtract, RegExpReplace, StringSplit, StringTrim, StringTrimLeft, StringTrimRight, Substring, UnaryExpression, UnixTimestamp}
 import org.apache.spark.sql.catalyst.util.TimestampFormatter
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.storage.StorageLevel
 
 import scala.collection.JavaConverters._
@@ -84,6 +87,48 @@ class ExpressionIndexSupport(spark: SparkSession,
       } else if (indexDefinition.getIndexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS)) {
         val prunedPartitionAndFileNames = getPrunedPartitionsAndFileNamesMap(prunedPartitionsAndFileSlices, includeLogFiles = true)
         Option.apply(getCandidateFilesForKeys(indexPartition, prunedPartitionAndFileNames, literals))
+      } else {
+        Option.empty
+      }
+    } else {
+      Option.empty
+    }
+  }
+
+  def prunePartitions(fileIndex: HoodieFileIndex,
+                      queryFilters: Seq[Expression],
+                      queryReferencedColumns: Seq[String]): Option[Set[String]] = {
+    lazy val expressionIndexPartitionOpt = getExpressionIndexPartitionAndLiterals(queryFilters)
+    if (isIndexAvailable && queryFilters.nonEmpty && expressionIndexPartitionOpt.nonEmpty) {
+      val (indexPartition, expressionIndexQuery, _) = expressionIndexPartitionOpt.get
+      val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.get(indexPartition)
+      if (indexDefinition.getIndexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS)) {
+        val readInMemory = shouldReadInMemory(fileIndex, queryReferencedColumns, inMemoryProjectionThreshold)
+        val expressionIndexRecords = loadExpressionIndexPartitionStatRecords(indexDefinition, readInMemory)
+        loadTransposed(queryReferencedColumns, readInMemory, expressionIndexRecords, expressionIndexQuery) {
+          transposedPartitionStatsDF => {
+            val allPartitions = transposedPartitionStatsDF.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+              .collect()
+              .map(_.getString(0))
+              .toSet
+            if (allPartitions.nonEmpty) {
+              // PARTITION_STATS index exist for all or some columns in the filters
+              // NOTE: [[translateIntoColumnStatsIndexFilterExpr]] has covered the case where the
+              //       column in a filter does not have the stats available, by making sure such a
+              //       filter does not prune any partition.
+              val indexSchema = transposedPartitionStatsDF.schema
+              val indexFilter = Seq(expressionIndexQuery).map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema, isExpressionIndex = true)).reduce(And)
+              Some(transposedPartitionStatsDF.where(new Column(indexFilter))
+                .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+                .collect()
+                .map(_.getString(0))
+                .toSet)
+            } else {
+              // PARTITION_STATS index does not exist for any column in the filters, skip the pruning
+              Option.empty
+            }
+          }
+        }
       } else {
         Option.empty
       }
@@ -448,6 +493,15 @@ class ExpressionIndexSupport(spark: SparkSession,
     colStatsRecords
   }
 
+  private def loadExpressionIndexPartitionStatRecords(indexDefinition: HoodieIndexDefinition, shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
+    // We are omitting the partition name and only using the column name and expression index partition stat prefix to fetch the records
+    val recordKeyPrefix = getPartitionStatsIndexKey(HoodieExpressionIndex.HOODIE_EXPRESSION_INDEX_PARTITION_STAT_PREFIX, indexDefinition.getSourceFields.get(0))
+    val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = loadExpressionIndexForColumnsInternal(
+      indexDefinition.getIndexName, shouldReadInMemory, Seq(recordKeyPrefix))
+    //TODO: [HUDI-8303] Explicit conversion might not be required for Scala 2.12+
+    colStatsRecords
+  }
+
   def loadExpressionIndexDataFrame(indexPartition: String,
                                    prunedPartitions: Set[String],
                                    shouldReadInMemory: Boolean): DataFrame = {
@@ -494,6 +548,10 @@ class ExpressionIndexSupport(spark: SparkSession,
     } else {
       encodedTargetColumnNames
     }
+    loadExpressionIndexForColumnsInternal(indexPartition, shouldReadInMemory, keyPrefixes)
+  }
+
+  private def loadExpressionIndexForColumnsInternal(indexPartition: String, shouldReadInMemory: Boolean, keyPrefixes: Iterable[String] with (String with Int => Any)) = {
     val metadataRecords: HoodieData[HoodieRecord[HoodieMetadataPayload]] =
       metadataTable.getRecordsByKeyPrefixes(keyPrefixes.toSeq.asJava, indexPartition, shouldReadInMemory)
     val columnStatsRecords: HoodieData[HoodieMetadataColumnStats] =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestExpressionIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestExpressionIndex.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.command.index
 
-import org.apache.hudi.DataSourceWriteOptions.{HIVE_PASS, HIVE_USER, HIVE_USE_PRE_APACHE_INPUT_FORMAT, INSERT_OPERATION_OPT_VAL, OPERATION, PARTITIONPATH_FIELD, PRECOMBINE_FIELD, RECORDKEY_FIELD, TABLE_TYPE}
+import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toProperties
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.common.HoodieSparkEngineContext
@@ -35,7 +35,7 @@ import org.apache.hudi.config.{HoodieCleanConfig, HoodieCompactionConfig, Hoodie
 import org.apache.hudi.hive.testutils.HiveTestUtil
 import org.apache.hudi.hive.{HiveSyncTool, HoodieHiveSyncClient}
 import org.apache.hudi.index.HoodieIndex
-import org.apache.hudi.index.expression.{HoodieExpressionIndex, HoodieSparkExpressionIndex}
+import org.apache.hudi.index.expression.HoodieExpressionIndex
 import org.apache.hudi.metadata.{HoodieMetadataFileSystemView, MetadataPartitionType}
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.sync.common.HoodieSyncConfig.{META_SYNC_BASE_PATH, META_SYNC_DATABASE_NAME, META_SYNC_NO_PARTITION_METADATA, META_SYNC_TABLE_NAME}
@@ -800,6 +800,106 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
   }
 
   /**
+   * Test expression index pruning with partition filters.
+   */
+  @Test
+  def testPruningWithPartitionFilters(): Unit = {
+    // TODO: ABCDEFGHI Test pruning with updates
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName + s"_pruning_partition_filters_$tableType"
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
+
+        spark.sql(
+          s"""
+           CREATE TABLE $tableName (
+             |    ts LONG,
+             |    id STRING,
+             |    rider STRING,
+             |    driver STRING,
+             |    fare DOUBLE,
+             |    dateDefault STRING,
+             |    date STRING,
+             |    city STRING,
+             |    state STRING
+             |) USING HUDI
+             |options(
+             |    primaryKey ='id',
+             |    type = '$tableType',
+             |    hoodie.metadata.enable = 'true',
+             |    hoodie.datasource.write.recordkey.field = 'id',
+             |    hoodie.enable.data.skipping = 'true'
+             |)
+             |PARTITIONED BY (state)
+             |location '$basePath'
+             |""".stripMargin)
+
+        spark.sql("set hoodie.parquet.small.file.limit=0")
+        if (HoodieSparkUtils.gteqSpark3_4) {
+          spark.sql("set spark.sql.defaultColumn.enabled=false")
+        }
+
+        spark.sql(
+          s"""
+             |insert into $tableName(ts, id, rider, driver, fare, dateDefault, date, city, state) VALUES
+             |  (1695414527,'trip1','rider-A','driver-K',19.10, '2020-11-30 01:30:40', '2020-11-30', 'san_francisco','california'),
+             |  (1695414531,'trip6','rider-C','driver-K',17.14, '2021-11-30 01:30:40', '2021-11-30', 'san_diego','california'),
+             |  (1695332066,'trip3','rider-E','driver-O',93.50, '2022-11-30 01:30:40', '2022-11-30', 'austin','texas'),
+             |  (1695516137,'trip4','rider-F','driver-P',34.15, '2023-11-30 01:30:40', '2023-11-30', 'houston','texas')
+             |""".stripMargin)
+        spark.sql(
+          s"""
+             |insert into $tableName(ts, id, rider, driver, fare, dateDefault, date, city, state) VALUES
+             |  (1695414520,'trip2','rider-C','driver-M',27.70,'2024-11-30 01:30:40', '2024-11-30', 'sunnyvale','california'),
+             |  (1699349649,'trip5','rider-A','driver-Q',3.32, '2019-11-30 01:30:40', '2019-11-30', 'san_diego','texas')
+             |""".stripMargin)
+
+        val tableSchema: StructType =
+          StructType(
+            Seq(
+              StructField("ts", LongType),
+              StructField("id", StringType),
+              StructField("rider", StringType),
+              StructField("driver", StringType),
+              StructField("fare", DoubleType),
+              StructField("dateDefault", StringType),
+              StructField("date", StringType),
+              StructField("city", StringType),
+              StructField("state", StringType)
+            )
+          )
+        val opts = Map.apply(DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true", HoodieMetadataConfig.ENABLE.key -> "true")
+
+        spark.sql(s"create index idx_ts on $tableName using column_stats(ts) options(expr='from_unixtime', format='yyyy-MM-dd')")
+        var metaClient = createMetaClient(spark, basePath)
+        // validate skipping with both types of expression
+        val fromUnixTimeExpr = resolveExpr(spark, unapply(functions.from_unixtime(functions.col("ts"), "yyyy-MM-dd")).get, tableSchema)
+        var literal = Literal.create("2023-11-07")
+        var dataFilter = EqualTo(fromUnixTimeExpr, literal)
+        verifyFilePruningPartitionFilter(opts, Seq(), Seq(dataFilter), metaClient, isDataSkippingExpected = true, verifyPartitionPruning = false)
+        spark.sql(s"drop index idx_ts on $tableName")
+
+        spark.sql(s"create index idx_unix on $tableName using column_stats(date) options(expr='unix_timestamp', format='yyyy-MM-dd')")
+        metaClient = HoodieTableMetaClient.reload(metaClient)
+        val unixTimestamp = resolveExpr(spark, unapply(functions.unix_timestamp(functions.col("date"), "yyyy-MM-dd")).get, tableSchema)
+        literal = Literal.create(1732924800L)
+        dataFilter = EqualTo(unixTimestamp, literal)
+        verifyFilePruningPartitionFilter(opts, Seq(), Seq(dataFilter), metaClient, isDataSkippingExpected = true, verifyPartitionPruning = false)
+        spark.sql(s"drop index idx_unix on $tableName")
+
+        spark.sql(s"create index idx_to_date on $tableName using column_stats(date) options(expr='to_date', format='yyyy-MM-dd')")
+        metaClient = HoodieTableMetaClient.reload(metaClient)
+        val toDate = resolveExpr(spark, unapply(functions.to_date(functions.col("date"), "yyyy-MM-dd")).get, tableSchema)
+        dataFilter = EqualTo(toDate, lit(18230).expr)
+        verifyFilePruningPartitionFilter(opts, Seq(), Seq(dataFilter), metaClient, isDataSkippingExpected = true, verifyPartitionPruning = false)
+        spark.sql(s"drop index idx_to_date on $tableName")
+      }
+    }
+  }
+
+  /**
    * Test expression index with data skipping for date and timestamp based expressions.
    */
   @Test
@@ -1508,13 +1608,30 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     assertFalse(bloomFilterRecords.isEmpty)
   }
 
-  private def verifyFilePruning(opts: Map[String, String], dataFilter: Expression, metaClient: HoodieTableMetaClient, isDataSkippingExpected: Boolean = false, isNoScanExpected: Boolean = false): Unit = {
+  private def verifyFilePruning(opts: Map[String, String], dataFilter: Expression, metaClient: HoodieTableMetaClient,
+                                isDataSkippingExpected: Boolean = false, isNoScanExpected: Boolean = false): Unit = {
+    verifyFilePruningPartitionFilter(opts, Seq(), Seq(dataFilter), metaClient, isDataSkippingExpected, isNoScanExpected, false)
+  }
+
+  private def verifyFilePruningPartitionFilter(opts: Map[String, String], partitionFilter: Seq[Expression], dataFilter: Seq[Expression], metaClient: HoodieTableMetaClient, isDataSkippingExpected: Boolean = false, isNoScanExpected: Boolean = false, verifyPartitionPruning: Boolean): Unit = {
     // with data skipping
     val commonOpts = opts + ("path" -> metaClient.getBasePath.toString)
     var fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts, includeLogFiles = true)
     try {
-      val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
-      val filteredFilesCount = filteredPartitionDirectories.flatMap(s => s.files).size
+      val filteredFilesCount = if (verifyPartitionPruning) {
+        val (isPruned, filteredPartitionDirectoriesAndFileSlices) = fileIndex.prunePartitionsAndGetFileSlices(dataFilter, partitionFilter)
+        if (isDataSkippingExpected) {
+          assertTrue(isPruned)
+        }
+        filteredPartitionDirectoriesAndFileSlices.map(o => o._2).flatMap(s => s.iterator).map((f1) => {
+          var totalLatestDataFiles = 0L
+          totalLatestDataFiles = totalLatestDataFiles + (f1.getLogFiles.count() + (if (f1.getBaseFile.isPresent) 1 else 0))
+          totalLatestDataFiles
+        }).sum
+      } else {
+        val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
+        filteredPartitionDirectories.flatMap(s => s.files).size
+      }
       val latestDataFilesCount = getLatestDataFilesCount(metaClient = metaClient)
       if (isDataSkippingExpected) {
         assertTrue(filteredFilesCount < latestDataFilesCount)
@@ -1529,7 +1646,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
 
       // with no data skipping
       fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false"), includeLogFiles = true)
-      val filesCountWithNoSkipping = fileIndex.listFiles(Seq(), Seq(dataFilter)).flatMap(s => s.files).size
+      val filesCountWithNoSkipping = fileIndex.listFiles(partitionFilter, dataFilter).flatMap(s => s.files).size
       assertTrue(filesCountWithNoSkipping == latestDataFilesCount)
     } finally {
       fileIndex.close()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1028,7 +1028,7 @@ public class HoodieMetadataTableValidator implements Serializable {
 
       TreeSet<HoodieColumnRangeMetadata<Comparable>> aggregatedColumnStats = aggregateColumnStats(partitionPath, colStats);
       // TODO: fix `isTightBound` flag when stats based on log files are available
-      List<HoodieRecord> partitionStatRecords = HoodieMetadataPayload.createPartitionStatsRecords(partitionPath, new ArrayList<>(aggregatedColumnStats), false, false)
+      List<HoodieRecord> partitionStatRecords = HoodieMetadataPayload.createPartitionStatsRecords(partitionPath, new ArrayList<>(aggregatedColumnStats), false, false, Option.empty())
           .collect(Collectors.toList());
       return partitionStatRecords.stream()
           .map(record -> {


### PR DESCRIPTION
### Change Logs

If partition stats index is enabled, and then expression index is created using col stats on a ts column, mapping it to a date. In this case, the stats based on derived value from expression should be tracked at partition level too.

### Impact

Partition level pruning can be achieved using expression index

### Risk level (write none, low medium or high below)

low

### Documentation Update

Expression Index can now perform partition pruning for valid queries

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
