### PR TITLE
[HUDI-8802] Avoid unnecessary conversion between HoodieIndexAvroRecord and HoodieAvroRecord in HoodieFileSliceReader

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -366,10 +366,11 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
             Option<HoodieFileReader> baseFileReader = StringUtils.isNullOrEmpty(clusteringOp.getDataFilePath())
                 ? Option.empty()
                 : Option.of(getBaseOrBootstrapFileReader(storageConf, bootstrapBasePath, partitionFields, clusteringOp));
+            Option<BaseKeyGenerator> keyGeneratorOp = HoodieSparkKeyGeneratorFactory.createBaseKeyGenerator(writeConfig);
             return new HoodieFileSliceReader(baseFileReader, scanner, readerSchema, tableConfig.getPreCombineField(), config.getRecordMerger(),
                 tableConfig.getProps(),
                 tableConfig.populateMetaFields() ? Option.empty() : Option.of(Pair.of(tableConfig.getRecordKeyFieldProp(),
-                    tableConfig.getPartitionFieldProp())));
+                    tableConfig.getPartitionFieldProp())), keyGeneratorOp);
           } catch (IOException e) {
             throw new HoodieClusteringException("Error reading input data for " + clusteringOp.getDataFilePath()
                 + " and " + clusteringOp.getDeltaFilePaths(), e);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2321,7 +2321,7 @@ public class HoodieTableMetadataUtil {
     }
     HoodieFileSliceReader fileSliceReader = new HoodieFileSliceReader(baseFileReader, mergedLogRecordScanner, tableSchema, metaClient.getTableConfig().getPreCombineField(), recordMerger,
         metaClient.getTableConfig().getProps(),
-        Option.empty());
+        Option.empty(), Option.empty());
     ClosableIterator<HoodieRecord> fileSliceIterator = ClosableIterator.wrap(fileSliceReader);
     return new ClosableIterator<HoodieRecord>() {
       private HoodieRecord nextValidRecord;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -25,6 +25,7 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.utils.ConcatenatingIterator;
 import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.ClusteringOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -45,6 +46,8 @@ import org.apache.hudi.io.storage.HoodieAvroFileReader;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
 import org.apache.hudi.metrics.FlinkClusteringMetrics;
 import org.apache.hudi.sink.bulk.BulkInsertWriterHelper;
 import org.apache.hudi.sink.bulk.sort.SortOperatorGen;
@@ -291,13 +294,14 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
             .withBitCaskDiskMapCompressionEnabled(writeConfig.getCommonConfig().isBitCaskDiskMapCompressionEnabled())
             .withRecordMerger(writeConfig.getRecordMerger())
             .build();
-
         HoodieTableConfig tableConfig = table.getMetaClient().getTableConfig();
+        Option<BaseKeyGenerator> keyGeneratorOpt = tableConfig.populateMetaFields() ? Option.empty() :
+            Option.of((BaseKeyGenerator) HoodieAvroKeyGeneratorFactory.createKeyGenerator(new TypedProperties(writeConfig.getProps())));
         HoodieFileSliceReader<? extends IndexedRecord> hoodieFileSliceReader = new HoodieFileSliceReader(baseFileReader, scanner, readerSchema,
             tableConfig.getPreCombineField(),writeConfig.getRecordMerger(),
             tableConfig.getProps(),
             tableConfig.populateMetaFields() ? Option.empty() : Option.of(Pair.of(tableConfig.getRecordKeyFieldProp(),
-                tableConfig.getPartitionFieldProp())));
+                tableConfig.getPartitionFieldProp())), keyGeneratorOpt);
 
         recordIterators.add(StreamSupport.stream(Spliterators.spliteratorUnknownSize(hoodieFileSliceReader, Spliterator.NONNULL), false).map(hoodieRecord -> {
           try {


### PR DESCRIPTION
When `HoodieFileSliceReader` performs reading:
For base records that have a corresponding update record in the log file, it first converts the HoodieAvroIndexRecord format that it reads from the Base Reader to the HoodieAvroRecord format. Then when it performs the merge, it convert itself to the HoodieAvroIndexRecord, and since it was the HoodieAvroIndexRecord in the first place, this extra conversion is not necessary.

`HoodieFileSlice`
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/fbfccea6-5307-48b3-9bfc-555f4db2edd3" />

`HoodieAvroRecordMerger`
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/03754ded-23fb-4e01-ba02-93098205bd7b" />



### Change Logs
1. avoid unnecessary conversion between HoodieIndexAvroRecord and HoodieAvroRecord in HoodieFileSliceReader

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
low
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
