### PR TITLE
[HUDI-8663] Look up in col stats based on indexed cols

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -98,7 +98,7 @@ class PartitionStatsIndexSupport(spark: SparkSession,
             //       filter does not prune any partition.
             val indexSchema = transposedPartitionStatsDF.schema
             val indexedCols : Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
-            // to be fixed. Siva.
+            // to be fixed. HUDI-8836.
             val hasNonIndexedCols = new AtomicBoolean(false)
             val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols,
               hasNonIndexedCols = hasNonIndexedCols)).reduce(And)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -27,15 +27,16 @@ import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.hash.ColumnIndexID
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
 import org.apache.hudi.util.JFunction
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{And, Expression}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, SparkSession}
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.JavaConverters._
 
 class PartitionStatsIndexSupport(spark: SparkSession,
@@ -96,7 +97,11 @@ class PartitionStatsIndexSupport(spark: SparkSession,
             //       column in a filter does not have the stats available, by making sure such a
             //       filter does not prune any partition.
             val indexSchema = transposedPartitionStatsDF.schema
-            val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema)).reduce(And)
+            val indexedCols : Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
+            // to be fixed. Siva.
+            val hasNonIndexedCols = new AtomicBoolean(false)
+            val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols,
+              hasNonIndexedCols = hasNonIndexedCols)).reduce(And)
             Some(transposedPartitionStatsDF.where(new Column(indexFilter))
               .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
               .collect()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -99,9 +99,7 @@ class PartitionStatsIndexSupport(spark: SparkSession,
             val indexSchema = transposedPartitionStatsDF.schema
             val indexedCols : Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
             // to be fixed. HUDI-8836.
-            val hasNonIndexedCols = new AtomicBoolean(false)
-            val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols,
-              hasNonIndexedCols = hasNonIndexedCols)).reduce(And)
+            val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols)).reduce(And)
             Some(transposedPartitionStatsDF.where(new Column(indexFilter))
               .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
               .collect()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -25,12 +25,15 @@ import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.keygen.KeyGenUtils
 import org.apache.hudi.keygen.KeyGenUtils.DEFAULT_RECORD_KEY_PARTS_SEPARATOR
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadata}
 import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, Expression, In, Literal}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.JavaConverters._
 import scala.util.control.Breaks.{break, breakable}
 import scala.util.control.NonFatal
@@ -99,31 +102,38 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
     (prunedPartitions, prunedFiles)
   }
 
