### PR TITLE
[HUDI-8824] MIT should error out for some assignment clause patterns

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -383,12 +383,13 @@ public class ConfigUtils {
    * config, if exists, is returned if the config is not found in the properties.
    *
    * @param props          Configs in {@link Map}.
-   * @param configProperty {@link ConfigProperty} config of String type to fetch.
+   * @param configProperty {@link ConfigProperty} config to fetch.
    * @return String value if the config exists; default String value if the config does not exist
-   * and there is default value defined in the {@link ConfigProperty} config; {@code null} otherwise.
+   * and there is default value defined in the {@link ConfigProperty} config and is convertible to
+   * String type; {@code null} otherwise.
    */
   public static String getStringWithAltKeys(Map<String, Object> props,
-                                            ConfigProperty<String> configProperty) {
+                                            ConfigProperty<?> configProperty) {
     return getStringWithAltKeys(props::get, configProperty);
   }
 
@@ -398,12 +399,13 @@ public class ConfigUtils {
    * config, if exists, is returned if the config is not found in the properties.
    *
    * @param keyMapper      Mapper function to map the key to values.
-   * @param configProperty {@link ConfigProperty} config of String type to fetch.
+   * @param configProperty {@link ConfigProperty} config to fetch.
    * @return String value if the config exists; default String value if the config does not exist
-   * and there is default value defined in the {@link ConfigProperty} config; {@code null} otherwise.
+   * and there is default value defined in the {@link ConfigProperty} config and is convertible to
+   * String type; {@code null} otherwise.
    */
   public static String getStringWithAltKeys(Function<String, Object> keyMapper,
-                                            ConfigProperty<String> configProperty) {
+                                            ConfigProperty<?> configProperty) {
     Object value = keyMapper.apply(configProperty.key());
     if (value != null) {
       return value.toString();
@@ -417,7 +419,7 @@ public class ConfigUtils {
         return value.toString();
       }
     }
-    return configProperty.hasDefaultValue() ? configProperty.defaultValue() : null;
+    return configProperty.hasDefaultValue() ? configProperty.defaultValue().toString() : null;
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -278,7 +278,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
 
   /**
    * Columns that relation has to read from the storage to properly execute on its semantic: for ex,
-   * for Merge-on-Read tables key fields as well and pre-combine field comprise mandatory set of columns,
+   * for Merge-on-Read tables key fields as well and precombine field comprise mandatory set of columns,
    * meaning that regardless of whether this columns are being requested by the query they will be fetched
    * regardless so that relation is able to combine records properly (if necessary)
    *

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -295,6 +295,19 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  protected def withSparkSqlSessionConfig(configNameValues: (String, String)*)(f: => Unit): Unit = {
+    try {
+      configNameValues.foreach { case (configName, configValue) =>
+        spark.sql(s"set $configName=$configValue")
+      }
+      f
+    } finally {
+      configNameValues.foreach { case (configName, _) =>
+        spark.sql(s"reset $configName")
+      }
+    }
+  }
+
   protected def withRecordType(recordTypes: Seq[HoodieRecordType] = Seq(HoodieRecordType.AVRO, HoodieRecordType.SPARK),
                                recordConfig: Map[HoodieRecordType, Map[String, String]] = Map.empty)(f: => Unit) {
     // TODO HUDI-5264 Test parquet log with avro record in spark sql test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -128,6 +128,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
    * In Spark 3.0.x, UPDATE and DELETE can appear at most once in MATCHED clauses in a MERGE INTO statement.
    * Refer to: `org.apache.spark.sql.catalyst.parser.AstBuilder#visitMergeIntoTable`
    *
+   * The test also provides test coverage for "Test merge into allowed patterns of assignment clauses".
    */
   test("Test MergeInto with more than once update actions") {
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -727,7 +727,7 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         //
         // 2) set source column name to be different with target column
         //
-        val errorMessage = "Failed to resolve pre-combine field `v` w/in the source-table output"
+        val errorMessage = "Failed to resolve precombine field `v` w/in the source-table output"
 
         checkException(
           s"""
@@ -815,9 +815,9 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
       )
 
       //
-      // 2.a) set source column name to be different with target column (should fail unable to match pre-combine field)
+      // 2.a) set source column name to be different with target column (should fail unable to match precombine field)
       //
-      val failedToResolveErrorMessage = "Failed to resolve pre-combine field `v` w/in the source-table output"
+      val failedToResolveErrorMessage = "Failed to resolve precombine field `v` w/in the source-table output"
 
       checkException(
         s"""merge into $tableName1 t0

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTableWithNonRecordKeyField.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTableWithNonRecordKeyField.scala
@@ -133,7 +133,7 @@ class TestMergeIntoTableWithNonRecordKeyField extends HoodieSparkSqlTestBase wit
              |""".stripMargin)
 
         if (sparkSqlOptimizedWrites) {
-          val errorMessage2 = "Hudi tables with primary key are required to match on all primary key colums. Column: 'name' not found"
+          val errorMessage2 = "Hudi tables with record key are required to match on all record key columns. Column: 'name' not found"
           checkException(
             s"""
                | merge into $tableName3 as t0

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestPartialUpdateForMergeInto.scala
@@ -411,7 +411,7 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
          | preCombineField = '_ts'
          |)""".stripMargin)
 
-    val failedToResolveErrorMessage = "Failed to resolve pre-combine field `_ts` w/in the source-table output"
+    val failedToResolveErrorMessage = "Failed to resolve precombine field `_ts` w/in the source-table output"
 
     checkExceptionContain(
       s"""


### PR DESCRIPTION
### Change Logs

For insert and update clause of MIT, in some cases if we didn't set the primary key/precombine field value explicitly, MIT errors out in the query analyze phase.

Also some changes that make sure the precombine key value data type is the same over source and target table (an irrelevant test maintenance)

### Impact

Better user facing error message and guard against cases we don't support.

### Risk level (write none, low medium or high below)

none
### Documentation Update

We track MIT doc update all in https://issues.apache.org/jira/browse/HUDI-8527

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
