### PR TITLE
[HUDI-8621] Revert single file slice optimisation for getRecordsByKeys in MDT table

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -263,23 +263,18 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
     // Lookup keys from each file slice
-    if (numFileSlices == 1) {
-      // Optimization for a single slice for smaller metadata table partitions
-      result = lookupKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
-    } else {
-      // Parallel lookup for large sized partitions with many file slices
-      // Partition the keys by the file slice which contains it
-      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-      result = new HashMap<>(keys.size());
-      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-      getEngineContext().map(partitionedKeys, keysList -> {
-        if (keysList.isEmpty()) {
-          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-        }
-        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-        return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-      }, partitionedKeys.size()).forEach(result::putAll);
-    }
+    // Parallel lookup for large sized partitions with many file slices
+    // Partition the keys by the file slice which contains it
+    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+    result = new HashMap<>(keys.size());
+    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+    getEngineContext().map(partitionedKeys, keysList -> {
+      if (keysList.isEmpty()) {
+        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+      }
+      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+      return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+    }, partitionedKeys.size()).forEach(result::putAll);
 
     return result;
   }
@@ -310,23 +305,18 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
     // Lookup keys from each file slice
-    if (numFileSlices == 1) {
-      // Optimization for a single slice for smaller metadata table partitions
-      result = lookupAllKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
-    } else {
-      // Parallel lookup for large sized partitions with many file slices
-      // Partition the keys by the file slice which contains it
-      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-      result = new HashMap<>(keys.size());
-      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-      getEngineContext().map(partitionedKeys, keysList -> {
-        if (keysList.isEmpty()) {
-          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-        }
-        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-        return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-      }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
-    }
+    // Parallel lookup for large sized partitions with many file slices
+    // Partition the keys by the file slice which contains it
+    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+    result = new HashMap<>(keys.size());
+    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+    getEngineContext().map(partitionedKeys, keysList -> {
+      if (keysList.isEmpty()) {
+        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+      }
+      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+      return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+    }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
 
     return result;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
@@ -283,6 +283,6 @@ public abstract class TestBootstrapReadBase extends HoodieSparkClientTestBase {
     return df.withColumn("partpath" + n,
         functions.md5(functions.concat_ws("," + n + ",",
             df.col("partition_path"),
-            functions.hash(df.col("_row_key")).mod(n))));
+            functions.hash(df.col("partition_path")).mod(n))));
   }
 }


### PR DESCRIPTION
### Change Logs

In https://github.com/apache/hudi/pull/12376 - we attempted to revert the optimization for single file slice, and do the computation such as getRecordByKeys, etc. over executors even if it is for a single file slice. This means when listing files using metadata files index, even if the data partition has only one file slice, it happens over the executor and the request is sent to the timeline server (RemoteFileSystemView). However, we noticed that the timeline server did not respond and the request timed out in the case of bootstrap of a MOR table having multiple partition fields.

The PR reverts the single file slice optimisation and also fixes the test failure in TestBootstrapRead.testBootstrapFunctional. The test was failing because all spark threads are used up in the list calls for the partition.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
