### PR TITLE
[HUDI-8857] Log shortened list of files instead of all files in MDT validator to avoid huge log message

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -367,6 +368,52 @@ public class StringUtils {
 
     // Concatenate the valid substring of 'a' with 'b'
     return a.substring(0, bestLength) + b;
+  }
+
+  /**
+   * Concatenates the string representation of each object in the list
+   * and returns a single string. The result is capped at "lengthThreshold" characters.
+   *
+   * @param objectList      object list
+   * @param lengthThreshold number of characters to cap the string
+   * @return capped string representation of the object list
+   * @param <T> type of the object
+   */
+  public static <T> String toStringWithThreshold(List<T> objectList, int lengthThreshold) {
+    if (objectList == null || objectList.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+
+    for (Object obj : objectList) {
+      if (sb.length() >= lengthThreshold) {
+        setLastThreeDots(sb);
+        break;
+      }
+
+      String objString = (sb.length() > 0 ? "," : "") + obj;
+
+      // Check if appending this string would exceed the limit
+      if (sb.length() + objString.length() > lengthThreshold) {
+        int remaining = lengthThreshold - sb.length();
+        sb.append(objString, 0, remaining);
+        setLastThreeDots(sb);
+        break;
+      } else {
+        sb.append(objString);
+      }
+    }
+
+    return sb.toString();
+  }
+
+  private static void setLastThreeDots(StringBuilder sb) {
+    IntStream.range(1, 4).forEach(i -> {
+      int loc = sb.length() - i;
+      if (loc >= 0) {
+        sb.setCharAt(loc, '.');
+      }
+    });
   }
 
   private static int getBestLength(String a, int threshold) {

--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -28,11 +28,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
 import static org.apache.hudi.common.util.StringUtils.concatenateWithThreshold;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.toStringWithThreshold;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,7 +60,7 @@ public class TestStringUtils {
     return sb.toString();
   }
 
-  private static String generateRandomString(int length) {
+  public static String generateRandomString(int length) {
     if (length < 1) {
       throw new IllegalArgumentException("Length must be greater than 0");
     }
@@ -216,6 +218,41 @@ public class TestStringUtils {
         IllegalArgumentException.class,
         () -> generateRandomString(-1)
     );
+  }
+
+  @Test
+  void testToStringWithThreshold() {
+    String str1 = "string_value1";
+    String str2 = "string_value2";
+    String str3 = "string_value3";
+    assertEquals("",
+        toStringWithThreshold(null, 10));
+    assertEquals("",
+        toStringWithThreshold(Collections.emptyList(), 10));
+    assertEquals("..",
+        toStringWithThreshold(Collections.singletonList(str1), 2));
+    assertEquals("string_...",
+        toStringWithThreshold(Collections.singletonList(str1), str1.length() - 3));
+    assertEquals(str1,
+        toStringWithThreshold(Collections.singletonList(str1), str1.length()));
+    assertEquals(str1,
+        toStringWithThreshold(Collections.singletonList(str1), str1.length() + 10));
+    List<String> stringList = new ArrayList<>();
+    stringList.add(str1);
+    stringList.add(str2);
+    stringList.add(str3);
+    assertEquals("string_val...",
+        toStringWithThreshold(stringList, str1.length()));
+    assertEquals("string_valu...",
+        toStringWithThreshold(stringList, str1.length() + 1));
+    assertEquals("string_value1,string...",
+        toStringWithThreshold(stringList, str1.length() + str2.length() - 3));
+    assertEquals("string_value1,string_v...",
+        toStringWithThreshold(stringList, str1.length() + str2.length() - 1));
+    assertEquals("string_value1,string_value2,strin...",
+        toStringWithThreshold(stringList, str1.length() + str2.length() + str3.length() - 3));
+    assertEquals("string_value1,string_value2,string_value3",
+        toStringWithThreshold(stringList, str1.length() + str2.length() + str3.length() + 2));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.sql.hudi.analysis
 
-import org.apache.hudi.common.util.ReflectionUtils.loadClass
-import org.apache.hudi.common.util.{ReflectionUtils, ValidationUtils}
 import org.apache.hudi.{HoodieSchemaUtils, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.hudi.common.util.{ReflectionUtils, ValidationUtils}
+import org.apache.hudi.common.util.ReflectionUtils.loadClass
 
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable}
@@ -31,10 +32,9 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{CreateTable, LogicalRelation}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isMetaField, removeMetaFields}
-import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.{MatchCreateIndex, MatchCreateTableLike, MatchDropIndex, MatchInsertIntoStatement, MatchMergeIntoTable, MatchRefreshIndex, MatchShowIndexes, ResolvesToHudiTable, sparkAdapter}
+import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.{sparkAdapter, MatchCreateIndex, MatchCreateTableLike, MatchDropIndex, MatchInsertIntoStatement, MatchMergeIntoTable, MatchRefreshIndex, MatchShowIndexes, ResolvesToHudiTable}
 import org.apache.spark.sql.hudi.command._
 import org.apache.spark.sql.hudi.command.procedures.{HoodieProcedures, Procedure, ProcedureArgs}
-import org.apache.spark.sql.{AnalysisException, SparkSession}
 
 import java.util
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -133,6 +133,7 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_TH
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.common.util.StringUtils.toStringWithThreshold;
 import static org.apache.hudi.io.storage.HoodieSparkIOFactory.getHoodieSparkIOFactory;
 import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBasePath;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.META_COL_SET_TO_INDEX;
@@ -199,6 +200,7 @@ public class HoodieMetadataTableValidator implements Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMetadataTableValidator.class);
+  static final int LOG_DETAIL_MAX_LENGTH = 100_000;
 
   // Spark context
   private transient JavaSparkContext jsc;
@@ -491,10 +493,10 @@ public class HoodieMetadataTableValidator implements Serializable {
       HoodieMetadataTableValidator validator = new HoodieMetadataTableValidator(jsc, cfg);
       validator.run();
     } catch (TableNotFoundException e) {
-      LOG.warn(String.format("The Hudi data table is not found: [%s]. "
-          + "Skipping the validation of the metadata table.", cfg.basePath), e);
+      LOG.warn("The Hudi data table is not found: [{}]. "
+          + "Skipping the validation of the metadata table.", cfg.basePath, e);
     } catch (Throwable throwable) {
-      LOG.error("Fail to do hoodie metadata table validation for " + cfg, throwable);
+      LOG.error("Fail to do hoodie metadata table validation for {}", cfg, throwable);
     } finally {
       jsc.stop();
     }
@@ -546,7 +548,7 @@ public class HoodieMetadataTableValidator implements Serializable {
       try {
         service.waitForShutdown();
       } catch (Exception e) {
-        throw new HoodieException(e.getMessage(), e);
+        throw new HoodieException(e);
       }
     });
   }
