### PR TITLE
[HUDI-8766] Enabling cols stats by default with writer

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -214,7 +214,7 @@ stages:
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
         displayName: UT spark-datasource Java Tests & DDL
-        timeoutInMinutes: '90'
+        timeoutInMinutes: '120'
         steps:
           - task: Maven@4
             displayName: maven install

--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -181,7 +181,6 @@ stages:
       - job: UT_FT_2
         displayName: UT flink & FT common & flink & spark-client & hudi-spark
         timeoutInMinutes: '120'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -216,7 +215,6 @@ stages:
       - job: UT_FT_3
         displayName: UT spark-datasource Java Tests & DDL
         timeoutInMinutes: '120'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -251,7 +249,6 @@ stages:
       - job: UT_FT_4
         displayName: UT spark-datasource DML & others
         timeoutInMinutes: '120'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -277,7 +274,6 @@ stages:
       - job: UT_FT_5
         displayName: UT FT Hudi Streamer
         timeoutInMinutes: '90'
-        condition: false
         steps:
           - task: Docker@2
             displayName: "login to docker hub"
@@ -317,7 +313,6 @@ stages:
       - job: UT_FT_6
         displayName: UT FT other modules
         timeoutInMinutes: '90'
-        condition: false
         steps:
           - task: Docker@2
             displayName: "login to docker hub"

--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -181,6 +181,7 @@ stages:
       - job: UT_FT_2
         displayName: UT flink & FT common & flink & spark-client & hudi-spark
         timeoutInMinutes: '120'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -215,6 +216,7 @@ stages:
       - job: UT_FT_3
         displayName: UT spark-datasource Java Tests & DDL
         timeoutInMinutes: '120'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -249,6 +251,7 @@ stages:
       - job: UT_FT_4
         displayName: UT spark-datasource DML & others
         timeoutInMinutes: '120'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -274,6 +277,7 @@ stages:
       - job: UT_FT_5
         displayName: UT FT Hudi Streamer
         timeoutInMinutes: '90'
+        condition: false
         steps:
           - task: Docker@2
             displayName: "login to docker hub"
@@ -313,6 +317,7 @@ stages:
       - job: UT_FT_6
         displayName: UT FT other modules
         timeoutInMinutes: '90'
+        condition: false
         steps:
           - task: Docker@2
             displayName: "login to docker hub"

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -535,7 +535,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   private Pair<List<String>, Pair<Integer, HoodieData<HoodieRecord>>> initializeColumnStatsPartition(Map<String, Map<String, Long>> partitionToFilesMap) {
     // Find the columns to index
     final List<String> columnsToIndex = HoodieTableMetadataUtil.getColumnsToIndex(dataMetaClient.getTableConfig(),
-        dataWriteConfig.getMetadataConfig(), Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataMetaClient)));
+        dataWriteConfig.getMetadataConfig(), Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataMetaClient)), true);
     if (columnsToIndex.isEmpty()) {
       // atleast meta fields will be chosen for indexing. So, we should not reach this state unless virtual keys are enabled and
       // all col types are unsupported among the ones configured.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
@@ -80,6 +81,7 @@ public class HoodieMetadataWriteUtils {
    * @param writeConfig                {@code HoodieWriteConfig} of the main dataset writer
    * @param failedWritesCleaningPolicy Cleaning policy on failed writes
    */
+  @VisibleForTesting
   public static HoodieWriteConfig createMetadataWriteConfig(
       HoodieWriteConfig writeConfig, HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy) {
     String tableName = writeConfig.getTableName() + METADATA_TABLE_NAME_SUFFIX;

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -533,6 +533,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
             .enable(true)
             .enableMetrics(false)
             .withMaxNumDeltaCommitsBeforeCompaction(2)
+            .withMetadataIndexColumnStats(false)
             .build()).build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -29,6 +29,7 @@ import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.fs.FSUtils;
@@ -473,6 +474,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
             .enable(true)
             .enableMetrics(false)
             .withMaxNumDeltaCommitsBeforeCompaction(3) // after 3 delta commits for regular writer operations, compaction should kick in.
+            .withMetadataIndexColumnStats(false) // HUDI-8774
             .build()).build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
 
@@ -572,6 +574,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
             .enable(true)
             .enableMetrics(false)
             .withMaxNumDeltaCommitsBeforeCompaction(4)
+            .withMetadataIndexColumnStats(false) // HUDI-8774
             .build()).build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
     doWriteOperation(testTable, metaClient.createNewInstantTime(), INSERT);
@@ -1681,6 +1684,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     properties.setProperty(LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY, "1000");
     properties.setProperty(LockConfiguration.LOCK_ACQUIRE_CLIENT_NUM_RETRIES_PROP_KEY, "20");
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
+        .withEngineType(EngineType.JAVA)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY).withAutoClean(false).build())
         .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.timeline.HoodieTimelineArchiver;
 import org.apache.hudi.client.timeline.versioning.v2.TimelineArchiverV2;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -105,6 +106,7 @@ public class TestHoodieMetadataBase extends HoodieJavaClientTestHarness {
         ? writeConfig.get() : getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true,
         enableMetadataTable, enableMetrics, true,
         validateMetadataPayloadStateConsistency)
+        .withEngineType(EngineType.JAVA)
         .build();
     initWriteConfigAndMetatableWriter(this.writeConfig, enableMetadataTable);
   }
@@ -307,6 +309,7 @@ public class TestHoodieMetadataBase extends HoodieJavaClientTestHarness {
             .withMetadataIndexColumnStats(false)
             .enableMetrics(enableMetrics)
             .ignoreSpuriousDeletes(validateMetadataPayloadConsistency)
+            .withMetadataIndexColumnStats(false) // HUDI-8774
             .build())
         .withMetricsConfig(HoodieMetricsConfig.newBuilder().on(enableMetrics)
             .withExecutorMetrics(enableMetrics).withReporterType(MetricsReporterType.INMEMORY.name()).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
@@ -408,7 +408,8 @@ public class TestClientRollback extends HoodieClientTestBase {
         .withRollbackUsingMarkers(false)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY).build())
-        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build()).build(); // HUDI-8815
 
     try (HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context)) {
       HoodieTestTable testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
@@ -633,7 +634,8 @@ public class TestClientRollback extends HoodieClientTestBase {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
-            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY).build()).build();
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build()).build();
 
     try (HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context)) {
       HoodieTestTable testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
@@ -668,7 +670,8 @@ public class TestClientRollback extends HoodieClientTestBase {
       // Set Failed Writes rollback to EAGER
       config = HoodieWriteConfig.newBuilder().withPath(basePath)
           .withRollbackUsingMarkers(false)
-          .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
+          .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+          .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build()).build();
       final String commitTime5 = "20160506030631";
       try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
         client.startCommitWithTime(commitTime5);
@@ -824,7 +827,8 @@ public class TestClientRollback extends HoodieClientTestBase {
         .withRollbackUsingMarkers(true) // rollback using markers to test fallback to listing based rollback for completed instant
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY).build())
-        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build()).build();
 
     // create test table with all commits completed
     try (HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(metaClient.getStorageConf(), config, context)) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -249,7 +249,9 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadata)
-            .withMaxNumDeltaCommitsBeforeCompaction(maxDeltaCommitsMetadataTable).build())
+            .withMaxNumDeltaCommitsBeforeCompaction(maxDeltaCommitsMetadataTable)
+            .withMetadataIndexColumnStats(false).build())
+        // test uses test table infra. So, col stats is not available/populated.
         .withWriteConcurrencyMode(writeConcurrencyMode)
         .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(InProcessLockProvider.class)
             .build())
@@ -343,7 +345,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(5).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(5).withMetadataIndexColumnStats(false).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER)
             .withCleanerPolicy(HoodieCleaningPolicy.valueOf(cleaningPolicy))
@@ -1652,6 +1654,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true)
             .withMaxNumDeltaCommitsBeforeCompaction(8)
+            .withMetadataIndexColumnStats(false) // test uses test table infra. So, col stats is not available/populated.
             .build())
         .forTable("test-trip-table").build();
     initWriteConfigAndMetatableWriter(writeConfig, true);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -616,6 +616,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
   public void testCleanWithReplaceCommits() throws Exception {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .withMetadataIndexColumnStats(false)
             .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
@@ -1042,6 +1043,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
   public void testRerunFailedClean(boolean simulateMetadataFailure) throws Exception {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .withMetadataIndexColumnStats(false)
             .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(2).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -25,6 +25,7 @@ import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.HoodieRollbackStat;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -360,8 +361,11 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
         .withBaseFilesInPartition(p1, "id21").getLeft()
         .withBaseFilesInPartition(p2, "id22").getLeft();
 
+    // we are using test table infra. So, col stats are not populated.
     HoodieTable table =
-        this.getHoodieTable(metaClient, getConfigBuilder().withRollbackBackupEnabled(true).build());
+        this.getHoodieTable(metaClient, getConfigBuilder().withRollbackBackupEnabled(true)
+            .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build())
+            .build());
     HoodieInstant needRollBackInstant = HoodieTestUtils.getCompleteInstant(
         metaClient.getStorage(), metaClient.getTimelinePath(),
         "002", HoodieTimeline.COMMIT_ACTION);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -342,7 +342,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
   public void testKeepLatestFileVersionsWithBootstrapFileClean() throws Exception {
     HoodieWriteConfig config =
         HoodieWriteConfig.newBuilder().withPath(basePath)
-            .withMetadataConfig(HoodieMetadataConfig.newBuilder().build())
+            .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build())
             .withCleanConfig(HoodieCleanConfig.newBuilder()
                 .withCleanBootstrapBaseFileEnabled(true)
                 .withCleanerParallelism(1)

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -284,6 +284,24 @@
                                             "name": "value"
                                         }
                                     ]
+                                },
+                                {
+                                    "namespace": "org.apache.hudi.avro.model",
+                                    "type": "record",
+                                    "name": "LocalDateWrapper",
+                                    "doc": "A record wrapping Local Date type to be able to be used it w/in Avro's Union",
+                                    "fields": [
+                                        {
+                                            "type": {
+                                                "type": "int"
+                                                // NOTE: Due to breaking changes in code-gen b/w Avro 1.8.2 and 1.10, we can't
+                                                //       rely on logical types to do proper encoding of the native Java types,
+                                                //       and hereby have to encode statistic manually
+                                                //"logicalType": "date"
+                                            },
+                                            "name": "value"
+                                        }
+                                    ]
                                 }
                             ],
                             "default": null
@@ -309,7 +327,8 @@
                                 "org.apache.hudi.avro.model.DateWrapper",
                                 "org.apache.hudi.avro.model.DecimalWrapper",
                                 "org.apache.hudi.avro.model.TimeMicrosWrapper",
-                                "org.apache.hudi.avro.model.TimestampMicrosWrapper"
+                                "org.apache.hudi.avro.model.TimestampMicrosWrapper",
+                                "org.apache.hudi.avro.model.LocalDateWrapper"
                             ],
                             "default": null
                         },

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.avro.model.DecimalWrapper;
 import org.apache.hudi.avro.model.DoubleWrapper;
 import org.apache.hudi.avro.model.FloatWrapper;
 import org.apache.hudi.avro.model.IntWrapper;
+import org.apache.hudi.avro.model.LocalDateWrapper;
 import org.apache.hudi.avro.model.LongWrapper;
 import org.apache.hudi.avro.model.StringWrapper;
 import org.apache.hudi.avro.model.TimestampMicrosWrapper;
