### PR TITLE
[MINOR] Avoid wrong way to get the latest completed instant

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -896,11 +896,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     HoodieTimeline activeTimeline = getActiveTimeline();
     Option<String> lastCommitSynced = activeTimeline.lastInstant().map(HoodieInstant::requestedTime);
     Option<String> lastCommitCompletionSynced = activeTimeline
-        .getInstantsOrderedByCompletionTime()
-        .skip(activeTimeline.countInstants() - 1)
-        .findFirst()
-        .map(i -> Option.of(i.getCompletionTime()))
-        .orElse(Option.empty());
+        .getLatestCompletionTime();
     if (lastCommitSynced.isPresent()) {
       try {
         HashMap<String, String> propertyMap = new HashMap<>();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -405,7 +405,7 @@ public interface HoodieTimeline extends Serializable {
   Option<String> getLatestCompletionTime();
 
   /**
-   * Get the stream of instants in order by state transition timestamp of actions.
+   * Get the stream of instants in order by completion timestamp of actions.
    */
   Stream<HoodieInstant> getInstantsOrderedByCompletionTime();
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSourceV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSourceV1.scala
@@ -107,11 +107,7 @@ class HoodieStreamSourceV1(sqlContext: SQLContext,
     filteredTimeline match {
       case activeInstants if !activeInstants.empty() =>
         val timestamp = if (hollowCommitHandling == USE_TRANSITION_TIME) {
-          activeInstants.getInstantsOrderedByCompletionTime
-            .skip(activeInstants.countInstants() - 1)
-            .findFirst()
-            .get()
-            .getCompletionTime
+          activeInstants.getLatestCompletionTime.get()
         } else {
           activeInstants.lastInstant().get().requestedTime()
         }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -99,13 +99,7 @@ public class DataHubSyncClient extends HoodieSyncClient {
   }
 
   protected Option<String> getLastCommitCompletionTime() {
-    int countInstants = getActiveTimeline().countInstants();
-    return getActiveTimeline()
-        .getInstantsOrderedByCompletionTime()
-        .skip(countInstants - 1)
-        .findFirst()
-        .map(HoodieInstant::getCompletionTime)
-        .map(Option::of).orElseGet(Option::empty);
+    return getActiveTimeline().getLatestCompletionTime();
   }
 
   @Override

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -404,12 +404,7 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     // Set the last commit time and commit completion from the TBLproperties
     HoodieTimeline activeTimeline = getActiveTimeline();
     Option<String> lastCommitSynced = activeTimeline.lastInstant().map(HoodieInstant::requestedTime);
-    Option<String> lastCommitCompletionSynced = activeTimeline
-        .getInstantsOrderedByCompletionTime()
-        .skip(activeTimeline.countInstants() - 1)
-        .findFirst()
-        .map(i -> Option.of(i.getCompletionTime()))
-        .orElse(Option.empty());
+    Option<String> lastCommitCompletionSynced = activeTimeline.getLatestCompletionTime();
     if (lastCommitSynced.isPresent()) {
       try {
         Table table = client.getTable(databaseName, tableName);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1979,9 +1979,7 @@ public class TestHiveSyncTool {
   }
 
   private String getLastCommitCompletionTimeSynced() {
-    return hiveClient.getActiveTimeline()
-        .getInstantsOrderedByCompletionTime()
-        .skip(hiveClient.getActiveTimeline().countInstants() - 1).findFirst().get().getCompletionTime();
+    return hiveClient.getActiveTimeline().getLatestCompletionTime().get();
   }
 
   private void reInitHiveSyncClient() {


### PR DESCRIPTION
There are many code like that to get latest_completed_time:

<img width="558" alt="image" src="https://github.com/user-attachments/assets/343a76cc-5ae6-4d82-b9c5-8edf27477997" />

There is a risk, however, that if timeline were not completed-timeline, it would filter out unfinished instant in `BaseHoodieTime::getInstantsOrderedByCompletionTime`, causing `skip(activeTimeline.countInstants() - 1)` will exceed the stream range.

I refactor the code that uses this pattern to avoid the associated risks.

### Change Logs
1. fix wrong way to get the latest completed instant

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
low
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update
none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
