### PR TITLE
[Draft][HUDI-7944]Adding Config to stop job incase of failure in any table during Multi…

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
@@ -139,4 +139,17 @@ public class HoodieStreamerConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("0.15.0")
       .withDocumentation("When enabled, the dataframe generated from reading source data is wrapped with an exception handler to explicitly surface exceptions.");
+
+  public static final ConfigProperty<Integer> FAILED_TABLE_LIMIT = ConfigProperty
+          .key(STREAMER_CONFIG_PREFIX + "failed.table.limit")
+          .defaultValue(0)
+          .markAdvanced()
+          .sinceVersion("1.1.0")
+          .withDocumentation("Checks the size of failed tables and limit if the failed size has went beyond then it will fail");
+  public static final ConfigProperty<Boolean> FAILED_TABLE_LIMIT_ENABLED = ConfigProperty
+          .key(STREAMER_CONFIG_PREFIX + "failed.table.limit.enabled")
+          .defaultValue(false)
+          .markAdvanced()
+          .sinceVersion("1.1.0")
+          .withDocumentation("When enabled,if the failed table limit goes beyond the limit then it starts failing");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -266,6 +266,9 @@ public class HoodieStreamer implements Serializable {
             + "JsonKafkaSource, AvroKafkaSource, HiveIncrPullSource}")
     public String sourceClassName = JsonDFSSource.class.getName();
 
+    @Parameter(names = {"--critical-table"}, description = "marks a table as critial table", required = false)
+    public boolean criticalTable = false;
+
     @Parameter(names = {"--source-ordering-field"}, description = "Field within source record to decide how"
         + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record")
     public String sourceOrderingField = "ts";
@@ -278,7 +281,7 @@ public class HoodieStreamer implements Serializable {
 
     @Parameter(names = {"--merge-mode", "--record-merge-mode"}, description = "mode to merge records with")
     public RecordMergeMode recordMergeMode = null;
-    
+
     @Parameter(names = {"--merge-strategy-id", "--record-merge-strategy-id"}, description = "only set this if you are using custom merge mode")
     public String recordMergeStrategyId = null;
 


### PR DESCRIPTION

### **Change Logs and Description Update**

#### **Overview**
This proposal introduces a feature allowing clients to designate specific tables as critical. If any critical table fails during a write operation, the sync job will terminate immediately. The implementation is highly configurable, offering both strict and lenient failure handling policies to accommodate diverse use cases.

---

### **Proposed Configurations**

1. **Critical Table Flag** (Table-level Configuration):  
   - **Description**: Marks specific tables as critical.  
   - **Behavior**: The job fails immediately if any critical table encounters a failure.  
   - **Default**: `false` (tables are non-critical by default).  

2. **Failed Table Limit** (Global Configuration for Multi-Streamer Job):  
   - **Description**: Sets a threshold for the number of table failures allowed before the job fails.  
   - **Default**: `0` (fail on any table failure unless overridden).  

3. **Failed Table Handling Enabled** (Global Configuration for Multi-Streamer Job):  
   - **Description**: Toggles enforcement of the failed table limit.  
   - **Default**: `false` (disabled by default).  

---

### **Configuration Scenarios**
#### **Global Failure Threshold**
- The job fails if the total number of failed tables exceeds the configured limit.  
- **Example Configuration**:  
  ```properties
  hoodie.streamer.failed_table_limit_enabled=true
  hoodie.streamer.failed_table_limit=2
  ```
#### **Table-Specific Failure Rule**
- Specific tables can be marked as critical:  
  ```properties
  hoodie.streamer.table.t2.criticalTable=true
  ```

### **Impact**
None for current jobs, clients given option to add configs in future releases. 
---

### **Risk Level**
 **Low**:  
---

### **Documentation Updates**

---

### **Contributor's Checklist**

- [X] Read the contributor's guide.  
- [ ] Clearly state Change Logs and Impact.  
- [ ] Add adequate tests to validate failure configurations.  
- [X] CI passed for implemented changes.  