@@ -147,6 +148,7 @@ public class HoodieAvroUtils {
   private static final Lazy<TimestampMicrosWrapper.Builder> TIMESTAMP_MICROS_WRAPPER_BUILDER_STUB = Lazy.lazily(TimestampMicrosWrapper::newBuilder);
   private static final Lazy<DecimalWrapper.Builder> DECIMAL_WRAPPER_BUILDER_STUB = Lazy.lazily(DecimalWrapper::newBuilder);
   private static final Lazy<DateWrapper.Builder> DATE_WRAPPER_BUILDER_STUB = Lazy.lazily(DateWrapper::newBuilder);
+  private static final Lazy<LocalDateWrapper.Builder> LOCAL_DATE_WRAPPER_BUILDER_STUB = Lazy.lazily(LocalDateWrapper::newBuilder);
 
   private static final long MILLIS_PER_DAY = 86400000L;
 
@@ -1413,14 +1415,20 @@ public class HoodieAvroUtils {
   public static Object wrapValueIntoAvro(Comparable<?> value) {
     if (value == null) {
       return null;
-    } else if (value instanceof Date || value instanceof LocalDate) {
+    } else if (value instanceof Date) {
       // NOTE: Due to breaking changes in code-gen b/w Avro 1.8.2 and 1.10, we can't
       //       rely on logical types to do proper encoding of the native Java types,
       //       and hereby have to encode value manually
-      LocalDate localDate = value instanceof LocalDate
-          ? (LocalDate) value
-          : ((Date) value).toLocalDate();
+      LocalDate localDate = ((Date) value).toLocalDate();
       return DateWrapper.newBuilder(DATE_WRAPPER_BUILDER_STUB.get())
+          .setValue((int) localDate.toEpochDay())
+          .build();
+    } else if (value instanceof LocalDate) {
+      // NOTE: Due to breaking changes in code-gen b/w Avro 1.8.2 and 1.10, we can't
+      //       rely on logical types to do proper encoding of the native Java types,
+      //       and hereby have to encode value manually
+      LocalDate localDate = (LocalDate) value;
+      return LocalDateWrapper.newBuilder(LOCAL_DATE_WRAPPER_BUILDER_STUB.get())
           .setValue((int) localDate.toEpochDay())
           .build();
     } else if (value instanceof BigDecimal) {
@@ -1480,6 +1488,8 @@ public class HoodieAvroUtils {
 
     if (avroValueWrapper instanceof DateWrapper) {
       return Date.valueOf(LocalDate.ofEpochDay(((DateWrapper) avroValueWrapper).getValue()));
+    } else if (avroValueWrapper instanceof LocalDateWrapper) {
+      return LocalDate.ofEpochDay(((LocalDateWrapper) avroValueWrapper).getValue());
     } else if (avroValueWrapper instanceof DecimalWrapper) {
       Schema valueSchema = DecimalWrapper.SCHEMA$.getField("value").schema();
       return AVRO_DECIMAL_CONVERSION.fromBytes(((DecimalWrapper) avroValueWrapper).getValue(), valueSchema, valueSchema.getLogicalType());
@@ -1515,6 +1525,8 @@ public class HoodieAvroUtils {
       return null;
     } else if (DateWrapper.class.getSimpleName().equals(wrapperClassName)) {
       return Date.valueOf(LocalDate.ofEpochDay((Integer)((Record) avroValueWrapper).get(0)));
+    } else if (LocalDateWrapper.class.getSimpleName().equals(wrapperClassName)) {
+      return LocalDate.ofEpochDay((Integer)((Record) avroValueWrapper).get(0));
     } else if (TimestampMicrosWrapper.class.getSimpleName().equals(wrapperClassName)) {
       Instant instant = microsToInstant((Long)((Record) avroValueWrapper).get(0));
       return Timestamp.from(instant);
@@ -1529,8 +1541,10 @@ public class HoodieAvroUtils {
   private static Pair<Boolean, String> getIsValueWrapperObfuscated(GenericRecord record, String subFieldName) {
     Object statsValue = ((GenericRecord) record.get(SCHEMA_FIELD_ID_COLUMN_STATS)).get(subFieldName);
     if (statsValue != null) {
-      boolean toReturn = ((GenericRecord) statsValue).getSchema().getName().equals(DateWrapper.class.getSimpleName())
-          || ((GenericRecord) statsValue).getSchema().getName().equals(TimestampMicrosWrapper.class.getSimpleName());
+      String statsValueSchemaClassName = ((GenericRecord) statsValue).getSchema().getName();
+      boolean toReturn = statsValueSchemaClassName.equals(DateWrapper.class.getSimpleName())
+          || statsValueSchemaClassName.equals(LocalDateWrapper.class.getSimpleName())
+          || statsValueSchemaClassName.equals(TimestampMicrosWrapper.class.getSimpleName());
       if (toReturn) {
         return Pair.of(true, ((GenericRecord) statsValue).getSchema().getName());
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -762,6 +762,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public HoodieMetadataConfig build() {
       metadataConfig.setDefaultValue(ENABLE, getDefaultMetadataEnable(engineType));
+      metadataConfig.setDefaultValue(ENABLE_METADATA_INDEX_COLUMN_STATS, getDefaultColStatsEnable(engineType));
+      // fix me: disable when schema on read is enabled.
       metadataConfig.setDefaults(HoodieMetadataConfig.class.getName());
       return metadataConfig;
     }
@@ -773,6 +775,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           return ENABLE.defaultValue();
         case JAVA:
           return false;
+        default:
+          throw new HoodieNotSupportedException("Unsupported engine " + engineType);
+      }
+    }
+
+    private boolean getDefaultColStatsEnable(EngineType engineType) {
+      switch (engineType) {
+        case SPARK:
+          return true;
+        case FLINK:
+        case JAVA:
+          return false; // HUDI-8814
         default:
           throw new HoodieNotSupportedException("Unsupported engine " + engineType);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnRangeMetadata.java
@@ -156,8 +156,8 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
     return HoodieColumnRangeMetadata.<Comparable>create(
         columnStats.getFileName(),
         columnStats.getColumnName(),
-        unwrapAvroValueWrapper(columnStats.getMinValue()),
-        unwrapAvroValueWrapper(columnStats.getMaxValue()),
+        unwrapAvroValueWrapper(columnStats.getMinValue()), // misses for special handling.
+        unwrapAvroValueWrapper(columnStats.getMaxValue()), // misses for special handling.
         columnStats.getNullCount(),
         columnStats.getValueCount(),
         columnStats.getTotalSize(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -286,8 +286,12 @@ public class HoodieTableMetaClient implements Serializable {
       StoragePath indexDefinitionPath =
           new StoragePath(basePath, tableConfig.getRelativeIndexDefinitionPath().get());
       try {
-        return Option.of(HoodieIndexMetadata.fromJson(
-            new String(FileIOUtils.readDataFromPath(storage, indexDefinitionPath).get())));
+        Option<byte[]> bytesOpt = FileIOUtils.readDataFromPath(storage, indexDefinitionPath, true);
+        if (bytesOpt.isPresent()) {
+          return Option.of(HoodieIndexMetadata.fromJson(new String(bytesOpt.get())));
+        } else {
+          return Option.of(new HoodieIndexMetadata());
+        }
       } catch (IOException e) {
         throw new HoodieIOException("Could not load expression index metadata at path: " + tableConfig.getRelativeIndexDefinitionPath().get(), e);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -27,7 +27,6 @@ import org.apache.hudi.avro.model.FloatWrapper;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
-import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.avro.model.HoodieRecordIndexInfo;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
@@ -122,6 +121,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -244,13 +244,19 @@ public class HoodieTableMetadataUtil {
       // with the values from this record
       targetFields.forEach(field -> {
         ColumnStats colStats = allColumnStats.computeIfAbsent(field.name(), ignored -> new ColumnStats());
-
         Schema fieldSchema = getNestedFieldSchemaFromWriteSchema(recordSchema, field.name());
         Object fieldValue;
         if (record.getRecordType() == HoodieRecordType.AVRO) {
           fieldValue = HoodieAvroUtils.getRecordColumnValues(record, new String[]{field.name()}, recordSchema, false)[0];
+          if (fieldSchema.getType() == Schema.Type.INT && fieldSchema.getLogicalType() != null && fieldSchema.getLogicalType() == LogicalTypes.date()) {
+            fieldValue = java.sql.Date.valueOf(fieldValue.toString());
+          }
+
         } else if (record.getRecordType() == HoodieRecordType.SPARK) {
           fieldValue = record.getColumnValues(recordSchema, new String[]{field.name()}, false)[0];
+          if (fieldSchema.getType() == Schema.Type.INT && fieldSchema.getLogicalType() != null && fieldSchema.getLogicalType() == LogicalTypes.date()) {
+            fieldValue = java.sql.Date.valueOf(LocalDate.ofEpochDay((Integer) fieldValue).toString());
+          }
         } else {
           throw new HoodieException(String.format("Unknown record type: %s", record.getRecordType()));
         }
@@ -752,7 +758,7 @@ public class HoodieTableMetadataUtil {
     });
 
     List<String> columnsToIndex = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig,
-        Lazy.lazily(() -> tryResolveSchemaForTable(dataMetaClient)));
+        Lazy.lazily(() -> tryResolveSchemaForTable(dataMetaClient)), false);
 
     if (columnsToIndex.isEmpty()) {
       // In case there are no columns to index, bail
@@ -1261,6 +1267,9 @@ public class HoodieTableMetadataUtil {
                                                                           int columnStatsIndexParallelism,
                                                                           int maxReaderBufferSize,
                                                                           List<String> columnsToIndex) {
+    if ((partitionToAppendedFiles.isEmpty() && partitionToDeletedFiles.isEmpty())) {
+      return engineContext.emptyHoodieData();
+    }
     LOG.info("Indexing {} columns for column stats index", columnsToIndex.size());
 
     // Create the tuple (partition, filename, isDeleted) to handle both deletes and appends
@@ -1481,7 +1490,7 @@ public class HoodieTableMetadataUtil {
         tableConfig.populateMetaFields() ? addMetadataFields(schema) : schema);
 
     return getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig,
-        Lazy.eagerly(tableSchema));
+        Lazy.eagerly(tableSchema), false);
   }
 
   @VisibleForTesting
@@ -1493,7 +1502,7 @@ public class HoodieTableMetadataUtil {
   public static List<String> getColumnsToIndex(HoodieTableConfig tableConfig,
                                                HoodieMetadataConfig metadataConfig,
                                                List<String> columnNames) {
-    return getColumnsToIndex(tableConfig, metadataConfig, Either.left(columnNames), Option.empty());
+    return getColumnsToIndex(tableConfig, metadataConfig, Either.left(columnNames), false, Option.empty());
   }
 
   @VisibleForTesting
@@ -1501,21 +1510,23 @@ public class HoodieTableMetadataUtil {
                                                HoodieMetadataConfig metadataConfig,
                                                Lazy<Option<Schema>> tableSchema,
                                                Option<HoodieRecordType> recordType) {
-    return getColumnsToIndex(tableConfig, metadataConfig, Either.right(tableSchema), recordType);
+    return getColumnsToIndex(tableConfig, metadataConfig, Either.right(tableSchema), false, recordType);
   }
 
   @VisibleForTesting
   public static List<String> getColumnsToIndex(HoodieTableConfig tableConfig,
                                                HoodieMetadataConfig metadataConfig,
-                                               Lazy<Option<Schema>> tableSchema) {
-    return getColumnsToIndex(tableConfig, metadataConfig, Either.right(tableSchema), Option.empty());
+                                               Lazy<Option<Schema>> tableSchema,
+                                               boolean isTableInitializing) {
+    return getColumnsToIndex(tableConfig, metadataConfig, Either.right(tableSchema), isTableInitializing, Option.empty());
   }
 
   private static List<String> getColumnsToIndex(HoodieTableConfig tableConfig,
                                                 HoodieMetadataConfig metadataConfig,
                                                 Either<List<String>, Lazy<Option<Schema>>> tableSchema,
+                                                boolean isTableInitializing,
                                                 Option<HoodieRecordType> recordType) {
-    Stream<String> columnsToIndexWithoutRequiredMetas = getColumnsToIndexWithoutRequiredMetaFields(metadataConfig, tableSchema, recordType);
+    Stream<String> columnsToIndexWithoutRequiredMetas = getColumnsToIndexWithoutRequiredMetaFields(metadataConfig, tableSchema, isTableInitializing, recordType);
     if (!tableConfig.populateMetaFields()) {
       return columnsToIndexWithoutRequiredMetas.collect(Collectors.toList());
     }
@@ -1531,14 +1542,19 @@ public class HoodieTableMetadataUtil {
    *
    * @param metadataConfig       metadata config
    * @param tableSchema          either a list of the columns in the table, or a lazy option of the table schema
+   * @param isTableInitializing true if table is being initialized.
    * @param recordType           Option of record type. Used to determine which types are valid to index
    * @return list of columns that should be indexed
    */
   private static Stream<String> getColumnsToIndexWithoutRequiredMetaFields(HoodieMetadataConfig metadataConfig,
                                                                            Either<List<String>, Lazy<Option<Schema>>> tableSchema,
+                                                                           boolean isTableInitializing,
                                                                            Option<HoodieRecordType> recordType) {
     List<String> columnsToIndex = metadataConfig.getColumnsEnabledForColumnStatsIndex();
     if (!columnsToIndex.isEmpty()) {
+      if (isTableInitializing) {
+        return columnsToIndex.stream();
+      }
       // filter for top level fields here.
       List<String> topLevelEligibleFields = tableSchema.isLeft() ? tableSchema.asLeft() :
           (tableSchema.asRight().get().map(schema -> schema.getFields().stream()
@@ -1548,15 +1564,18 @@ public class HoodieTableMetadataUtil {
       return columnsToIndex.stream().filter(fieldName -> !META_COL_SET_TO_INDEX.contains(fieldName) && !fieldName.contains(".")
           && (topLevelEligibleFields.isEmpty() || topLevelEligibleFields.contains(fieldName)));
     }
-    if (tableSchema.isLeft()) {
-      return getFirstNFieldNames(tableSchema.asLeft().stream(), metadataConfig.maxColumnsToIndexForColStats());
+    if (isTableInitializing) {
+      return Stream.empty();
     } else {
-      return tableSchema.asRight().get()
-          .map(schema -> getFirstNFieldNames(schema, metadataConfig.maxColumnsToIndexForColStats(), recordType)).orElse(Stream.empty());
+      if (tableSchema.isLeft()) {
+        return getFirstNFieldNames(tableSchema.asLeft().stream(), metadataConfig.maxColumnsToIndexForColStats());
+      } else {
+        return tableSchema.asRight().get().map(schema -> getFirstNSupportedFieldNames(schema, metadataConfig.maxColumnsToIndexForColStats(), recordType)).orElse(Stream.empty());
+      }
     }
   }
 
-  private static Stream<String> getFirstNFieldNames(Schema tableSchema, int n, Option<HoodieRecordType> recordType) {
+  private static Stream<String> getFirstNSupportedFieldNames(Schema tableSchema, int n, Option<HoodieRecordType> recordType) {
     return getFirstNFieldNames(tableSchema.getFields().stream()
         .filter(field -> isColumnTypeSupported(field.schema(), recordType)).map(Schema.Field::name), n);
   }
@@ -1781,7 +1800,15 @@ public class HoodieTableMetadataUtil {
   }
 
   private static boolean isColumnTypeSupported(Schema schema, Option<HoodieRecordType> recordType) {
-    return schema.getType() != Schema.Type.RECORD && schema.getType() != Schema.Type.ARRAY && schema.getType() != Schema.Type.MAP;
+    // if record type is set and if its AVRO, MAP, ARRAY, RECORD and ENUM types are unsupported.
+    if (recordType.isPresent() && recordType.get() == HoodieRecordType.AVRO) {
+      return (schema.getType() != Schema.Type.RECORD && schema.getType() != Schema.Type.ARRAY && schema.getType() != Schema.Type.MAP
+          && schema.getType() != Schema.Type.ENUM);
+    }
+    // if record Type is not set or if recordType is SPARK then we cannot support AVRO, MAP, ARRAY, RECORD, ENUM and FIXED and BYTES type as well.
+    // HUDI-8585 will add support for BYTES and FIXED
+    return schema.getType() != Schema.Type.RECORD && schema.getType() != Schema.Type.ARRAY && schema.getType() != Schema.Type.MAP
+        && schema.getType() != Schema.Type.ENUM && schema.getType() != Schema.Type.BYTES && schema.getType() != Schema.Type.FIXED;
   }
 
   public static Set<String> getInflightMetadataPartitions(HoodieTableConfig tableConfig) {
@@ -2389,8 +2416,12 @@ public class HoodieTableMetadataUtil {
                                                                              HoodieMetadataConfig metadataConfig,
                                                                              HoodieTableMetaClient dataTableMetaClient,
                                                                              Option<Schema> writerSchemaOpt) {
+    if (partitionInfoList.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
     Lazy<Option<Schema>> lazyWriterSchemaOpt = writerSchemaOpt.isPresent() ? Lazy.eagerly(writerSchemaOpt) : Lazy.lazily(() -> tryResolveSchemaForTable(dataTableMetaClient));
-    final List<String> columnsToIndex = getColumnsToIndex(dataTableMetaClient.getTableConfig(), metadataConfig, lazyWriterSchemaOpt);
+    final List<String> columnsToIndex = getColumnsToIndex(dataTableMetaClient.getTableConfig(), metadataConfig, lazyWriterSchemaOpt,
+        dataTableMetaClient.getActiveTimeline().filterCompletedInstants().empty());
     if (columnsToIndex.isEmpty()) {
       LOG.warn("No columns to index for partition stats index");
       return engineContext.emptyHoodieData();
@@ -2483,7 +2514,7 @@ public class HoodieTableMetadataUtil {
       HoodieTableConfig tableConfig = dataMetaClient.getTableConfig();
       Option<Schema> tableSchema = writerSchema.map(schema -> tableConfig.populateMetaFields() ? addMetadataFields(schema) : schema);
       Lazy<Option<Schema>> writerSchemaOpt = Lazy.eagerly(tableSchema);
-      List<String> columnsToIndex = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig, writerSchemaOpt);
+      List<String> columnsToIndex = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig, writerSchemaOpt, false);
       if (columnsToIndex.isEmpty()) {
         return engineContext.emptyHoodieData();
       }
@@ -2518,18 +2549,19 @@ public class HoodieTableMetadataUtil {
               .filter(Objects::nonNull)
               .collect(Collectors.toSet());
           // Fetch metadata table COLUMN_STATS partition records for above files
-          List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata =
-              tableMetadata.getRecordsByKeyPrefixes(generateKeyPrefixes(validColumnsToIndex, partitionName), MetadataPartitionType.COLUMN_STATS.getPartitionPath(), false)
-                  // schema and properties are ignored in getInsertValue, so simply pass as null
-                  .map(record -> record.getData().getInsertValue(null, null))
-                  .filter(Option::isPresent)
-                  .map(data -> ((HoodieMetadataRecord) data.get()).getColumnStatsMetadata())
-                  .filter(stats -> fileNames.contains(stats.getFileName()))
-                  .map(HoodieColumnRangeMetadata::fromColumnStats)
-                  .collectAsList();
-          // incase of shouldScanColStatsForTightBound = true, we compute stats for the partition of interest for all files from getLatestFileSlice() excluding current commit here
-          // already fileColumnMetadata contains stats for files from the current infliht commit. so, we are adding both together and sending it to collectAndProcessColumnMetadata
-          fileColumnMetadata.addAll(partitionColumnMetadata);
+          List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata = tableMetadata
+              .getRecordsByKeyPrefixes(generateKeyPrefixes(validColumnsToIndex, partitionName), MetadataPartitionType.COLUMN_STATS.getPartitionPath(), false)
+              // schema and properties are ignored in getInsertValue, so simply pass as null
+              .map(record -> ((HoodieMetadataPayload)record.getData()).getColumnStatMetadata())
+              .filter(Option::isPresent)
+              .map(colStatsOpt -> colStatsOpt.get())
+              .filter(stats -> fileNames.contains(stats.getFileName()))
+              .map(HoodieColumnRangeMetadata::fromColumnStats).collectAsList();
+          if (!partitionColumnMetadata.isEmpty()) {
+            // incase of shouldScanColStatsForTightBound = true, we compute stats for the partition of interest for all files from getLatestFileSlice() excluding current commit here
+            // already fileColumnMetadata contains stats for files from the current infliht commit. so, we are adding both together and sending it to collectAndProcessColumnMetadata
+            fileColumnMetadata.addAll(partitionColumnMetadata);
+          }
         }
 
         return Pair.of(partitionName, fileColumnMetadata);
@@ -2564,17 +2596,8 @@ public class HoodieTableMetadataUtil {
   @VisibleForTesting
   public static boolean validateDataTypeForPartitionStats(String columnToIndex, Schema tableSchema) {
     Schema fieldSchema = getNestedFieldSchemaFromWriteSchema(tableSchema, columnToIndex);
-    // Exclude fields based on logical type
-    if ((fieldSchema.getType() == Schema.Type.INT || fieldSchema.getType() == Schema.Type.LONG)
-        && fieldSchema.getLogicalType() != null) {
-
-      // Skip fields with logical types DATE or TIME_MILLIS for INT, TIMESTAMP_MILLIS for LONG
-      String logicalType = fieldSchema.getLogicalType().getName();
-      return !logicalType.equals("date") && !logicalType.equals("timestamp-millis") && !logicalType.equals("timestamp-micros") && !logicalType.equals("time-millis")
-          && !logicalType.equals("time-micros") && !logicalType.equals("local-timestamp-millis") && !logicalType.equals("local-timestamp-micros");
-    }
-    // Include other supported primitive types
-    return SUPPORTED_TYPES_PARTITION_STATS.contains(fieldSchema.getType());
+    // to be fixed HUDI-8680.
+    return isColumnTypeSupported(fieldSchema, Option.of(HoodieRecordType.SPARK));
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -26,6 +26,7 @@ import org.apache.hudi.avro.model.HoodieSecondaryIndexInfo;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 
 import org.apache.avro.generic.GenericRecord;
@@ -301,8 +302,8 @@ public enum MetadataPartitionType {
           // AVRO-2377 1.9.2 Modified the type of org.apache.avro.Schema#FIELD_RESERVED to Collections.unmodifiableSet.
           // This causes Kryo to fail when deserializing a GenericRecord, See HUDI-5484.
           // We should avoid using GenericRecord and convert GenericRecord into a serializable type.
-          .setMinValue(wrapValueIntoAvro(unwrapAvroValueWrapper(columnStatsRecord.get(COLUMN_STATS_FIELD_MIN_VALUE))))
-          .setMaxValue(wrapValueIntoAvro(unwrapAvroValueWrapper(columnStatsRecord.get(COLUMN_STATS_FIELD_MAX_VALUE))))
+          .setMinValue(wrapValueIntoAvro(unwrapAvroValueWrapper(columnStatsRecord.get(COLUMN_STATS_FIELD_MIN_VALUE), true, Option.of(COLUMN_STATS_FIELD_MIN_VALUE), Option.of(record))))
+          .setMaxValue(wrapValueIntoAvro(unwrapAvroValueWrapper(columnStatsRecord.get(COLUMN_STATS_FIELD_MAX_VALUE), true, Option.of(COLUMN_STATS_FIELD_MAX_VALUE), Option.of(record))))
           .setValueCount((Long) columnStatsRecord.get(COLUMN_STATS_FIELD_VALUE_COUNT))
           .setNullCount((Long) columnStatsRecord.get(COLUMN_STATS_FIELD_NULL_COUNT))
           .setTotalSize((Long) columnStatsRecord.get(COLUMN_STATS_FIELD_TOTAL_SIZE))

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.RewriteAvroPayload;
+import org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.SchemaCompatibilityException;
@@ -55,6 +56,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -92,6 +95,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests hoodie avro utilities.
  */
 public class TestHoodieAvroUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieAvroUtils.class);
 
   private static String EVOLVED_SCHEMA = "{\"type\": \"record\",\"name\": \"testrec1\",\"fields\": [ "
       + "{\"name\": \"timestamp\",\"type\": \"double\"},{\"name\": \"_row_key\", \"type\": \"string\"},"
@@ -700,7 +705,8 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      assertTrue(((Date)value).equals((Date)unwrapAvroValueWrapper(wrapperValue)));
+      LOG.warn("AAA Expected " + value +", actual : before unwrap " + wrapperValue +", after unwrapping " + (unwrapAvroValueWrapper(wrapperValue)));
+      assertEquals(((Date)value), (Date)unwrapAvroValueWrapper(wrapperValue));
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -704,7 +704,6 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      LOG.warn("AAA Expected " + value + ", actual : before unwrap " + wrapperValue + ", after unwrapping " + (unwrapAvroValueWrapper(wrapperValue)));
       assertEquals(((Date)value).toString(), ((Date)unwrapAvroValueWrapper(wrapperValue)).toString());
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -705,7 +705,7 @@ public class TestHoodieAvroUtils {
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
       LOG.warn("AAA Expected " + value + ", actual : before unwrap " + wrapperValue + ", after unwrapping " + (unwrapAvroValueWrapper(wrapperValue)));
-      assertEquals(((Date)value), (Date)unwrapAvroValueWrapper(wrapperValue));
+      assertEquals(((Date)value).toString(), ((Date)unwrapAvroValueWrapper(wrapperValue)).toString());
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -700,11 +700,11 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(((Date)(value)).getTime(), ((Date)unwrapAvroValueWrapper(wrapperValue)).getTime());
+      assertEquals(value, unwrapAvroValueWrapper(wrapperValue));
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(Date.valueOf((LocalDate)value).getTime(), ((Date)unwrapAvroValueWrapper(wrapperValue)).getTime());
+      assertEquals(Date.valueOf((LocalDate)value), unwrapAvroValueWrapper(wrapperValue));
     } else {
       assertEquals("0.000000000000000",
           ((BigDecimal) value)

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -700,11 +700,11 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(value, unwrapAvroValueWrapper(wrapperValue));
+      assertTrue(((Date)value).equals((Date)unwrapAvroValueWrapper(wrapperValue)));
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(Date.valueOf((LocalDate)value), unwrapAvroValueWrapper(wrapperValue));
+      assertTrue(Date.valueOf((LocalDate)value).equals((Date)unwrapAvroValueWrapper(wrapperValue)));
     } else {
       assertEquals("0.000000000000000",
           ((BigDecimal) value)

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -700,11 +700,11 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals((value), unwrapAvroValueWrapper(wrapperValue));
+      assertEquals(((Date)(value)).getTime(), ((Date)unwrapAvroValueWrapper(wrapperValue)).getTime());
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(Date.valueOf((LocalDate)value), unwrapAvroValueWrapper(wrapperValue));
+      assertEquals(Date.valueOf((LocalDate)value).getTime(), ((Date)unwrapAvroValueWrapper(wrapperValue)).getTime());
     } else {
       assertEquals("0.000000000000000",
           ((BigDecimal) value)

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -33,7 +33,6 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.RewriteAvroPayload;
-import org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.SchemaCompatibilityException;
@@ -705,7 +704,7 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      LOG.warn("AAA Expected " + value +", actual : before unwrap " + wrapperValue +", after unwrapping " + (unwrapAvroValueWrapper(wrapperValue)));
+      LOG.warn("AAA Expected " + value + ", actual : before unwrap " + wrapperValue + ", after unwrapping " + (unwrapAvroValueWrapper(wrapperValue)));
       assertEquals(((Date)value), (Date)unwrapAvroValueWrapper(wrapperValue));
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.avro.model.DecimalWrapper;
 import org.apache.hudi.avro.model.DoubleWrapper;
 import org.apache.hudi.avro.model.FloatWrapper;
 import org.apache.hudi.avro.model.IntWrapper;
+import org.apache.hudi.avro.model.LocalDateWrapper;
 import org.apache.hudi.avro.model.LongWrapper;
 import org.apache.hudi.avro.model.StringWrapper;
 import org.apache.hudi.avro.model.TimestampMicrosWrapper;
@@ -684,7 +685,7 @@ public class TestHoodieAvroUtils {
         new Object[][] {
             {new Timestamp(1690766971000L), TimestampMicrosWrapper.class},
             {new Date(1672560000000L), DateWrapper.class},
-            {LocalDate.of(2023, 1, 1), DateWrapper.class},
+            {LocalDate.of(2023, 1, 1), LocalDateWrapper.class},
             {new BigDecimal("12345678901234.2948"), DecimalWrapper.class}
         };
     return Stream.of(data).map(Arguments::of);
@@ -708,7 +709,7 @@ public class TestHoodieAvroUtils {
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));
-      assertTrue(Date.valueOf((LocalDate)value).equals((Date)unwrapAvroValueWrapper(wrapperValue)));
+      assertEquals(value, unwrapAvroValueWrapper(wrapperValue));
     } else {
       assertEquals("0.000000000000000",
           ((BigDecimal) value)

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -700,11 +700,11 @@ public class TestHoodieAvroUtils {
       assertEquals((int) ChronoUnit.DAYS.between(
               LocalDate.ofEpochDay(0), ((Date) value).toLocalDate()),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(((Date) value).toLocalDate(), unwrapAvroValueWrapper(wrapperValue));
+      assertEquals((value), unwrapAvroValueWrapper(wrapperValue));
     } else if (value instanceof LocalDate) {
       assertEquals((int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), (LocalDate) value),
           ((GenericRecord) wrapperValue).get(0));
-      assertEquals(value, unwrapAvroValueWrapper(wrapperValue));
+      assertEquals(Date.valueOf((LocalDate)value), unwrapAvroValueWrapper(wrapperValue));
     } else {
       assertEquals("0.000000000000000",
           ((BigDecimal) value)

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -71,7 +71,7 @@ public class TestMetadataPartitionType {
         break;
       case COLUMN_STATS:
         metadataConfigBuilder.enable(true).withMetadataIndexColumnStats(true);
-        expectedEnabledPartitions = 3;
+        expectedEnabledPartitions = 2;
         break;
       case BLOOM_FILTERS:
         metadataConfigBuilder.enable(true).withMetadataIndexBloomFilter(true);
@@ -93,10 +93,10 @@ public class TestMetadataPartitionType {
 
     // Verify partition type is enabled due to config
     if (partitionType == MetadataPartitionType.EXPRESSION_INDEX || partitionType == MetadataPartitionType.SECONDARY_INDEX) {
-      assertEquals(2, enabledPartitions.size(), "EXPRESSION_INDEX should be enabled by SQL, only FILES and SECONDARY_INDEX is enabled in this case.");
+      assertEquals(2 + 1, enabledPartitions.size(), "EXPRESSION_INDEX should be enabled by SQL, only FILES and SECONDARY_INDEX is enabled in this case.");
       assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES));
     } else {
-      assertEquals(expectedEnabledPartitions, enabledPartitions.size());
+      assertEquals(expectedEnabledPartitions + 1, enabledPartitions.size());
       assertTrue(enabledPartitions.contains(partitionType) || MetadataPartitionType.ALL_PARTITIONS.equals(partitionType));
     }
   }
@@ -116,7 +116,7 @@ public class TestMetadataPartitionType {
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify RECORD_INDEX and FILES is enabled due to availability, and SECONDARY_INDEX by default
-    assertEquals(3, enabledPartitions.size(), "RECORD_INDEX, SECONDARY_INDEX and FILES should be available");
+    assertEquals(4, enabledPartitions.size(), "RECORD_INDEX, SECONDARY_INDEX, FILES, COL_STATS should be available");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.RECORD_INDEX), "RECORD_INDEX should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.SECONDARY_INDEX), "SECONDARY_INDEX should be enabled by default");
@@ -156,7 +156,7 @@ public class TestMetadataPartitionType {
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfig.getProps(), metaClient);
 
     // Verify EXPRESSION_INDEX and FILES is enabled due to availability, and SECONDARY_INDEX by default
-    assertEquals(3, enabledPartitions.size(), "EXPRESSION_INDEX, FILES and SECONDARY_INDEX should be available");
+    assertEquals(4, enabledPartitions.size(), "EXPRESSION_INDEX, FILES, COL_STATS and SECONDARY_INDEX should be available");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.FILES), "FILES should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.EXPRESSION_INDEX), "EXPRESSION_INDEX should be enabled by availability");
     assertTrue(enabledPartitions.contains(MetadataPartitionType.SECONDARY_INDEX), "SECONDARY_INDEX should be enabled by default");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.sink;
 
 import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
@@ -614,6 +615,8 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   public void testReuseEmbeddedServer() throws IOException {
     conf.setInteger("hoodie.filesystem.view.remote.timeout.secs", 500);
     conf.setString("hoodie.metadata.enable","true");
+    conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false"); // HUDI-8814
+
     HoodieFlinkWriteClient writeClient = null;
     HoodieFlinkWriteClient writeClient2 = null;
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.sink;
 
 import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
@@ -96,6 +97,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // disable schedule compaction in writers
     conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
+    conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false"); // HUDI-8814
 
     // start pipeline1 and insert record: [id1,Danny,null,1,par1], suspend the tx commit
     List<RowData> dataset1 = Collections.singletonList(
@@ -290,6 +292,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // disable schedule compaction in writers
     conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
+    conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
 
     Configuration conf1 = conf.clone();
     conf1.setString(FlinkOptions.OPERATION, "BULK_INSERT");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolution.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolution.java
@@ -20,6 +20,7 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -363,7 +364,9 @@ public class ITTestSchemaEvolution {
         FlinkOptions.COMPACTION_TASKS.key(), 1,
         FlinkOptions.COMPACTION_SCHEDULE_ENABLED.key(), false,
         HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_REUSE_ENABLED.key(), false,
-        HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key(), true);
+        HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key(), true,
+        HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "false", // HUDI-8587
+        HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(), "false");
   }
 
   private void checkAnswerEvolved(String... expectedResult) throws Exception {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieDeleteBlock.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieDeleteBlock.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -101,7 +100,7 @@ public class TestHoodieDeleteBlock {
             {new Double[] {Double.MIN_VALUE, 0.125, 809.25, Double.MAX_VALUE}},
             {new String[] {"val1", "val2", "val3", null}},
             {new Timestamp[] {new Timestamp(1690766971000L), new Timestamp(1672536571000L)}},
-            {new LocalDate[] {LocalDate.of(2023, 1, 1), LocalDate.of(1980, 7, 1)}},
+            // {new LocalDate[] {LocalDate.of(2023, 1, 1), LocalDate.of(1980, 7, 1)}} // HUDI-8854
             {new BigDecimal[] {new BigDecimal("12345678901234.2948"), new BigDecimal("23456789012345.4856")}}
         };
     return Stream.of(data).map(Arguments::of);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieDeleteBlock.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieDeleteBlock.java
@@ -102,8 +102,7 @@ public class TestHoodieDeleteBlock {
             {new String[] {"val1", "val2", "val3", null}},
             {new Timestamp[] {new Timestamp(1690766971000L), new Timestamp(1672536571000L)}},
             {new LocalDate[] {LocalDate.of(2023, 1, 1), LocalDate.of(1980, 7, 1)}},
-            {new BigDecimal[] {new BigDecimal("12345678901234.2948"),
-                new BigDecimal("23456789012345.4856")}}
+            {new BigDecimal[] {new BigDecimal("12345678901234.2948"), new BigDecimal("23456789012345.4856")}}
         };
     return Stream.of(data).map(Arguments::of);
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -462,7 +462,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     expected.add("booleanField");
     expected.add("decimalField");
     expected.add("localTimestampMillisField");
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema)), true));
 
     //test with avro schema and nested fields and unsupported types
     schema = new Schema.Parser().parse(SCHEMA_WITH_NESTED_FIELD);
@@ -472,7 +472,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         .build();
     expected = new ArrayList<>(Arrays.asList(HoodieTableMetadataUtil.META_COLS_TO_ALWAYS_INDEX));
     expected.add("firstname");
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema)), false));
 
     //test with avro schema with max cols set
     schema = new Schema.Parser().parse(SCHEMA_WITH_AVRO_TYPES);
@@ -483,9 +483,9 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     expected = new ArrayList<>(Arrays.asList(HoodieTableMetadataUtil.META_COLS_TO_ALWAYS_INDEX));
     expected.add("booleanField");
     expected.add("intField");
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema)), false));
     //test with avro schema with meta cols
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieAvroUtils.addMetadataFields(schema)))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieAvroUtils.addMetadataFields(schema))), false));
 
     //test with avro schema with type filter
     metadataConfig = HoodieMetadataConfig.newBuilder()
@@ -496,7 +496,6 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     expected.add("timestamp");
     expected.add("_row_key");
     expected.add("partition_path");
-    expected.add("trip_type");
     expected.add("rider");
     expected.add("driver");
     expected.add("begin_lat");
@@ -506,14 +505,13 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     expected.add("distance_in_meters");
     expected.add("seconds_since_epoch");
     expected.add("weight");
-    expected.add("nation");
     expected.add("current_date");
     expected.add("current_ts");
-    expected.add("height");
     expected.add("_hoodie_is_deleted");
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieTestDataGenerator.AVRO_SCHEMA))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieTestDataGenerator.AVRO_SCHEMA)), false));
     //test with avro schema with meta cols
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieAvroUtils.addMetadataFields(HoodieTestDataGenerator.AVRO_SCHEMA)))));
+    assertEquals(expected,
+        HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(HoodieAvroUtils.addMetadataFields(HoodieTestDataGenerator.AVRO_SCHEMA))), false));
 
     //test with meta cols disabled
     tableConfig.setValue(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
@@ -548,7 +546,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     expected.add("booleanField");
     expected.add("decimalField");
     expected.add("localTimestampMillisField");
-    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema))));
+    assertEquals(expected, HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, metadataConfig, Lazy.eagerly(Option.of(schema)), true));
   }
 
   private void addNColumns(List<String> list, int n) {
@@ -586,13 +584,13 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     assertTrue(validateDataTypeForPartitionStats("floatField", schema));
     assertTrue(validateDataTypeForPartitionStats("doubleField", schema));
     assertTrue(validateDataTypeForPartitionStats("longField", schema));
-    assertTrue(validateDataTypeForPartitionStats("bytesField", schema));
     assertTrue(validateDataTypeForPartitionStats("unionIntField", schema));
 
-    // Test for complex fields
+    // Test for unsupported fields
     assertFalse(validateDataTypeForPartitionStats("arrayField", schema));
     assertFalse(validateDataTypeForPartitionStats("mapField", schema));
     assertFalse(validateDataTypeForPartitionStats("structField", schema));
+    assertFalse(validateDataTypeForPartitionStats("bytesField", schema));
 
     // Test for logical types
     Schema dateFieldSchema = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
@@ -600,7 +598,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         .fields()
         .name("dateField").type(dateFieldSchema).noDefault()
         .endRecord();
-    assertFalse(validateDataTypeForPartitionStats("dateField", schema));
+    assertTrue(validateDataTypeForPartitionStats("dateField", schema));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
@@ -81,13 +81,15 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
           .setBasePath(mdtBasePath).build();
       HoodieActiveTimeline timeline = mdtMetaClient.getActiveTimeline();
       List<HoodieInstant> instants = timeline.getInstants();
-      assertEquals(3, instants.size());
+      assertEquals(4, instants.size());
       // For MDT bootstrap instant.
       assertEquals("00000000000000000", instants.get(0).requestedTime());
-      // For RLI bootstrap instant.
+      // For col stats bootstrap instant.
       assertEquals("00000000000000001", instants.get(1).requestedTime());
+      // For RLI bootstrap instant.
+      assertEquals("00000000000000002", instants.get(3).requestedTime());
       // For the insert instant.
-      assertEquals(timestamp0, instants.get(2).requestedTime());
+      assertEquals(timestamp0, instants.get(3).requestedTime());
 
       // Insert second batch.
       String timestamp1 = "20241015000000001";
@@ -101,13 +103,15 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
       mdtMetaClient = HoodieTableMetaClient.reload(mdtMetaClient);
       timeline = mdtMetaClient.getActiveTimeline();
       instants = timeline.getInstants();
-      assertEquals(3, timeline.getInstants().size());
+      assertEquals(5, timeline.getInstants().size());
       // For MDT bootstrap instant.
       assertEquals("00000000000000000", instants.get(0).requestedTime());
-      // For RLI bootstrap instant.
+      // For col stats bootstrap instant.
       assertEquals("00000000000000001", instants.get(1).requestedTime());
+      // For RLI bootstrap instant.
+      assertEquals("00000000000000002", instants.get(3).requestedTime());
       // For the insert_overwrite_table instant.
-      assertEquals(timestamp1, instants.get(2).requestedTime());
+      assertEquals(timestamp1, instants.get(3).requestedTime());
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
@@ -87,7 +87,7 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
       // For col stats bootstrap instant.
       assertEquals("00000000000000001", instants.get(1).requestedTime());
       // For RLI bootstrap instant.
-      assertEquals("00000000000000002", instants.get(3).requestedTime());
+      assertEquals("00000000000000002", instants.get(2).requestedTime());
       // For the insert instant.
       assertEquals(timestamp0, instants.get(3).requestedTime());
 
@@ -103,13 +103,13 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
       mdtMetaClient = HoodieTableMetaClient.reload(mdtMetaClient);
       timeline = mdtMetaClient.getActiveTimeline();
       instants = timeline.getInstants();
-      assertEquals(5, timeline.getInstants().size());
+      assertEquals(4, timeline.getInstants().size());
       // For MDT bootstrap instant.
       assertEquals("00000000000000000", instants.get(0).requestedTime());
       // For col stats bootstrap instant.
       assertEquals("00000000000000001", instants.get(1).requestedTime());
       // For RLI bootstrap instant.
-      assertEquals("00000000000000002", instants.get(3).requestedTime());
+      assertEquals("00000000000000002", instants.get(2).requestedTime());
       // For the insert_overwrite_table instant.
       assertEquals(timestamp1, instants.get(3).requestedTime());
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -299,9 +299,47 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     client4.close();
   }
 
