### PR TITLE
[HUDI-8829] reduce bytes copy during writing avro records to log file

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -124,12 +124,10 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
           writer.write(data, encoder);
           encoder.flush();
 
-          // Get the size of the bytes
-          int size = temp.toByteArray().length;
           // Write the record size
-          output.writeInt(size);
+          output.writeInt(temp.size());
           // Write the content
-          output.write(temp.toByteArray());
+          temp.writeTo(output);
         } catch (IOException e) {
           throw new HoodieIOException("IOException converting HoodieAvroDataBlock to bytes", e);
         }
@@ -341,12 +339,10 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
           writer.write(s, encoder);
           encoder.flush();
 
-          // Get the size of the bytes
-          int size = temp.toByteArray().length;
           // Write the record size
-          output.writeInt(size);
+          output.writeInt(temp.size());
           // Write the content
-          output.write(temp.toByteArray());
+          temp.writeTo(output);
           itr.remove();
         } catch (IOException e) {
           throw new HoodieIOException("IOException converting HoodieAvroDataBlock to bytes", e);


### PR DESCRIPTION
### Change Logs

Currently, there exists some redundant byte copies at the record level during appending 
`HoodieAvroDataBlock` to log file. Reducing these copies will effectively decrease GC  pressure.

### Impact

reduce unnecessary memory usage during writing log

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
