### PR TITLE
[HUDI-8830] use maxLatestCommitTime to compute splitLatestCommitDelay

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
@@ -83,11 +83,11 @@ public class FlinkStreamReadMetrics extends HoodieFlinkMetrics {
     }
   }
 
-  public void setSplitLatestCommit(String splitLatestCommit) {
+  public void setSplitLatestCommit(String splitLatestCommit, String maxLatestCommitTime) {
     try {
       Instant instant = HoodieInstantTimeGenerator.parseDateFromInstantTime(splitLatestCommit).toInstant();
       this.splitLatestCommit = instant.getEpochSecond();
-      this.splitLatestCommitDelay = Duration.between(instant, Instant.now()).getSeconds();
+      this.splitLatestCommitDelay = Duration.between(instant, Instant.parse(maxLatestCommitTime)).getSeconds();
     } catch (ParseException e) {
       LOG.warn("Invalid input latest commit" + splitLatestCommit);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.source;
 
+import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.metrics.FlinkStreamReadMetrics;
 import org.apache.hudi.table.format.mor.MergeOnReadInputFormat;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
@@ -91,6 +92,9 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
 
   private transient FlinkStreamReadMetrics readMetrics;
 
+  // max latest commit time the reader operator received used to compute splitLatestCommitDelay metric
+  private String maxLatestCommitTime = "";
+
   private StreamReadOperator(MergeOnReadInputFormat format, ProcessingTimeService timeService,
       MailboxExecutor mailboxExecutor) {
     this.format = Preconditions.checkNotNull(format, "The InputFormat should not be null.");
@@ -119,6 +123,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
 
       for (MergeOnReadInputSplit split : inputSplitsState.get()) {
         splits.add(split);
+        setMaxLatestCommitTime(split.getLatestCommit());
       }
     }
 
@@ -143,6 +148,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
   @Override
   public void processElement(StreamRecord<MergeOnReadInputSplit> element) {
     splits.add(element.getValue());
+    setMaxLatestCommitTime(element.getValue().getLatestCommit());
     enqueueProcessSplits();
   }
 
@@ -169,7 +175,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
       // there is only one log message for one data bucket.
       LOG.info("Processing input split : {}", split);
       format.open(split);
-      readMetrics.setSplitLatestCommit(split.getLatestCommit());
+      readMetrics.setSplitLatestCommit(split.getLatestCommit(), maxLatestCommitTime);
     }
 
     try {
@@ -285,5 +291,9 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
         watermarkInterval,
         -1,
         true);
+  }
+
+  private void setMaxLatestCommitTime(String inputSplitLatestCommitInstant) {
+    maxLatestCommitTime = InstantComparison.maxInstant(maxLatestCommitTime, inputSplitLatestCommitInstant);
   }
 }


### PR DESCRIPTION
### Change Logs

currently, we use now() - splitLatestCommit, however, when the time goes and the task just processes a huge data commit, then the diff between now and splitLatestCommit may get larger. so we may let reader operator holds a maxLatestCommitTime attribute to record the max split latestcommit time has got, and then use it to compute splitLatestCommitDelay

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