-  @ParameterizedTest
-  @MethodSource("providerClassResolutionStrategyAndTableType")
-  public void testHoodieClientBasicMultiWriter(HoodieTableType tableType, Class providerClass,
+  @Test
+  public void testHoodieClientBasicMultiWriterCOW_InProcessLP_SimpleCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.COPY_ON_WRITE, InProcessLockProvider.class, new SimpleConcurrentFileWritesConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterCOW_FSBasedLP_SimpleCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.COPY_ON_WRITE, FileSystemBasedLockProvider.class, new SimpleConcurrentFileWritesConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterCOW_FSBasedLP_PreferWriterCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.COPY_ON_WRITE, FileSystemBasedLockProvider.class, new PreferWriterConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterCOW_InProcessLP_PreferWriterCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.COPY_ON_WRITE, InProcessLockProvider.class, new PreferWriterConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterMOR_InProcessLP_SimpleCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.MERGE_ON_READ, InProcessLockProvider.class, new SimpleConcurrentFileWritesConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterMOR_FSBasedLP_SimpleCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.MERGE_ON_READ, FileSystemBasedLockProvider.class, new SimpleConcurrentFileWritesConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterMOR_FSBasedLP_PreferWriterCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.MERGE_ON_READ, FileSystemBasedLockProvider.class, new PreferWriterConflictResolutionStrategy());
+  }
+
+  @Test
+  public void testHoodieClientBasicMultiWriterMOR_InProcessLP_PreferWriterCRS() throws Exception {
+    testHoodieClientBasicMultiWriter(HoodieTableType.MERGE_ON_READ, InProcessLockProvider.class, new PreferWriterConflictResolutionStrategy());
+  }
+
+  private void testHoodieClientBasicMultiWriter(HoodieTableType tableType, Class providerClass,
                                                ConflictResolutionStrategy resolutionStrategy) throws Exception {
     if (tableType == HoodieTableType.MERGE_ON_READ) {
       setUpMORTestTable();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -897,6 +897,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
             .enable(true)
             .enableMetrics(false)
             .withMaxNumDeltaCommitsBeforeCompaction(4)
+            .withMetadataIndexColumnStats(false)
             .build()).build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
     doWriteOperation(testTable, metaClient.createNewInstantTime(), INSERT);
@@ -2224,7 +2225,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     // Ensure all commits were synced to the Metadata Table
     HoodieTableMetaClient metadataMetaClient = createMetaClient(metadataTableBasePath);
-    assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 5);
+    assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 6);
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000002")));
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000003")));
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000004")));
@@ -2277,7 +2278,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       LOG.warn("total commits in metadata table " + metadataMetaClient.getActiveTimeline().getCommitsTimeline().countInstants());
 
       // 6 commits and 2 cleaner commits.
