### PR TITLE
[HUDI-8860] Avoid calling values() on ExternalSpillableMap

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/LogFileIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/LogFileIterator.java
@@ -22,7 +22,6 @@ package org.apache.hudi.common.table.log;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.CachingIterator;
-import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -43,7 +42,7 @@ public class LogFileIterator<T> extends CachingIterator<HoodieRecord<T>> {
 
   private boolean hasNextInternal() {
     if (iterator == null) {
-      iterator = (records instanceof ExternalSpillableMap) ? ((ExternalSpillableMap) records).iterator() : records.values().iterator();
+      iterator = records.values().iterator();
     }
     if (iterator.hasNext()) {
       nextRecord = iterator.next();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/LogFileIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/LogFileIterator.java
@@ -22,6 +22,7 @@ package org.apache.hudi.common.table.log;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.CachingIterator;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class LogFileIterator<T> extends CachingIterator<HoodieRecord<T>> {
 
   private boolean hasNextInternal() {
     if (iterator == null) {
-      iterator = records.values().iterator();
+      iterator = (records instanceof ExternalSpillableMap) ? ((ExternalSpillableMap) records).iterator() : records.values().iterator();
     }
     if (iterator.hasNext()) {
       nextRecord = iterator.next();

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestLogFileIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestLogFileIterator.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.DefaultSizeEstimator;
+import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class TestLogFileIterator {
+
+  @Test
+  public void testIteratorWithPlainHashMap() {
+    // 1) Create a simple in-memory Map of HoodieRecords
+    Map<String, HoodieRecord> inMemoryMap = new HashMap<>();
+    HoodieRecord record1 = new HoodieAvroRecord(new HoodieKey("key1", "p1"), null);
+    HoodieRecord record2 = new HoodieAvroRecord(new HoodieKey("key2", "p2"), null);
+    inMemoryMap.put("key1", record1);
+    inMemoryMap.put("key2", record2);
+
+    // 2) Mock a scanner that returns the inMemoryMap
+    HoodieMergedLogRecordScanner scanner = Mockito.mock(HoodieMergedLogRecordScanner.class);
+    when(scanner.getRecords()).thenReturn(inMemoryMap);
+
+    // 3) Create the LogFileIterator using the new fix
+    LogFileIterator<HoodieRecord> iterator = new LogFileIterator<>(scanner);
+
+    // 4) Validate iteration (should use records.values().iterator())
+    assertTrue(iterator.hasNext());
+    HoodieRecord next1 = iterator.next();
+    assertNotNull(next1);
+
+    assertTrue(iterator.hasNext());
+    HoodieRecord next2 = iterator.next();
+    assertNotNull(next2);
+
+    assertFalse(iterator.hasNext());
+    iterator.close();
+  }
+
+  @Test
+  public void testIteratorWithExternalSpillableMap() throws Exception {
+    // 1) Create ExternalSpillableMap
+    ExternalSpillableMap<String, HoodieRecord> spillableMap = getSpillableRecordMap();
+
+    // 3) Mock a scanner that returns the ExternalSpillableMap
+    HoodieMergedLogRecordScanner scanner = Mockito.mock(HoodieMergedLogRecordScanner.class);
+    when(scanner.getRecords()).thenReturn(spillableMap);
+
+    // 4) Create the LogFileIterator (with the fix)
+    LogFileIterator<HoodieRecord> iterator = new LogFileIterator<>(scanner);
+
+    // 5) Validate iteration (should use ExternalSpillableMap.iterator(), not values().iterator())
+    int count = 0;
+    while (iterator.hasNext()) {
+      HoodieRecord rec = iterator.next();
+      assertNotNull(rec);
+      count++;
+    }
+    // We expect 2 records
+    assertEquals(2, count);
+
+    iterator.close();
+  }
+
+  private static ExternalSpillableMap<String, HoodieRecord> getSpillableRecordMap() throws IOException {
+    ExternalSpillableMap<String, HoodieRecord> spillableMap =
+        new ExternalSpillableMap<>(
+            1L, // maxInMemorySizeInBytes
+            "/tmp",                        // basePathForSpill
+            new DefaultSizeEstimator(),
+            new HoodieRecordSizeEstimator(HoodieTestDataGenerator.AVRO_SCHEMA),
+            ExternalSpillableMap.DiskMapType.BITCASK,
+            false
+        );
+
+    // 2) Put some records in the spillable map
+    HoodieRecord recordA = new HoodieAvroRecord(new HoodieKey("keyA", "p1"), null);
+    HoodieRecord recordB = new HoodieAvroRecord(new HoodieKey("keyB", "p2"), null);
+    spillableMap.put("keyA", recordA);
+    spillableMap.put("keyB", recordB);
+    return spillableMap;
+  }
+}


### PR DESCRIPTION
### Change Logs

Issue already fixed in https://github.com/apache/hudi/commit/6db37510ab07dcd5ff99b84dc85e480e1bb3a373

Just adding a test.

Without the above fix, it leads to following exception

```
Caused by org.apache.hudi.exception.HoodieException: Unsupported Operation Exception
	at org.apache.hudi.common.util.collection.BitCaskDiskMap.values(BitCaskDiskMap.java:302)
	at org.apache.hudi.common.util.collection.ExternalSpillableMap.values(ExternalSpillableMap.java:290)
	at org.apache.hudi.common.table.log.LogFileIterator.hasNextInternal(LogFileIterator.java:44)
	at org.apache.hudi.common.table.log.LogFileIterator.doHasNext(LogFileIterator.java:55)
	at org.apache.hudi.common.table.log.HoodieFileSliceReader.hasNextInternal(HoodieFileSliceReader.java:90)
	at org.apache.hudi.common.table.log.HoodieFileSliceReader.doHasNext(HoodieFileSliceReader.java:95)
	at org.apache.hudi.common.table.log.CachingIterator.hasNext(CachingIterator.java:31)
	at org.apache.hudi.client.utils.ConcatenatingIterator.hasNext(ConcatenatingIterator.java:45)
```

### Impact

Test coverage especially for clustering path with external spillable map

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
