### PR TITLE
[HUDI-7994] Support secondary index on nested fields

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -676,13 +676,15 @@ public class HoodieAvroUtils {
    */
   public static Schema getNestedFieldSchemaFromWriteSchema(Schema writeSchema, String fieldName) {
     String[] parts = fieldName.split("\\.");
-    int i = 0;
-    for (; i < parts.length; i++) {
+    Schema currentSchema = writeSchema;
+    for (int i = 0; i < parts.length; i++) {
       String part = parts[i];
-      Schema schema = writeSchema.getField(part).schema();
+      // Resolve nullable/union schema to the actual schema
+      currentSchema = resolveNullableSchema(currentSchema.getField(part).schema());
 
       if (i == parts.length - 1) {
-        return resolveNullableSchema(schema);
+        // Return the schema for the final part
+        return resolveNullableSchema(currentSchema);
       }
     }
     throw new HoodieException("Failed to get schema. Not a valid field name: " + fieldName);


### PR DESCRIPTION
### Change Logs

- Fix the nested type detection in order to support secondary index on nested fields.
- Add test with secondary index on nested field, create and update SI and validate index records and pruning.

### Impact

Support secondary index on nested fields.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
