### PR TITLE
[HUDI-8868] Use external spillable map for cachedAllInputFileSlices in BaseHoodieTableFileIndex

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -459,7 +459,6 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     } catch (IOException e) {
       throw new HoodieIOException("Failed to refresh file index", e);
     }
-    this.cachedAllInputFileSlices = new HashMap<>();
     if (!shouldListLazily) {
       ensurePreloadedPartitions(getAllQueryPartitionPaths());
     }

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi;
 
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -26,15 +27,20 @@ import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieTableQueryType;
+import org.apache.hudi.common.serialization.HoodieFileSliceSerializer;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap.DiskMapType;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -50,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,6 +69,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED;
+import static org.apache.hudi.common.config.HoodieCommonConfig.HOODIE_FILE_INDEX_SPILLABLE_MEMORY;
+import static org.apache.hudi.common.config.HoodieCommonConfig.HOODIE_FILE_INDEX_USE_SPILLABLE_MAP;
+import static org.apache.hudi.common.config.HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE;
 import static org.apache.hudi.common.table.timeline.TimelineUtils.validateTimestampAsOf;
@@ -82,7 +93,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   private final String[] partitionColumns;
 
   protected final HoodieMetadataConfig metadataConfig;
-
+  private final TypedProperties configProperties;
   private final HoodieTableQueryType queryType;
   private final Option<String> specifiedQueryInstant;
   private final Option<String> startCompletionTime;
@@ -165,7 +176,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     this.metaClient = metaClient;
     this.engineContext = engineContext;
     this.fileStatusCache = fileStatusCache;
-
+    this.configProperties = configProperties;
     doRefresh();
   }
 
@@ -433,6 +444,21 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     // Reset it to null to trigger re-loading of all partition path
     this.cachedAllPartitionPaths = null;
     // Reset to force reload file slices inside partitions
