### PR TITLE
[HUDI-8823] Ban update from updating primary key and partition key

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -19,20 +19,56 @@ package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.DataSourceWriteOptions.{SPARK_SQL_OPTIMIZED_WRITES, SPARK_SQL_WRITES_PREPPED_KEY}
 import org.apache.hudi.SparkAdapterSupport
-
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.attributeEquals
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference}
-import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, Project, UpdateTable}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, LogicalPlan, Project, UpdateTable}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
+import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.failAnalysis
 
 case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableCommand
   with SparkAdapterSupport with ProvidesHoodieConfig {
 
+  private var sparkSession: SparkSession = _
+
+  private lazy val hoodieCatalogTable = sparkAdapter.resolveHoodieTable(ut.table) match {
+    case Some(catalogTable) => HoodieCatalogTable(sparkSession, catalogTable)
+    case _ =>
+      failAnalysis(s"Failed to resolve update statement into the Hudi table. Got instead: ${ut.table}")
+  }
+
+  /**
+   * Validate there is no assignment clause for the given attribute in the given table.
+   *
+   * @param resolver The resolver to use
+   * @param fields The fields from the target table who should not have any assignment clause
+   * @param tableId Table identifier (for error messages)
+   * @param fieldType Type of the attribute to be validated (for error messages)
+   * @param assignments The assignments clause of the merge into action
+   *
+   *
+   * @throws AnalysisException if assignment clause for the given target table attribute is found
+   */
+  private def validateNoAssignmentsToTargetTableAttr(resolver: Resolver,
+                                                     fields: Seq[String],
+                                                     tableId: String,
+                                                     fieldType: String,
+                                                     assignments: Seq[(AttributeReference, Expression)]
+                                                     ): Unit = {
+    fields.foreach(field => if (assignments.exists {
+      case (attr, _) => resolver(attr.name, field)
+    }) {
+      throw new AnalysisException(s"Detected update query with disallowed assignment clause for $fieldType " +
+        s"`$field` for table `$tableId`")
+    })
+  }
+
   override def run(sparkSession: SparkSession): Seq[Row] = {
+    this.sparkSession = sparkSession
     val catalogTable = sparkAdapter.resolveHoodieTable(ut.table)
       .map(HoodieCatalogTable(sparkSession, _))
       .get
@@ -44,6 +80,24 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
     val assignedAttributes = ut.assignments.map {
       case Assignment(attr: AttributeReference, value) => attr -> value
     }
+
+    // We don't support update queries changing partition column value.
+    validateNoAssignmentsToTargetTableAttr(
+      sparkSession.sessionState.conf.resolver,
+      hoodieCatalogTable.tableConfig.getPartitionFields.orElse(Array.empty),
+      tableId,
+      "partition field",
+      assignedAttributes
+    )
+
+    // We don't support update queries changing the primary key column value.
+    validateNoAssignmentsToTargetTableAttr(
+      sparkSession.sessionState.conf.resolver,
+      hoodieCatalogTable.tableConfig.getRecordKeyFields.orElse(Array.empty),
+      tableId,
+      "primaryKey field",
+      assignedAttributes
+    )
 
     val filteredOutput = if (sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
       , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -401,13 +401,13 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
         val e1 = intercept[AnalysisException] {
           spark.sql(s"update $tableName set id = 2 where id = 1")
         }
-        assert(e1.getMessage.contains("Detected update query with disallowed assignment clause for primaryKey field `id`"))
+        assert(e1.getMessage.contains("Detected disallowed assignment clause in UPDATE statement for record key field `id`"))
 
         // Try to update partition column (should fail)
         val e2 = intercept[AnalysisException] {
           spark.sql(s"update $tableName set pt = '2022' where id = 1")
         }
-        assert(e2.getMessage.contains("Detected update query with disallowed assignment clause for partition field `pt`"))
+        assert(e2.getMessage.contains("Detected disallowed assignment clause in UPDATE statement for partition field `pt`"))
 
         // Verify data remains unchanged after failed updates
         checkAnswer(s"select id, name, price, ts, pt from $tableName")(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -401,13 +401,15 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
         val e1 = intercept[AnalysisException] {
           spark.sql(s"update $tableName set id = 2 where id = 1")
         }
-        assert(e1.getMessage.contains("Detected disallowed assignment clause in UPDATE statement for record key field `id`"))
+        assert(e1.getMessage.contains(s"Detected disallowed assignment clause in UPDATE statement for record key field `id`" +
+          s" for table `spark_catalog.default.$tableName`. Please remove the assignment clause to avoid the error."))
 
         // Try to update partition column (should fail)
         val e2 = intercept[AnalysisException] {
           spark.sql(s"update $tableName set pt = '2022' where id = 1")
         }
-        assert(e2.getMessage.contains("Detected disallowed assignment clause in UPDATE statement for partition field `pt`"))
+        assert(e2.getMessage.contains(s"Detected disallowed assignment clause in UPDATE statement for partition field `pt`" +
+          s" for table `spark_catalog.default.$tableName`. Please remove the assignment clause to avoid the error."))
 
         // Verify data remains unchanged after failed updates
         checkAnswer(s"select id, name, price, ts, pt from $tableName")(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -363,5 +364,62 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
         )
       }
     }
+  }
+
+  test("Test Update Table With Primary Key and Partition Key Updates error out") {
+    withRecordType()(withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        // create table with primary key and partition
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long,
+             |  pt string
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |  type = '$tableType',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by (pt)
+       """.stripMargin)
+
+        // Insert initial data
+        spark.sql(s"insert into $tableName values (1, 'a1', 10.0, 1000, '2021')")
+
+        // Verify initial state
+        checkAnswer(s"select id, name, price, ts, pt from $tableName")(
+          Seq(1, "a1", 10.0, 1000, "2021")
+        )
+
+        // Try to update primary key (should fail)
+        val e1 = intercept[AnalysisException] {
+          spark.sql(s"update $tableName set id = 2 where id = 1")
+        }
+        assert(e1.getMessage.contains("Detected update query with disallowed assignment clause for primaryKey field `id`"))
+
+        // Try to update partition column (should fail)
+        val e2 = intercept[AnalysisException] {
+          spark.sql(s"update $tableName set pt = '2022' where id = 1")
+        }
+        assert(e2.getMessage.contains("Detected update query with disallowed assignment clause for partition field `pt`"))
+
+        // Verify data remains unchanged after failed updates
+        checkAnswer(s"select id, name, price, ts, pt from $tableName")(
+          Seq(1, "a1", 10.0, 1000, "2021")
+        )
+
+        // Verify normal update still works
+        spark.sql(s"update $tableName set price = 20.0 where id = 1")
+        checkAnswer(s"select id, name, price, ts, pt from $tableName")(
+          Seq(1, "a1", 20.0, 1000, "2021")
+        )
+      }
+    })
   }
 }


### PR DESCRIPTION
### Change Logs

update will error out when it tries to change partition column /primary key column value.

### Impact

guard update against unsupported use cases.

### Risk level (write none, low medium or high below)

none
### Documentation Update

Maybe we should update the update query doc on this behavior.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
