### PR TITLE
[HUDI-8634] Support schema on read in file group reader-based compaction and clustering in Spark

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieCompactionHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieCompactionHandler.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.CompactionOperation;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -48,6 +49,7 @@ public interface HoodieCompactionHandler<T> {
 
   default List<WriteStatus> compactUsingFileGroupReader(String instantTime,
                                                         CompactionOperation operation,
+                                                        HoodieWriteConfig writeConfig,
                                                         HoodieReaderContext readerContext,
                                                         Configuration conf) {
     throw new HoodieNotSupportedException("This engine does not support file group reader based compaction.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -149,7 +149,6 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
         && config.getBooleanOrDefault(HoodieReaderConfig.FILE_GROUP_READER_ENABLED)
         && operationType == WriteOperationType.COMPACT
         && !hasBootstrapFile(operations)                                            // bootstrap file read for fg reader is not ready
-        && StringUtils.isNullOrEmpty(config.getInternalSchema())                    // schema evolution support for fg reader is not ready
         && config.populateMetaFields();                                             // Virtual key support by fg reader is not ready
 
     if (useFileGroupReaderBasedCompaction) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -156,7 +156,7 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
       // Broadcast required information.
       broadcastManagerOpt.ifPresent(EngineBroadcastManager::prepareAndBroadcast);
       return context.parallelize(operations).map(
-              operation -> compact(compactionHandler, metaClient, operation, compactionInstantTime, broadcastManagerOpt))
+              operation -> compact(compactionHandler, metaClient, config, operation, compactionInstantTime, broadcastManagerOpt))
           .flatMap(List::iterator);
     } else {
       return context.parallelize(operations).map(
@@ -298,11 +298,12 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
    */
   public List<WriteStatus> compact(HoodieCompactionHandler compactionHandler,
                                    HoodieTableMetaClient metaClient,
+                                   HoodieWriteConfig writeConfig,
                                    CompactionOperation operation,
                                    String instantTime,
                                    Option<EngineBroadcastManager> broadcastManagerOpt) throws IOException {
-    return compactionHandler.compactUsingFileGroupReader(instantTime,
-        operation, broadcastManagerOpt.get().retrieveFileGroupReaderContext(metaClient.getBasePath()).get(),
+    return compactionHandler.compactUsingFileGroupReader(instantTime, operation,
+        writeConfig, broadcastManagerOpt.get().retrieveFileGroupReaderContext(metaClient.getBasePath()).get(),
         broadcastManagerOpt.get().retrieveStorageConfig().get());
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -373,8 +373,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
         .map(ClusteringOperation::create).collect(Collectors.toList());
     boolean canUseFileGroupReaderBasedClustering = getWriteConfig().getBooleanOrDefault(HoodieReaderConfig.FILE_GROUP_READER_ENABLED)
         && getWriteConfig().getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS)
-        && clusteringOps.stream().allMatch(slice -> StringUtils.isNullOrEmpty(slice.getBootstrapFilePath()))
-        && StringUtils.isNullOrEmpty(getWriteConfig().getInternalSchema());
+        && clusteringOps.stream().allMatch(slice -> StringUtils.isNullOrEmpty(slice.getBootstrapFilePath()));
 
     if (canUseFileGroupReaderBasedClustering) {
       return readRecordsForGroupAsRowWithFileGroupReader(jsc, instantTime, tableSchemaWithMetaFields, clusteringOps);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -271,8 +271,10 @@ public class HoodieSparkCopyOnWriteTable<T>
   @Override
   public List<WriteStatus> compactUsingFileGroupReader(String instantTime,
                                                        CompactionOperation operation,
+                                                       HoodieWriteConfig writeConfig,
                                                        HoodieReaderContext readerContext,
                                                        Configuration conf) {
+    config.setDefault(writeConfig);
     Option<BaseKeyGenerator> keyGeneratorOpt = HoodieSparkKeyGeneratorFactory.createBaseKeyGenerator(config);
     HoodieSparkFileGroupReaderBasedMergeHandle mergeHandle = new HoodieSparkFileGroupReaderBasedMergeHandle(config,
         instantTime, this, operation, taskContextSupplier, keyGeneratorOpt, readerContext, conf);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -124,7 +124,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
-    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
+    val ex = expects.map(row => Row(row: _*)).toArray.sortBy(_.toString())
+    val actual = spark.sql(sql).collect().sortBy(_.toString())
+    assertResult(ex)(actual)
   }
 
   protected def checkAnswer(array: Array[Row])(expects: Seq[Any]*): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -124,9 +124,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
-    val ex = expects.map(row => Row(row: _*)).toArray.sortBy(_.toString())
-    val actual = spark.sql(sql).collect().sortBy(_.toString())
-    assertResult(ex)(actual)
+    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
   }
 
   protected def checkAnswer(array: Array[Row])(expects: Seq[Any]*): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier


### PR DESCRIPTION
### Change Logs

This PR enables schema on read in file group reader-based compaction and clustering in Spark after #12510 makes the schema on read-related configs are propagated properly.  For compaction, the write config containing the schema on read related information needs to be propagated properly to the merge handle.

Before this PR, `TestSpark3DDL`.`Test alter table properties and add rename drop column` fails if we enable schema evolution on read in the file group reader-based compaction without fixing the write config.  In this PR, this test is enhanced (renamed to `Test alter table properties and add rename drop column with table services`) to cover both compaction and clustering with schema on read enabled in Spark.

### Impact

Removes limitation of file group reader-based compaction and clustering in Spark around schema on read.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
