### PR TITLE
[HUDI-8817] fix backward compatibility issue

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -49,7 +49,7 @@ import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, T
 import org.apache.hudi.common.util.ConfigUtils.getAllConfigKeys
 import org.apache.hudi.common.util.{CommitUtils, StringUtils, Option => HOption}
 import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME}
-import org.apache.hudi.config.HoodieWriteConfig.{SPARK_SQL_MERGE_INTO_PREPPED_KEY, WRITE_TABLE_VERSION}
+import org.apache.hudi.config.HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieInternalConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.{HoodieException, HoodieRecordCreationException, HoodieWriteConflictException}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -66,6 +66,7 @@ import org.apache.hudi.storage.HoodieStorage
 import org.apache.hudi.sync.common.HoodieSyncConfig
 import org.apache.hudi.sync.common.util.SyncUtilHelpers
 import org.apache.hudi.sync.common.util.SyncUtilHelpers.getHoodieMetaSyncException
+import org.apache.hudi.util.SparkConfigUtils.getStringWithAltKeys
 import org.apache.hudi.util.SparkKeyGenUtils
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.sql.HoodieDataTypeUtils.tryOverrideParquetWriteLegacyFormatProperty
@@ -302,6 +303,7 @@ class HoodieSparkSqlWriterInternal {
           else KeyGeneratorType.getKeyGeneratorClassName(hoodieConfig)
         HoodieTableMetaClient.newTableBuilder()
           .setTableType(tableType)
+          .setTableVersion(Integer.valueOf(getStringWithAltKeys(parameters, HoodieWriteConfig.WRITE_TABLE_VERSION)))
           .setDatabaseName(databaseName)
           .setTableName(tblName)
           .setBaseFileFormat(baseFileFormat)
@@ -748,7 +750,7 @@ class HoodieSparkSqlWriterInternal {
           .setTableType(HoodieTableType.valueOf(tableType))
           .setTableName(tableName)
           .setRecordKeyFields(recordKeyFields)
-          .setTableVersion(hoodieConfig.getIntOrDefault(WRITE_TABLE_VERSION))
+          .setTableVersion(Integer.valueOf(getStringWithAltKeys(parameters, HoodieWriteConfig.WRITE_TABLE_VERSION)))
           .setArchiveLogFolder(archiveLogFolder)
           .setPayloadClassName(payloadClass)
           .setRecordMergeMode(RecordMergeMode.getValue(hoodieConfig.getString(HoodieWriteConfig.RECORD_MERGE_MODE)))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/SparkConfigUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/SparkConfigUtils.scala
@@ -28,11 +28,11 @@ object SparkConfigUtils {
    * the alternate config keys for the specified key as well.
    *
    * @param props          Configs in scala map
-   * @param configProperty {@link ConfigProperty} config of String type to fetch.
+   * @param configProperty {@link ConfigProperty} config of type T to fetch.
    * @return String value if the config exists; default String value if the config does not exist
    *         and there is default value defined in the {@link ConfigProperty} config; {@code null} otherwise.
    */
-  def getStringWithAltKeys(props: Map[String, String], configProperty: ConfigProperty[String]): String = {
+  def getStringWithAltKeys[T](props: Map[String, String], configProperty: ConfigProperty[T]): String = {
     ConfigUtils.getStringWithAltKeys(JFunction.toJavaFunction[String, Object](key => props.getOrElse(key, null)), configProperty)
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -28,12 +28,13 @@ import org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING
 import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
+import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.constant.{KeyGeneratorOptions, KeyGeneratorType}
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
 import org.apache.hudi.storage.HoodieStorageUtils
 import org.apache.hudi.util.SparkConfigUtils
-
+import org.apache.hudi.util.SparkConfigUtils.getStringWithAltKeys
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.avro.SchemaConverters
@@ -225,6 +226,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
 
       HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
+        .setTableVersion(Integer.valueOf(getStringWithAltKeys(tableConfigs, HoodieWriteConfig.WRITE_TABLE_VERSION)))
         .setDatabaseName(catalogDatabaseName)
         .setTableName(table.identifier.table)
         .setTableCreateSchema(schema.toString())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestWriteTableVersionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestWriteTableVersionConfig.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.apache.hudi.common.table.HoodieTableConfig.VERSION
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+
+class TestWriteTableVersionConfig extends HoodieSparkSqlTestBase {
+
+  test("Test create table with various write version") {
+    Seq(6, 8).foreach { tableVersion =>
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val basePath = tmp.getCanonicalPath
+        spark.sql(
+          s"""
+             | create table $tableName (
+             |  id int,
+             |  ts long,
+             |  dt string
+             | ) using hudi
+             | tblproperties (
+             |  type = 'mor',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts',
+             |  hoodie.write.table.version = $tableVersion
+             | )
+             | partitioned by(dt)
+             | location '$basePath'
+         """.stripMargin)
+        val metaClient = HoodieTableMetaClient.builder().setBasePath(basePath)
+          .setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf())).build()
+        assertEquals(metaClient.getTableConfig.getTableVersion.versionCode(), tableVersion)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs
There are 3 configs at interplay:

table config `hoodie.table.version` - can be 6 or 8
writer config `hoodie.write.table.version` - can be 6 or 8
writer config `hoodie.write.auto.upgrade` - boolean flag to control transition during upgrade, avoiding unintended upgrades.
`hoodie.table.version` reflects the **actual state** of the table.
`hoodie.write.table.version` defines the **intended state** of data written by the writer.

During upgrade, the initial phase for writers should be configured with `hoodie.write.auto.upgrade=false` and `hoodie.write.table.version=6 `until when users are ready to start writing in the new format (i.e. after all readers have been upgraded).

For creating new tables using 1.0, by default i.e. when none of the writer configs are set, hoodie.table.version should be 8. `hoodie.write.table.version` is automatically inferred to be 8.

With my change that explicitly set the write version, when user does not override the config, the version would be 8 automatically.

For creating new tables using 1.0, if there is a need to create one with older format, then writers should be configured with `hoodie.write.auto.upgrade=false` and `hoodie.write.table.version=6`. In this case, hoodie.table.version should also be 6.

It means in hudi 1.0, if a user wants to create version 6 table, they would set the config above and the system should honor that configuration in metaClient.initTable. This is why this change enforces when metaClient is created, we set the table version to write version. This is what is missing without the change


when we specify write table version as 6
```
CREATE TABLE hudi_14_table_sql_005 (
    event_id INT,
    event_date STRING,
    event_name STRING,
    event_ts STRING,
    event_type STRING
) USING hudi
 OPTIONS(
    type = 'cow', -- or 'mor'
    primaryKey = 'event_id,event_date',
    preCombileField = 'event_ts',
    hoodie.write.table.version = 6
)
PARTITIONED BY (event_type)
LOCATION 's3://<some_bucket>/hudi_14_table_sql_005';
```
the hoodie.properties said the version is 8.

It is because when building the meta client table version is not set according to the write table version. Found similar misses else where, fixed as well with test coverage.

### Impact

hoodie.write.table.version will also contribute to hoodie.table.version.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
