### PR TITLE
[HUDI-8841] Fix schema validating exception during flink async cluste…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -598,24 +598,22 @@ public class AvroSchemaUtils {
   }
 
   /**
-   * Create a new schema by change the nullabilities of the given columns.
+   * Create a new schema by force changing the nullabilities of the given columns.
    *
    * @param schema original schema
-   * @param nullableUpdateCols columns that would be updated with given nullability
-   * @param nullable nullability of column type
+   * @param columns columns that would be updated with given nullability
    * @return a new schema with the nullabilities of the given columns updated
    */
-  public static Schema forceNullableColumns(
-          Schema schema, List<String> nullableUpdateCols, boolean nullable) {
-    List<String> filterCols = nullableUpdateCols.stream()
-            .filter(col -> schema.getField(col).schema().isNullable() != nullable).collect(Collectors.toList());
+  public static Schema forceNullableColumns(Schema schema, List<String> columns) {
+    List<String> filterCols = columns.stream()
+            .filter(col -> !schema.getField(col).schema().isNullable()).collect(Collectors.toList());
     if (filterCols.isEmpty()) {
       return schema;
     }
     InternalSchema internalSchema = convert(schema);
     TableChanges.ColumnUpdateChange schemaChange = TableChanges.ColumnUpdateChange.get(internalSchema);
     schemaChange = reduce(filterCols, schemaChange,
-            (change, field) -> change.updateColumnNullability(field, nullable));
+            (change, field) -> change.updateColumnNullability(field, true));
     return convert(SchemaChangeUtils.applyTableChanges2Schema(internalSchema, schemaChange), schema.getFullName());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -28,6 +28,9 @@ import org.apache.hudi.exception.SchemaCompatibilityException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.action.TableChanges;
+import org.apache.hudi.internal.schema.utils.SchemaChangeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +45,9 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.CollectionUtils.reduce;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter.convert;
 
 /**
  * Utils for Avro Schema.
@@ -590,5 +595,25 @@ public class AvroSchemaUtils {
 
   public static String createSchemaErrorString(String errorMessage, Schema writerSchema, Schema tableSchema) {
     return String.format("%s\nwriterSchema: %s\ntableSchema: %s", errorMessage, writerSchema, tableSchema);
+  }
+
+  /**
+   * Create a new schema by change the nullabilities of the given columns.
+   *
+   * @param schema original schema
+   * @param nullableUpdateCols columns that would be updated with given nullability
+   * @param nullable nullability of column type
+   * @return a new schema with the nullabilities of the given columns updated
+   */
+  public static Schema createSchemaWithNullabilityUpdate(
+          Schema schema, List<String> nullableUpdateCols, boolean nullable) {
+    if (nullableUpdateCols.isEmpty()) {
+      return schema;
+    }
+    InternalSchema internalSchema = convert(schema);
+    TableChanges.ColumnUpdateChange schemaChange = TableChanges.ColumnUpdateChange.get(internalSchema);
+    schemaChange = reduce(nullableUpdateCols, schemaChange,
+            (change, field) -> change.updateColumnNullability(field, nullable));
+    return convert(SchemaChangeUtils.applyTableChanges2Schema(internalSchema, schemaChange), schema.getFullName());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -598,15 +598,14 @@ public class AvroSchemaUtils {
   }
 
   /**
-   * Create a new schema by force changing the nullabilities of the given columns.
+   * Create a new schema by force changing all the fields as nullable.
    *
    * @param schema original schema
-   * @param columns columns that would be updated with given nullability
-   * @return a new schema with the nullabilities of the given columns updated
+   * @return a new schema with all the fields updated as nullable.
    */
-  public static Schema forceNullableColumns(Schema schema, List<String> columns) {
-    List<String> filterCols = columns.stream()
-            .filter(col -> !schema.getField(col).schema().isNullable()).collect(Collectors.toList());
+  public static Schema asNullable(Schema schema) {
+    List<String> filterCols = schema.getFields().stream()
+            .filter(f -> !f.schema().isNullable()).map(Schema.Field::name).collect(Collectors.toList());
     if (filterCols.isEmpty()) {
       return schema;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
@@ -214,5 +214,46 @@ public class AvroSchemaEvolutionUtils {
 
     return convert(SchemaChangeUtils.applyTableChanges2Schema(sourceInternalSchema, schemaChange), sourceSchema.getFullName());
   }
+
+  /**
+   * Reconciles nullability requirement b/w {@code source} and {@code target} schemas.
+   * For example,if colA in source is non-nullable, but is nullable in target, output schema will have colA as nullable.
+   *
+   * @param sourceSchema source schema that needs reconciliation
+   * @param targetSchema target schema that source schema will be reconciled against
+   * @return schema (based off {@code source} one) that has nullability constraints reconciled
+   */
+  public static Schema reconcileSchemaWithNullability(Schema sourceSchema, Schema targetSchema) {
+    if (targetSchema.getType() == Schema.Type.NULL || targetSchema.getFields().isEmpty()) {
+      return sourceSchema;
+    }
+    if (sourceSchema == null || sourceSchema.getType() == Schema.Type.NULL || sourceSchema.getFields().isEmpty()) {
+      return targetSchema;
+    }
+    InternalSchema targetInternalSchema = convert(targetSchema);
+    // Use existing fieldIds for consistent field ordering between commits when shouldReorderColumns is true
+    InternalSchema sourceInternalSchema = convert(sourceSchema, Collections.emptyMap());
+
+    List<String> colNamesSourceSchema = sourceInternalSchema.getAllColsFullName();
+    List<String> colNamesTargetSchema = targetInternalSchema.getAllColsFullName();
+
+    List<String> nullableUpdateColsInSource = new ArrayList<>();
+    colNamesSourceSchema.forEach(field -> {
+      // handle columns that needs to be made nullable
+      if (colNamesTargetSchema.contains(field) && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional()) {
+        nullableUpdateColsInSource.add(field);
+      }
+    });
+
+    if (nullableUpdateColsInSource.isEmpty()) {
+      //standardize order of unions
+      return convert(sourceInternalSchema, sourceSchema.getFullName());
+    }
+
+    TableChanges.ColumnUpdateChange schemaChange = TableChanges.ColumnUpdateChange.get(sourceInternalSchema);
+    schemaChange = reduce(nullableUpdateColsInSource, schemaChange,
+        (change, field) -> change.updateColumnNullability(field, true));
+    return convert(SchemaChangeUtils.applyTableChanges2Schema(sourceInternalSchema, schemaChange), sourceSchema.getFullName());
+  }
 }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -361,7 +361,7 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     if (recordKeyOp.isEmpty() || Arrays.stream(recordKeyOp.get()).anyMatch(s -> !fieldNames.contains(s))) {
       return schema;
     }
-    return AvroSchemaUtils.forceNullableColumns(schema, Arrays.asList(recordKeyOp.get()), true);
+    return AvroSchemaUtils.forceNullableColumns(schema, Arrays.asList(recordKeyOp.get()));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -20,17 +20,16 @@ package org.apache.hudi.sink.clustering;
 
 import org.apache.hudi.adapter.MaskingOutputAdapter;
 import org.apache.hudi.adapter.Utils;
+import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.utils.ConcatenatingIterator;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.ClusteringOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.HoodieFileSliceReader;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -43,8 +42,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieClusteringException;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.exception.SchemaCompatibilityException;
-import org.apache.hudi.internal.schema.utils.AvroSchemaEvolutionUtils;
 import org.apache.hudi.io.IOUtils;
 import org.apache.hudi.io.storage.HoodieAvroFileReader;
 import org.apache.hudi.io.storage.HoodieFileReader;
@@ -93,6 +90,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -288,7 +286,7 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
             .withStorage(table.getStorage())
             .withBasePath(table.getMetaClient().getBasePath())
             .withLogFilePaths(clusteringOp.getDeltaFilePaths())
-            .withReaderSchema(reconcileSchemaWithNullability(clusteringOp))
+            .withReaderSchema(reconcileSchemaWithRecordKeyNullability(readerSchema))
             .withLatestInstantTime(instantTime)
             .withMaxMemorySizeInBytes(maxMemoryPerCompaction)
             .withReverseReader(writeConfig.getCompactionReverseLogReadEnabled())
@@ -330,7 +328,7 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     List<Iterator<RowData>> iteratorsForPartition = clusteringOps.stream().map(clusteringOp -> {
       Iterable<IndexedRecord> indexedRecords = () -> {
         try {
-          Schema reconciledSchema = reconcileSchemaWithNullability(clusteringOp);
+          Schema reconciledSchema = reconcileSchemaWithRecordKeyNullability(readerSchema);
           HoodieFileReaderFactory fileReaderFactory = HoodieIOFactory.getIOFactory(table.getStorage())
               .getReaderFactory(table.getConfig().getRecordMerger().getRecordType());
           HoodieAvroFileReader fileReader = (HoodieAvroFileReader) fileReaderFactory.getFileReader(
@@ -351,23 +349,18 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
 
   /**
    * Since there exists discrepancies between flink and spark dealing with nullability of primary key field,
-   * and there may be some files written by spark, we reconcile read schema against write schema to promote
-   * the nullability, so that schema validating would not fail.
+   * and there may be some files written by spark, we force update the nullability of record key to nullable,
+   * so that schema validating would not fail.
    *
-   * @param clusteringOperation the cluster operation
+   * @param schema the original schema to be updated
    * @return schema that has nullability constraints reconciled
    */
-  private Schema reconcileSchemaWithNullability(ClusteringOperation clusteringOperation) {
-    String instantTs = StringUtils.isNullOrEmpty(clusteringOperation.getDataFilePath())
-        ? FSUtils.getCommitTime(clusteringOperation.getDeltaFilePaths().get(0))
-        : FSUtils.getCommitTime(clusteringOperation.getDataFilePath());
-    try {
-      TableSchemaResolver schemaResolver = new TableSchemaResolver(table.getMetaClient());
-      Schema writeSchema = schemaResolver.getTableAvroSchema(instantTs);
-      return AvroSchemaEvolutionUtils.reconcileSchemaWithNullability(readerSchema, writeSchema);
-    } catch (Exception e) {
-      throw new SchemaCompatibilityException("Failed to read schema for given instant: " + instantTs, e);
+  private Schema reconcileSchemaWithRecordKeyNullability(Schema schema) {
+    Option<String[]> recordKeyOp = table.getMetaClient().getTableConfig().getRecordKeyFields();
+    if (recordKeyOp.isEmpty()) {
+      return schema;
     }
+    return AvroSchemaUtils.createSchemaWithNullabilityUpdate(schema, Arrays.asList(recordKeyOp.get()), true);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
@@ -533,6 +533,79 @@ public class ITTestHoodieFlinkClustering {
     // wait for the asynchronous commit to finish
     TimeUnit.SECONDS.sleep(3);
 
+    runCluster(rowType);
+
+    // test output
+    final Map<String, String> expected = new HashMap<>();
+    expected.put("par1", "[id1,par1,id1,Danny,23,1100001,par1, id2,par1,id2,Stephen,33,2100001,par1]");
+    expected.put("par2", "[id3,par2,id3,Julian,53,3100001,par2, id4,par2,id4,Fabian,31,4100001,par2]");
+    expected.put("par3", "[id5,par3,id5,Sophia,18,5100001,par3, id6,par3,id6,Emma,20,6100001,par3]");
+    expected.put("par4", "[id7,par4,id7,Bob,44,7100001,par4, id8,par4,id8,Han,56,8100001,par4]");
+    TestData.checkWrittenData(tempFile, expected, 4);
+  }
+
+  @Test
+  public void testInsertWithDifferentRecordKeyNullabilityAndClustering() throws Exception {
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+    TableEnvironment tableEnv = TableEnvironmentImpl.create(settings);
+    tableEnv.getConfig().getConfiguration()
+        .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
+
+    // create a table without primary key defined, so that the nullability of the record key field
+    // would be nullable.
+    String tblWithoutPkDDL = "create table t1(\n"
+        + "  `uuid` VARCHAR(20)\n"
+        + ",  `name` VARCHAR(10)\n"
+        + ",  `age` INT\n"
+        + ",  `ts` TIMESTAMP(3)\n"
+        + ",  `partition` VARCHAR(10)\n"
+        + ")\n"
+        + "PARTITIONED BY (`partition`)\n"
+        + "with (\n"
+        + "  'connector' = 'hudi',\n"
+        + "  'hoodie.datasource.write.recordkey.field' = 'uuid',\n"
+        + "  'path' = '" + tempFile.getAbsolutePath() + "'\n"
+        + ")";
+    tableEnv.executeSql(tblWithoutPkDDL);
+    tableEnv.executeSql(TestSQL.INSERT_T1).await();
+
+    final RowType rowType = (RowType) DataTypes.ROW(
+            DataTypes.FIELD("uuid", DataTypes.VARCHAR(20).notNull()), // primary key set as not null
+            DataTypes.FIELD("name", DataTypes.VARCHAR(10)),
+            DataTypes.FIELD("age", DataTypes.INT()),
+            DataTypes.FIELD("ts", DataTypes.TIMESTAMP(3)),
+            DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
+        .notNull().getLogicalType();
+
+    // run cluster with row type
+    runCluster(rowType);
+
+    final Map<String, String> expected = new HashMap<>();
+    expected.put("par1", "[id1,par1,id1,Danny,23,1000,par1, id2,par1,id2,Stephen,33,2000,par1]");
+    expected.put("par2", "[id3,par2,id3,Julian,53,3000,par2, id4,par2,id4,Fabian,31,4000,par2]");
+    expected.put("par3", "[id5,par3,id5,Sophia,18,5000,par3, id6,par3,id6,Emma,20,6000,par3]");
+    expected.put("par4", "[id7,par4,id7,Bob,44,7000,par4, id8,par4,id8,Han,56,8000,par4]");
+    TestData.checkWrittenData(tempFile, expected, 4);
+  }
+
+  @Test
+  public void testOfflineClusterFailoverAfterCommit() throws Exception {
+    StreamTableEnvironment tableEnv = prepareEnvAndTable();
+
+    FlinkClusteringConfig cfg = new FlinkClusteringConfig();
+    cfg.path = tempFile.getAbsolutePath();
+    cfg.targetPartitions = 4;
+    Configuration conf = FlinkClusteringConfig.toFlinkConfig(cfg);
+    assertDoesNotThrow(() -> runOfflineCluster(tableEnv, conf));
+
+    Table result = tableEnv.sqlQuery("select count(*) from t1");
+    assertEquals(16L, tableEnv.toDataStream(result, Row.class).executeAndCollect(1).get(0).getField(0));
+  }
+
+  /**
+   * schedule clustering, run clustering.
+   */
+  private void runCluster(RowType rowType) throws Exception {
     // make configuration and setAvroSchema.
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     FlinkClusteringConfig cfg = new FlinkClusteringConfig();
@@ -604,29 +677,7 @@ public class ITTestHoodieFlinkClustering {
           .setParallelism(1);
 
       env.execute("flink_hudi_clustering");
-
-      // test output
-      final Map<String, String> expected = new HashMap<>();
-      expected.put("par1", "[id1,par1,id1,Danny,23,1100001,par1, id2,par1,id2,Stephen,33,2100001,par1]");
-      expected.put("par2", "[id3,par2,id3,Julian,53,3100001,par2, id4,par2,id4,Fabian,31,4100001,par2]");
-      expected.put("par3", "[id5,par3,id5,Sophia,18,5100001,par3, id6,par3,id6,Emma,20,6100001,par3]");
-      expected.put("par4", "[id7,par4,id7,Bob,44,7100001,par4, id8,par4,id8,Han,56,8100001,par4]");
-      TestData.checkWrittenData(tempFile, expected, 4);
     }
-  }
-
-  @Test
-  public void testOfflineClusterFailoverAfterCommit() throws Exception {
-    StreamTableEnvironment tableEnv = prepareEnvAndTable();
-
-    FlinkClusteringConfig cfg = new FlinkClusteringConfig();
-    cfg.path = tempFile.getAbsolutePath();
-    cfg.targetPartitions = 4;
-    Configuration conf = FlinkClusteringConfig.toFlinkConfig(cfg);
-    assertDoesNotThrow(() -> runOfflineCluster(tableEnv, conf));
-
-    Table result = tableEnv.sqlQuery("select count(*) from t1");
-    assertEquals(16L, tableEnv.toDataStream(result, Row.class).executeAndCollect(1).get(0).getField(0));
   }
 
   private StreamTableEnvironment prepareEnvAndTable() {


### PR DESCRIPTION
…ring

### Change Logs

In Flink SQL, primary key constraint can be defined, and the type of pk field become non-null，while spark has no primary key constraint, so they have discrepancies in the schema of the underlying files, e.g., parquet.

we can make a schema reconciliation during the async clustering reading.

### Impact

Consolidating flink clustering by reconcile schemas to tolerate different nullabilities  of record key.

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
