### PR TITLE
[HUDI-8315] update SqlKeyGenerator#convertPartitionPathToSqlType to handle default_partition_path

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.{StructType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.joda.time.format.DateTimeFormat
+import org.apache.hudi.common.util.PartitionPathEncodeUtils
 
 import java.sql.Timestamp
 import java.util
@@ -152,7 +153,11 @@ class SqlKeyGenerator(props: TypedProperties) extends BuiltinKeyGenerator(props)
       // in this case.
       if (partitionFragments.size != partitionSchema.get.size) {
         partitionPath
-      } else {
+      }
+      else if (partitionPath == PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH) {
+        partitionPath
+      }
+      else {
         partitionFragments.zip(partitionSchema.get.fields).map {
           case (partitionValue, partitionField) =>
             val hiveStylePrefix = s"${partitionField.name}="

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
@@ -100,6 +100,41 @@ class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
       }
     }
   }
+  test("Test Spark SQL with default partition path for timestamp key generator") {
+    withTempDir { tmp =>
+      val keyGeneratorSettings = timestampKeyGeneratorSettings(3)
+      val tsType = if (keyGeneratorSettings.contains("DATE_STRING")) "string" else "long"
+      spark.sql(
+        s"""
+           | CREATE TABLE test_default_path_ts (
+           |   id int,
+           |   name string,
+           |   precomb long,
+           |   ts TIMESTAMP
+           | ) USING HUDI
+           | LOCATION '${tmp.getCanonicalPath + "/test_default_path_ts"}'
+           | PARTITIONED BY (ts)
+           | TBLPROPERTIES (
+           |   type = 'COPY_ON_WRITE',
+           |   primaryKey = 'id',
+           |   preCombineField = 'precomb'
+           | )
+           |""".stripMargin)
+      val dataBatches =   Array(
+        "(1, 'a1', 1,TIMESTAMP '2025-01-15 01:02:03')",
+        "(2, 'a3', 1, null)"
+      )
+      val expectedQueryResult: String = "[1,a1,1,2025-01-15 01:02:03.0]; [2,a3,1,null]"
+      spark.sql(s"INSERT INTO test_default_path_ts VALUES ${dataBatches(0)}")
+      // inserting value with partition_timestamp value as null
+      spark.sql(s"INSERT INTO test_default_path_ts VALUES ${dataBatches(1)}")
+
+      val queryResult = spark.sql(s"SELECT id, name, precomb, ts FROM test_default_path_ts ORDER BY id").collect().mkString("; ")
+      LOG.warn(s"Query result: $queryResult")
+      assertResult(expectedQueryResult)(queryResult)
+
+    }
+  }
 
   test("Test mandatory partitioning for timestamp key generator") {
     withTempDir { tmp =>


### PR DESCRIPTION

### Change Logs

the issue is at SqlKeyGenerator#convertPartitionPathToSqlType
where the default HIVE_DEFAULT_PARTITION value is trying to be converted into Long/milli second.

update SqlKeyGenerator#convertPartitionPathToSqlType to handle default_partition_path

TODO:
 - [x] add testcase for ts default_partition_path at TestSparkSqlWithTimestampKeyGenerator

### Impact

partition_path for timestamp partition

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