-  protected def getCandidateFiles(indexDf: DataFrame, queryFilters: Seq[Expression], prunedFileNames: Set[String], isExpressionIndex: Boolean = false): Set[String] = {
-    val indexSchema = indexDf.schema
-    val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema, isExpressionIndex)).reduce(And)
-    val prunedCandidateFileNames =
-      indexDf.where(new Column(indexFilter))
-        .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+  protected def getCandidateFiles(indexDf: DataFrame, queryFilters: Seq[Expression], fileNamesFromPrunedPartitions: Set[String], isExpressionIndex: Boolean = false): Set[String] = {
+    val indexedCols : Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
+    val hasNonIndexedFilters = new AtomicBoolean(false)
+    val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, isExpressionIndex, indexedCols, hasNonIndexedFilters)).reduce(And)
+    if (hasNonIndexedFilters.get()) {
+      // if there are any non indexed cols or we can't translate source expr, we have to read all files and may not benefit from col stats lookup.
+       fileNamesFromPrunedPartitions
+    } else {
+      // only lookup in col stats if all filters are eligible to be looked up in col stats index in MDT
+      val prunedCandidateFileNames =
+        indexDf.where(new Column(indexFilter))
+          .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+          .collect()
+          .map(_.getString(0))
+          .toSet
+
+      // NOTE: Col-Stats Index isn't guaranteed to have complete set of statistics for every
+      //       base-file or log file: since it's bound to clustering, which could occur asynchronously
+      //       at arbitrary point in time, and is not likely to be touching all of the base files.
+      //
+      //       To close that gap, we manually compute the difference b/w all indexed (by col-stats-index)
+      //       files and all outstanding base-files or log files, and make sure that all base files and
+      //       log file not represented w/in the index are included in the output of this method
+      val allIndexedFileNames =
+      indexDf.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
         .collect()
         .map(_.getString(0))
         .toSet
+      val notIndexedFileNames = fileNamesFromPrunedPartitions -- allIndexedFileNames
 
-    // NOTE: Col-Stats Index isn't guaranteed to have complete set of statistics for every
-    //       base-file or log file: since it's bound to clustering, which could occur asynchronously
-    //       at arbitrary point in time, and is not likely to be touching all of the base files.
-    //
-    //       To close that gap, we manually compute the difference b/w all indexed (by col-stats-index)
-    //       files and all outstanding base-files or log files, and make sure that all base files and
-    //       log file not represented w/in the index are included in the output of this method
-    val allIndexedFileNames =
-    indexDf.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
-      .collect()
-      .map(_.getString(0))
-      .toSet
-    val notIndexedFileNames = prunedFileNames -- allIndexedFileNames
-
-    prunedCandidateFileNames ++ notIndexedFileNames
+      prunedCandidateFileNames ++ notIndexedFileNames
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -45,8 +45,7 @@ object DataSkippingUtils extends Logging {
    * @param isExpressionIndex whether the index is an expression index
    * @return filter for column-stats index's table
    */
-  def translateIntoColumnStatsIndexFilterExpr(dataTableFilterExpr: Expression, isExpressionIndex: Boolean = false,
-                                              indexedCols : Seq[String] = Seq.empty,
+  def translateIntoColumnStatsIndexFilterExpr(dataTableFilterExpr: Expression, isExpressionIndex: Boolean = false, indexedCols : Seq[String] = Seq.empty,
                                               hasNonIndexedCols : AtomicBoolean = new AtomicBoolean(false)): Expression = {
     try {
       createColumnStatsIndexFilterExprInternal(dataTableFilterExpr, isExpressionIndex, indexedCols,
@@ -391,13 +390,13 @@ object DataSkippingUtils extends Logging {
           indexedCols = indexedCols, hasNonIndexedCols = rightHasNonIndexedCols)
         // only if both left and right has non indexed cols, we can set hasNonIndexedCols to true.
         // If not, we can still afford to prune files based on col stats lookup.
-        if (leftHasNonIndexedCols.get() && !rightHasNonIndexedCols.get()) {
-          Option(resRight)  // if only left has non indexed cols, ignore from the expression to be looked up in col stats df
-        } else if (!leftHasNonIndexedCols.get() && rightHasNonIndexedCols.get()) {
-          Option(resLeft) // if only right has non indexed cols, ignore from the expression to be looked up in col stats df
-        } else if (leftHasNonIndexedCols.get() && rightHasNonIndexedCols.get()) {
+        if (leftHasNonIndexedCols.get() && rightHasNonIndexedCols.get()) {
           hasNonIndexedCols.set(true)
           None
+        } else if (leftHasNonIndexedCols.get()) {
+          Option(resRight) // Ignore the non-indexed left expression
+        } else if (rightHasNonIndexedCols.get()) {
+          Option(resLeft) // Ignore the non-indexed right expression
         } else {
           Option(And(resLeft, resRight))
         }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -125,7 +125,7 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
   @MethodSource(Array("testStringsLookupFilterExpressionsSource"))
   def testStringsLookupFilterExpressions(sourceExpr: Expression, input: Seq[IndexRow], output: Seq[String]): Unit = {
     val resolvedExpr = resolveExpr(spark, sourceExpr, sourceTableSchema)
-    val lookupFilter = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(resolvedExpr, indexSchema)
+    val lookupFilter = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(resolvedExpr, indexedCols = indexedCols)
 
     val sparkB = spark
     import sparkB.implicits._
@@ -155,7 +155,7 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
   }
 
   private def applyFilterExpr(resolvedExpr: Expression, input: Seq[IndexRow]): Seq[String] = {
-    val lookupFilter = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(resolvedExpr, indexSchema)
+    val lookupFilter = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(resolvedExpr, indexedCols = indexedCols)
 
     val indexDf = spark.createDataFrame(input.map(_.toRow).asJava, indexSchema)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -46,6 +46,7 @@ import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions, config}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.codegen.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
@@ -1012,16 +1013,11 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
           GreaterThan(AttributeReference("c4", StringType, nullable = true)(), Literal("c4 filed value")))
       )
 
-      val expectedOrConditionIndexedFilter = Or(
-        GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1)),
-        Literal(true)
-      )
-
       columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
         val orConditionActualFilter = orConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_,
           indexedCols = targetColumnsToIndex))
           .reduce(And)
-        assertEquals(expectedOrConditionIndexedFilter, orConditionActualFilter)
+        assertEquals(Literal("true").toString(), orConditionActualFilter.toString())
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -995,7 +995,8 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       )
 
       columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
-        val andConditionActualFilter = andConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
+        val andConditionActualFilter = andConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_,
+          indexedCols = targetColumnsToIndex))
           .reduce(And)
         assertEquals(expectedAndConditionIndexedFilter, andConditionActualFilter)
       }
