### PR TITLE
[HUDI-8865] Fix error message of unresolved columns in MERGE INTO on Spark 3.5

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -1527,7 +1527,8 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
       "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name " +
         s"$columnName cannot be resolved. Did you mean one of the following? $fieldNames."
     } else {
-      s"cannot resolve $columnName in MERGE command given columns $fieldNames."
+      s"cannot resolve $columnName in MERGE command given columns $fieldNames" +
+        (if (HoodieSparkUtils.gteqSpark3_4) "." else "")
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -17,16 +17,14 @@
 
 package org.apache.spark.sql.hudi.dml
 
-import org.apache.hudi.{DataSourceReadOptions, ScalaAssertionSupport}
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils, ScalaAssertionSupport}
 import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_OPTIMIZED_WRITES
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.testutils.DataSourceTestUtils
 
-import org.apache.spark.sql.hudi.ProvidesHoodieConfig.getClass
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.internal.SQLConf
-
 import org.slf4j.LoggerFactory
 
 class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSupport {
@@ -1443,6 +1441,93 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
           Seq(2, "a2", null, "2021-03-20")
         )
       })
+    }
+  }
+
+  test("Test unresolved columns in Merge Into statement") {
+    Seq("cow", "mor").foreach { tableType =>
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        // Create a partitioned table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  dt string,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (primaryKey = 'id', type = '$tableType')
+             | partitioned by (dt)
+             | location '${tmp.getCanonicalPath}'
+             | """.stripMargin)
+
+        spark.sql(
+          s"""
+             | insert into $tableName partition(dt = '2024-01-14')
+             | select 1 as id, 'a1' as name, 10 as price, 1000 as ts
+             | union
+             | select 2 as id, 'a2' as name, 20 as price, 1002 as ts
+             | """.stripMargin)
+        checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+          Seq(1, "a1", 10.0, 1000, "2024-01-14"),
+          Seq(2, "a2", 20.0, 1002, "2024-01-14")
+        )
+
+        val targetTableFields = spark.sql(s"select * from $tableName").schema.fields
+          .map(e => (e.name, tableName, s"spark_catalog.default.$tableName.${e.name}"))
+        val sourceTableFields = Seq("s0._id", "s0._price", "s0._ts", "s0.dt", "s0.name")
+          .map(e => {
+            val splits = e.split('.')
+            (splits(1), splits(0), e)
+          })
+        // Target table column cannot be found
+        val sqlStatement1 =
+          s"""
+             | merge into $tableName
+             | using (
+             |  select 2 as _id, '2024-01-14' as dt, 'a2_new' as name, 25 as _price, 1005 as _ts
+             |  union
+             |  select 3 as _id, '2024-01-14' as dt, 'a3' as name, 30 as _price, 1003 as _ts
+             | ) s0
+             | on s0._id = $tableName.id
+             | when matched then update set
+             | id = s0._id, dt = s0.dt, new_col = s0.name, price = s0._price + $tableName.price,
+             | ts = s0._ts
+             | """.stripMargin
+        // Source table column cannot be found
+        val sqlStatement2 =
+          s"""
+             | merge into $tableName
+             | using (
+             |  select 2 as _id, '2024-01-14' as dt, 'a2_new' as name, 25 as _price, 1005 as _ts
+             |  union
+             |  select 3 as _id, '2024-01-14' as dt, 'a3' as name, 30 as _price, 1003 as _ts
+             | ) s0
+             | on s0._id = $tableName.id
+             | when matched then update set
+             | id = s0._id, dt = s0.dt, name = s0.new_col, price = s0._price + $tableName.price,
+             | ts = s0._ts
+             | """.stripMargin
+
+        checkExceptionContain(sqlStatement1)(
+          getExpectedExceptionMessage("new_col", targetTableFields))
+        checkExceptionContain(sqlStatement2)(
+          getExpectedExceptionMessage("s0.new_col", sourceTableFields ++ targetTableFields))
+      }
+    }
+  }
+
+  private def getExpectedExceptionMessage(columnName: String,
+                                          fieldNameTuples: Seq[(String, String, String)]): String = {
+    val fieldNames = fieldNameTuples.sortBy(e => (e._1, e._2))
+      .map(e => e._3).mkString("[", ", ", "]")
+    if (HoodieSparkUtils.gteqSpark3_5) {
+      "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name " +
+        s"$columnName cannot be resolved. Did you mean one of the following? $fieldNames."
+    } else {
+      s"cannot resolve $columnName in MERGE command given columns $fieldNames."
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystPlanUtils.scala
@@ -25,8 +25,8 @@ import org.apache.spark.sql.catalyst.planning.ScanOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.execution.command.RepairTableCommand
-import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, ParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, ParquetFileFormat}
 import org.apache.spark.sql.types.StructType
 
 object HoodieSpark35CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
@@ -74,10 +74,10 @@ object HoodieSpark35CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
 
   override def failAnalysisForMIT(a: Attribute, cols: String): Unit = {
     a.failAnalysis(
-      errorClass = "_LEGACY_ERROR_TEMP_2309",
+      errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
       messageParameters = Map(
-        "sqlExpr" -> a.sql,
-        "cols" -> cols))
+        "objectName" -> a.sql,
+        "proposal" -> cols))
   }
 
   override def unapplyCreateIndex(plan: LogicalPlan): Option[(LogicalPlan, String, String, Boolean, Seq[(Seq[String], Map[String, String])], Map[String, String])] = {


### PR DESCRIPTION
### Change Logs

Before this fix, If there are unresolved columns in the `MERGE INTO` statement using Hudi, currently Spark 3.5 throws the exception below which is not user-friendly:

```
Caused by: org.apache.spark.SparkException: [INTERNAL_ERROR] Cannot find main error class '_LEGACY_ERROR_TEMP_2309'
    at org.apache.spark.SparkException$.internalError(SparkException.scala:92)
    at org.apache.spark.SparkException$.internalError(SparkException.scala:96)
    at org.apache.spark.ErrorClassesJsonReader.$anonfun$getMessageTemplate$1(ErrorClassesJSONReader.scala:68)
    at scala.collection.immutable.HashMap$HashMap1.getOrElse0(HashMap.scala:361)
    at scala.collection.immutable.HashMap$HashTrieMap.getOrElse0(HashMap.scala:594)
    at scala.collection.immutable.HashMap$HashTrieMap.getOrElse0(HashMap.scala:589)
    at scala.collection.immutable.HashMap.getOrElse(HashMap.scala:73)
    at org.apache.spark.ErrorClassesJsonReader.getMessageTemplate(ErrorClassesJSONReader.scala:68)
    at org.apache.spark.ErrorClassesJsonReader.getErrorMessage(ErrorClassesJSONReader.scala:47)
    at org.apache.spark.SparkThrowableHelper$.getMessage(SparkThrowableHelper.scala:53)
    at org.apache.spark.SparkThrowableHelper$.getMessage(SparkThrowableHelper.scala:40)
    at org.apache.spark.sql.AnalysisException.<init>(AnalysisException.scala:77)
    at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:52)
    at org.apache.spark.sql.HoodieSpark35CatalystPlanUtils$.failAnalysisForMIT(HoodieSpark35CatalystPlanUtils.scala:80)
    at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.$anonfun$resolveMergeExprOrFail$2(HoodieSpark3Analysis.scala:263)
    at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.$anonfun$resolveMergeExprOrFail$2$adapted(HoodieSpark3Analysis.scala:258)
```

This is because the error class has changed in Spark 3.5 (specifically from this PR [SPARK-44244] https://github.com/apache/spark/pull/41788), from `_LEGACY_ERROR_TEMP_2309` to `UNRESOLVED_COLUMN.WITH_SUGGESTION`, and `_LEGACY_ERROR_TEMP_2309` is removed.  Spark 3.4 and below are not affected.

To fix it, `HoodieSpark35CatalystPlanUtils#failAnalysisForMIT` now uses `UNRESOLVED_COLUMN.WITH_SUGGESTION` error class to align with Spark 3.5, and the error message looks like behow. A new test is added to validate the behavior.

```
org.apache.spark.sql.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name new_col cannot be resolved. Did you mean one of the following? [spark_catalog.default.h1._hoodie_commit_seqno, spark_catalog.default.h1._hoodie_commit_time, spark_catalog.default.h1._hoodie_file_name, spark_catalog.default.h1._hoodie_partition_path, spark_catalog.default.h1._hoodie_record_key, spark_catalog.default.h1.dt, spark_catalog.default.h1.id, spark_catalog.default.h1.name, spark_catalog.default.h1.price, spark_catalog.default.h1.ts].; line 10 pos 1
	at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:52)
	at org.apache.spark.sql.HoodieSpark35CatalystPlanUtils$.failAnalysisForMIT(HoodieSpark35CatalystPlanUtils.scala:80)
	at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.$anonfun$resolveMergeExprOrFail$2(HoodieSpark3Analysis.scala:263)
	at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.$anonfun$resolveMergeExprOrFail$2$adapted(HoodieSpark3Analysis.scala:258)
	at scala.collection.mutable.LinkedHashSet.foreach(LinkedHashSet.scala:95)
	at org.apache.spark.sql.catalyst.expressions.AttributeSet.foreach(AttributeSet.scala:137)
	at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.resolveMergeExprOrFail(HoodieSpark3Analysis.scala:258)
	at org.apache.spark.sql.hudi.analysis.HoodieSpark3ResolveReferences.$anonfun$resolveAssignments$1(HoodieSpark3Analysis.scala:238)
```

### Impact

Improves error message.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
