### PR TITLE
[MINOR] Add file slice in delta write stats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -176,15 +176,15 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
       // table versions 8 and greater.
       prevCommit = instantTime;
-      if (hoodieTable.getMetaClient().getTableConfig().isCDCEnabled()) {
-        // the cdc reader needs the base file metadata to have deterministic update sequence.
-        TableFileSystemView.SliceView rtView = hoodieTable.getSliceView();
-        Option<FileSlice> fileSlice = rtView.getLatestFileSlice(partitionPath, fileId);
-        if (fileSlice.isPresent()) {
+      TableFileSystemView.SliceView rtView = hoodieTable.getSliceView();
+      Option<FileSlice> fileSlice = rtView.getLatestFileSlice(partitionPath, fileId);
+      if (fileSlice.isPresent()) {
+        if (hoodieTable.getMetaClient().getTableConfig().isCDCEnabled()) {
+          // the cdc reader needs the base file metadata to have deterministic update sequence.
           prevCommit = fileSlice.get().getBaseInstantTime();
-          baseFile = fileSlice.get().getBaseFile().map(BaseFile::getFileName).orElse("");
-          logFiles = fileSlice.get().getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
         }
+        baseFile = fileSlice.get().getBaseFile().map(BaseFile::getFileName).orElse("");
+        logFiles = fileSlice.get().getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
       }
     } else {
       // older table versions.


### PR DESCRIPTION
### Change Logs

In table version 8, we do not populate file slice in delta write stats unless CDC reader is enabled. As per my understanding, for CDC reader, just setting the base instant time correctly should be sufficient. So, in this patch, we just make the setting of previous base instant time conditional on cdc reader, while yet populate the file slice in the write stat.
 
### Impact

Add file slice in delta write stats. This can save filesystem view call when building secondary index.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
