### PR TITLE
[HUDI-8628] Table Service writer config hard wired to table schema 

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -293,7 +293,7 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
     // Disable auto commit. Strategy is only expected to write data in new files.
     config.setValue(HoodieWriteConfig.AUTO_COMMIT_ENABLE, Boolean.FALSE.toString());
 
-    final Schema schema = new TableSchemaResolver(table.getMetaClient()).getTableAvroSchemaIfPresentV2(false).get();
+    final Schema schema = new TableSchemaResolver(table.getMetaClient()).getTableAvroSchemaForClustering(false).get();
     HoodieWriteMetadata<HoodieData<WriteStatus>> writeMetadata = (
         (ClusteringExecutionStrategy<T, HoodieData<HoodieRecord<T>>, HoodieData<HoodieKey>, HoodieData<WriteStatus>>)
             ReflectionUtils.loadClass(config.getClusteringExecutionStrategyClass(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -242,8 +242,9 @@ public class TableSchemaResolver {
     }
   }
 
-  public Option<Schema> getTableAvroSchemaIfPresentV2(boolean includeMetadataFields) {
-    return getTableSchemaFromLatestCommitMetadataV2(includeMetadataFields)
+  // [HUDI-8219]: needs to be cleaned up when the jira is fully implemented.
+  public Option<Schema> getTableAvroSchemaForClustering(boolean includeMetadataFields) {
+    return getTableSchemaFromLatestCommitMetadataForClustering(includeMetadataFields)
       .or(() -> getTableCreateSchemaWithMetadata(includeMetadataFields))
       .or(() -> getSchemaFromDataFileIfPresent(includeMetadataFields))
         .map(this::handlePartitionColumnsIfNeeded);
@@ -256,7 +257,7 @@ public class TableSchemaResolver {
         : schemaFromDataFile.map(HoodieAvroUtils::removeMetadataFields));
   }
 
-  private Option<Schema> getTableSchemaFromLatestCommitMetadataV2(boolean includeMetadataFields) {
+  private Option<Schema> getTableSchemaFromLatestCommitMetadataForClustering(boolean includeMetadataFields) {
     HoodieTimeline reversedTimeline = getSchemaEvolutionTimelineInReverseOrder();
     // To find the table schema given an instant time, need to walk backwards from the latest instant in
     // the timeline finding a completed instant containing a valid schema.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -32,6 +32,8 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -58,14 +60,23 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.avro.AvroSchemaUtils.appendFieldsToSchema;
 import static org.apache.hudi.avro.AvroSchemaUtils.containsFieldInSchema;
 import static org.apache.hudi.avro.AvroSchemaUtils.createNullableSchema;
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 
 /**
  * Helper class to read schema from data files and log files and to convert it between different formats.
@@ -176,32 +187,43 @@ public class TableSchemaResolver {
     return getTableAvroSchemaInternal(includeMetadataFields, Option.empty());
   }
 
-  private Option<Schema> getTableAvroSchemaInternal(boolean includeMetadataFields, Option<HoodieInstant> instantOpt) {
-    Option<Schema> schema =
-        (instantOpt.isPresent()
-            ? getTableSchemaFromCommitMetadata(instantOpt.get(), includeMetadataFields)
-            : getTableSchemaFromLatestCommitMetadata(includeMetadataFields))
-            .or(() ->
-                metaClient.getTableConfig().getTableCreateSchema()
-                    .map(tableSchema ->
-                        includeMetadataFields
-                            ? HoodieAvroUtils.addMetadataFields(tableSchema, hasOperationField.get())
-                            : tableSchema)
-            )
-            .or(() -> {
-              Option<Schema> schemaFromDataFile = getTableAvroSchemaFromDataFileInternal();
-              return includeMetadataFields
-                  ? schemaFromDataFile
-                  : schemaFromDataFile.map(HoodieAvroUtils::removeMetadataFields);
-            });
+  Option<Schema> getTableAvroSchemaInternal(boolean includeMetadataFields, Option<HoodieInstant> instantOpt) {
+    return (instantOpt.isPresent()
+        ? getTableSchemaFromCommitMetadata(instantOpt.get(), includeMetadataFields)
+        : getTableSchemaFromLatestCommitMetadata(includeMetadataFields))
+        .or(() -> getTableCreateSchemaWithMetadata(includeMetadataFields))
+        .or(() -> getSchemaFromDataFileIfPresent(includeMetadataFields))
+        .map(this::handlePartitionColumnsIfNeeded);
+  }
 
-    // TODO partition columns have to be appended in all read-paths
-    if (metaClient.getTableConfig().shouldDropPartitionColumns() && schema.isPresent()) {
+  /**
+   * Retrieves the table creation schema with metadata fields and partition columns handled.
+   *
+   * @param includeMetadataFields whether to include metadata fields in the schema
+   * @return Option containing the fully processed schema if available, empty Option otherwise
+   */
+  public Option<Schema> getTableCreateSchemaWithMetadata(boolean includeMetadataFields) {
+    return metaClient.getTableConfig().getTableCreateSchema()
+        .map(tableSchema ->
+            includeMetadataFields
+                ? HoodieAvroUtils.addMetadataFields(tableSchema, hasOperationField.get())
+                : tableSchema)
+        .map(this::handlePartitionColumnsIfNeeded);
+  }
+
+  /**
+   * Handles partition column logic for a given schema.
+   *
+   * @param schema the input schema to process
+   * @return the processed schema with partition columns handled appropriately
+   */
+  private Schema handlePartitionColumnsIfNeeded(Schema schema) {
+    if (metaClient.getTableConfig().shouldDropPartitionColumns()) {
       return metaClient.getTableConfig().getPartitionFields()
-          .map(partitionFields -> appendPartitionColumns(schema.get(), Option.ofNullable(partitionFields)))
-          .or(() -> schema);
+          .map(partitionFields -> appendPartitionColumns(schema, Option.ofNullable(partitionFields)))
+          .or(() -> Option.of(schema))
+          .get();
     }
-
     return schema;
   }
 
@@ -220,6 +242,50 @@ public class TableSchemaResolver {
     } else {
       return Option.empty();
     }
+  }
+
+  public Option<Schema> getTableAvroSchemaIfPresentV2(boolean includeMetadataFields) {
+    return getTableSchemaFromLatestCommitMetadataV2(includeMetadataFields)
+      .or(() -> getTableCreateSchemaWithMetadata(includeMetadataFields))
+      .or(() -> getSchemaFromDataFileIfPresent(includeMetadataFields))
+        .map(this::handlePartitionColumnsIfNeeded);
+  }
+
+  private Option<Schema> getSchemaFromDataFileIfPresent(boolean includeMetadataFields) {
+    Option<Schema> schemaFromDataFile = getTableAvroSchemaFromDataFileInternal();
+    return (includeMetadataFields
+        ? schemaFromDataFile
+        : schemaFromDataFile.map(HoodieAvroUtils::removeMetadataFields));
+  }
+
+  private Option<Schema> getTableSchemaFromLatestCommitMetadataV2(boolean includeMetadataFields) {
+    HoodieTimeline reversedTimeline = getSchemaEvolutionTimelineInReverseOrder();
+    // To find the table schema given an instant time, need to walk backwards from the latest instant in
+    // the timeline finding a completed instant containing a valid schema.
+    Option<HoodieInstant> instantWithTableSchema = Option.fromJavaOptional(reversedTimeline.getInstantsAsStream()
+        // Make sure the commit metadata has a valid schema inside. Same caching the result for expensive operation.
+        .filter(s -> {
+          try {
+            return !StringUtils.isNullOrEmpty(metaClient.getCommitMetadataSerDe().deserialize(
+                      s,
+                      reversedTimeline.getInstantDetails(s).get(),
+                      HoodieCommitMetadata.class)
+                .getMetadata(HoodieCommitMetadata.SCHEMA_KEY));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        })
+        .findFirst());
+
+    if (instantWithTableSchema.isPresent()) {
+      // If there is a qualified instant, parse the table schema out of it.
+      try {
+        return Option.of(getTableAvroSchema(instantWithTableSchema.get(), includeMetadataFields));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return Option.empty();
   }
 
   private Option<Schema> getTableSchemaFromCommitMetadata(HoodieInstant instant, boolean includeMetadataFields) {
@@ -513,5 +579,57 @@ public class TableSchemaResolver {
 
   private Supplier<Exception> schemaNotFoundError() {
     return () -> new HoodieSchemaNotFoundException("No schema found for table at " + metaClient.getBasePath());
+  }
+
+  /**
+   * WARNING: This method should be only used as part of HUDI-8438 before the jira owner fully accommodate all existing use
+   * cases.
+   *
+   * Get timeline in REVERSE order that only contains completed instants which POTENTIALLY evolve the table schema.
+   * For types of instants that are included and not reflecting table schema at their instant completion time please refer
+   * comments inside the code.
+   * */
+  HoodieTimeline getSchemaEvolutionTimelineInReverseOrder() {
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    Stream<HoodieInstant> timelineStream = timeline.getInstantsAsStream();
+    final Set<String> actions;
+    switch (metaClient.getTableType()) {
+      case COPY_ON_WRITE: {
+        actions = new HashSet<>(Arrays.asList(COMMIT_ACTION, REPLACE_COMMIT_ACTION));
+        break;
+      }
+      case MERGE_ON_READ: {
+        actions = new HashSet<>(Arrays.asList(DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION));
+        break;
+      }
+      default:
+        throw new HoodieException("Unsupported table type :" + metaClient.getTableType());
+    }
+
+    // We only care committed instant when it comes to table schema.
+    TimelineLayout timelineLayout = metaClient.getTimelineLayout();
+    Comparator<HoodieInstant> reversedComparator = timelineLayout.getInstantComparator().requestedTimeOrderedComparator().reversed();
+
+    // The timeline still contains DELTA_COMMIT_ACTION/COMMIT_ACTION which might not contain a valid schema
+    // field in their commit metadata.
+    // Since the operations of filtering them out are expensive, we should do on-demand stream based
+    // filtering when we actually need the table schema.
+    Stream<HoodieInstant> reversedTimelineWithTableSchema = timelineStream
+        // Only focuses on those who could potentially evolve the table schema.
+        .filter(s -> actions.contains(s.getAction()))
+        // Further filtering out clustering operations as it does not evolve table schema.
+        .filter(s -> isaBoolean(s, timeline))
+        .filter(HoodieInstant::isCompleted)
+        // We reverse the order as the operation against this timeline would be very efficient if
+        // we always start from the tail.
+        .sorted(reversedComparator);
+    return timelineLayout.getTimelineFactory().createDefaultTimeline(
+        reversedTimelineWithTableSchema,
+        metaClient.getActiveTimeline()::getInstantDetails);
+  }
+
+  private boolean isaBoolean(HoodieInstant s, HoodieActiveTimeline timeline) {
+    return !s.getAction().equals(REPLACE_COMMIT_ACTION)
+      || !ClusteringUtils.isClusteringInstant(timeline, s, metaClient.getInstantGenerator());
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -19,10 +19,22 @@
 package org.apache.hudi.common.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieClusteringStrategy;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -34,29 +46,59 @@ import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.apache.hudi.common.functional.TestHoodieLogFormat.getDataBlock;
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK;
+import static org.apache.hudi.common.table.timeline.HoodieInstant.State.COMPLETED;
+import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
+import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSimpleSchema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link TableSchemaResolver}.
  */
-public class TestTableSchemaResolver {
+public class TestTableSchemaResolver extends HoodieCommonTestHarness {
 
-  @TempDir
-  public java.nio.file.Path tempDir;
+  @BeforeEach
+  public void setUp() throws Exception {
+    initMetaClient();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanMetaClient();
+  }
 
   @Test
   public void testRecreateSchemaWhenDropPartitionColumns() {
@@ -91,18 +133,252 @@ public class TestTableSchemaResolver {
 
   @Test
   public void testReadSchemaFromLogFile() throws IOException, URISyntaxException, InterruptedException {
-    String testDir = initTestDir("read_schema_from_log_file");
-    StoragePath partitionPath = new StoragePath(testDir, "partition1");
+    initPath("read_schema_from_log_file");
+    StoragePath partitionPath = new StoragePath(basePath, "partition1");
     Schema expectedSchema = getSimpleSchema();
     StoragePath logFilePath = writeLogFile(partitionPath, expectedSchema);
     assertEquals(expectedSchema, TableSchemaResolver.readSchemaFromLogFile(new HoodieHadoopStorage(
         logFilePath, HoodieTestUtils.getDefaultStorageConfWithDefaults()), logFilePath));
   }
 
-  private String initTestDir(String folderName) throws IOException {
-    java.nio.file.Path basePath = tempDir.resolve(folderName);
-    java.nio.file.Files.createDirectories(basePath);
-    return basePath.toString();
+  @Test
+  public void testGetTableSchemaFromLatestCommitMetadataV2() throws Exception {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    String commitTime1 = "001";
+    HoodieInstant instant1 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant1);
+
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HoodieCommitMetadata.SCHEMA_KEY, originalSchema.toString());
+
+    activeTimeline.saveAsComplete(instant1,
+        Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, extraMetadata)));
+    metaClient.reloadActiveTimeline();
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    assertTrue(schemaOption.isPresent());
+    assertEquals(originalSchema, schemaOption.get());
+  }
+
+  @Test
+  public void testGetTableCreateSchemaWithMetadata() throws IOException {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    // Set table create schema in table config
+    // Create commit metadata without schema information, which should be ignored.
+    Map<String, String> emptyMetadata = new HashMap<>();
+
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    String commitTime1 = "001";
+    HoodieInstant instant1 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant1);
+    activeTimeline.saveAsComplete(instant1, Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, emptyMetadata)));
+    metaClient.reloadActiveTimeline();
+    metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    assertTrue(schemaOption.isPresent());
+    assertEquals(originalSchema, schemaOption.get());
+  }
+
+  @Test
+  public void testHandlePartitionColumnsIfNeeded() {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    String[] partitionFields = new String[] {"partition_path"};
+    metaClient.getTableConfig().setValue(PARTITION_FIELDS, String.join(",", partitionFields));
+    metaClient.getTableConfig().setValue(HoodieTableConfig.DROP_PARTITION_COLUMNS, "true");
+    metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    assertTrue(schemaOption.isPresent());
+
+    Schema resultSchema = schemaOption.get();
+    assertTrue(resultSchema.getFields().stream()
+        .anyMatch(f -> f.name().equals("partition_path")));
+  }
+
+  static class SchemaEvolutionTestCase {
+    private final String name;
+    private final HoodieTableType tableType;
+    private final List<HoodieInstant> inputInstants;
+    private final List<HoodieInstant> expectedInstants;
+    private final Option<HoodieInstant> clusteringInstants;
+
+    public SchemaEvolutionTestCase(
+        String name,
+        HoodieTableType tableType,
+        List<HoodieInstant> inputInstants,
+        List<HoodieInstant> expectedInstants) {
+      this.name = name;
+      this.tableType = tableType;
+      this.inputInstants = inputInstants;
+      this.expectedInstants = expectedInstants;
+      this.clusteringInstants = Option.empty();
+    }
+
+    public SchemaEvolutionTestCase(
+        String name,
+        HoodieTableType tableType,
+        List<HoodieInstant> inputInstants,
+        List<HoodieInstant> expectedInstants,
+        HoodieInstant clusteringInstants
+    ) {
+      this.name = name;
+      this.tableType = tableType;
+      this.inputInstants = inputInstants;
+      this.expectedInstants = expectedInstants;
+      this.clusteringInstants = Option.of(clusteringInstants);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s (%s)", name, tableType);
+    }
+  }
+
+  static Stream<SchemaEvolutionTestCase> schemaEvolutionTestCases() {
+    return Stream.of(
+        // Empty timeline case
+        new SchemaEvolutionTestCase(
+            "Empty Timeline",
+            HoodieTableType.COPY_ON_WRITE,
+            new ArrayList<>(),
+            new ArrayList<>()
+        ),
+
+        // Empty timeline case
+        new SchemaEvolutionTestCase(
+            "Empty Timeline",
+            HoodieTableType.MERGE_ON_READ,
+            new ArrayList<>(),
+            new ArrayList<>()
+        ),
+
+        // Mixed actions case
+        new SchemaEvolutionTestCase(
+            "Mixed Actions",
+            HoodieTableType.COPY_ON_WRITE,
+            Arrays.asList(
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                // Table service actions that should be filtered out
+                new HoodieInstant(REQUESTED, CLEAN_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(REQUESTED, ROLLBACK_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(REQUESTED, CLUSTERING_ACTION, "006", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(INFLIGHT, CLEAN_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(INFLIGHT, ROLLBACK_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(INFLIGHT, CLUSTERING_ACTION, "006", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, CLEAN_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, CLUSTERING_ACTION, "006", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR) // clustering commits
+
+            ),
+            Arrays.asList(
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)
+            ),
+            new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)
+        ),
+
+        // Case 3: Comprehensive Mixed Timeline
+        new SchemaEvolutionTestCase(
+            "Comprehensive Mixed Timeline",
+            HoodieTableType.COPY_ON_WRITE,
+            Arrays.asList(
+                // Valid instants
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+
+                // Invalid states
+                new HoodieInstant(REQUESTED, COMMIT_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(INFLIGHT, COMMIT_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                // Invalid actions
+                new HoodieInstant(COMPLETED, CLEAN_ACTION, "006", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, CLUSTERING_ACTION, "007", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR) // clustering commits
+            ),
+            Arrays.asList(
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)
+            ),
+            new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)
+        )
+    );
+  }
+
+  private HoodieTableMetaClient prepareMetaClient(List<HoodieInstant> instants, HoodieTableType tableType, Option<HoodieInstant> clusteringInstant) throws IOException {
+    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig mockTableConfig = mock(HoodieTableConfig.class);
+    TimelineLayout timelineLayout = TimelineLayout.TIMELINE_LAYOUT_V2;
+    HoodieActiveTimeline mockActiveTimeline = mock(HoodieActiveTimeline.class);
+
+    when(mockMetaClient.getTableType()).thenReturn(tableType);
+    when(mockMetaClient.getTimelineLayout()).thenReturn(timelineLayout);
+    when(mockMetaClient.getActiveTimeline()).thenReturn(mockActiveTimeline);
+    when(mockActiveTimeline.getInstantsAsStream()).thenReturn(instants.stream());
+    when(mockActiveTimeline.getInstantDetails(any()))
+        .thenReturn(Option.of(new byte[0]));
+    when(mockMetaClient.getBasePath()).thenReturn(new StoragePath("file://dummy/path"));
+    when(mockMetaClient.scanHoodieInstantsFromFileSystem(any(), any(), eq(true)))
+        .thenReturn(instants);
+    when(mockMetaClient.getMetaPath()).thenReturn(new StoragePath("file://dummy/path/.hoodie"));
+    when(mockMetaClient.getTableConfig()).thenReturn(mockTableConfig);
+    when(mockMetaClient.getTableConfig().getTimelinePath()).thenReturn("timeline");
+    when(mockMetaClient.getInstantGenerator()).thenReturn(INSTANT_GENERATOR);
+
+    if (clusteringInstant.isPresent()) {
+      // Create clustering plan metadata
+      HoodieRequestedReplaceMetadata requestedReplaceMetadata =
+          HoodieRequestedReplaceMetadata.newBuilder()
+              .setOperationType("CLUSTER")
+              .setClusteringPlan(HoodieClusteringPlan.newBuilder()
+                  .setVersion(1)
+                  .setStrategy(HoodieClusteringStrategy.newBuilder()
+                      .setStrategyClassName("org.apache.hudi.client.clustering.run.strategy.SparkSingleFileSortStrategy")
+                      .build())
+                  .build())
+              .build();
+      // Get the corresponding requested instant for the inflight instant
+      HoodieInstant requestedInstant = new HoodieInstant(
+          HoodieInstant.State.REQUESTED, CLUSTERING_ACTION, clusteringInstant.get().requestedTime(), InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+      when(mockActiveTimeline.getInstantDetails(requestedInstant)).thenReturn(serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    }
+    return mockMetaClient;
+  }
+
+  @ParameterizedTest
+  @MethodSource("schemaEvolutionTestCases")
+  public void testGetSchemaEvolutionTimelineInReverseOrder(SchemaEvolutionTestCase testCase) throws IOException {
+    HoodieTableMetaClient mockMetaClient = prepareMetaClient(testCase.inputInstants, testCase.tableType, testCase.clusteringInstants);
+    TableSchemaResolver resolver = new TableSchemaResolver(mockMetaClient);
+    HoodieTimeline timeline = resolver.getSchemaEvolutionTimelineInReverseOrder();
+
+    verifyTimelineInstants(testCase.expectedInstants, timeline);
+  }
+
+  private void verifyTimelineInstants(List<HoodieInstant> expectedInstants, HoodieTimeline timeline) {
+    // Verify the timeline contains exactly the expected instants in reverse order
+    List<HoodieInstant> actualInstants = timeline.getInstantsAsStream().collect(Collectors.toList());
+    assertEquals(expectedInstants.size(), actualInstants.size());
+
+    for (int i = 0; i < expectedInstants.size(); i++) {
+      HoodieInstant expected = expectedInstants.get(i);
+      HoodieInstant actual = actualInstants.get(i);
+      assertEquals(expected.getAction(), actual.getAction());
+      assertEquals(expected.getCompletionTime(), actual.getCompletionTime());
+      assertEquals(expected.getState(), actual.getState());
+    }
   }
 
   private StoragePath writeLogFile(StoragePath partitionPath, Schema schema) throws IOException, URISyntaxException, InterruptedException {
@@ -118,5 +394,120 @@ public class TestTableSchemaResolver {
     writer.appendBlock(dataBlock);
     writer.close();
     return writer.getLogFile().getPath();
+  }
+
+  @Test
+  public void testGetTableAvroSchemaInternalFromCommitMetadata() throws Exception {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    // Setup commit with schema in metadata
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    String commitTime = "001";
+    HoodieInstant instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant);
+
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HoodieCommitMetadata.SCHEMA_KEY, originalSchema.toString());
+
+    activeTimeline.saveAsComplete(instant,
+        Option.of(getCommitMetadata(basePath, "partition1", commitTime, 2, extraMetadata)));
+    metaClient.reloadActiveTimeline();
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+
+    // Test with includeMetadataFields = false
+    Option<Schema> schemaWithoutMetadata = resolver.getTableAvroSchemaInternal(false, Option.empty());
+    assertTrue(schemaWithoutMetadata.isPresent());
+    assertNull(schemaWithoutMetadata.get().getField(HoodieRecord.RECORD_KEY_METADATA_FIELD));
+  }
+
+  @Test
+  public void testGetTableAvroSchemaInternalFromTableConfig() {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    // Set schema in table config
+    metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+
+    // Test with includeMetadataFields = true
+    Option<Schema> schemaWithMetadata = resolver.getTableAvroSchemaInternal(true, Option.empty());
+    assertTrue(schemaWithMetadata.isPresent());
+    assertTrue(schemaWithMetadata.get().getField(HoodieRecord.RECORD_KEY_METADATA_FIELD) != null);
+
+    // Test with includeMetadataFields = false
+    Option<Schema> schemaWithoutMetadata = resolver.getTableAvroSchemaInternal(false, Option.empty());
+    assertTrue(schemaWithoutMetadata.isPresent());
+    assertNull(schemaWithoutMetadata.get().getField(HoodieRecord.RECORD_KEY_METADATA_FIELD));
+  }
+
+  @Test
+  public void testGetTableAvroSchemaInternalWithPartitionFields() throws Exception {
+    Schema originalSchema = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+
+    // Setup table config with partition fields
+    String[] partitionFields = new String[] {"partition_path"};
+    metaClient.getTableConfig().setValue(PARTITION_FIELDS, String.join(",", partitionFields));
+    metaClient.getTableConfig().setValue(HoodieTableConfig.DROP_PARTITION_COLUMNS, "true");
+    metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaInternal(true, Option.empty());
+
+    assertTrue(schemaOption.isPresent());
+    Schema resultSchema = schemaOption.get();
+    assertTrue(resultSchema.getFields().stream()
+        .anyMatch(f -> f.name().equals("partition_path")));
+  }
+
+  @Test
+  public void testGetTableAvroSchemaInternalNoSchemaFound() throws Exception {
+    // Don't set any schema in commit metadata or table config
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaInternal(true, Option.empty());
+    assertFalse(schemaOption.isPresent());
+  }
+
+  @Test
+  public void testGetTableAvroSchemaInternalWithSpecificInstant() throws Exception {
+    Schema schema1 = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    Schema schema2 = new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_SCHEMA);
+
+    // Create two commits with different schemas
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // First commit with schema1
+    String commitTime1 = "001";
+    HoodieInstant instant1 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant1);
+    Map<String, String> metadata1 = new HashMap<>();
+    metadata1.put(HoodieCommitMetadata.SCHEMA_KEY, schema1.toString());
+    activeTimeline.saveAsComplete(instant1,
+        Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, metadata1)));
+
+    // Second commit with schema2
+    String commitTime2 = "002";
+    HoodieInstant instant2 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime2, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant2);
+    Map<String, String> metadata2 = new HashMap<>();
+    metadata2.put(HoodieCommitMetadata.SCHEMA_KEY, schema2.toString());
+    activeTimeline.saveAsComplete(instant2,
+        Option.of(getCommitMetadata(basePath, "partition1", commitTime2, 2, metadata2)));
+
+    metaClient.reloadActiveTimeline();
+
+    TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
+
+    // Test getting schema from first instant
+    Option<Schema> schema1Option = resolver.getTableAvroSchemaInternal(false, Option.of(
+        new HoodieInstant(COMPLETED, COMMIT_ACTION, commitTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    assertTrue(schema1Option.isPresent());
+    assertEquals(schema1.toString(), schema1Option.get().toString());
+
+    // Test getting schema from second instant
+    Option<Schema> schema2Option = resolver.getTableAvroSchemaInternal(false, Option.of(
+        new HoodieInstant(COMPLETED, COMMIT_ACTION, commitTime2, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    assertTrue(schema2Option.isPresent());
+    assertEquals(schema2.toString(), schema2Option.get().toString());
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -158,7 +158,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     metaClient.reloadActiveTimeline();
 
     TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
-    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaForClustering(false);
     assertTrue(schemaOption.isPresent());
     assertEquals(originalSchema, schemaOption.get());
   }
@@ -180,7 +180,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
 
     TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
-    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaForClustering(false);
     assertTrue(schemaOption.isPresent());
     assertEquals(originalSchema, schemaOption.get());
   }
@@ -195,7 +195,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
 
     TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
-    Option<Schema> schemaOption = resolver.getTableAvroSchemaIfPresentV2(false);
+    Option<Schema> schemaOption = resolver.getTableAvroSchemaForClustering(false);
     assertTrue(schemaOption.isPresent());
 
     Schema resultSchema = schemaOption.get();

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -25,14 +25,13 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
@@ -382,8 +381,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
   private HoodieTableMetaClient prepareMetaClient(
       List<HoodieInstant> activeInstants,
       List<HoodieInstant> archivedInstants,
-      String startTs
-  ) throws IOException {
+      String startTs) throws IOException {
     HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
     HoodieArchivedTimeline mockArchivedTimeline = mock(HoodieArchivedTimeline.class);
     HoodieTableConfig mockTableConfig = mock(HoodieTableConfig.class);
@@ -542,22 +540,6 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     List<HoodieRollbackStat> rollbackStats = new ArrayList<>();
     rollbackStats.add(rollbackStat);
     return TimelineMetadataUtils.convertRollbackMetadata(commitTs, Option.empty(), rollbacks, rollbackStats);
-  }
-
-  private byte[] getCommitMetadata(String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
-      throws IOException {
-    HoodieCommitMetadata commit = new HoodieCommitMetadata();
-    for (int i = 1; i <= count; i++) {
-      HoodieWriteStat stat = new HoodieWriteStat();
-      stat.setFileId(i + "");
-      stat.setPartitionPath(Paths.get(basePath, partition).toString());
-      stat.setPath(commitTs + "." + i + metaClient.getTableConfig().getBaseFileFormat().getFileExtension());
-      commit.addWriteStat(partition, stat);
-    }
-    for (Map.Entry<String, String> extraEntries : extraMetadata.entrySet()) {
-      commit.addMetadata(extraEntries.getKey(), extraEntries.getValue());
-    }
-    return serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commit).get();
   }
 
   private byte[] getReplaceCommitMetadata(String basePath, String commitTs, String replacePartition, int replaceCount,

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -20,9 +20,11 @@ package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -55,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +73,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 
 /**
  * The common hoodie test harness to provide the basic infrastructure.
@@ -376,5 +380,21 @@ public class HoodieCommonTestHarness {
       default:
         throw new RuntimeException("Unknown data block type " + dataBlockType);
     }
+  }
+
+  protected byte[] getCommitMetadata(String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
+      throws IOException {
+    HoodieCommitMetadata commit = new HoodieCommitMetadata();
+    for (int i = 1; i <= count; i++) {
+      HoodieWriteStat stat = new HoodieWriteStat();
+      stat.setFileId(i + "");
+      stat.setPartitionPath(Paths.get(basePath, partition).toString());
+      stat.setPath(commitTs + "." + i + metaClient.getTableConfig().getBaseFileFormat().getFileExtension());
+      commit.addWriteStat(partition, stat);
+    }
+    for (Map.Entry<String, String> extraEntries : extraMetadata.entrySet()) {
+      commit.addMetadata(extraEntries.getKey(), extraEntries.getValue());
+    }
+    return serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commit).get();
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -17,12 +17,15 @@
 
 package org.apache.spark.sql.hudi.dml
 
-import org.apache.hudi.{DataSourceReadOptions, ScalaAssertionSupport}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSparkUtils, ScalaAssertionSupport}
 import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_OPTIMIZED_WRITES
+import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.testutils.DataSourceTestUtils
 
+import org.apache.spark.sql.hudi.ProvidesHoodieConfig.getClass
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType, StructField}
@@ -1411,6 +1414,447 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
         )
       })
     }
+  }
+
+  test("Test partial insert schema") {
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      val tableType = "mor"
+      val logDataBlockFormat = "parquet"
+//      val logDataBlockFormat = "avro"
+
+      spark.sql(s"set ${HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key} = 0")
+      spark.sql(s"set ${DataSourceWriteOptions.ENABLE_MERGE_INTO_PARTIAL_UPDATES.key} = true")
+      spark.sql(s"set ${HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key} = $logDataBlockFormat")
+      spark.sql(s"set ${HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key} = false")
+
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |   id int,
+           |   name string,
+           |   price long,
+           |   ts long,
+           |   description string
+           | ) using hudi
+           | tblproperties(
+           |   type ='$tableType',
+           |   primaryKey = 'id',
+           |   preCombineField = 'ts'
+           | )
+           | location '$basePath'
+        """.stripMargin)
+      spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, 'a1: desc1')," +
+        "(2, 'a2', 20, 1200, 'a2: desc2'), (3, 'a3', 30.0, 1250, 'a3: desc3')")
+
+      // Partial updates using MERGE INTO statement with changed fields: "price" and "ts"
+      spark.sql(
+        s"""
+           | merge into $tableName t0
+           | using (
+           |   select 1 as id, 'a1' as name1, 12 as price, 1001 as _ts
+           | union
+           |   select 3 as id, 'a3' as name1, 25 as price, 1260 as _ts
+           |   ) s0
+           | on t0.id = s0.id
+           | when matched then update set price = s0.price, ts = s0._ts
+      """.stripMargin)
+      val a = 1
+    })
+  }
+
+
+  // org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 76.0 failed 1 times, most recent failure: Lost task 0.0 in stage 76.0 (TID 115) (daviss-mbp.attlocal.net executor driver): java.io.EOFException
+  //	at org.apache.avro.io.BinaryDecoder$ByteArrayByteSource.readRaw(BinaryDecoder.java:970)
+  //	at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:372)
+  //	at org.apache.avro.io.BinaryDecoder.readString(BinaryDecoder.java:289)
+  //	at org.apache.avro.io.ResolvingDecoder.readString(ResolvingDecoder.java:208)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:470)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:460)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:192)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:188)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readField(GenericDatumReader.java:260)
+  //	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:248)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:180)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:154)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:264)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:252)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:244)
+  //	at org.apache.hudi.common.model.DefaultHoodieRecordPayload.combineAndGetUpdateValue(DefaultHoodieRecordPayload.java:82)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.combineAndGetUpdateValue(HoodieAvroRecordMerger.java:62)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.merge(HoodieAvroRecordMerger.java:47)
+  //	at org.apache.hudi.RecordMergingFileIterator.merge(Iterators.scala:322)
+  //	at org.apache.hudi.RecordMergingFileIterator.hasNextInternal(Iterators.scala:285)
+  //	at org.apache.hudi.RecordMergingFileIterator.doHasNext(Iterators.scala:270)
+  //	at org.apache.hudi.util.CachingIterator.hasNext(CachingIterator.scala:36)
+  //	at org.apache.hudi.util.CachingIterator.hasNext$(CachingIterator.scala:36)
+  //	at org.apache.hudi.LogFileIterator.hasNext(Iterators.scala:61)
+  //	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
+  //	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
+  //	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at org.apache.spark.util.random.SamplingUtils$.reservoirSampleAndCount(SamplingUtils.scala:41)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1(Partitioner.scala:322)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1$adapted(Partitioner.scala:320)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2(RDD.scala:910)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2$adapted(RDD.scala:910)
+  //	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
+  //	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:367)
+  //	at org.apache.spark.rdd.RDD.iterator(RDD.scala:331)
+  //	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
+  //	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:166)
+  //	at org.apache.spark.scheduler.Task.run(Task.scala:141)
+  //	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
+  //	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
+  //	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)
+  //	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+  //	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+  //	at java.lang.Thread.run(Thread.java:750)
+  //
+  //Driver stacktrace:
+  //java.util.concurrent.CompletionException: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 76.0 failed 1 times, most recent failure: Lost task 0.0 in stage 76.0 (TID 115) (daviss-mbp.attlocal.net executor driver): java.io.EOFException
+  //	at org.apache.avro.io.BinaryDecoder$ByteArrayByteSource.readRaw(BinaryDecoder.java:970)
+  //	at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:372)
+  //	at org.apache.avro.io.BinaryDecoder.readString(BinaryDecoder.java:289)
+  //	at org.apache.avro.io.ResolvingDecoder.readString(ResolvingDecoder.java:208)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:470)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:460)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:192)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:188)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readField(GenericDatumReader.java:260)
+  //	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:248)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:180)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:154)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:264)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:252)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:244)
+  //	at org.apache.hudi.common.model.DefaultHoodieRecordPayload.combineAndGetUpdateValue(DefaultHoodieRecordPayload.java:82)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.combineAndGetUpdateValue(HoodieAvroRecordMerger.java:62)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.merge(HoodieAvroRecordMerger.java:47)
+  //	at org.apache.hudi.RecordMergingFileIterator.merge(Iterators.scala:322)
+  //	at org.apache.hudi.RecordMergingFileIterator.hasNextInternal(Iterators.scala:285)
+  //	at org.apache.hudi.RecordMergingFileIterator.doHasNext(Iterators.scala:270)
+  //	at org.apache.hudi.util.CachingIterator.hasNext(CachingIterator.scala:36)
+  //	at org.apache.hudi.util.CachingIterator.hasNext$(CachingIterator.scala:36)
+  //	at org.apache.hudi.LogFileIterator.hasNext(Iterators.scala:61)
+  //	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
+  //	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
+  //	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at org.apache.spark.util.random.SamplingUtils$.reservoirSampleAndCount(SamplingUtils.scala:41)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1(Partitioner.scala:322)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1$adapted(Partitioner.scala:320)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2(RDD.scala:910)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2$adapted(RDD.scala:910)
+  //	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
+  //	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:367)
+  //	at org.apache.spark.rdd.RDD.iterator(RDD.scala:331)
+  //	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
+  //	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:166)
+  //	at org.apache.spark.scheduler.Task.run(Task.scala:141)
+  //	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
+  //	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
+  //	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)
+  //	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+  //	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+  //	at java.lang.Thread.run(Thread.java:750)
+  //
+  //Driver stacktrace:
+  //	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
+  //	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
+  //	at java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1606)
+  //	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java)
+  //	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+  //	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+  //	at java.lang.Thread.run(Thread.java:750)
+  //Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 76.0 failed 1 times, most recent failure: Lost task 0.0 in stage 76.0 (TID 115) (daviss-mbp.attlocal.net executor driver): java.io.EOFException
+  //	at org.apache.avro.io.BinaryDecoder$ByteArrayByteSource.readRaw(BinaryDecoder.java:970)
+  //	at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:372)
+  //	at org.apache.avro.io.BinaryDecoder.readString(BinaryDecoder.java:289)
+  //	at org.apache.avro.io.ResolvingDecoder.readString(ResolvingDecoder.java:208)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:470)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:460)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:192)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:188)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readField(GenericDatumReader.java:260)
+  //	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:248)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:180)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:154)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:264)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:252)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:244)
+  //	at org.apache.hudi.common.model.DefaultHoodieRecordPayload.combineAndGetUpdateValue(DefaultHoodieRecordPayload.java:82)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.combineAndGetUpdateValue(HoodieAvroRecordMerger.java:62)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.merge(HoodieAvroRecordMerger.java:47)
+  //	at org.apache.hudi.RecordMergingFileIterator.merge(Iterators.scala:322)
+  //	at org.apache.hudi.RecordMergingFileIterator.hasNextInternal(Iterators.scala:285)
+  //	at org.apache.hudi.RecordMergingFileIterator.doHasNext(Iterators.scala:270)
+  //	at org.apache.hudi.util.CachingIterator.hasNext(CachingIterator.scala:36)
+  //	at org.apache.hudi.util.CachingIterator.hasNext$(CachingIterator.scala:36)
+  //	at org.apache.hudi.LogFileIterator.hasNext(Iterators.scala:61)
+  //	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
+  //	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
+  //	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at org.apache.spark.util.random.SamplingUtils$.reservoirSampleAndCount(SamplingUtils.scala:41)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1(Partitioner.scala:322)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1$adapted(Partitioner.scala:320)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2(RDD.scala:910)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2$adapted(RDD.scala:910)
+  //	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
+  //	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:367)
+  //	at org.apache.spark.rdd.RDD.iterator(RDD.scala:331)
+  //	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
+  //	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:166)
+  //	at org.apache.spark.scheduler.Task.run(Task.scala:141)
+  //	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
+  //	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
+  //	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)
+  //	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+  //	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+  //	at java.lang.Thread.run(Thread.java:750)
+  //
+  //Driver stacktrace:
+  //	at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2856)
+  //	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2792)
+  //	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2791)
+  //	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
+  //	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
+  //	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
+  //	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2791)
+  //	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1247)
+  //	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1247)
+  //	at scala.Option.foreach(Option.scala:407)
+  //	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1247)
+  //	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3060)
+  //	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2994)
+  //	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2983)
+  //	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
+  //	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:989)
+  //	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2393)
+  //	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2414)
+  //	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2433)
+  //	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2458)
+  //	at org.apache.spark.rdd.RDD.$anonfun$collect$1(RDD.scala:1049)
+  //	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
+  //	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
+  //	at org.apache.spark.rdd.RDD.withScope(RDD.scala:410)
+  //	at org.apache.spark.rdd.RDD.collect(RDD.scala:1048)
+  //	at org.apache.spark.RangePartitioner$.sketch(Partitioner.scala:320)
+  //	at org.apache.spark.RangePartitioner.<init>(Partitioner.scala:187)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$.prepareShuffleDependency(ShuffleExchangeExec.scala:296)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.shuffleDependency$lzycompute(ShuffleExchangeExec.scala:179)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.shuffleDependency(ShuffleExchangeExec.scala:173)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.mapOutputStatisticsFuture$lzycompute(ShuffleExchangeExec.scala:149)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.mapOutputStatisticsFuture(ShuffleExchangeExec.scala:145)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeLike.$anonfun$submitShuffleJob$1(ShuffleExchangeExec.scala:73)
+  //	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:246)
+  //	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
+  //	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:243)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeLike.submitShuffleJob(ShuffleExchangeExec.scala:73)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeLike.submitShuffleJob$(ShuffleExchangeExec.scala:72)
+  //	at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.submitShuffleJob(ShuffleExchangeExec.scala:120)
+  //	at org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec.shuffleFuture$lzycompute(QueryStageExec.scala:194)
+  //	at org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec.shuffleFuture(QueryStageExec.scala:194)
+  //	at org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec.doMaterialize(QueryStageExec.scala:196)
+  //	at org.apache.spark.sql.execution.adaptive.QueryStageExec.materialize(QueryStageExec.scala:61)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$getFinalPhysicalPlan$5(AdaptiveSparkPlanExec.scala:302)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$getFinalPhysicalPlan$5$adapted(AdaptiveSparkPlanExec.scala:300)
+  //	at scala.collection.Iterator.foreach(Iterator.scala:943)
+  //	at scala.collection.Iterator.foreach$(Iterator.scala:943)
+  //	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
+  //	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
+  //	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
+  //	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.$anonfun$getFinalPhysicalPlan$1(AdaptiveSparkPlanExec.scala:300)
+  //	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.getFinalPhysicalPlan(AdaptiveSparkPlanExec.scala:272)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.withFinalPlanUpdate(AdaptiveSparkPlanExec.scala:419)
+  //	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.doExecute(AdaptiveSparkPlanExec.scala:404)
+  //	at org.apache.spark.sql.execution.SparkPlan.$anonfun$execute$1(SparkPlan.scala:195)
+  //	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:246)
+  //	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
+  //	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:243)
+  //	at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:191)
+  //	at org.apache.spark.sql.execution.QueryExecution.toRdd$lzycompute(QueryExecution.scala:207)
+  //	at org.apache.spark.sql.execution.QueryExecution.toRdd(QueryExecution.scala:206)
+  //	at org.apache.hudi.HoodieDatasetBulkInsertHelper$.bulkInsert(HoodieDatasetBulkInsertHelper.scala:154)
+  //	at org.apache.hudi.HoodieDatasetBulkInsertHelper.bulkInsert(HoodieDatasetBulkInsertHelper.scala)
+  //	at org.apache.hudi.client.clustering.run.strategy.SparkSortAndSizeExecutionStrategy.performClusteringWithRecordsAsRow(SparkSortAndSizeExecutionStrategy.java:76)
+  //	at org.apache.hudi.client.clustering.run.strategy.MultipleSparkJobExecutionStrategy.lambda$runClusteringForGroupAsyncAsRow$7(MultipleSparkJobExecutionStrategy.java:298)
+  //	at java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1604)
+  //	... 4 more
+  //Caused by: java.io.EOFException
+  //	at org.apache.avro.io.BinaryDecoder$ByteArrayByteSource.readRaw(BinaryDecoder.java:970)
+  //	at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:372)
+  //	at org.apache.avro.io.BinaryDecoder.readString(BinaryDecoder.java:289)
+  //	at org.apache.avro.io.ResolvingDecoder.readString(ResolvingDecoder.java:208)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:470)
+  //	at org.apache.avro.generic.GenericDatumReader.readString(GenericDatumReader.java:460)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:192)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:188)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.readField(GenericDatumReader.java:260)
+  //	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:248)
+  //	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:180)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:161)
+  //	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:154)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:264)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:252)
+  //	at org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro(HoodieAvroUtils.java:244)
+  //	at org.apache.hudi.common.model.DefaultHoodieRecordPayload.combineAndGetUpdateValue(DefaultHoodieRecordPayload.java:82)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.combineAndGetUpdateValue(HoodieAvroRecordMerger.java:62)
+  //	at org.apache.hudi.common.model.HoodieAvroRecordMerger.merge(HoodieAvroRecordMerger.java:47)
+  //	at org.apache.hudi.RecordMergingFileIterator.merge(Iterators.scala:322)
+  //	at org.apache.hudi.RecordMergingFileIterator.hasNextInternal(Iterators.scala:285)
+  //	at org.apache.hudi.RecordMergingFileIterator.doHasNext(Iterators.scala:270)
+  //	at org.apache.hudi.util.CachingIterator.hasNext(CachingIterator.scala:36)
+  //	at org.apache.hudi.util.CachingIterator.hasNext$(CachingIterator.scala:36)
+  //	at org.apache.hudi.LogFileIterator.hasNext(Iterators.scala:61)
+  //	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
+  //	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
+  //	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
+  //	at org.apache.spark.util.random.SamplingUtils$.reservoirSampleAndCount(SamplingUtils.scala:41)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1(Partitioner.scala:322)
+  //	at org.apache.spark.RangePartitioner$.$anonfun$sketch$1$adapted(Partitioner.scala:320)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2(RDD.scala:910)
+  //	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2$adapted(RDD.scala:910)
+  //	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
+  //	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:367)
+  //	at org.apache.spark.rdd.RDD.iterator(RDD.scala:331)
+  //	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
+  //	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:166)
+  //	at org.apache.spark.scheduler.Task.run(Task.scala:141)
+  //	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
+  //	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
+  //	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
+  //	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)
+  //	... 3 more
+  test("Test partial insert with inline clustering") {
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      val tableType = "mor"
+      val logDataBlockFormat = "parquet"
+//      val logDataBlockFormat = "avro"
+
+      spark.sql(s"set ${HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key} = 0")
+      spark.sql(s"set ${DataSourceWriteOptions.ENABLE_MERGE_INTO_PARTIAL_UPDATES.key} = true")
+      spark.sql(s"set ${HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key} = $logDataBlockFormat")
+      spark.sql(s"set ${HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key} = false")
+      spark.sql(s"Set ${HoodieClusteringConfig.INLINE_CLUSTERING.key()} = true")
+      spark.sql(s"Set ${HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key()} = 2")
+      spark.sql(s"Set ${HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key()} = id,price")
+
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |   id int,
+           |   name string,
+           |   price long,
+           |   ts long,
+           |   description string
+           | ) using hudi
+           | tblproperties(
+           |   type ='$tableType',
+           |   primaryKey = 'id',
+           |   preCombineField = 'ts'
+           | )
+           | location '$basePath'
+        """.stripMargin)
+      spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, 'a1: desc1')," +
+        "(2, 'a2', 20, 1200, 'a2: desc2'), (3, 'a3', 30.0, 1250, 'a3: desc3')")
+
+      // Partial updates using MERGE INTO statement with changed fields: "price" and "ts"
+      spark.sql(
+        s"""
+           | merge into $tableName t0
+           | using (
+           |   select 1 as id, 'a1' as name1, 12 as price, 1001 as _ts
+           | union
+           |   select 3 as id, 'a3' as name1, 25 as price, 1260 as _ts
+           |   ) s0
+           | on t0.id = s0.id
+           | when matched then update set price = s0.price, ts = s0._ts
+      """.stripMargin)
+      val a = 1
+    })
+  }
+
+  // Same exception stack trace as above
+  test("Test partial insert with inline clustering & multi files") {
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      val tableType = "mor"
+      val logDataBlockFormat = "avro"
+
+      spark.sql(s"set ${HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key} = 0")
+      spark.sql(s"set ${DataSourceWriteOptions.ENABLE_MERGE_INTO_PARTIAL_UPDATES.key} = true")
+      spark.sql(s"set ${HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key} = $logDataBlockFormat")
+      spark.sql(s"set ${HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key} = false")
+      spark.sql(s"Set ${HoodieClusteringConfig.INLINE_CLUSTERING.key()} = true")
+      spark.sql(s"Set ${HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key()} = 3")
+      spark.sql(s"Set ${HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key()} = id,price")
+      spark.sql(s"set hoodie.parquet.small.file.limit = 0")
+
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |   id int,
+           |   name string,
+           |   price long,
+           |   ts long,
+           |   description string
+           | ) using hudi
+           | tblproperties(
+           |   type ='$tableType',
+           |   primaryKey = 'id',
+           |   preCombineField = 'ts'
+           | )
+           | location '$basePath'
+        """.stripMargin)
+      spark.sql(s"insert into $tableName values (1, 'a1', 10, 1000, 'a1: desc1')," +
+        "(2, 'a2', 20, 1200, 'a2: desc2'), (3, 'a3', 30.0, 1250, 'a3: desc3')")
+      spark.sql(s"insert into $tableName values (4, 'a4', 10, 1000, 'a4: desc4')," +
+        "(5, 'a5', 20, 1200, 'a5: desc5'), (6, 'a6', 30, 1250, 'a6: desc6')")
+      // Partial updates using MERGE INTO statement with changed fields: "price" and "ts"
+      spark.sql(
+        s"""
+           | merge into $tableName t0
+           | using (
+           |   select 1 as id, 'a1' as name1, 12 as price, 1001 as _ts
+           | union
+           |   select 3 as id, 'a3' as name1, 25 as price, 1260 as _ts
+           |   ) s0
+           | on t0.id = s0.id
+           | when matched then update set price = s0.price, ts = s0._ts
+      """.stripMargin)
+      val a = 1
+    })
   }
 
   test("Test MergeInto with partial update and insert") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.hudi.dml
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSparkUtils, ScalaAssertionSupport}
 import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_OPTIMIZED_WRITES
 import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.testutils.DataSourceTestUtils
-
+import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig.getClass
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.internal.SQLConf
@@ -1346,6 +1347,8 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
           Seq(2, "a2", 20, 1200, "a2: desc2"),
           Seq(3, "a3", 25, 1260, "a3: desc3")
         )
+        assert(createMetaClient(spark, basePath).getActiveTimeline.lastInstant().get().getAction.equals(
+          HoodieTimeline.REPLACE_COMMIT_ACTION))
       }
     })
   }


### PR DESCRIPTION
### Change Logs

Introduced API that correctly retrieve the table schema `getTableSchemaFromLatestCommitMetadataV2`. Compared to what we previously do it only focuses on instants that can evolve table schema. We need the rest of the RFC-82 code change to be in place in order for this API to be fully functional.

Also for inline clustering it is now hard wired to use table schema as the write schema.

### Impact

Table service will never use a wrong writer schema 

### Risk level (write none, low medium or high below)

none
### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