-      assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 8);
+      assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 9);
       assertTrue(metadataMetaClient.getActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants().countInstants() <= 1);
       // Validation
       validateMetadata(writeClient);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
@@ -267,7 +267,8 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
             .withBootstrapParallelism(3)
             .withBootstrapModeSelector(bootstrapModeSelectorClass)
             .withBootstrapModeForRegexMatch(modeForRegexMatch).build())
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3)
+            .withMetadataIndexColumnStats(false).build()) // HUDI-8774
         .build();
 
     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);
@@ -415,7 +416,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
     reloadInputFormats();
     List<GenericRecord> records = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(
         HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()),
-        FSUtils.getAllPartitionPaths(context, storage, basePath, HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS).stream()
+        FSUtils.getAllPartitionPaths(context, storage, basePath, false).stream()
             .map(f -> basePath + "/" + f).collect(Collectors.toList()),
         basePath, roJobConf, false, schema, TRIP_HIVE_COLUMN_TYPES, false, new ArrayList<>());
     assertEquals(totalRecords, records.size());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.bootstrap.selector.BootstrapRegexModeSelector;
 import org.apache.hudi.client.bootstrap.selector.FullRecordBootstrapModeSelector;
 import org.apache.hudi.client.bootstrap.selector.MetadataOnlyBootstrapModeSelector;
 import org.apache.hudi.client.bootstrap.translator.DecodedBootstrapPartitionPathTranslator;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.config.HoodieBootstrapConfig;
