### PR TITLE
[HUDI-8862] Fix inconsistent instant when sync hive in StreamWriteOperatorCoordinator

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -252,6 +252,7 @@ public class StreamWriteOperatorCoordinator
 
   @Override
   public void notifyCheckpointComplete(long checkpointId) {
+    String currentInstant = this.instant;
     executor.execute(
         () -> {
           // The executor thread inherits the classloader of the #notifyCheckpointComplete
@@ -268,7 +269,7 @@ public class StreamWriteOperatorCoordinator
             // start new instant.
             startInstant();
             // sync Hive if is enabled
-            syncHiveAsync();
+            syncHiveAsync(currentInstant);
           }
         }, "commits the instant %s", this.instant
     );
@@ -326,9 +327,9 @@ public class StreamWriteOperatorCoordinator
     this.hiveSyncContext = HiveSyncContext.create(conf, this.storageConf);
   }
 
-  private void syncHiveAsync() {
+  private void syncHiveAsync(String currentInstant) {
     if (tableState.syncHive) {
-      this.hiveSyncExecutor.execute(this::doSyncHive, "sync hive metadata for instant %s", this.instant);
+      this.hiveSyncExecutor.execute(this::doSyncHive, "sync hive metadata for instant %s", currentInstant);
     }
   }
 


### PR DESCRIPTION
### Change Logs

when sync hive in `StreamWriteOperatorCoordinator.notifyCheckpointComplete`,  `this.instant` has beed updated in `startInstant` which causes `syncHiveAsync` logs the newer instant(actually should be the committed one ), which will cause misleading when troubleshooting.

case like:
timeline
```
-rw-r--r-- 3 xx_edw xx_edw 19.8 K 2024-12-31 12:04 hdfs://nsxxx/user/xx_edw/dwd.db/dwd_product_other_sku_1_chain_hudi/.hoodie/20241231120258437.deltacommit
-rw-r--r-- 3 xx_edw xx_edw 0 2024-12-31 12:02 hdfs://nsxxx/user/xx_edw/dwd.db/dwd_product_other_sku_1_chain_hudi/.hoodie/20241231120258437.deltacommit.inflight
-rw-r--r-- 3 xx_edw xx_edw 0 2024-12-31 12:02 hdfs://nsxxx/user/xx_edw/dwd.db/dwd_product_other_sku_1_chain_hudi/.hoodie/20241231120258437.deltacommit.requested
-rw-r--r-- 3 xx_edw xx_edw 0 2024-12-31 12:04 hdfs://nsxxx/user/xx_edw/dwd.db/dwd_product_other_sku_1_chain_hudi/.hoodie/20241231120457665.deltacommit.inflight
-rw-r--r-- 3 xx_edw xx_edw 0 2024-12-31 12:04 hdfs://nsxxx/user/xx_edw/dwd.db/dwd_product_other_sku_1_chain_hudi/.hoodie/20241231120457665.deltacommit.requested
```
committed instant is 20241231120258437 , but logs in `syncHiveAsync` is :
```
2024-12-31 12:05:02.062 INFO [pool-22-thread-1:2-thread-1] org.apache.hudi.sink.StreamWriteOperatorCoordinator - Executor executes action [sync hive metadata for instant 20241231120457665] success!
```


### Impact

hudi-flink-datasource

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
