### PR TITLE
[HUDI-8803] Fix ArrayIndexOutOfBoundsException while vectorized read with schema evolution

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestVectorizedReadWithSchemaEvolution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestVectorizedReadWithSchemaEvolution.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.common
+
+import org.apache.hudi.HoodieSparkUtils
+
+class TestVectorizedReadWithSchemaEvolution extends HoodieSparkSqlTestBase {
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test vectorized read for $tableType table") {
+      if (HoodieSparkUtils.isSpark3) {
+        withSQLConf(
+          "hoodie.schema.on.read.enable" -> "true",
+          "spark.sql.parquet.enableVectorizedReader" -> "true",
+          "spark.sql.codegen.maxFields" -> "1",
+          "hoodie.parquet.small.file.limit" -> "0",
+          "hoodie.file.group.reader.enabled" -> "false"
+        ) {
+          withTempDir { tmp =>
+            val tableName = generateTableName
+            val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+            // create table
+            spark.sql(
+              s"""
+                 |create table $tableName (
+                 |  id int,
+                 |  name string,
+                 |  price double,
+                 |  ts long
+                 |) using hudi
+                 | partitioned by (ts)
+                 | location '$tablePath'
+                 | tblproperties (
+                 |  type = '$tableType',
+                 |  primaryKey = 'id',
+                 |  preCombineField = 'ts'
+                 | )
+         """.stripMargin)
+            // insert data to table
+            spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+
+            // alter table change data type of column 'id'
+            spark.sql(s"alter table $tableName alter column price type string")
+
+            // insert new records
+            spark.sql(s"insert into $tableName values(2, 'a2', '20', 2000)")
+
+            checkAnswer(s"select id, name, price, ts from $tableName")(
+              Seq(1, "a1", "10.0", 1000),
+              Seq(2, "a2", "20", 2000)
+            )
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

While vectorized reading parquet file with schema evolution,  occasionally it will failed with ArrayIndexOutOfBoundsException

```
24/11/25 11:53:38 [Executor task launch worker for task 9] ERROR Executor: Exception in task 0.5 in stage 3.0 (TID 9)
java.lang.ArrayIndexOutOfBoundsException: -1
	at org.apache.spark.sql.execution.vectorized.OnHeapColumnVector.isNullAt(OnHeapColumnVector.java:130)
	at org.apache.spark.sql.execution.vectorized.WritableColumnVector.getUTF8String(WritableColumnVector.java:396)
	at org.apache.spark.sql.vectorized.ColumnarBatchRow.getUTF8String(ColumnarBatch.java:220)
	at org.apache.spark.sql.catalyst.InternalRow.getString(InternalRow.scala:34)
	at org.apache.hudi.RecordMergingFileIterator.hasNextInternal(Iterators.scala:200)
	at org.apache.hudi.RecordMergingFileIterator.doHasNext(Iterators.scala:192)
	at org.apache.hudi.util.CachingIterator.hasNext(CachingIterator.scala:36)
	at org.apache.hudi.util.CachingIterator.hasNext$(CachingIterator.scala:36)
	at org.apache.hudi.LogFileIterator.hasNext(Iterators.scala:60)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:355)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:878)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2$adapted(RDD.scala:878)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:355)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:319)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:129)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:478)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1480)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:481)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

 
The root cause is `Spark3HoodieVectorizedParquetRecordReader` extends 
`VectorizedParquetRecordReader`，both of them keep a member variable named "batchIdx", but Spark3HoodieVectorizedParquetRecordReader never change the value of "batchIdx" from super,  Exception occured when call `super.getCurrentValue` 

```
// code in Spark3HoodieVectorizedParquetRecordReader

@Override
public Object getCurrentValue() {
  if (typeChangeInfos == null || typeChangeInfos.isEmpty()) {
    return super.getCurrentValue();
  }

  if (returnColumnarBatch) {
    return columnarBatch == null ? super.getCurrentValue() : columnarBatch;
  }

  return columnarBatch == null ? super.getCurrentValue() : columnarBatch.getRow(batchIdx - 1);
}

@Override
public boolean nextKeyValue() throws IOException {
  resultBatch();

  if (returnColumnarBatch)  {
    return nextBatch();
  }

  if (batchIdx >= numBatched) {
    if (!nextBatch()) {
      return false;
    }
  }
  ++batchIdx;
  return true;
} 
```

```
// VectorizedParquetRecordReader

@Override
public boolean nextKeyValue() throws IOException {
  resultBatch();

  if (returnColumnarBatch) return nextBatch();

  if (batchIdx >= numBatched) {
    if (!nextBatch()) return false;
  }
  ++batchIdx;
  return true;
}

@Override
public Object getCurrentValue() {
  if (returnColumnarBatch) return columnarBatch;
  return columnarBatch.getRow(batchIdx - 1);
} 
```
### Impact

None

### Risk level (write none, low medium or high below)

medium
### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