@@ -94,6 +95,7 @@ public abstract class TestBootstrapReadBase extends HoodieSparkClientTestBase {
     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType.name());
     options.put(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING().key(), "true");
     options.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "false");
     if (nPartitions == 0) {
       options.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), NonpartitionedKeyGenerator.class.getName());
     } else {
@@ -116,6 +118,7 @@ public abstract class TestBootstrapReadBase extends HoodieSparkClientTestBase {
     Map<String, String> options = basicOptions();
     options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL());
     options.put(HoodieBootstrapConfig.BASE_PATH.key(), bootstrapBasePath);
+    options.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "false");
     if (!dashPartitions) {
       options.put(HoodieBootstrapConfig.PARTITION_PATH_TRANSLATOR_CLASS_NAME.key(), DecodedBootstrapPartitionPathTranslator.class.getName());
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional;
+
+import org.apache.hudi.avro.model.DecimalWrapper;
+import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.EngineProperty;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.InProcessTimeGenerator;
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SpillableMapUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.io.HoodieCreateHandle;
+import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.io.storage.HoodieSeekingFileReader;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieMetadataWriteUtils;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestColStatsRecordWithMetadataRecord extends HoodieSparkClientTestHarness {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestColStatsRecordWithMetadataRecord.class);
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    initSparkContexts("TestHoodieCreateHandle");
+    initPath();
+    initHoodieStorage();
+    initTestDataGenerator();
+    initMetaClient();
+    initTimelineService();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanupResources();
+  }
+
+  @Test
+  public void testColsStatsSerDe() throws Exception {
+
+    Random random = new Random();
+    // create a data table which will auto create mdt table as well
+    HoodieWriteConfig cfg = getConfig();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg);) {
+      writeData(client, InProcessTimeGenerator.createNewInstantTime(), 100, false);
+    }
+
+    String fileName = "file.parquet";
+    String targetColNamePrefix = "col";
+    List<Pair<Comparable, Comparable>> minMaxValues = new ArrayList<>();
+    // string
+    minMaxValues.add(Pair.of("abcdec", "zyxwvu"));
+    // Utf8
+    minMaxValues.add(Pair.of(new Utf8(getUTF8Bytes("abcdec")), new Utf8(getUTF8Bytes("zyxwvu"))));
+    // Int
+    minMaxValues.add(Pair.of(new Integer(-1000), new Integer(999999)));
+    // Long
+    minMaxValues.add(Pair.of(new Long(-100000L), Long.MAX_VALUE));
+    // boolean
+    minMaxValues.add(Pair.of(false, true));
+    // double
+    minMaxValues.add(Pair.of(new Double(0.123), new Double(10.123)));
+    // float
+    minMaxValues.add(Pair.of(new Float(0.0123), new Float(200.123)));
+    // Date
+    minMaxValues.add(Pair.of(new Date(1000 * 60 * 60 * 10), new Date(1000 * 60 * 60 * 60)));
+    // LocalDate
+    minMaxValues.add(Pair.of(LocalDate.ofEpochDay(1000 * 60 * 60 * 10), LocalDate.ofEpochDay(1000 * 60 * 60 * 60)));
+    // Timestamp
+    minMaxValues.add(Pair.of(new Timestamp(1000 * 60 * 60 * 10), new Timestamp(1000 * 60 * 60 * 60)));
+    minMaxValues.add(generateRandomMinMaxValue(random, (Functions.Function1<Random, Comparable>) random1
+        -> new Timestamp(random1.nextInt(1000) * 60 * 60 * 1000)));
+
+    //Bytes
+    byte[] bytes1 = new byte[10];
+    byte[] bytes2 = new byte[10];
+    random.nextBytes(bytes1);
+    random.nextBytes(bytes2);
+    ByteBuffer val1ByteBuffer = ByteBuffer.wrap(bytes1);
+    ByteBuffer val2ByteBuffer = ByteBuffer.wrap(bytes2);
+    Comparable minValue = val1ByteBuffer;
+    Comparable maxValue = val2ByteBuffer;
+    if (val1ByteBuffer.compareTo(val2ByteBuffer) >= 0) {
+      minValue = val2ByteBuffer;
+      maxValue = val1ByteBuffer;
+    }
+    minMaxValues.add(Pair.of(minValue, maxValue));
+
+    // Big Decimal
+    BigDecimal val1 = new BigDecimal(String.format(Locale.ENGLISH, "%5f", random.nextFloat()));
+    BigDecimal val2 = new BigDecimal(String.format(Locale.ENGLISH, "%5f", random.nextFloat()));
+    if (val1.compareTo(val2) > 0) {
+      minMaxValues.add(Pair.of(val2, val1));
+    } else {
+      minMaxValues.add(Pair.of(val1, val2));
+    }
+
+    List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadata = new ArrayList<>();
+    AtomicInteger counter = new AtomicInteger();
+    AtomicInteger finalCounter1 = counter;
+    minMaxValues.forEach(entry -> {
+      columnRangeMetadata.add(HoodieColumnRangeMetadata.<Comparable>create(fileName, targetColNamePrefix + "_" + (finalCounter1.getAndIncrement()),
+          entry.getKey(), entry.getValue(), 5, 1000, 123456, 123456));
+    });
+
+    // create mdt records
+    List<HoodieRecord<HoodieMetadataPayload>> columnStatsRecords =
+        HoodieMetadataPayload.createColumnStatsRecords("p1", columnRangeMetadata, false)
+            .map(record -> (HoodieRecord<HoodieMetadataPayload>) record).collect(Collectors.toList());
+
+    Collections.sort(columnStatsRecords, new Comparator<HoodieRecord<HoodieMetadataPayload>>() {
+      @Override
+      public int compare(HoodieRecord<HoodieMetadataPayload> o1, HoodieRecord<HoodieMetadataPayload> o2) {
+        return o1.getRecordKey().compareTo(o2.getRecordKey());
+      }
+    });
+
+    List<HoodieRecord<HoodieMetadataPayload>> expectedColumnStatsRecords =
+        HoodieMetadataPayload.createColumnStatsRecords("p1", columnRangeMetadata, false)
+            .map(record -> (HoodieRecord<HoodieMetadataPayload>) record).collect(Collectors.toList());
+
+    Collections.sort(expectedColumnStatsRecords, new Comparator<HoodieRecord<HoodieMetadataPayload>>() {
+      @Override
+      public int compare(HoodieRecord<HoodieMetadataPayload> o1, HoodieRecord<HoodieMetadataPayload> o2) {
+        return o1.getRecordKey().compareTo(o2.getRecordKey());
+      }
+    });
+
+    HoodieWriteConfig mdtWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(cfg, HoodieFailedWritesCleaningPolicy.EAGER);
+    HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder().setBasePath(mdtWriteConfig.getBasePath()).setConf(context.getStorageConf().newInstance()).build();
+
+    HoodieTable table = HoodieSparkTable.create(mdtWriteConfig, context, mdtMetaClient);
+    String newCommitTime = InProcessTimeGenerator.createNewInstantTime();
+    HoodieCreateHandle handle = new HoodieCreateHandle(mdtWriteConfig, newCommitTime, table, COLUMN_STATS.getPartitionPath(), "col-stats-00001-0", new PhoneyTaskContextSupplier());
+
+    // write the record to hfile.
+    Schema writeSchema = new Schema.Parser().parse(mdtWriteConfig.getSchema());
+    TypedProperties properties = new TypedProperties();
+    columnStatsRecords.forEach(record -> handle.write(record, writeSchema, properties));
+    WriteStatus writeStatus = (WriteStatus) handle.close().get(0);
+    String filePath = writeStatus.getStat().getPath();
+
+    // read the hfile using base file reader.
+    StoragePath baseFilePath = new StoragePath(mdtMetaClient.getBasePath() + "/" + filePath);
+    HoodieSeekingFileReader baseFileReader = (HoodieSeekingFileReader<?>) HoodieIOFactory.getIOFactory(mdtMetaClient.getStorage())
+        .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+        .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, baseFilePath);
+
+    ClosableIterator itr = baseFileReader.getRecordIterator();
+    List<HoodieRecord<HoodieMetadataPayload>> allRecords = new ArrayList<>();
+    while (itr.hasNext()) {
+      GenericRecord genericRecord = (GenericRecord) ((HoodieRecord) itr.next()).getData();
+      HoodieRecord<HoodieMetadataPayload> mdtRec = SpillableMapUtils.convertToHoodieRecordPayload(genericRecord,
+          mdtWriteConfig.getPayloadClass(), mdtWriteConfig.getPreCombineField(),
+          Pair.of(mdtMetaClient.getTableConfig().getRecordKeyFieldProp(), mdtMetaClient.getTableConfig().getPartitionFieldProp()),
+          false, Option.of(COLUMN_STATS.getPartitionPath()), Option.empty());
+      allRecords.add(mdtRec);
+    }
+
+    assertEquals(columnStatsRecords.size(), allRecords.size());
+    // validate the min and max values.
+    counter = new AtomicInteger(0);
+    AtomicInteger finalCounter = counter;
+
+    allRecords.forEach(record -> {
+      HoodieMetadataColumnStats actualColStatsMetadata = record.getData().getColumnStatMetadata().get();
+      HoodieMetadataColumnStats expectedColStatsMetadata = expectedColumnStatsRecords.get(finalCounter.getAndIncrement()).getData().getColumnStatMetadata().get();
+      LOG.info("Validating " + expectedColStatsMetadata.getColumnName() + ", " + expectedColStatsMetadata.getMinValue().getClass().getSimpleName());
+      if (expectedColStatsMetadata.getMinValue().getClass().getSimpleName().equals(DecimalWrapper.class.getSimpleName())) {
+        // Big decimal gets wrapped w/ Decimal wrapper and converts to bytes.
+        assertEquals(expectedColStatsMetadata.getMinValue().toString(), actualColStatsMetadata.getMinValue().toString());
+        assertEquals(expectedColStatsMetadata.getMaxValue().toString(), actualColStatsMetadata.getMaxValue().toString());
+      } else {
+        assertEquals(expectedColStatsMetadata.getMinValue(), actualColStatsMetadata.getMinValue());
+        assertEquals(expectedColStatsMetadata.getMaxValue(), actualColStatsMetadata.getMaxValue());
+      }
+    });
+  }
+
+  @Test
+  public void testColsStatsMergeString() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> {
+      byte[] bytes = new byte[10];
+      random.nextBytes(bytes);
+      return new String(bytes, Charset.forName("UTF-8"));
+    });
+  }
+
+  @Test
+  public void testColsStatsMergeInt() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> random.nextInt());
+  }
+
+  @Test
+  public void testColsStatsMergeLong() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> random.nextLong());
+  }
+
+  @Test
+  public void testColsStatsMergeDouble() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> random.nextDouble());
+  }
+
+  @Test
+  public void testColsStatsMergeBoolean() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> random.nextBoolean());
+  }
+
+  @Test
+  public void testColsStatsMergeFloat() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> random.nextFloat());
+  }
+
+  @Test
+  public void testColsStatsMergeBytes() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> {
+      byte[] bytes = new byte[20];
+      random.nextBytes(bytes);
+      return ByteBuffer.wrap(bytes);
+    });
+  }
+
+  @Test
+  public void testColsStatsMergeDate() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> new Date(random.nextInt(100) * 60 * 60 * 1000));
+  }
+
+  @Test
+  public void testColsStatsMergeLocalDate() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> LocalDate.ofEpochDay(random.nextInt(100) * 60 * 60 * 1000));
+  }
+
+  @Test
+  public void testColsStatsMergeLocalTimestamp() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> new Timestamp(random.nextInt(1000) * 60 * 60 * 1000));
+  }
+
+  @Test
+  public void testColsStatsMergeBigDecimal() throws Exception {
+    generateNColStatsEntriesAndValidateMerge((Functions.Function1<Random, Comparable>) random -> new BigDecimal(String.format(Locale.ENGLISH, "%5f", random.nextFloat())));
+  }
+
+  private void generateNColStatsEntriesAndValidateMerge(Functions.Function1<Random, Comparable> randomValueGenFunc) {
+    String fileName = "abc.parquet";
+    String colName = "colName";
+    Random random = new Random();
+
+    List<Pair<Comparable, Comparable>> minMaxValues = new ArrayList<>();
+    List<Comparable> allMinValues = new ArrayList<>();
+    List<Comparable> allMaxValues = new ArrayList<>();
+    // generate 50 min, max values and merge them.
+    for (int i = 0; i < 50; i++) {
+      Pair<Comparable, Comparable> minMaxValue = generateRandomMinMaxValue(random, randomValueGenFunc);
+      minMaxValues.add(Pair.of(minMaxValue.getKey(), minMaxValue.getValue()));
+      allMinValues.add(minMaxValue.getKey());
+      allMaxValues.add(minMaxValue.getValue());
+    }
+
+    List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadata = new ArrayList<>();
+    minMaxValues.forEach(entry -> {
+      columnRangeMetadata.add(HoodieColumnRangeMetadata.<Comparable>create(fileName, colName,
+          entry.getKey(), entry.getValue(), 5, 1000, 123456, 123456));
+    });
+
+    HoodieColumnRangeMetadata<Comparable> mergedColStatsRangeMetadata = (HoodieColumnRangeMetadata<Comparable>) columnRangeMetadata.stream()
+        .reduce((left, right) -> HoodieColumnRangeMetadata.merge(left, right)).get();
+
+    Object finalMin = getExpectedMinValue(allMinValues);
+    Object finalMax = getExpectedMaxValue(allMaxValues);
+
+    assertEquals(finalMin, mergedColStatsRangeMetadata.getMinValue());
+    assertEquals(finalMax, mergedColStatsRangeMetadata.getMaxValue());
+  }
+
+  private Comparable getExpectedMinValue(List<Comparable> allValues) {
+    return allValues.stream().reduce((left, right) -> {
+      if (left.compareTo(right) < 0) {
+        return left;
+      } else {
+        return right;
+      }
+    }).get();
+  }
+
+  private Comparable getExpectedMaxValue(List<Comparable> allValues) {
+    return allValues.stream().reduce((left, right) -> {
+      if (left.compareTo(right) >= 0) {
+        return left;
+      } else {
+        return right;
+      }
+    }).get();
+  }
+
+  private Pair<Comparable, Comparable> generateRandomMinMaxValue(Random random, Functions.Function1<Random, Comparable> randomValueGenFunc) {
+    Comparable value1 = randomValueGenFunc.apply(random);
+    Comparable value2 = randomValueGenFunc.apply(random);
+    if (value1.compareTo(value2) > 0) {
+      return Pair.of(value2, value1);
+    } else {
+      return Pair.of(value1, value2);
+    }
+  }
+
+  private List<WriteStatus> writeData(SparkRDDWriteClient client, String instant, int numRecords, boolean doCommit) {
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    JavaRDD records = jsc.parallelize(dataGen.generateInserts(instant, numRecords), 2);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    client.startCommitWithTime(instant);
+    List<WriteStatus> writeStatuses = client.upsert(records, instant).collect();
+    org.apache.hudi.testutils.Assertions.assertNoWriteErrors(writeStatuses);
+    if (doCommit) {
+      List<HoodieWriteStat> writeStats = writeStatuses.stream().map(WriteStatus::getStat).collect(Collectors.toList());
+      boolean committed = client.commitStats(instant, writeStats, Option.empty(), metaClient.getCommitActionType());
+      Assertions.assertTrue(committed);
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    return writeStatuses;
+  }
+
+  class PhoneyTaskContextSupplier extends TaskContextSupplier {
+
+    @Override
+    public Supplier<Integer> getPartitionIdSupplier() {
+      return () -> 1;
+    }
+
+    @Override
+    public Supplier<Integer> getStageIdSupplier() {
+      return () -> 1;
+    }
+
+    @Override
+    public Supplier<Long> getAttemptIdSupplier() {
+      return () -> 1L;
+    }
+
+    @Override
+    public Option<String> getProperty(EngineProperty prop) {
+      return Option.empty();
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
@@ -28,6 +28,7 @@ import org.apache.hudi.client.bootstrap.selector.FullRecordBootstrapModeSelector
 import org.apache.hudi.client.bootstrap.selector.MetadataOnlyBootstrapModeSelector;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -246,6 +247,8 @@ public class TestOrcBootstrap extends HoodieSparkClientTestBase {
             .withBootstrapParallelism(3)
             .withBootstrapModeSelector(bootstrapModeSelectorClass)
             .withBootstrapModeForRegexMatch(modeForRegexMatch).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3)
+            .withMetadataIndexColumnStats(false).build()) // HUDI-8774
         .build();
 
     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -426,6 +426,8 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
         .withAvroSchemaValidate(false)
         .withAllowAutoEvolutionColumnDrop(true)
         .withAutoCommit(false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMetadataIndexColumnStats(false).build())
+        // in this test we mock few entries in timeline. hence col stats initialization does not work.
         .build();
 
     setUp(cfg.getProps());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -30,9 +30,9 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.{ComplexKeyGenerator, NonpartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieClientTestUtils}
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
-
 import org.apache.avro.Schema
 import org.apache.commons.io.FileUtils
+import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.functions.{expr, lit}
@@ -48,7 +48,6 @@ import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, intercept}
 
 import java.time.Instant
 import java.util.{Collections, Date, UUID}
-
 import scala.collection.JavaConverters._
 
 /**
@@ -541,7 +540,8 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
         DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
         DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getCanonicalName,
-        DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getCanonicalName)
+        DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getCanonicalName,
+        HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false")
       val fooTableParams = HoodieWriterUtils.parametersWithWriteDefaults(fooTableModifier)
       initializeMetaClientForBootstrap(fooTableParams, tableType, addBootstrapPath = true, initBasePath = false)
 
@@ -731,7 +731,8 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
         DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
         DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
-        HoodieWriteConfig.TBL_NAME.key -> "hoodie_test")
+        HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+        HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false")
       val df = spark.range(0, 1000).toDF("keyid")
         .withColumn("col3", expr("keyid"))
         .withColumn("age", lit(1))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -59,7 +59,8 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
     RECORDKEY_FIELD.key -> "_row_key",
     PARTITIONPATH_FIELD.key -> "partition",
     PRECOMBINE_FIELD.key -> "timestamp",
-    HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+    HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+    HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "15"
   ) ++ metadataOpts
 
   val secondaryIndexOpts = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
@@ -19,7 +19,7 @@ package org.apache.hudi.functional
 
 import org.apache.hudi.{AvroConversionUtils, DataSourceWriteOptions, ScalaAssertionSupport}
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
-import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType, OverwriteWithLatestAvroPayload}
 import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
 import org.apache.hudi.common.util.Option
@@ -28,9 +28,8 @@ import org.apache.hudi.exception.SchemaCompatibilityException
 import org.apache.hudi.functional.TestBasicSchemaEvolution.{dropColumn, injectColumnAt}
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.util.JFunction
-
 import org.apache.hadoop.fs.FileSystem
-import org.apache.spark.sql.{functions, HoodieUnsafeUtils, Row, SaveMode, SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.{HoodieUnsafeUtils, Row, SaveMode, SparkSession, SparkSessionExtensions, functions}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
@@ -39,7 +38,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 import java.util.function.Consumer
-
 import scala.collection.JavaConverters._
 
 class TestBasicSchemaEvolution extends HoodieSparkClientTestBase with ScalaAssertionSupport {
@@ -55,7 +53,8 @@ class TestBasicSchemaEvolution extends HoodieSparkClientTestBase with ScalaAsser
     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
     DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
-    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+    HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key -> "false" // HUDI-8587
   )
 
   val verificationCol: String = "driver"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -216,7 +216,8 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
   def testMetadataColumnStatsIndexInitializationWithUpserts(tableType: HoodieTableType, partitionCol : String): Unit = {
     val testCase = ColumnStatsTestCase(tableType, shouldReadInMemory = true)
     val metadataOpts = Map(
-      HoodieMetadataConfig.ENABLE.key -> "true"
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key() -> "false"
     )
 
     val commonOpts = Map(
@@ -331,7 +332,8 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
   def testMetadataColumnStatsIndexInitializationWithRollbacks(tableType: HoodieTableType, partitionCol : String): Unit = {
     val testCase = ColumnStatsTestCase(tableType, shouldReadInMemory = true)
     val metadataOpts = Map(
-      HoodieMetadataConfig.ENABLE.key -> "true"
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key() -> "false"
     )
 
     val commonOpts = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -117,7 +117,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val metadataOpts1 = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
-      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key() -> "c1,c2,c3,c5,c6,c7,c8" // ignore c4
+      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "c1,c2,c3,c5,c6,c7,c8" // ignore c4
     )
 
     expectedColStatsSourcePath = if (testCase.tableType == HoodieTableType.COPY_ON_WRITE) {
@@ -140,7 +140,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val metadataOpts2 = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
-      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key() -> "c1,c2,c3,c5,c7,c8" // ignore c4,c6
+      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "c1,c2,c3,c5,c7,c8" // ignore c4,c6
     )
 
     expectedColStatsSourcePath = if (testCase.tableType == HoodieTableType.COPY_ON_WRITE) {
@@ -162,7 +162,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val metadataOpts3 = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false",
-      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key() -> "c1,c2,c3,c5,c7" // ignore c4,c5,c8.
+      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "c1,c2,c3,c5,c7" // ignore c4,c5,c8.
     )
     // disable col stats
     doWriteAndValidateColumnStats(ColumnStatsTestParams(testCase, metadataOpts3, commonOpts,
@@ -187,7 +187,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val metadataOpts = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
-      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key() -> "c1,c2,c3,c4,c5,c6,c7,c8,c9.car_brand"
+      HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "c1,c2,c3,c4,c5,c6,c7,c8,c9.car_brand"
     )
 
     val commonOpts = Map(
@@ -217,7 +217,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val testCase = ColumnStatsTestCase(tableType, shouldReadInMemory = true)
     val metadataOpts = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
-      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key() -> "false"
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
     )
 
     val commonOpts = Map(
@@ -227,9 +227,9 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
       RECORDKEY_FIELD.key -> "c1",
       PRECOMBINE_FIELD.key -> "c1",
-      PARTITIONPATH_FIELD.key() -> partitionCol,
+      PARTITIONPATH_FIELD.key -> partitionCol,
       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
-      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "5"
+      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "5"
     ) ++ metadataOpts
 
     // inserts
@@ -333,7 +333,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val testCase = ColumnStatsTestCase(tableType, shouldReadInMemory = true)
     val metadataOpts = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
-      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key() -> "false"
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
     )
 
     val commonOpts = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -406,8 +406,8 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
-      HoodieCompactionConfig.INLINE_COMPACT.key() -> "true",
-      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "1"
+      HoodieCompactionConfig.INLINE_COMPACT.key -> "true",
+      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "1"
     ) ++ metadataOpts
     setupTable(testCase, metadataOpts, commonOpts, shouldValidate = false)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -20,7 +20,7 @@ package org.apache.hudi.functional
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieDataSourceHelpers}
 import org.apache.hudi.bootstrap.SparkParquetBootstrapDataProvider
 import org.apache.hudi.client.bootstrap.selector.{FullRecordBootstrapModeSelector, MetadataOnlyBootstrapModeSelector}
-import org.apache.hudi.common.config.HoodieStorageConfig
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.timeline.{HoodieInstantTimeGenerator, HoodieTimeline}
@@ -29,7 +29,6 @@ import org.apache.hudi.functional.TestDataSourceForBootstrap.{dropMetaCols, sort
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.{NonpartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieClientTestUtils}
-
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SaveMode, SparkSession}
@@ -42,7 +41,6 @@ import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
 
 import java.time.Instant
 import java.util.Collections
-
 import scala.collection.JavaConverters._
 
 class TestDataSourceForBootstrap {
@@ -58,7 +56,8 @@ class TestDataSourceForBootstrap {
     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
     DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
-    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+    HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
   )
 
   val sparkRecordTypeOpts = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -65,7 +65,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
   @Test
   def testPartitionStatsWithoutColumnStats(): Unit = {
     // remove column stats enable key from commonOpts
-    val hudiOpts = commonOpts - HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key
+    val hudiOpts = commonOpts + (HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false")
     // should throw an exception as column stats is required for partition stats
     assertThrows[HoodieException] {
       doWriteAndValidateDataAndPartitionStats(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -320,8 +320,8 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase {
     assertEquals(0, getFileGroupCountForRecordIndex(writeConfig))
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertEquals(0, metaClient.getTableConfig.getMetadataPartitionsInflight.size())
-    // only files partition should be present
-    assertEquals(1, metaClient.getTableConfig.getMetadataPartitions.size())
+    // only files, col stats partition should be present.
+    assertEquals(2, metaClient.getTableConfig.getMetadataPartitions.size())
 
     doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -45,10 +45,13 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
   @ParameterizedTest
   @ValueSource(strings = Array("COPY_ON_WRITE", "MERGE_ON_READ"))
   def testRLIWithSQL(tableType: String): Unit = {
-    var hudiOpts = commonOpts
-    hudiOpts = hudiOpts + (
+    val hudiOpts = commonOpts ++ Map(
       DataSourceWriteOptions.TABLE_TYPE.key -> tableType,
+      "hoodie.metadata.index.column.stats.enable" -> "false",
       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
+
+    // some negative test cases in this class assumes
+    // only RLI being enabled. So, disabling col stats for now.
 
     val df = doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
@@ -276,7 +279,8 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
       HoodieWriteConfig.TBL_NAME.key -> tableName,
       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "record_key_col,name",
       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_key_col",
-      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true"
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+      "hoodie.metadata.index.column.stats.enable" -> "false"
     ) ++ metadataOpts
 
     spark.sql(
@@ -292,7 +296,8 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
          |  hoodie.metadata.enable = 'true',
          |  hoodie.metadata.record.index.enable = 'true',
          |  hoodie.datasource.write.recordkey.field = 'record_key_col,name',
-         |  hoodie.enable.data.skipping = 'true'
+         |  hoodie.enable.data.skipping = 'true',
+         |  hoodie.metadata.index.column.stats.enable = 'false'
          | )
          | partitioned by(partition_key_col)
          | location '$dummyTablePath'
@@ -338,7 +343,8 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
          |  hoodie.metadata.enable = 'true',
          |  hoodie.metadata.record.index.enable = 'true',
          |  hoodie.datasource.write.recordkey.field = 'record_key_col1,record_key_col2,record_key_col3',
-         |  hoodie.enable.data.skipping = 'true'
+         |  hoodie.enable.data.skipping = 'true',
+         |  hoodie.metadata.index.column.stats.enable = 'false'
          | )
          | partitioned by(partition_key_col)
          | location '$dummyTablePath'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -97,6 +97,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
         spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
         checkAnswer(s"show indexes from default.$tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("record_index", "record_index", "")
         )
 
@@ -107,6 +108,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         // Secondary index is created by default for non record key column when index type is not specified
         spark.sql(s"create index idx_name on $tableName (name)")
         checkAnswer(s"show indexes from default.$tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("secondary_index_idx_name", "secondary_index", "name"),
           Seq("record_index", "record_index", "")
         )
@@ -119,6 +121,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
 
         // Both indexes should be shown
         checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("secondary_index_idx_name", "secondary_index", "name"),
           Seq("secondary_index_idx_price", "secondary_index", "price"),
           Seq("record_index", "record_index", "")
@@ -127,6 +130,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         checkAnswer(s"drop index idx_name on $tableName")()
         // show index shows only one index after dropping
         checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("secondary_index_idx_price", "secondary_index", "price"),
           Seq("record_index", "record_index", "")
         )
@@ -138,6 +142,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         // drop index should work now
         checkAnswer(s"drop index idx_name on $tableName")()
         checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("secondary_index_idx_price", "secondary_index", "price"),
           Seq("record_index", "record_index", "")
         )
@@ -155,11 +160,13 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         metaClient.getTableConfig.setMetadataPartitionState(metaClient, indexDefinition.getIndexName, false)
         checkAnswer(s"drop index idx_price on $tableName")()
         checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
           Seq("record_index", "record_index", "")
         )
 
         // Drop the record index and show index should show no index
         checkAnswer(s"drop index record_index on $tableName")()
+        checkAnswer(s"drop index column_stats on $tableName")()
         checkAnswer(s"show indexes from $tableName")()
 
         checkException(s"drop index idx_price on $tableName")("Index does not exist: idx_price")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -28,6 +28,7 @@ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_RECORD_KEY_SEPARATOR
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX
 import org.apache.hudi.metadata.SecondaryIndexKeyUtils
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSparkUtils}
@@ -36,7 +37,6 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.JavaConverters._
 
 class TestSecondaryIndex extends HoodieSparkSqlTestBase {
@@ -155,7 +155,8 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
           .build()
         assertFalse(metaClient.getTableConfig.getRelativeIndexDefinitionPath.get().contains(metaClient.getBasePath))
         assertTrue(metaClient.getIndexDefinitionPath.contains(metaClient.getBasePath.toString))
-        val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.values().stream().findFirst().get()
+        val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.values().stream()
+          .filter(indexDefn => indexDefn.getIndexType.equals(PARTITION_NAME_SECONDARY_INDEX)).findFirst().get()
 
         metaClient.getTableConfig.setMetadataPartitionState(metaClient, indexDefinition.getIndexName, false)
         checkAnswer(s"drop index idx_price on $tableName")()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
@@ -77,6 +77,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         spark.sql("set " + DataSourceWriteOptions.SPARK_SQL_INSERT_INTO_OPERATION.key + "=upsert")
         spark.sql("set hoodie.schema.on.read.enable=true")
+        spark.sql("set hoodie.metadata.index.column.stats.enable=false")
         // NOTE: This is required since as this tests use type coercions which were only permitted in Spark 2.x
         //       and are disallowed now by default in Spark 3.x
         spark.sql("set spark.sql.storeAssignmentPolicy=legacy")
@@ -139,6 +140,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         spark.sessionState.conf.unsetConf(DataSourceWriteOptions.SPARK_SQL_INSERT_INTO_OPERATION.key)
         spark.sessionState.conf.unsetConf("spark.sql.storeAssignmentPolicy")
       }
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable")
     })
   }
 
@@ -240,6 +242,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         spark.sql("set hoodie.compact.schedule.inline=false")
 
         spark.sql("set hoodie.schema.on.read.enable=true")
+        spark.sql("set hoodie.metadata.index.column.stats.enable=false")
         spark.sql("set " + DataSourceWriteOptions.SPARK_SQL_INSERT_INTO_OPERATION.key + "=upsert")
         // NOTE: This is required since as this tests use type coercions which were only permitted in Spark 2.x
         //       and are disallowed now by default in Spark 3.x
@@ -334,6 +337,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
       }
       spark.sessionState.conf.unsetConf("spark.sql.storeAssignmentPolicy")
       spark.sessionState.conf.unsetConf(DataSourceWriteOptions.SPARK_SQL_INSERT_INTO_OPERATION.key)
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
@@ -54,6 +54,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       }
 
       spark.sql("set hoodie.bootstrap.parallelism = 20")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = false")
       checkAnswer(
         s"""call run_bootstrap(
            |table => '$tableName',
@@ -93,6 +94,8 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       spark.sql("set hoodie.datasource.write.row.writer.enable = false")
       spark.sql(s"""call run_clustering(table => '$tableName')""".stripMargin)
       assertResult(0)(spark.sql(s"select * from $tableName").except(beforeClusterDf).count())
+
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable") // HUDI-8774
     }
   }
 
@@ -119,6 +122,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       }
 
       spark.sql("set hoodie.bootstrap.parallelism = 20")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = false")
       checkAnswer(
         s"""call run_bootstrap(
            |table => '$tableName',
@@ -158,7 +162,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       assertResult("true") {
         metaClient.getTableConfig.getString(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE)
       };
-
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable")
     }
   }
 
@@ -181,6 +185,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       df.write.parquet(sourcePath)
 
       spark.sql("set hoodie.bootstrap.parallelism = 20")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = false")
       // run bootstrap
       checkAnswer(
         s"""call run_bootstrap(
@@ -214,6 +219,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       spark.sql("set hoodie.datasource.write.row.writer.enable = false")
       spark.sql(s"""call run_clustering(table => '$tableName')""".stripMargin)
       assertResult(0)(spark.sql(s"select * from $tableName").except(beforeClusterDf).count())
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable")
     }
   }
 
@@ -241,6 +247,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
 
       spark.sql("set hoodie.bootstrap.parallelism = 20")
       spark.sql("set hoodie.datasource.write.precombine.field=timestamp")
+      spark.sql("set hoodie.metadata.index.column.stats.enable = false")
 
       checkAnswer(
         s"""call run_bootstrap(
@@ -254,6 +261,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
            |bootstrap_overwrite => true)""".stripMargin) {
         Seq(0)
       }
+      spark.sessionState.conf.unsetConf("unset hoodie.metadata.index.column.stats.enable")
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
@@ -56,14 +56,14 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(4) {
+      assertResult(5) {
         commits.length
       }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(3) {
+      assertResult(2) {
         archivedCommits.length
       }
     }
@@ -106,14 +106,14 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(4) {
+      assertResult(5) {
         commits.length
       }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits_metadata(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(3) {
+      assertResult(2) {
         archivedCommits.length
       }
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -136,6 +136,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.io.storage.HoodieSparkIOFactory.getHoodieSparkIOFactory;
 import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBasePath;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.META_COL_SET_TO_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getLocationFromRecordIndexInfo;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getLogFileColumnRangeMetadata;
 
@@ -1106,7 +1107,9 @@ public class HoodieMetadataTableValidator implements Serializable {
                                       HoodieTableMetaClient metaClient) {
     Collection<HoodieIndexDefinition> indexDefinitions = metaClient.getIndexMetadata().get().getIndexDefinitions().values();
     for (HoodieIndexDefinition indexDefinition : indexDefinitions) {
-      validateSecondaryIndex(engineContext, metadataContext, metaClient, indexDefinition);
+      if (indexDefinition.getIndexType().equals(PARTITION_NAME_SECONDARY_INDEX)) {
+        validateSecondaryIndex(engineContext, metadataContext, metaClient, indexDefinition);
+      }
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -133,8 +133,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   @Test
   public void testIndexerWithNotAllIndexesEnabled() {
     String tableName = "indexer_test";
-    // enable files and bloom_filters on the regular write client
-    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true);
+    // enable files and bloom_filters only w/ the regular write client
+    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true).withMetadataIndexColumnStats(false);
     upsertToTable(metadataConfigBuilder.build(), tableName);
 
     // validate table config
@@ -148,7 +148,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   @Test
   public void testIndexerWithFilesPartition() {
     String tableName = "indexer_test";
-    // enable files and bloom_filters on the regular write client
+    // enable files and bloom_filters only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(false, false).withMetadataIndexBloomFilter(true);
     upsertToTable(metadataConfigBuilder.build(), tableName);
 
@@ -165,8 +165,10 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   @Test
   public void testIndexerForRecordIndex() {
     String tableName = "indexer_test";
-    // enable files and bloom_filters on the regular write client
-    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false);
+    // enable files and bloom_filters only with the regular write client
+    HoodieMetadataConfig.Builder metadataConfigBuilder = HoodieMetadataConfig.newBuilder()
+        .enable(true)
+        .withAsyncIndex(false).withMetadataIndexColumnStats(false);
     upsertToTable(metadataConfigBuilder.build(), tableName);
 
     // validate table config
@@ -183,9 +185,9 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // is inflight, while the regular writer is updating metadata table.
     // The delta commit from the indexer should not be rolled back.
     String tableName = "indexer_with_writer_finishing_first";
-    // Enable files and bloom_filters on the regular write client
+    // Enable files and bloom_filters only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder =
-        getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true);
+        getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true).withMetadataIndexColumnStats(false);
     HoodieMetadataConfig metadataConfig = metadataConfigBuilder.build();
     upsertToTable(metadataConfig, tableName);
 
@@ -256,9 +258,9 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // finishes the original delta commit.  In this case, the async indexer should not
     // trigger the rollback on other inflight writes in the metadata table.
     String tableName = "indexer_with_writer_finishing_first";
-    // Enable files and bloom_filters on the regular write client
+    // Enable files and bloom_filters only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder =
-        getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true);
+        getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true).withMetadataIndexColumnStats(false);
     HoodieMetadataConfig metadataConfig = metadataConfigBuilder.build();
     upsertToTable(metadataConfig, tableName);
     upsertToTable(metadataConfig, tableName);
@@ -324,7 +326,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   public void testColStatsFileGroupCount(int colStatsFileGroupCount) {
     TestHoodieIndexer.colStatsFileGroupCount = colStatsFileGroupCount;
     String tableName = "indexer_test";
-    // enable files and bloom_filters on the regular write client
+    // enable files and bloom_filters only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(false, false).withMetadataIndexBloomFilter(true);
     upsertToTable(metadataConfigBuilder.build(), tableName);
 
@@ -352,7 +354,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   @Test
   public void testIndexerForExceptionWithNonFilesPartition() {
     String tableName = "indexer_test";
-    // enable files and bloom_filters on the regular write client
+    // enable files and bloom_filters only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(false, false);
     upsertToTable(metadataConfigBuilder.build(), tableName);
     // validate table config
@@ -447,8 +449,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   public void testIndexerDropPartitionDeletesInstantFromTimeline() {
     String tableName = "indexer_test";
     HoodieWriteConfig.Builder writeConfigBuilder = getWriteConfigBuilder(basePath(), tableName);
-    // enable files on the regular write client
-    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true);
+    // enable files only with the regular write client
+    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true).withMetadataIndexColumnStats(false);
     HoodieWriteConfig writeConfig = writeConfigBuilder.withMetadataConfig(metadataConfigBuilder.build()).build();
     // do one upsert with synchronous metadata update
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig)) {
@@ -501,8 +503,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   public void testTwoIndexersOneCreateOneDropPartition() {
     String tableName = "indexer_test";
     HoodieWriteConfig.Builder writeConfigBuilder = getWriteConfigBuilder(basePath(), tableName);
-    // enable files on the regular write client
-    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false);
+    // enable files only with the regular write client
+    HoodieMetadataConfig.Builder metadataConfigBuilder = getMetadataConfigBuilder(true, false).withMetadataIndexColumnStats(false);
     HoodieWriteConfig writeConfig = writeConfigBuilder.withMetadataConfig(metadataConfigBuilder.build()).build();
     // do one upsert with synchronous metadata update
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig)) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -286,9 +286,9 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
             + "location '" + basePath + "'");
 
     Dataset<Row> rows = getRowDataset(1, "row1", "abc", "p1");
-    rows.write().format("hudi").mode(SaveMode.Append).save(basePath);
+    rows.write().mode(SaveMode.Append).save(basePath);
     rows = getRowDataset(2, "row2", "ghi", "p2");
-    rows.write().format("hudi").mode(SaveMode.Append).save(basePath);
+    rows.write().mode(SaveMode.Append).save(basePath);
     rows = getRowDataset(3, "row3", "def", "p2");
     rows.write().format("hudi").mode(SaveMode.Append).save(basePath);
 
@@ -301,6 +301,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     rows.write().format("hudi")
         .option("hoodie.metadata.enable", "true")
         .option("hoodie.metadata.record.index.enable", "true")
+        .option("hoodie.metadata.index.column.stats.enable", "false")
         .mode(SaveMode.Append)
         .save(basePath);
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -490,6 +490,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     cfg.configs.add(String.format("hoodie.datasource.write.keygenerator.class=%s", SimpleKeyGenerator.class.getName()));
     cfg.configs.add("hoodie.datasource.write.hive_style_partitioning=true");
     cfg.configs.add("hoodie.bootstrap.parallelism=5");
+    cfg.configs.add(String.format("%s=false", HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key()));
     cfg.targetBasePath = newDatasetBasePath;
     new HoodieDeltaStreamer(cfg, jsc).sync();
     Dataset<Row> res = sqlContext.read().format("org.apache.hudi").load(newDatasetBasePath);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -25,6 +25,7 @@ import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.TestHoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -155,6 +156,8 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
 
   protected HoodieDeltaStreamer.Config getDeltaStreamerConfig(String[] transformerClasses, boolean nullForDeletedCols,
                                                               TypedProperties extraProps) throws IOException {
+    extraProps.setProperty(HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key(),"false"); // HUDI-8587
+
     extraProps.setProperty("hoodie.datasource.write.table.type", tableType);
     extraProps.setProperty("hoodie.datasource.write.row.writer.enable", rowWriterEnable.toString());
     extraProps.setProperty(DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS().key(), Boolean.toString(nullForDeletedCols));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -506,7 +506,8 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
                 .withScheduleInlineCompaction(true)
                 .withMaxNumDeltaCommitsBeforeCompaction(1)
                 .build())
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMetadataIndexColumnStats(false).build())
+        // if col stats is enabled, col stats based pruning kicks in and changes expected value in this test.
         .build();
     List<WriteResult> inserts = new ArrayList<>();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {


### PR DESCRIPTION
### Change Logs

- Enabling cols stats by default on writer in SPARK engine 
- Added support for timestamp, Date, LocalDate, Decimal. 

Few features/tests where col stats is disabled:
- Bootstrap feature is not yet supported. We need to fix it for whole of metadata table. https://issues.apache.org/jira/browse/HUDI-8774
- Schema evolution w/ partition stats is not yet tackled in this patch. https://issues.apache.org/jira/browse/HUDI-8587
- Some tests w/ test table infra does not support. Bcoz, whole premise w/ test table infra is to just mock the functionality w/ empty files. And so both col stats and partition stats are not supported. 
- https://issues.apache.org/jira/browse/HUDI-8774 (more complex data types) 
- https://issues.apache.org/jira/browse/HUDI-8814 Enabling col stats and partition stats by default in flink and java. 

### Impact

Enabling col stats by default on the writer will improve query performance. 

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