+    try {
+      if (ConfigUtils.getBooleanWithAltKeys(configProperties, HOODIE_FILE_INDEX_USE_SPILLABLE_MAP)) {
+        long spillableMemory = ConfigUtils.getLongWithAltKeys(configProperties, HOODIE_FILE_INDEX_SPILLABLE_MEMORY);
+        String spillablePath = ConfigUtils.getStringWithAltKeys(configProperties, HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH, true);
+        DiskMapType diskMapType = ConfigUtils.getRawValueWithAltKeys(configProperties, SPILLABLE_DISK_MAP_TYPE, true);
+        boolean isBitCaskCompressionEnabled = ConfigUtils.getBooleanWithAltKeys(configProperties, DISK_MAP_BITCASK_COMPRESSION_ENABLED);
+        this.cachedAllInputFileSlices = new ExternalSpillableMap<>(
+            spillableMemory, spillablePath, new DefaultSizeEstimator<>(), new DefaultSizeEstimator<>(), diskMapType,
+            new HoodieFileSliceSerializer(), isBitCaskCompressionEnabled);
+      } else {
+        this.cachedAllInputFileSlices = new HashMap<>();
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to refresh file index", e);
+    }
     this.cachedAllInputFileSlices = new HashMap<>();
     if (!shouldListLazily) {
       ensurePreloadedPartitions(getAllQueryPartitionPaths());
@@ -522,7 +548,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
    * Partition path information containing the relative partition path
    * and values of partition columns.
    */
-  public static final class PartitionPath {
+  public static final class PartitionPath implements Serializable {
 
     final String path;
     final Object[] values;

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -452,7 +452,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
         boolean isBitCaskCompressionEnabled = ConfigUtils.getBooleanWithAltKeys(configProperties, DISK_MAP_BITCASK_COMPRESSION_ENABLED);
         this.cachedAllInputFileSlices = new ExternalSpillableMap<>(
             spillableMemory, spillablePath, new DefaultSizeEstimator<>(), new DefaultSizeEstimator<>(), diskMapType,
-            new HoodieFileSliceSerializer(), isBitCaskCompressionEnabled);
+            new HoodieFileSliceSerializer(), isBitCaskCompressionEnabled, this.getClass().getName());
       } else {
         this.cachedAllInputFileSlices = new HashMap<>();
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -139,6 +139,7 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> HOODIE_FILE_INDEX_USE_SPILLABLE_MAP = ConfigProperty
       .key("hoodie.file.index.cache.use.spillable.map")
       .defaultValue(false)
+      .sinceVersion("1.1.0")
       .markAdvanced()
       .withDocumentation("Property to enable spillable map for caching input file slices in org.apache.hudi.BaseHoodieTableFileIndex");
 
@@ -146,7 +147,7 @@ public class HoodieCommonConfig extends HoodieConfig {
       .key("hoodie.file.index.cache.spillable.mem")
       .defaultValue(500 * 1024L * 1024L) // 500 MB
       .markAdvanced()
-      .sinceVersion("0.16.0")
+      .sinceVersion("1.1.0")
       .withDocumentation("Amount of memory to be used in bytes for holding cachedAllInputFileSlices in org.apache.hudi.BaseHoodieTableFileIndex.");
   
   public static final long DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES = 1024 * 1024 * 1024L;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -136,6 +136,19 @@ public class HoodieCommonConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Property to control the max memory in bytes for dfs input stream buffer size");
 
+  public static final ConfigProperty<Boolean> HOODIE_FILE_INDEX_USE_SPILLABLE_MAP = ConfigProperty
+      .key("hoodie.file.index.cache.use.spillable.map")
+      .defaultValue(false)
+      .markAdvanced()
+      .withDocumentation("Property to enable spillable map for caching input file slices in org.apache.hudi.BaseHoodieTableFileIndex");
+
+  public static final ConfigProperty<Long> HOODIE_FILE_INDEX_SPILLABLE_MEMORY = ConfigProperty
+      .key("hoodie.file.index.cache.spillable.mem")
+      .defaultValue(500 * 1024L * 1024L) // 500 MB
+      .markAdvanced()
+      .sinceVersion("0.16.0")
+      .withDocumentation("Amount of memory to be used in bytes for holding cachedAllInputFileSlices in org.apache.hudi.BaseHoodieTableFileIndex.");
+  
   public static final long DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES = 1024 * 1024 * 1024L;
 
   public ExternalSpillableMap.DiskMapType getSpillableDiskMapType() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/serialization/HoodieFileSliceSerializer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/serialization/HoodieFileSliceSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.serialization;
+
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
+import org.apache.hudi.common.util.SerializationUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Serializes list of {@link FileSlice}.
+ */
+public class HoodieFileSliceSerializer implements CustomSerializer<List<FileSlice>> {
+
+  @Override
+  public byte[] serialize(List<FileSlice> input) throws IOException {
+    List<FileSliceDTO> fileSliceDTOs = input.stream().map(FileSliceDTO::fromFileSlice).collect(Collectors.toList());
+    return SerializationUtils.serialize(fileSliceDTOs);
+  }
+
+  @Override
+  public List<FileSlice> deserialize(byte[] bytes) {
+    List<FileSliceDTO> fileSliceDTOs = SerializationUtils.deserialize(bytes);
+    return fileSliceDTOs.stream().map(FileSliceDTO::toFileSlice).collect(Collectors.toList());
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -325,8 +325,8 @@ public class ConfigUtils {
    * @param props           Configs in {@link Properties}.
    * @param configProperty  {@link ConfigProperty} config to fetch.
    * @param useDefaultValue If enabled, uses default value for configProperty.
-   * @param <T>             Raw value of the config.
-   * @return
+   * @return raw value of the config.
+   * @param <T> type of the value.
    */
   public static <T> T getRawValueWithAltKeys(TypedProperties props, ConfigProperty<T> configProperty, boolean useDefaultValue) {
     Option<T> rawValue = (Option<T>) getRawValueWithAltKeys(props, configProperty);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -318,6 +318,17 @@ public class ConfigUtils {
     return Option.empty();
   }
 
+  public static <T> T getRawValueWithAltKeys(TypedProperties props, ConfigProperty<T> configProperty, boolean useDefaultValue) {
+    Option<T> rawValue = (Option<T>) getRawValueWithAltKeys(props, configProperty);
+    if (rawValue.isPresent()) {
+      return rawValue.get();
+    }
+    if (useDefaultValue) {
+      return configProperty.defaultValue();
+    }
+    throw new IllegalArgumentException("Property " + configProperty.key() + " not found");
+  }
+
   /**
    * Gets the String value for a {@link ConfigProperty} config from properties. The key and
    * alternative keys are used to fetch the config. If the config is not found, an

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -318,6 +318,16 @@ public class ConfigUtils {
     return Option.empty();
   }
 
+  /**
+   * Gets the raw value for a {@link ConfigProperty<T>} config from properties with the option
+   * of using default value.
+   *
+   * @param props           Configs in {@link Properties}.
+   * @param configProperty  {@link ConfigProperty} config to fetch.
+   * @param useDefaultValue If enabled, uses default value for configProperty.
+   * @param <T>             Raw value of the config.
+   * @return
+   */
   public static <T> T getRawValueWithAltKeys(TypedProperties props, ConfigProperty<T> configProperty, boolean useDefaultValue) {
     Option<T> rawValue = (Option<T>) getRawValueWithAltKeys(props, configProperty);
     if (rawValue.isPresent()) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileSliceSerializer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileSliceSerializer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.serialization;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+class TestHoodieFileSliceSerializer {
+  private static final String LOG_FILE_PATH_FORMAT = "file:///tmp/basePath/partitionPath/.fileId%s_100.log.%s_1-0-1";
+  private static final short BLOCK_REPLICATION = 1;
+  private static final StoragePath BASE_FILE_STORAGE_PATH_1 = new StoragePath("fileId-1/baseFilepath.parquet");
+  private static final StoragePath BASE_FILE_STORAGE_PATH_2 = new StoragePath("fileId-1/baseFilepath.parquet");
+  private static final StoragePath LOG_FILE_STORAGE_PATH_1 = new StoragePath(String.format(LOG_FILE_PATH_FORMAT, "1", "0"));
+  private static final StoragePath LOG_FILE_STORAGE_PATH_2 = new StoragePath(String.format(LOG_FILE_PATH_FORMAT, "2", "2"));
+
+  @Test
+  void testSerDe() throws IOException {
+    HoodieFileSliceSerializer hoodieFileSliceSerializer = new HoodieFileSliceSerializer();
+    HoodieBaseFile baseFile1 = new HoodieBaseFile(new StoragePathInfo(BASE_FILE_STORAGE_PATH_1, 100, false, BLOCK_REPLICATION, 1024, 0));
+    HoodieLogFile logFile1 = new HoodieLogFile(new StoragePathInfo(LOG_FILE_STORAGE_PATH_1, 100, false, BLOCK_REPLICATION, 1024, 0));
+    HoodieLogFile logFile2 = new HoodieLogFile("/dummy/base/" + FSUtils.makeLogFileName("fileId-1", HoodieLogFile.DELTA_EXTENSION, "001", 2, "1-0-1"));
+
+    HoodieBaseFile baseFile2 = new HoodieBaseFile(new StoragePathInfo(BASE_FILE_STORAGE_PATH_2, 100, false, BLOCK_REPLICATION, 1024, 0));
+    HoodieLogFile logFile3 = new HoodieLogFile(new StoragePathInfo(LOG_FILE_STORAGE_PATH_2, 100, false, BLOCK_REPLICATION, 1024, 0));
+    HoodieLogFile logFile4 = new HoodieLogFile("/dummy/base/" + FSUtils.makeLogFileName("fileId-2", HoodieLogFile.DELTA_EXTENSION, "002", 2, "1-0-1"));
+
+    List<FileSlice> fileSliceList = Arrays.asList(
+        new FileSlice(new HoodieFileGroupId("partition1", "fileId-1"), "001", baseFile1, Arrays.asList(logFile1, logFile2)),
+        new FileSlice(new HoodieFileGroupId("partition2", "fileId-2"), "001", baseFile2, Arrays.asList(logFile3, logFile4)),
+        new FileSlice("partition3", "002", "fileId-3")
+    );
+
+    byte[] serializedBytes = hoodieFileSliceSerializer.serialize(fileSliceList);
+    List<FileSlice> deserialized = hoodieFileSliceSerializer.deserialize(serializedBytes);
+    Assertions.assertEquals(fileSliceList, deserialized);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
@@ -20,7 +20,12 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap.DiskMapType;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -88,6 +93,18 @@ public class TestConfigUtils {
         " k.1.1.2 =   v1%s k.2.1.2 = v2 %sk.3.1.2 = v3", sepString, sepString);
     outMap = toMap(srcKv, separator);
     assertEquals(expectedMap, outMap);
+  }
+
+  @Test
+  void testGetRawValueWithAltKeys() {
+    TypedProperties properties = new TypedProperties();
+    DiskMapType diskMapType = ConfigUtils.getRawValueWithAltKeys(properties, HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE, true);
+    Assertions.assertEquals(DiskMapType.BITCASK, diskMapType);
+    properties.put(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), DiskMapType.ROCKS_DB);
+    diskMapType = ConfigUtils.getRawValueWithAltKeys(properties, HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE, true);
+    Assertions.assertEquals(DiskMapType.ROCKS_DB, diskMapType);
+    properties.remove(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> ConfigUtils.getRawValueWithAltKeys(properties, HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE, false));
   }
 
   @ParameterizedTest

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/bootstrap/index/TestBaseHoodieTableFileIndex.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/bootstrap/index/TestBaseHoodieTableFileIndex.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.bootstrap.index;
+
+import org.apache.hudi.BaseHoodieTableFileIndex;
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieTableQueryType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.StoragePath;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConf;
+
+@ExtendWith(MockitoExtension.class)
+class TestBaseHoodieTableFileIndex extends HoodieCommonTestHarness {
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void refresh(boolean useSpillableMap) throws IOException {
+    initMetaClient();
+    TypedProperties properties = new TypedProperties();
+    if (useSpillableMap) {
+      properties.put(HoodieCommonConfig.HOODIE_FILE_INDEX_USE_SPILLABLE_MAP.key(), true);
+    }
+    BaseHoodieTableFileIndex baseHoodieTableFileIndex = new TestLocalIndex(
+        new HoodieLocalEngineContext(getStorageConf()),
+        metaClient,
+        properties,
+        HoodieTableQueryType.READ_OPTIMIZED,
+        Collections.emptyList(),
+        Option.empty(),
+        false,
+        true,
+        null,
+        true,
+        Option.empty(),
+        Option.empty()
+    );
+    Assertions.assertTrue(baseHoodieTableFileIndex.getFileSlicesCount() == 0);
+  }
+
+  private static class TestLocalIndex extends BaseHoodieTableFileIndex {
+
+    public TestLocalIndex(HoodieEngineContext engineContext, HoodieTableMetaClient metaClient, TypedProperties configProperties, HoodieTableQueryType queryType,
+                          List<StoragePath> queryPaths, Option<String> specifiedQueryInstant, boolean shouldIncludePendingCommits, boolean shouldValidateInstant,
+                          FileStatusCache fileStatusCache, boolean shouldListLazily, Option<String> startCompletionTime, Option<String> endCompletionTime) {
+      super(engineContext, metaClient, configProperties, queryType, queryPaths, specifiedQueryInstant, shouldIncludePendingCommits, shouldValidateInstant, fileStatusCache, shouldListLazily,
+          startCompletionTime, endCompletionTime);
+    }
+
+    @Override
+    protected Object[] parsePartitionColumnValues(String[] partitionColumns, String partitionPath) {
+      return new Object[0];
+    }
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/bootstrap/index/TestBaseHoodieTableFileIndex.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/bootstrap/index/TestBaseHoodieTableFileIndex.java
@@ -46,7 +46,7 @@ class TestBaseHoodieTableFileIndex extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
-  void refresh(boolean useSpillableMap) throws IOException {
+  void testGetFileSlicesCount(boolean useSpillableMap) throws IOException {
     initMetaClient();
     TypedProperties properties = new TypedProperties();
     if (useSpillableMap) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -633,7 +633,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
           .format("hudi").load(basePath());
       dataset.persist(StorageLevel.MEMORY_AND_DISK_SER());
       dataset.count();
-      List<LogicalPlan> logicalPlanChildren = JavaConverters.seqAsJavaList(dataset.logicalPlan().children().seq());
+      List<LogicalPlan> logicalPlanChildren = JavaConverters.seqAsJavaList(dataset.logicalPlan().children().toSeq());
       BaseHoodieTableFileIndex hoodieTableFileIndex = (BaseHoodieTableFileIndex) (((HadoopFsRelation) ((LogicalRelation) logicalPlanChildren.get(0)).relation()).location());
       if (useSpillableMap) {
         ExternalSpillableMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> cachedAllInputFileSlices =

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -18,10 +18,14 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.BaseHoodieTableFileIndex;
+import org.apache.hudi.MergeOnReadSnapshotRelation;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -37,12 +41,15 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.ObjectSizeCalculator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.config.HoodieIncrSourceConfig;
@@ -59,6 +66,9 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.storage.StorageLevel;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,7 +77,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -585,6 +597,80 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     }
   }
 
+  @Test
+  void testFileIndexLogicalPlanSize() throws Exception {
+    this.tableType = MERGE_ON_READ;
+    metaClient = getHoodieMetaClient(storageConf(), basePath());
+    HoodieWriteConfig writeConfig = getConfigBuilder(basePath(), metaClient)
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(10, 12).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(9).build())
+        .withCompactionConfig(
+            HoodieCompactionConfig.newBuilder()
+                .withScheduleInlineCompaction(true)
+                .withMaxNumDeltaCommitsBeforeCompaction(1)
+                .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).build())
+        .build();
+    // Write a hudi table with 20 file slices.
+    int numFileSlices = 20;
+    try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
+      for (int i = 0; i < numFileSlices; i++) {
+        writeRecordsForPartition(writeClient, BULK_INSERT, "100" + i, String.format("2016/03/%s", i));
+      }
+    }
+    // Arguments are in order -> fileSlicesCachedInMemory, spillableMemory, useSpillableMap
+    getArgsForLogicalPlanSizeValidation().forEach(argumentsStream -> {
+      Object[] arguments = argumentsStream.get();
+      int fileSlicesCachedInMemory = (int) arguments[0];
+      long spillableMemoryBytes = (long) arguments[1];
+      boolean useSpillableMap = (boolean) arguments[2];
+      Dataset<Row> dataset = spark().read()
+          .option(HoodieCommonConfig.HOODIE_FILE_INDEX_USE_SPILLABLE_MAP.key(), useSpillableMap)
+          .option(HoodieCommonConfig.HOODIE_FILE_INDEX_SPILLABLE_MEMORY.key(), spillableMemoryBytes)
+          .format("hudi").load(basePath());
+      dataset.persist(StorageLevel.MEMORY_AND_DISK_SER());
+      dataset.count();
+      BaseHoodieTableFileIndex hoodieTableFileIndex = ((MergeOnReadSnapshotRelation) ((LogicalRelation) dataset.logicalPlan()).relation()).fileIndex();
+      if (useSpillableMap) {
+        ExternalSpillableMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> cachedAllInputFileSlices =
+            getSpillableMap(hoodieTableFileIndex);
+        Assertions.assertEquals(fileSlicesCachedInMemory, cachedAllInputFileSlices.getInMemoryMapNumEntries());
+        Assertions.assertEquals(numFileSlices - fileSlicesCachedInMemory, cachedAllInputFileSlices.getDiskBasedMapNumEntries());
+        Assertions.assertTrue(cachedAllInputFileSlices.getCurrentInMemoryMapSize() < spillableMemoryBytes,
+            "In-memory map size is greater than expected " + cachedAllInputFileSlices.getCurrentInMemoryMapSize());
+      } else {
+        HashMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> cachedAllInputFileSlices = getHashMap(hoodieTableFileIndex);
+        Assertions.assertEquals(fileSlicesCachedInMemory, cachedAllInputFileSlices.size());
+        Assertions.assertTrue(ObjectSizeCalculator.getObjectSize(cachedAllInputFileSlices) > spillableMemoryBytes);
+      }
+      dataset.unpersist();
+    });
+  }
+
+  private static ExternalSpillableMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> getSpillableMap(BaseHoodieTableFileIndex hoodieTableFileIndex) {
+    // cachedAllInputFileSlices is a private field, using reflection to assert the size.
+    try {
+      Field cachedAllInputFileSlicesField = null;
+      cachedAllInputFileSlicesField = BaseHoodieTableFileIndex.class.getDeclaredField("cachedAllInputFileSlices");
+      cachedAllInputFileSlicesField.setAccessible(true);
+      return (ExternalSpillableMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>>) cachedAllInputFileSlicesField.get(hoodieTableFileIndex);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new HoodieException("field not found in BaseHoodieTableFileIndex", e);
+    }
+  }
+
+  private static HashMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> getHashMap(BaseHoodieTableFileIndex hoodieTableFileIndex) {
+    // cachedAllInputFileSlices is a private field, using reflection to assert the size.
+    try {
+      Field cachedAllInputFileSlicesField = null;
+      cachedAllInputFileSlicesField = BaseHoodieTableFileIndex.class.getDeclaredField("cachedAllInputFileSlices");
+      cachedAllInputFileSlicesField.setAccessible(true);
+      return (HashMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>>) cachedAllInputFileSlicesField.get(hoodieTableFileIndex);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new HoodieException("field not found in BaseHoodieTableFileIndex", e);
+    }
+  }
+
   private void readAndAssertCheckpointTranslation(IncrSourceHelper.MissingCheckpointStrategy missingCheckpointStrategy,
                                                   HoodieTableVersion targetTableVersion, Option<Checkpoint> checkpointToPull,
                                                   int expectedCount, Checkpoint expectedCheckpoint) {
@@ -711,6 +797,14 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     public Schema getSourceSchema() {
       return schema;
     }
+  }
+
+  private static Stream<Arguments> getArgsForLogicalPlanSizeValidation() {
+    return Stream.of(
+        Arguments.of(1, 3072L, true),
+        Arguments.of(20, 3072L, false),
+        Arguments.of(20, 20 * 1024L * 1024L, true)
+    );
   }
 
   static class TestSourceProfile implements SourceProfile<Integer> {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -640,7 +640,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
             getSpillableMap(hoodieTableFileIndex);
         Assertions.assertEquals(fileSlicesCachedInMemory, cachedAllInputFileSlices.getInMemoryMapNumEntries());
         Assertions.assertEquals(numFileSlices - fileSlicesCachedInMemory, cachedAllInputFileSlices.getDiskBasedMapNumEntries());
-        Assertions.assertTrue(cachedAllInputFileSlices.getCurrentInMemoryMapSize() < spillableMemoryBytes,
+        Assertions.assertTrue(cachedAllInputFileSlices.getCurrentInMemoryMapSize() < 2 * spillableMemoryBytes,
             "In-memory map size is greater than expected " + cachedAllInputFileSlices.getCurrentInMemoryMapSize());
       } else {
         HashMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> cachedAllInputFileSlices = getHashMap(hoodieTableFileIndex);
@@ -805,8 +805,8 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
   private static Stream<Arguments> getArgsForLogicalPlanSizeValidation() {
     return Stream.of(
-        Arguments.of(1, 4096L, true),
-        Arguments.of(20, 4096L, false),
+        Arguments.of(1, 3072L, true),
+        Arguments.of(20, 3072L, false),
         Arguments.of(20, 20 * 1024L * 1024L, true)
     );
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -65,6 +65,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.storage.StorageLevel;
@@ -83,6 +84,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
+
+import scala.collection.JavaConverters;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
@@ -630,7 +633,8 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
           .format("hudi").load(basePath());
       dataset.persist(StorageLevel.MEMORY_AND_DISK_SER());
       dataset.count();
-      BaseHoodieTableFileIndex hoodieTableFileIndex = (BaseHoodieTableFileIndex) (((HadoopFsRelation) ((LogicalRelation) dataset.logicalPlan().children().seq().apply(0)).relation()).location());
+      List<LogicalPlan> logicalPlanChildren = JavaConverters.seqAsJavaList(dataset.logicalPlan().children().seq());
+      BaseHoodieTableFileIndex hoodieTableFileIndex = (BaseHoodieTableFileIndex) (((HadoopFsRelation) ((LogicalRelation) logicalPlanChildren.get(0)).relation()).location());
       if (useSpillableMap) {
         ExternalSpillableMap<BaseHoodieTableFileIndex.PartitionPath, List<FileSlice>> cachedAllInputFileSlices =
             getSpillableMap(hoodieTableFileIndex);


### PR DESCRIPTION
### Change Logs

`cachedAllInputFileSlices` in `BaseHoodieTableFileIndex` is using a HashMap, when doing multiple queries on large tables (1000+ partitions and each partition has 20K file groups/slices for example) on a single spark driver we cache all the file slices for queried partitions. This overwhelms the driver especially in the scenario when there are multiple downstream consumers for the same table and the ingestion/spark sql is running on the same driver.  

### Impact

Using an `ExternalSpillableMap` for cachedAllInputFileSlices to not overwhelm the spark driver in such cases.  The default value for `HOODIE_FILE_INDEX_SPILLABLE_MEMORY` is 500MB

### Risk level (write none, low medium or high below)

Medium 

### Documentation Update

```
  public static final ConfigProperty<Long> HOODIE_FILE_INDEX_SPILLABLE_MEMORY = ConfigProperty
      .key("hoodie.file.index.cache.spillable.mem")
      .defaultValue(500 * 1024L * 1024L) // 500 MB
      .markAdvanced()
      .sinceVersion("0.16.0")
      .withDocumentation("Amount of memory to be used in bytes for holding cachedAllInputFileSlices in org.apache.hudi.BaseHoodieTableFileIndex.");
```

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