@@ -1017,7 +1018,8 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       )
 
       columnStatsIndex.loadTransposed(requestedColumns, shouldReadInMemory) { partialTransposedColStatsDF =>
-        val orConditionActualFilter = orConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_, partialTransposedColStatsDF.schema))
+        val orConditionActualFilter = orConditionFilters.map(translateIntoColumnStatsIndexFilterExpr(_,
+          indexedCols = targetColumnsToIndex))
           .reduce(And)
         assertEquals(expectedOrConditionIndexedFilter, orConditionActualFilter)
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -269,7 +269,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
       dataFilter4,
       Seq("c1", "c2"),
       TrueLiteral,
-      false
+      true
     )
 
     // too many filters, out of which only half are indexed.
@@ -297,11 +297,14 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
   }
 
   def translateIntoColStatsExprAndValidate(dataFilter: Expression, indexedCols: Seq[String], expectedExpr: Expression,
-                                           expectedHasNonIndexedCols: Boolean): Unit = {
-    val hasNonIndexedCols = new AtomicBoolean(false)
-    val transformedExpr = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(dataFilter, false, indexedCols, hasNonIndexedCols)
-    assertEquals(expectedExpr.toString(), transformedExpr.toString())
-    assertEquals(expectedHasNonIndexedCols, hasNonIndexedCols.get())
+                                           expectTrueLiteral: Boolean): Unit = {
+    val transformedExpr = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(dataFilter, false, indexedCols)
+    assertTrue(expectedExpr.equals(transformedExpr))
+    if (expectTrueLiteral) {
+      assertTrue(expectedExpr.equals(TrueLiteral))
+    } else {
+      assertTrue(!expectedExpr.equals(TrueLiteral))
+    }
   }
 
   def generateColStatsExprForGreaterthanOrEquals(colName: String, colValue: String): Expression = {


### PR DESCRIPTION
### Change Logs

- As of now, we lookup in col stats for all filter expressions. This patch checks for any non indexed cols and avoids col stats based pruning. The files from pruned files are used as candidate files if any non indexed cols are detected. If not, pruning happens based on col stats index in MDT and candidate files are deduced.  We have also optimized the AND clause. If we have a `leftExpr AND rightExpr`, where leftExpr has non indexed cols, while rightExpr has all indexed cols, we can still afford to prune files based on col stats index. The expression to look up in col stats will omit leftExpr accordingly. Only if both leftExpr and rightExpr has non indexex cols, we can avoid looking up in col stats index. Incase of 'Or' clause, we can't do much, but have to resort to bypass col stats lookup completely. 

lets walk through an example to understand this in detail

c1 = 619sdc or c2 = 100 and c3 = 200 

Say this is the filter expression in the query issued. 

case 1:
when all 3 cols are indexed w/ col stats:
 expected col stats lookup expression is 
```
(((('c1_minValue <= 619sdc) AND ('c1_maxValue >= 619sdc)) OR (('c2_minValue <= 100) AND ('c2_maxValue >= 100))) AND (('c3_minValue <= 200) AND ('c3_maxValue >= 200)))
```
i.e. all 3 cols will be looked up. 

case 2: 
only c1 and c2 are indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
since left of AND exp is indexed, we can ignore c3 which is not indexed (rigth expr of AND). 
we translate to 
```
((('c1_minValue <= 619sdc) AND ('c1_maxValue >= 619sdc)) OR (('c2_minValue <= 100) AND ('c2_maxValue >= 100)))
```
and lookup in col stats translated df. 


case 3:
only c1 and c3 are indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Among c1 and c2, c2 is not indexed. So, left Expr of (c1 = 619sdc or c2 = 100) is deemed as not indexed. But the right expr of 'c3 = 200' is indexed. and so, we translate this to 
```
(('c3_minValue <= 200) AND ('c3_maxValue >= 200))
```
and lookup in col stats translated df. 

case 4: 
only c2 and c3 are indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Same as case 3
So, we translate it to 
```
(('c3_minValue <= 200) AND ('c3_maxValue >= 200))
```
and lookup in col stats translated df. 

case 5:
only c2 is indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Since either of Or clause is not indexed, we have to bypass looking up in col stats. 

case 6:
only c3 is indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Since either of Or clause is not indexed, we have to bypass looking up in col stats. 

case 7:
only c1 is indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Since either of Or clause is not indexed, we have to bypass looking up in col stats. 

case 8:
only c2 is indexed for filter "c1 = 619sdc or c2 = 100 and c3 = 200":
Since either of Or clause is not indexed, we have to bypass looking up in col stats. 

Whenever we deem as col stats should not be looked up, we return the files w/o pruning from the col stats lookup step. 

### Impact

Optimized lookup in col stats. 

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
