### PR TITLE
[HUDI-8859] Support filter by instants in ShowInvalidParquetProcedure

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -141,6 +141,16 @@ public class FSUtils {
     }
   }
 
+  public static String getCommitTimeWithFullPath(String path) {
+    String fullFileName;
+    if (path.contains("/")) {
+      fullFileName = path.substring(path.lastIndexOf("/") + 1);
+    } else {
+      fullFileName = path;
+    }
+    return getCommitTime(fullFileName);
+  }
+
   public static long getFileSize(HoodieStorage storage, StoragePath path) throws IOException {
     return storage.getPathInfo(path).getLength();
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
@@ -22,11 +22,14 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.hudi.command.procedures
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util.function.Supplier
@@ -37,7 +40,8 @@ class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
     ProcedureParameter.required(0, "path", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 100),
     ProcedureParameter.optional(2, "needDelete", DataTypes.BooleanType, false),
-    ProcedureParameter.optional(3, "partitions", DataTypes.StringType, "")
+    ProcedureParameter.optional(3, "partitions", DataTypes.StringType, ""),
+    ProcedureParameter.optional(4, "instants", DataTypes.StringType, "")
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -55,16 +59,26 @@ class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
     val limit = getArgValueOrDefault(args, PARAMETERS(1))
     val needDelete = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[Boolean]
     val partitions = getArgValueOrDefault(args, PARAMETERS(3)).map(_.toString).getOrElse("")
+    val instants = getArgValueOrDefault(args, PARAMETERS(4)).map(_.toString).getOrElse("")
     val storageConf = HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration())
     val storage = new HoodieHadoopStorage(srcPath, storageConf)
     val metadataConfig = HoodieMetadataConfig.newBuilder.enable(false).build
     val metadata = HoodieTableMetadata.create(new HoodieSparkEngineContext(jsc), storage, metadataConfig, srcPath)
     val partitionPaths: java.util.List[String] = metadata.getPartitionPathWithPathPrefixes(partitions.split(",").toList.asJava)
     val partitionPathsSize = if (partitionPaths.size() == 0) 1 else partitionPaths.size()
+    val instantsList = if (StringUtils.isNullOrEmpty(instants)) Array.empty[String] else instants.split(",")
+
     val javaRdd: JavaRDD[String] = jsc.parallelize(partitionPaths, partitionPathsSize)
     val parquetRdd = javaRdd.rdd.map(part => {
         val fs = HadoopFSUtils.getFs(new Path(srcPath), storageConf.unwrap())
-        HadoopFSUtils.getAllDataFilesInPartition(fs, HadoopFSUtils.constructAbsolutePathInHadoopPath(srcPath, part))
+        HadoopFSUtils.getAllDataFilesInPartition(fs, HadoopFSUtils.constructAbsolutePathInHadoopPath(srcPath, part)).filter(fileStatus => {
+          var isFilter = true
+          if (!instantsList.isEmpty) {
+            val parquetCommitTime = FSUtils.getCommitTimeWithFullPath(fileStatus.getPath.toString)
+            isFilter = instantsList.contains(parquetCommitTime)
+          }
+          isFilter
+        })
     }).flatMap(_.toList)
       .filter(status => {
         val filePath = status.getPath

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
@@ -18,8 +18,13 @@
 package org.apache.spark.sql.hudi.procedure
 
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
-
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieFileFormat
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator
+
+import java.util.{Date, UUID}
+
 
 class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
   test("Test Call show_invalid_parquet Procedure") {
@@ -153,23 +158,34 @@ class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
       checkExceptionContain(s"""call show_invalid_parquet(limit => 10)""")(
         s"Argument: path is required")
 
+      val TEST_WRITE_TOKEN = "1-0-1"
+      val instantTime = HoodieInstantTimeGenerator.formatDate(new Date)
+      val fileName1 = UUID.randomUUID.toString
+      val fullFileName1 = FSUtils.makeBaseFileName(instantTime, TEST_WRITE_TOKEN, fileName1, HoodieFileFormat.PARQUET.getFileExtension)
+      val fileName2 = UUID.randomUUID.toString
+      val fullFileName2 = FSUtils.makeBaseFileName(instantTime, TEST_WRITE_TOKEN, fileName2, HoodieFileFormat.PARQUET.getFileExtension)
+      val fileName3 = UUID.randomUUID.toString
+      val fullFileName3 = FSUtils.makeBaseFileName(instantTime, TEST_WRITE_TOKEN, fileName3, HoodieFileFormat.PARQUET.getFileExtension)
+      val fileName4 = UUID.randomUUID.toString
+      val fullFileName4 = FSUtils.makeBaseFileName(instantTime, TEST_WRITE_TOKEN, fileName4, HoodieFileFormat.PARQUET.getFileExtension)
+
       val fs = HadoopFSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
-      val invalidPath1 = new Path(basePath, "year=2022/month=08/day=30/1.parquet")
+      val invalidPath1 = new Path(basePath, "year=2022/month=08/day=30/" + fullFileName1)
       val out1 = fs.create(invalidPath1)
       out1.write(1)
       out1.close()
 
-      val invalidPath2 = new Path(basePath, "year=2022/month=08/day=31/2.parquet")
+      val invalidPath2 = new Path(basePath, "year=2022/month=08/day=31/" + fullFileName2)
       val out2 = fs.create(invalidPath2)
       out2.write(1)
       out2.close()
 
-      val invalidPath3 = new Path(basePath, "year=2022/month=07/day=03/3.parquet")
+      val invalidPath3 = new Path(basePath, "year=2022/month=07/day=03/" + fullFileName3)
       val out3 = fs.create(invalidPath3)
       out3.write(1)
       out3.close()
 
-      val invalidPath4 = new Path(basePath, "year=2022/month=07/day=04/4.parquet")
+      val invalidPath4 = new Path(basePath, "year=2022/month=07/day=04/" + fullFileName4)
       val out4 = fs.create(invalidPath4)
       out4.write(1)
       out4.close()
@@ -202,6 +218,17 @@ class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
       result = spark.sql(
         s"""call show_invalid_parquet(path => '$basePath', partitions => 'year=2023')""".stripMargin).collect()
       assertResult(0) {
+        result.length
+      }
+
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', instants => '$instantTime')""".stripMargin).collect()
+      assertResult(4) {
+        result.length
+      }
+      result = spark.sql(
+        s"""call show_invalid_parquet(path => '$basePath', instants => '$instantTime', partitions => 'year=2022/month=08')""".stripMargin).collect()
+      assertResult(2) {
         result.length
       }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowInvalidParquetProcedure.scala
@@ -125,7 +125,7 @@ class TestShowInvalidParquetProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  test("Test Call show_invalid_parquet Procedure and Specify Partitions") {
+  test("Test Call show_invalid_parquet Procedure, Specify Partitions and/or Instants.") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val basePath = s"${tmp.getCanonicalPath}/$tableName"


### PR DESCRIPTION
### Change Logs

recent production troubleshooting has requirements for filtering by instants in ShowInvalidParquetProcedure.
this PR support specifying 'instants' and filter invalid parquet files by instants.

### Impact

None.

### Risk level (write none, low medium or high below)

Low

### Documentation Update
None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
