### PR TITLE
[HUDI-8298] refactor SparkDatasetTestUtils#serializeRow

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
@@ -237,13 +237,9 @@ public class SparkDatasetTestUtils {
   }
 
   public static InternalRow serializeRow(ExpressionEncoder encoder, Row row)
-      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, ClassNotFoundException {
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
     Object serializer = encoder.createSerializer();
-    try {
-      Method applyMethod = serializer.getClass().getMethod("apply", Object.class);
-      return (InternalRow) applyMethod.invoke(serializer, row);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to serialize row", e);
-    }
+    Method applyMethod = serializer.getClass().getMethod("apply", Object.class);
+    return (InternalRow) applyMethod.invoke(serializer, row);
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/KeyGeneratorTestUtilities.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/KeyGeneratorTestUtilities.java
@@ -24,7 +24,6 @@ import org.apache.hudi.SparkAdapterSupport$;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.spark.package$;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
@@ -32,7 +31,6 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.StructType;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import scala.Function1;
 
@@ -101,21 +99,6 @@ public class KeyGeneratorTestUtilities {
   }
 
   public static InternalRow getInternalRow(Row row, ExpressionEncoder<Row> encoder) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-    return serializeRow(encoder, row);
+    return SparkDatasetTestUtils.serializeRow(encoder, row);
   }
-
-  private static InternalRow serializeRow(ExpressionEncoder encoder, Row row)
-      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, ClassNotFoundException {
-    // TODO [HUDI-8298] only spark 3 needed
-    if (package$.MODULE$.SPARK_VERSION().startsWith("2.")) {
-      Method spark2method = encoder.getClass().getMethod("toRow", Object.class);
-      return (InternalRow) spark2method.invoke(encoder, row);
-    } else {
-      Class<?> serializerClass = Class.forName("org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$Serializer");
-      Object serializer = encoder.getClass().getMethod("createSerializer").invoke(encoder);
-      Method aboveSpark2method = serializerClass.getMethod("apply", Object.class);
-      return (InternalRow) aboveSpark2method.invoke(serializer, row);
-    }
-  }
-
 }


### PR DESCRIPTION
### Change Logs

refactor SparkDatasetTestUtils#serializeRow -> removed Spark 2 case, and reduced the reflection (optimized to work with spark3+ versions)
org.apache.hudi.testutils.KeyGeneratorTestUtilities#serializeRow -> since same code is used, SparkDatasetTestUtils#serializeRow is reused.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