@@ -607,13 +609,12 @@ public class HoodieMetadataTableValidator implements Serializable {
               LOG.info("Metadata table validation succeeded for partition {} (partition {})", partitionPath, taskLabels);
               return Pair.<Boolean, Exception>of(true, null);
             } catch (HoodieValidationException e) {
-              LOG.error(
-                  String.format("Metadata table validation failed for partition %s due to HoodieValidationException (partition %s)",
-                      partitionPath, taskLabels), e);
+              LOG.error("Metadata table validation failed for partition {} due to HoodieValidationException (partition {})",
+                  partitionPath, taskLabels, e);
               if (!cfg.ignoreFailed) {
                 throw e;
               }
-              return Pair.of(false, new HoodieValidationException(e.getMessage() + " for partition: " + partitionPath, e));
+              return Pair.of(false, new HoodieValidationException("Validation failed for partition: " + partitionPath, e));
             }
           }).collectAsList());
 
@@ -645,7 +646,7 @@ public class HoodieMetadataTableValidator implements Serializable {
       for (Pair<Boolean, ? extends Exception> res : result) {
         finalResult &= res.getKey();
         if (res.getKey().equals(false)) {
-          LOG.error("Metadata Validation failed for table: " + cfg.basePath + " with error: " + res.getValue());
+          LOG.error("Metadata Validation failed for table: {} with error: {}", cfg.basePath, res.getValue());
           if (res.getRight() != null) {
             throwables.add(res.getRight());
           }
@@ -675,7 +676,7 @@ public class HoodieMetadataTableValidator implements Serializable {
   }
 
   private void handleValidationException(HoodieValidationException e, List<Pair<Boolean, ? extends Exception>> result, String errorMsg) {
-    LOG.error(errorMsg + " for table: {} ", cfg.basePath, e);
+    LOG.error("{} for table: {} ", errorMsg, cfg.basePath, e);
     if (!cfg.ignoreFailed) {
       throw e;
     }
@@ -748,8 +749,8 @@ public class HoodieMetadataTableValidator implements Serializable {
                 Option<HoodieInstant> lastInstant = completedTimeline.lastInstant();
                 if (lastInstant.isPresent()
                     && InstantComparison.compareTimestamps(partitionCreationTimeOpt.get(), GREATER_THAN, lastInstant.get().requestedTime())) {
-                  LOG.warn("Ignoring additional partition " + partitionFromMDT + ", as it was deduced to be part of a "
-                      + "latest completed commit which was inflight when FS based listing was polled.");
+                  LOG.warn("Ignoring additional partition {}, as it was deduced to be part of a "
+                      + "latest completed commit which was inflight when FS based listing was polled.", partitionFromMDT);
                   actualAdditionalPartitionsInMDT.remove(partitionFromMDT);
                 }
               }
@@ -764,9 +765,14 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
       }
       if (misMatch.get()) {
-        String message = "Compare Partitions Failed! " + " Additional partitions from FS, but missing from MDT : \"" + additionalFromFS
-            + "\" and additional partitions from MDT, but missing from FS listing : \"" + actualAdditionalPartitionsInMDT
-            + "\".\n All partitions from FS listing " + allPartitionPathsFromFS;
+        String message = "Compare Partitions Failed! " + " Additional "
+            + additionalFromFS.size() + " partitions from FS, but missing from MDT : \""
+            + toStringWithThreshold(additionalFromFS, LOG_DETAIL_MAX_LENGTH)
+            + "\" and additional " + actualAdditionalPartitionsInMDT.size()
+            + "partitions from MDT, but missing from FS listing : \""
+            + toStringWithThreshold(actualAdditionalPartitionsInMDT, LOG_DETAIL_MAX_LENGTH)
+            + "\".\n All " + allPartitionPathsFromFS.size() + " partitions from FS listing "
+            + toStringWithThreshold(allPartitionPathsFromFS, LOG_DETAIL_MAX_LENGTH);
         LOG.error(message);
         throw new HoodieValidationException(message);
       }
@@ -901,8 +907,6 @@ public class HoodieMetadataTableValidator implements Serializable {
       }
     }
 
-    LOG.debug("All file slices from metadata: {}. For partitions {}", allFileSlicesFromMeta, partitionPath);
-    LOG.debug("All file slices from direct listing: {}. For partitions {}", allFileSlicesFromFS, partitionPath);
     validateFileSlices(
         allFileSlicesFromMeta, allFileSlicesFromFS, partitionPath,
         fsBasedContext.getMetaClient(), "all file groups");
@@ -928,9 +932,6 @@ public class HoodieMetadataTableValidator implements Serializable {
       latestFilesFromFS = fsBasedContext.getSortedLatestBaseFileList(partitionPath);
     }
 
-    LOG.debug("Latest base file from metadata: {}. For partitions {}", latestFilesFromMetadata, partitionPath);
-    LOG.debug("Latest base file from direct listing: {}. For partitions {}", latestFilesFromFS, partitionPath);
-
     validate(latestFilesFromMetadata, latestFilesFromFS, partitionPath, "latest base files");
   }
 
@@ -952,9 +953,6 @@ public class HoodieMetadataTableValidator implements Serializable {
       latestFileSlicesFromMetadataTable = metadataTableBasedContext.getSortedLatestFileSliceList(partitionPath);
       latestFileSlicesFromFS = fsBasedContext.getSortedLatestFileSliceList(partitionPath);
     }
-
-    LOG.debug("Latest file list from metadata: {}. For partition {}", latestFileSlicesFromMetadataTable, partitionPath);
-    LOG.debug("Latest file list from direct listing: {}. For partition {}", latestFileSlicesFromFS, partitionPath);
 
     validateFileSlices(
         latestFileSlicesFromMetadataTable, latestFileSlicesFromFS, partitionPath,
@@ -1383,13 +1381,38 @@ public class HoodieMetadataTableValidator implements Serializable {
     return latestBaseFilenameList;
   }
 
-  private <T> void validate(
+  <T> void validate(
       List<T> infoListFromMetadataTable, List<T> infoListFromFS, String partitionPath, String label) {
-    if (infoListFromMetadataTable.size() != infoListFromFS.size()
-        || !infoListFromMetadataTable.equals(infoListFromFS)) {
-      String message = String.format("Validation of %s for partition %s failed for table: %s "
-              + "\n%s from metadata: %s\n%s from file system and base files: %s",
-          label, partitionPath, cfg.basePath, label, infoListFromMetadataTable, label, infoListFromFS);
+    boolean mismatch = false;
+    String errorDetails = "";
+    if (infoListFromMetadataTable.size() != infoListFromFS.size()) {
+      errorDetails = String.format(
+          "Number of %s based on the file system does not match that based on the "
+              + "metadata table. File system-based listing (%s): %s; "
+              + "MDT-based listing (%s): %s.",
+          label,
+          infoListFromFS.size(),
+          toStringWithThreshold(infoListFromFS, LOG_DETAIL_MAX_LENGTH),
+          infoListFromMetadataTable.size(),
+          toStringWithThreshold(infoListFromMetadataTable, LOG_DETAIL_MAX_LENGTH));
+      mismatch = true;
+    } else {
+      for (int i = 0; i < infoListFromMetadataTable.size(); i++) {
+        T itemFromMdt = infoListFromMetadataTable.get(i);
+        T itemFromFs = infoListFromFS.get(i);
+        if (!Objects.equals(itemFromFs, itemFromMdt)) {
+          errorDetails = String.format("%s mismatch. "
+                  + "File slice from file system-based listing: %s; "
+                  + "File slice from MDT-based listing: %s.",
+              label, itemFromFs, itemFromMdt);
+          mismatch = true;
+          break;
+        }
+      }
+    }
+    if (mismatch) {
+      String message = String.format("Validation of %s for partition %s failed for table: %s. %s",
+          label, partitionPath, cfg.basePath, errorDetails);
       LOG.error(message);
       throw new HoodieValidationException(message);
     } else {
@@ -1397,11 +1420,20 @@ public class HoodieMetadataTableValidator implements Serializable {
     }
   }
 
-  private void validateFileSlices(
+  void validateFileSlices(
       List<FileSlice> fileSliceListFromMetadataTable, List<FileSlice> fileSliceListFromFS,
       String partitionPath, HoodieTableMetaClient metaClient, String label) {
     boolean mismatch = false;
+    String errorDetails = "";
     if (fileSliceListFromMetadataTable.size() != fileSliceListFromFS.size()) {
+      errorDetails = String.format(
+          "Number of file slices based on the file system does not match that based on the "
+              + "metadata table. File system-based listing (%s file slices): %s; "
+              + "MDT-based listing (%s file slices): %s.",
+          fileSliceListFromFS.size(),
+          toStringWithThreshold(fileSliceListFromFS, LOG_DETAIL_MAX_LENGTH),
+          fileSliceListFromMetadataTable.size(),
+          toStringWithThreshold(fileSliceListFromMetadataTable, LOG_DETAIL_MAX_LENGTH));
       mismatch = true;
     } else if (!fileSliceListFromMetadataTable.equals(fileSliceListFromFS)) {
       // In-memory cache for the set of committed files of commits of interest
@@ -1411,16 +1443,28 @@ public class HoodieMetadataTableValidator implements Serializable {
         FileSlice fileSlice2 = fileSliceListFromFS.get(i);
         if (!Objects.equals(fileSlice1.getFileGroupId(), fileSlice2.getFileGroupId())
             || !Objects.equals(fileSlice1.getBaseInstantTime(), fileSlice2.getBaseInstantTime())) {
+          errorDetails = String.format("File group ID (missing a file group in MDT) "
+                  + "or base instant time mismatches. File slice from file system-based listing: %s; "
+                  + "File slice from MDT-based listing: %s.",
+              fileSlice2, fileSlice1);
           mismatch = true;
           break;
         }
         if (!assertBaseFilesEquality(fileSlice1, fileSlice2)) {
+          errorDetails = String.format("Base files mismatch. "
+                  + "File slice from file system-based listing: %s; "
+                  + "File slice from MDT-based listing: %s.",
+              fileSlice2, fileSlice1);
           mismatch = true;
           break;
         }
         // test for log files equality
-        if (!areFileSliceCommittedLogFilesMatching(
-            fileSlice1, fileSlice2, metaClient, committedFilesMap)) {
+        Pair<Boolean, String> matchingResult = areFileSliceCommittedLogFilesMatching(
+            fileSlice1, fileSlice2, metaClient, committedFilesMap);
+        if (Boolean.FALSE.equals(matchingResult.getLeft())) {
+          errorDetails = "Log files mismatch (first file slice based on MDT, "
+              + "second file slice based on the file system). "
+              + matchingResult.getRight();
           mismatch = true;
           break;
         } else {
@@ -1430,9 +1474,8 @@ public class HoodieMetadataTableValidator implements Serializable {
     }
 
     if (mismatch) {
-      String message = String.format("Validation of %s for partition %s failed for table: %s "
-              + "\n%s from metadata: %s\n%s from file system and base files: %s",
-          label, partitionPath, cfg.basePath, label, fileSliceListFromMetadataTable, label, fileSliceListFromFS);
+      String message = String.format("Validation of %s for partition %s failed for table: %s. %s",
+          label, partitionPath, cfg.basePath, errorDetails);
       LOG.error(message);
       throw new HoodieValidationException(message);
     } else {
@@ -1461,9 +1504,9 @@ public class HoodieMetadataTableValidator implements Serializable {
    * @param fs2               File slice 2
    * @param metaClient        {@link HoodieTableMetaClient} instance
    * @param committedFilesMap In-memory map for caching committed files of commits
-   * @return {@code true} if matching; {@code false} otherwise.
+   * @return {@code true} if matching; {@code false} and the error message otherwise.
    */
-  private boolean areFileSliceCommittedLogFilesMatching(
+  private Pair<Boolean, String> areFileSliceCommittedLogFilesMatching(
       FileSlice fs1,
       FileSlice fs2,
       HoodieTableMetaClient metaClient,
@@ -1481,24 +1524,32 @@ public class HoodieMetadataTableValidator implements Serializable {
     // that is committed, the committed log files of two file slices are different
     HoodieStorage storage = metaClient.getStorage();
 
-    if (hasCommittedLogFiles(storage, fs1LogPathSet, metaClient, committedFilesMap)) {
-      LOG.error("The first file slice has committed log files that cause mismatching: {}; Different log files are: {}", fs1, fs1LogPathSet);
-      return false;
+    Pair<Boolean, String> checkResult =
+        hasCommittedLogFiles(storage, fs1LogPathSet, metaClient, committedFilesMap);
+    if (Boolean.TRUE.equals(checkResult.getLeft())) {
+      return Pair.of(false, String.format(
+          "The first file slice has committed log files that cause mismatching: %s"
+              + "; Different log files are: %s. Details: %s.",
+          fs1, fs1LogPathSet, checkResult.getRight()));
     }
-    if (hasCommittedLogFiles(storage, fs2LogPathSet, metaClient, committedFilesMap)) {
-      LOG.error("The second file slice has committed log files that cause mismatching: {}; Different log files are: {}", fs2, fs2LogPathSet);
-      return false;
+    checkResult =
+        hasCommittedLogFiles(storage, fs2LogPathSet, metaClient, committedFilesMap);
+    if (Boolean.TRUE.equals(checkResult.getLeft())) {
+      return Pair.of(false, String.format(
+          "The second file slice has committed log files that cause mismatching: %s"
+              + "; Different log files are: %s.  Details: %s.",
+          fs2, fs2LogPathSet, checkResult.getRight()));
     }
-    return true;
+    return Pair.of(true, "");
   }
 
-  private boolean hasCommittedLogFiles(
+  Pair<Boolean, String> hasCommittedLogFiles(
       HoodieStorage storage,
       Set<String> logFilePathSet,
       HoodieTableMetaClient metaClient,
       Map<String, Set<String>> committedFilesMap) {
     if (logFilePathSet.isEmpty()) {
-      return false;
+      return Pair.of(false, "");
     }
 
     String basePath = metaClient.getBasePath().toString();
@@ -1547,15 +1598,17 @@ public class HoodieMetadataTableValidator implements Serializable {
             // behavior.
             String relativeLogFilePathStr = getRelativePath(basePath, logFilePathStr);
             if (committedFilesMap.get(instantTime).contains(relativeLogFilePathStr)) {
-              LOG.warn("Log file is committed in an instant in active timeline: instantTime={} {}", instantTime, logFilePathStr);
-              return true;
+              return Pair.of(true, String.format(
+                  "Log file is committed in an instant in active timeline: instantTime=%s %s",
+                  instantTime, logFilePathStr));
             } else {
               LOG.warn("Log file is uncommitted in a completed instant, likely due to retry: instantTime={} {}", instantTime, logFilePathStr);
             }
           } else if (completedInstantsTimeline.isBeforeTimelineStarts(instantTime)) {
             // The instant is in archived timeline
-            LOG.warn("Log file is committed in an instant in archived timeline: instantTime={} {}", instantTime, logFilePathStr);
-            return true;
+            return Pair.of(true, String.format(
+                "Log file is committed in an instant in archived timeline: instantTime=%s %s",
+                instantTime, logFilePathStr));
           } else if (inflightInstantsTimeline.containsInstant(instantTime)) {
             // The instant is inflight in active timeline
             // hit an uncommitted block possibly from a failed write
@@ -1570,13 +1623,13 @@ public class HoodieMetadataTableValidator implements Serializable {
           LOG.warn("There is no log block in {}", logFilePathStr);
         }
       } catch (IOException e) {
-        LOG.warn(String.format("Cannot read log file %s: %s. Skip the check as it's likely being written by an inflight instant.",
-            logFilePathStr, e.getMessage()), e);
+        LOG.warn("Cannot read log file {}. Skip the check as it's likely being written by an inflight instant.",
+            logFilePathStr, e);
       } finally {
         FileIOUtils.closeQuietly(reader);
       }
     }
-    return false;
+    return Pair.of(false, "");
   }
 
   private String getRelativePath(String basePath, String absoluteFilePath) {
@@ -1850,7 +1903,7 @@ public class HoodieMetadataTableValidator implements Serializable {
           return Option.empty();
         }
       } catch (IOException e) {
-        LOG.error("Failed to get file reader for {} {}", path, e.getMessage());
+        LOG.error("Failed to get file reader for {} {}", path, e);
         return Option.empty();
       }
       return Option.of(BloomFilterData.builder()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -27,15 +27,23 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimeGenerator;
 import org.apache.hudi.common.table.timeline.TimeGenerators;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -77,20 +85,30 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.fs.FileUtil.copy;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.RawTripTestPayload.recordToString;
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getSimpleSchema;
+import static org.apache.hudi.common.util.StringUtils.toStringWithThreshold;
+import static org.apache.hudi.common.util.TestStringUtils.generateRandomString;
+import static org.apache.hudi.utilities.HoodieMetadataTableValidator.LOG_DETAIL_MAX_LENGTH;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -99,6 +117,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase {
+  private static final Random RANDOM = new Random();
 
   private static Stream<Arguments> lastNFileSlicesTestArgs() {
     return Stream.of(-1, 1, 3, 4, 5).flatMap(i -> Stream.of(Arguments.of(i, true), Arguments.of(i, false)));
@@ -721,6 +740,406 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     } else {
       assertThrows(HoodieValidationException.class, localValidator::run);
     }
+  }
+
+  @Test
+  void testHasCommittedLogFiles() throws IOException, InterruptedException {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath(tempDir.toString()));
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    config.validateLatestFileSlices = true;
+    config.validateAllFileGroups = true;
+    TimeGenerator timeGenerator = TimeGenerators
+        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
+            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    Map<String, Set<String>> committedFilesMap = new HashMap<>();
+    String baseInstantTime = TimelineUtils.generateInstantTime(true, timeGenerator);
+    String logInstantTime = TimelineUtils.generateInstantTime(true, timeGenerator);
+    String newInstantTime = TimelineUtils.generateInstantTime(true, timeGenerator);
+
+    // Empty log file set
+    assertEquals(Pair.of(false, ""), validator.hasCommittedLogFiles(
+        storage, Collections.emptySet(), metaClient, committedFilesMap));
+    // Empty log file
+    HoodieLogFile logFile = new HoodieLogFile(new StoragePath(
+        tempDir.toString(),
+        FSUtils.makeLogFileName(
+            UUID.randomUUID().toString(), HoodieLogFile.DELTA_EXTENSION, logInstantTime, 1, "1-0-1")));
+    storage.create(logFile.getPath()).close();
+    prepareTimelineAndValidate(metaClient, validator, Collections.emptyList(),
+        logFile, committedFilesMap, Pair.of(false, ""));
+
+    // Log file with command log block
+    logFile = prepareLogFile(
+        UUID.randomUUID().toString(), baseInstantTime, logInstantTime, false);
+    prepareTimelineAndValidate(metaClient, validator, Collections.emptyList(),
+        logFile, committedFilesMap, Pair.of(false, ""));
+
+    // Log file with data log block
+    logFile = prepareLogFile(
+        UUID.randomUUID().toString(), baseInstantTime, logInstantTime, true);
+    // Log block created by completed delta commit in active timeline
+    committedFilesMap.put(logInstantTime, Collections.emptySet());
+    prepareTimelineAndValidate(metaClient, validator,
+        Collections.singletonList(INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, logInstantTime)),
+        logFile, committedFilesMap, Pair.of(false, ""));
+
+    // Log block created by completed delta commit but not included in the commit metadata
+    committedFilesMap.put(logInstantTime,
+        new HashSet<>(Collections.singletonList(logFile.getPath().getName())));
+    prepareTimelineAndValidate(metaClient, validator,
+        Collections.singletonList(INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, logInstantTime)),
+        logFile, committedFilesMap,
+        Pair.of(true,
+            String.format("Log file is committed in an instant in active timeline: instantTime=%s %s",
+                logInstantTime, logFile.getPath().toString())));
+    committedFilesMap.clear();
+
+    // Log block created by completed delta commit before active timeline starts
+    prepareTimelineAndValidate(metaClient, validator,
+        Collections.singletonList(INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime)),
+        logFile, committedFilesMap,
+        Pair.of(true,
+            String.format("Log file is committed in an instant in archived timeline: instantTime=%s %s",
+                logInstantTime, logFile.getPath().toString())));
+
+    // Log block created by inflight delta commit in active timeline
+    prepareTimelineAndValidate(metaClient, validator,
+        Collections.singletonList(INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, logInstantTime)),
+        logFile, committedFilesMap, Pair.of(false, ""));
+
+    // Log block created by a delta commit not in active timeline
+    prepareTimelineAndValidate(metaClient, validator,
+        Collections.singletonList(INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, baseInstantTime)),
+        logFile, committedFilesMap, Pair.of(false, ""));
+  }
+
+  private void prepareTimelineAndValidate(HoodieTableMetaClient metaClient,
+                                          MockHoodieMetadataTableValidator validator,
+                                          List<HoodieInstant> instantList,
+                                          HoodieLogFile logFile,
+                                          Map<String, Set<String>> committedFilesMap,
+                                          Pair<Boolean, String> expected) {
+    HoodieTimeline timeline = new ActiveTimelineV2();
+    timeline.setInstants(instantList);
+    when(metaClient.getCommitsTimeline()).thenReturn(timeline);
+    assertEquals(expected,
+        validator.hasCommittedLogFiles(
+            storage, new HashSet<>(Collections.singletonList(logFile.getPath().toString())),
+            metaClient, committedFilesMap));
+  }
+
+  private HoodieLogFile prepareLogFile(String fileId,
+                                       String baseInstantTime,
+                                       String instantTime,
+                                       boolean writeDataBlock) throws IOException, InterruptedException {
+    try (HoodieLogFormat.Writer writer = HoodieLogFormat.newWriterBuilder()
+        .onParentPath(new StoragePath(tempDir.toString()))
+        .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
+        .withFileId(fileId)
+        .withInstantTime(instantTime)
+        .withStorage(storage)
+        .withSizeThreshold(Long.MAX_VALUE).build()) {
+      Map<HoodieLogBlock.HeaderMetadataType, String> header =
+          new EnumMap<>(HoodieLogBlock.HeaderMetadataType.class);
+      if (writeDataBlock) {
+        header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
+        header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, getSimpleSchema().toString());
+        writer.appendBlock(new HoodieAvroDataBlock(
+            Collections.emptyList(), false, header, HoodieRecord.RECORD_KEY_METADATA_FIELD));
+      } else {
+        header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
+        header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, baseInstantTime);
+        header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
+            String.valueOf(HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_BLOCK.ordinal()));
+        writer.appendBlock(new HoodieCommandBlock(header));
+      }
+      return writer.getLogFile();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testValidate(boolean oversizeList) {
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    config.validateLatestFileSlices = true;
+    config.validateAllFileGroups = true;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    int listSize = oversizeList ? 5000 : 100;
+    String partition = "partition10";
+    String label = "metadata item";
+
+    // Base file list
+    Pair<List<HoodieBaseFile>, List<HoodieBaseFile>> filelistPair = generateTwoEqualBaseFileList(listSize);
+    runValidateAndVerify(
+        validator, oversizeList, partition, label, filelistPair.getLeft(), filelistPair.getRight(),
+        generateRandomBaseFile().getLeft());
+
+    // Column stats list
+    Pair<List<HoodieColumnRangeMetadata<Comparable>>, List<HoodieColumnRangeMetadata<Comparable>>> statsListPair =
+        generateTwoEqualColumnStatsList(listSize);
+    runValidateAndVerify(
+        validator, oversizeList, partition, label, statsListPair.getLeft(), statsListPair.getRight(),
+        generateRandomColumnStats().getLeft());
+  }
+
+  private <T> void runValidateAndVerify(HoodieMetadataTableValidator validator,
+                                        boolean oversizeList, String partition, String label,
+                                        List<T> listMdt, List<T> listFs, T newItem) {
+    assertEquals(
+        oversizeList,
+        toStringWithThreshold(listMdt, Integer.MAX_VALUE).length() > LOG_DETAIL_MAX_LENGTH);
+    assertEquals(
+        oversizeList,
+        toStringWithThreshold(listFs, Integer.MAX_VALUE).length() > LOG_DETAIL_MAX_LENGTH);
+    // Equal case
+    assertDoesNotThrow(() ->
+        validator.validate(listMdt, listFs, partition, label));
+    // Size mismatch
+    listFs.add(newItem);
+    Exception exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validate(listMdt, listFs, partition, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "Number of %s based on the file system does not match that based on "
+                + "the metadata table. File system-based listing (%s): %s; "
+                + "MDT-based listing (%s): %s.",
+            label, partition, basePath, label, listFs.size(),
+            toStringWithThreshold(listFs, LOG_DETAIL_MAX_LENGTH),
+            listMdt.size(), toStringWithThreshold(listMdt, LOG_DETAIL_MAX_LENGTH)),
+        exception.getMessage());
+    listFs.remove(listFs.size() - 1);
+    // Item mismatch
+    int i = 35;
+    listFs.set(i, newItem);
+    exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validate(listMdt, listFs, partition, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "%s mismatch. File slice from file system-based listing: %s; "
+                + "File slice from MDT-based listing: %s.",
+            label, partition, basePath, label, listFs.get(i), listMdt.get(i)),
+        exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testValidateFileSlices(boolean oversizeList) {
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    config.validateLatestFileSlices = true;
+    config.validateAllFileGroups = true;
+    TimeGenerator timeGenerator = TimeGenerators
+        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
+            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    int listSize = oversizeList ? 500 : 50;
+    String partition = "partition10";
+    String label = "metadata item";
+
+    // Base file list
+    Pair<List<FileSlice>, List<FileSlice>> filelistPair =
+        generateTwoEqualFileSliceList(listSize, timeGenerator);
+    List<FileSlice> listMdt = filelistPair.getLeft();
+    List<FileSlice> listFs = filelistPair.getRight();
+    // Equal case
+    assertDoesNotThrow(() ->
+        validator.validateFileSlices(listMdt, listFs, partition, metaClient, label));
+    // Size mismatch
+    listFs.add(generateRandomFileSlice(
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator)).getLeft());
+    assertEquals(
+        oversizeList,
+        toStringWithThreshold(listMdt, Integer.MAX_VALUE).length() > LOG_DETAIL_MAX_LENGTH);
+    assertEquals(
+        oversizeList,
+        toStringWithThreshold(listFs, Integer.MAX_VALUE).length() > LOG_DETAIL_MAX_LENGTH);
+    Exception exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validateFileSlices(listMdt, listFs, partition, metaClient, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "Number of file slices based on the file system does not match that based on the "
+                + "metadata table. File system-based listing (%s file slices): %s; "
+                + "MDT-based listing (%s file slices): %s.",
+            label, partition, basePath, listFs.size(),
+            toStringWithThreshold(listFs, LOG_DETAIL_MAX_LENGTH),
+            listMdt.size(), toStringWithThreshold(listMdt, LOG_DETAIL_MAX_LENGTH)),
+        exception.getMessage());
+    listFs.remove(listFs.size() - 1);
+    // Item mismatch
+    int i = 35;
+    // Instant time mismatch
+    FileSlice originalFileSlice = listMdt.get(i);
+    FileSlice mismatchFileSlice = new FileSlice(
+        originalFileSlice.getFileGroupId(),
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        originalFileSlice.getBaseFile().get(),
+        originalFileSlice.getLogFiles().collect(Collectors.toList()));
+    listMdt.set(i, mismatchFileSlice);
+    exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validateFileSlices(listMdt, listFs, partition, metaClient, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "File group ID (missing a file group in MDT) "
+                + "or base instant time mismatches. File slice from file system-based listing: %s; "
+                + "File slice from MDT-based listing: %s.",
+            label, partition, basePath, listFs.get(i), listMdt.get(i)),
+        exception.getMessage());
+    // base file mismatch
+    mismatchFileSlice = new FileSlice(
+        originalFileSlice.getFileGroupId(),
+        originalFileSlice.getBaseInstantTime(),
+        generateRandomBaseFile().getLeft(),
+        originalFileSlice.getLogFiles().collect(Collectors.toList()));
+    listMdt.set(i, mismatchFileSlice);
+    exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validateFileSlices(listMdt, listFs, partition, metaClient, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "Base files mismatch. "
+                + "File slice from file system-based listing: %s; "
+                + "File slice from MDT-based listing: %s.",
+            label, partition, basePath, listFs.get(i), listMdt.get(i)),
+        exception.getMessage());
+  }
+
+  Pair<List<HoodieBaseFile>, List<HoodieBaseFile>> generateTwoEqualBaseFileList(int size) {
+    List<HoodieBaseFile> list1 = new ArrayList<>();
+    List<HoodieBaseFile> list2 = new ArrayList<>();
+    IntStream.range(0, size).forEach(i -> {
+      Pair<HoodieBaseFile, HoodieBaseFile> pair = generateRandomBaseFile();
+      list1.add(pair.getLeft());
+      list2.add(pair.getRight());
+    });
+    return Pair.of(
+        list1.stream().sorted(new HoodieMetadataTableValidator.HoodieBaseFileComparator())
+            .collect(Collectors.toList()),
+        list2.stream().sorted(new HoodieMetadataTableValidator.HoodieBaseFileComparator())
+            .collect(Collectors.toList()));
+  }
+
+  Pair<List<HoodieColumnRangeMetadata<Comparable>>,
+      List<HoodieColumnRangeMetadata<Comparable>>> generateTwoEqualColumnStatsList(int size) {
+    List<HoodieColumnRangeMetadata<Comparable>> list1 = new ArrayList<>();
+    List<HoodieColumnRangeMetadata<Comparable>> list2 = new ArrayList<>();
+    IntStream.range(0, size).forEach(i -> {
+      Pair<HoodieColumnRangeMetadata, HoodieColumnRangeMetadata> pair = generateRandomColumnStats();
+      list1.add(pair.getLeft());
+      list2.add(pair.getRight());
+    });
+    return Pair.of(
+        list1.stream().sorted(new HoodieMetadataTableValidator.HoodieColumnRangeMetadataComparator())
+            .collect(Collectors.toList()),
+        list2.stream().sorted(new HoodieMetadataTableValidator.HoodieColumnRangeMetadataComparator())
+            .collect(Collectors.toList()));
+  }
+
+  Pair<List<FileSlice>, List<FileSlice>> generateTwoEqualFileSliceList(int size,
+                                                                       TimeGenerator timeGenerator) {
+    List<FileSlice> list1 = new ArrayList<>();
+    List<FileSlice> list2 = new ArrayList<>();
+    String baseInstantTime = TimelineUtils.generateInstantTime(true, timeGenerator);
+    String logInstantTime1 = TimelineUtils.generateInstantTime(true, timeGenerator);
+    String logInstantTime2 = TimelineUtils.generateInstantTime(true, timeGenerator);
+    IntStream.range(0, size).forEach(i -> {
+      Pair<FileSlice, FileSlice> pair =
+          generateRandomFileSlice(baseInstantTime, logInstantTime1, logInstantTime2);
+      list1.add(pair.getLeft());
+      list2.add(pair.getRight());
+    });
+    return Pair.of(
+        list1.stream().sorted(new HoodieMetadataTableValidator.FileSliceComparator())
+            .collect(Collectors.toList()),
+        list2.stream().sorted(new HoodieMetadataTableValidator.FileSliceComparator())
+            .collect(Collectors.toList()));
+  }
+
+  private Pair<HoodieBaseFile, HoodieBaseFile> generateRandomBaseFile() {
+    String filePath = "/dummy/base/" + FSUtils.makeBaseFileName(
+        "001", "1-0-1", UUID.randomUUID().toString(), HoodieFileFormat.PARQUET.getFileExtension());
+    return Pair.of(new HoodieBaseFile(filePath), new HoodieBaseFile(new String(filePath)));
+  }
+
+  private Pair<HoodieColumnRangeMetadata, HoodieColumnRangeMetadata> generateRandomColumnStats() {
+    long count = RANDOM.nextLong();
+    long size = RANDOM.nextLong();
+    switch (RANDOM.nextInt(3)) {
+      case 0:
+        HoodieColumnRangeMetadata<Integer> intMetadata = HoodieColumnRangeMetadata.create(
+            generateRandomString(30), generateRandomString(5),
+            RANDOM.nextInt() % 30, RANDOM.nextInt() % 1000_000_000 + 30,
+            count / 3L, count, size, size / 8L);
+        return Pair.of(intMetadata,
+            HoodieColumnRangeMetadata.create(
+                new String(intMetadata.getFilePath()), new String(intMetadata.getColumnName()),
+                (int) intMetadata.getMinValue(), (int) intMetadata.getMaxValue(),
+                count / 3L, count, size, size / 8L));
+      case 1:
+        HoodieColumnRangeMetadata<Long> longMetadata = HoodieColumnRangeMetadata.create(
+            generateRandomString(30), generateRandomString(5),
+            RANDOM.nextLong() % 30L, RANDOM.nextInt() % 1000_000_000_000_000L + 30L,
+            count / 3L, count, size, size / 8L);
+        return Pair.of(longMetadata,
+            HoodieColumnRangeMetadata.create(
+                new String(longMetadata.getFilePath()), new String(longMetadata.getColumnName()),
+                (long) longMetadata.getMinValue(), (long) longMetadata.getMaxValue(),
+                count / 3L, count, size, size / 8L));
+      default:
+        String stringValue1 = generateRandomString(20);
+        String stringValue2 = generateRandomString(20);
+        HoodieColumnRangeMetadata<String> stringMetadata = HoodieColumnRangeMetadata.create(
+            generateRandomString(30), generateRandomString(5),
+            stringValue1, stringValue2,
+            count / 3L, count, size, size / 8L);
+        return Pair.of(stringMetadata,
+            HoodieColumnRangeMetadata.create(
+                new String(stringMetadata.getFilePath()), new String(stringMetadata.getColumnName()),
+                new String(stringValue1), new String(stringValue2),
+                count / 3L, count, size, size / 8L));
+    }
+  }
+
+  private Pair<FileSlice, FileSlice> generateRandomFileSlice(String baseInstantTime,
+                                                             String logInstantTime1,
+                                                             String logInstantTime2) {
+    String partition = "partition";
+    String fileId = UUID.randomUUID().toString();
+    Pair<HoodieBaseFile, HoodieBaseFile> baseFilePair = generateRandomBaseFile();
+    List<HoodieLogFile> logFileList = new ArrayList<>();
+    logFileList.add(generateRandomLogFile(fileId, logInstantTime1));
+    logFileList.add(generateRandomLogFile(fileId, logInstantTime2));
+    FileSlice fileSlice = new FileSlice(
+        new HoodieFileGroupId(partition, fileId), baseInstantTime,
+        baseFilePair.getLeft(), logFileList);
+    return Pair.of(fileSlice,
+        new FileSlice(new HoodieFileGroupId(partition, fileId),
+            new String(baseInstantTime), baseFilePair.getRight(),
+            logFileList.stream().map(HoodieLogFile::new).collect(Collectors.toList())));
+  }
+
+  private HoodieLogFile generateRandomLogFile(String fileId, String instantTime) {
+    return new HoodieLogFile("/dummy/base/" + FSUtils.makeLogFileName(
+        fileId, HoodieLogFile.DELTA_EXTENSION, instantTime, 1, "1-0-1"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

This PR improves the logging from MDT validator to avoid oversized log message that can cause OpenSearch to throw error on indexing the logs.

```
The length of [log] field of [1252665] doc of [logstash-%{[url][path]}-2024.11.29] index has exceeded [1000000] - maximum allowed to be analyzed for highlighting. This maximum can be set by changing the [index.highlight.max_analyzed_offset] index level setting. For large texts, indexing with offsets or term vectors is recommended!
```

Specifically:
- Introduces `StringUtils#toStringWithThreshold` to limit the size of String when converting the list of objects to String;
- Improves logging in the validation of metadata listing to limit the list of metadata items to show using `StringUtils#toStringWithThreshold` or only show necessary item that causes mismatch;
- Improves logging statements.

New tests are added to validate that the new logging of capping log size works.

### Impact

Logging improvement

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
