### PR TITLE
[HUDI-8831] Hudi parser should passthrough unsupport procedure to delegate

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/parser/HoodieSqlCommonAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/parser/HoodieSqlCommonAstBuilder.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.parser.{ParserInterface, ParserUtils}
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.hudi.command.procedures.HoodieProcedures
 
 import scala.collection.JavaConverters._
 
@@ -94,12 +95,22 @@ class HoodieSqlCommonAstBuilder(session: SparkSession, delegate: ParserInterface
   override def visitCall(ctx: CallContext): LogicalPlan = withOrigin(ctx) {
     if (ctx.callArgumentList() == null || ctx.callArgumentList().callArgument() == null || ctx.callArgumentList().callArgument().size() == 0) {
       val name: Seq[String] = ctx.multipartIdentifier().parts.asScala.map(_.getText).toSeq
-      CallCommand(name, Seq())
+      if (isHudiCallCommand(name)) {
+        return CallCommand(name, Seq())
+      }
     } else {
       val name: Seq[String] = ctx.multipartIdentifier().parts.asScala.map(_.getText).toSeq
       val args: Seq[CallArgument] = ctx.callArgumentList().callArgument().asScala.map(typedVisit[CallArgument]).toSeq
-      CallCommand(name, args)
+      if (isHudiCallCommand(name)) {
+        return CallCommand(name, args)
+      }
     }
+    null
+  }
+
+  def isHudiCallCommand(name: Seq[String]): Boolean = {
+    val builder = HoodieProcedures.newBuilder(name.last)
+    builder != null;
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/parser/HoodieSqlCommonAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/parser/HoodieSqlCommonAstBuilder.scala
@@ -107,8 +107,7 @@ class HoodieSqlCommonAstBuilder(session: SparkSession, delegate: ParserInterface
   }
 
   def isHudiCallCommand(name: Seq[String]): Boolean = {
-    val builder = HoodieProcedures.newBuilder(name.last)
-    builder != null;
+    name.nonEmpty && HoodieProcedures.newBuilder(name.last) != null
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.common.util.CollectionUtils.createImmutableList
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical.{CallCommand, NamedArgument, PositionalArgument}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.command.procedures.HelpProcedure
 import org.apache.spark.sql.types.{DataType, DataTypes}
 
 import java.math.BigDecimal
@@ -33,8 +34,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   private val parser = spark.sessionState.sqlParser
 
   test("Test Call Produce with Positional Arguments") {
-    val call = parser.parsePlan("CALL c.n.func(1, '2', 3L, true, 1.0D, 9.0e1, 900e-1BD)").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("c", "n", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+    val call = parser.parsePlan(s"CALL c.n.${HelpProcedure.NAME}(1, '2', 3L, true, 1.0D, 9.0e1, 900e-1BD)").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("c", "n", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(7)(call.args.size)
 
@@ -48,8 +49,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   }
 
   test("Test Call Produce with Named Arguments") {
-    val call = parser.parsePlan("CALL system.func(c1 => 1, c2 => '2', c3 => true)").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+    val call = parser.parsePlan(s"CALL system.${HelpProcedure.NAME}(c1 => 1, c2 => '2', c3 => true)").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("system", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(3)(call.args.size)
 
@@ -59,8 +60,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   }
 
   test("Test Call Produce with Var Substitution") {
-    val call = parser.parsePlan("CALL system.func('${spark.extra.prop}')").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+    val call = parser.parsePlan(s"CALL system.${HelpProcedure.NAME}('$${spark.extra.prop}')").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("system", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(1)(call.args.size)
 
@@ -68,8 +69,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   }
 
   test("Test Call Produce with Mixed Arguments") {
-    val call = parser.parsePlan("CALL system.func(c1 => 1, '2')").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+    val call = parser.parsePlan(s"CALL system.${HelpProcedure.NAME}(c1 => 1, '2')").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("system", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(2)(call.args.size)
 
@@ -82,8 +83,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   }
 
   test("Test Call Produce with semicolon") {
-    val call = parser.parsePlan("CALL system.func(c1 => 1, c2 => '2', c3 => true)").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+    val call = parser.parsePlan(s"CALL system.${HelpProcedure.NAME}(c1 => 1, c2 => '2', c3 => true)").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("system", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(3)(call.args.size)
 
@@ -91,8 +92,8 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
     checkArg(call, 1, "c2", "2", DataTypes.StringType)
     checkArg(call, 2, "c3", true, DataTypes.BooleanType)
 
-    val call2 = parser.parsePlan("CALL system.func2(c1 => 1, c2 => '2', c3 => true);").asInstanceOf[CallCommand]
-    assertResult(createImmutableList("system", "func2"))(JavaConverters.seqAsJavaListConverter(call2.name).asJava)
+    val call2 = parser.parsePlan(s"CALL system.${HelpProcedure.NAME}(c1 => 1, c2 => '2', c3 => true);").asInstanceOf[CallCommand]
+    assertResult(createImmutableList("system", HelpProcedure.NAME))(JavaConverters.seqAsJavaListConverter(call2.name).asJava)
 
     assertResult(3)(call2.args.size)
 


### PR DESCRIPTION

### Change Logs

Hudi parser parse any sql text that looks like 'call xx.yy(z1,z2)' as `CallCommand`,  then fails with AnalysisException in `HoodieAnalysis` if the command is not support by hudi。 This make other parsers like Iceberg or other user defined  lost chance to parse the call sql

### Impact
None

### Risk level (write none, low medium or high below)
medium

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
