### PR TITLE
[MINOR] Fixed run of `javadoc:aggregate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ spark-3.5.0-bin-hadoop3/bin/spark-shell \
 
 To build for integration tests that include `hudi-integ-test-bundle`, use `-Dintegration-tests`.
 
-To build the Javadoc for all Java and Scala classes:
+To build the Javadoc for all Java and Scala classes (project should be already compiled):
 ```
 # Javadoc generated under target/site/apidocs
-mvn clean javadoc:aggregate -Pjavadocs
+mvn javadoc:aggregate -Pjavadocs
 ```
 
 ### Build with different Spark versions

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.4</maven-deploy-plugin.version>
-    <genjavadoc-plugin.version>0.15</genjavadoc-plugin.version>
+    <genjavadoc-plugin.version>0.18_2.13.10</genjavadoc-plugin.version>
     <build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-docker-plugin.version>0.45.0</maven-docker-plugin.version>
@@ -2122,27 +2122,22 @@
                 </goals>
                 <configuration>
                   <excludes>
-                    <exclude>${project.basedir}/src/main/scala</exclude>
+                    <exclude>**/*.scala</exclude>
                   </excludes>
                   <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
+                  <args>
+                    <arg>-P:genjavadoc:out=${project.build.directory}/genjavadoc</arg>
+                  </args>
+                  <compilerPlugins>
+                    <compilerPlugin>
+                      <groupId>com.typesafe.genjavadoc</groupId>
+                      <artifactId>genjavadoc-plugin_${scala.version}</artifactId>
+                      <version>${genjavadoc-plugin.version}</version>
+                    </compilerPlugin>
+                  </compilerPlugins>
                 </configuration>
               </execution>
             </executions>
-            <configuration>
-              <args>
-                <arg>-P:genjavadoc:out=${project.build.directory}/genjavadoc</arg>
-              </args>
-              <compilerPlugins>
-                <compilerPlugin>
-                  <groupId>com.typesafe.genjavadoc</groupId>
-                  <artifactId>genjavadoc-plugin_${scala.version}</artifactId>
-                  <version>${genjavadoc-plugin.version}</version>
-                </compilerPlugin>
-              </compilerPlugins>
-              <excludes>
-                <exclude>**/*.scala</exclude>
-              </excludes>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
@@ -2320,6 +2315,7 @@
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <log4j2.version>2.20.0</log4j2.version>
         <slf4j.version>2.0.7</slf4j.version>
+        <genjavadoc-plugin.version>0.19</genjavadoc-plugin.version>
         <skipITs>true</skipITs>
       </properties>
       <modules>
@@ -2467,6 +2463,7 @@
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
         <log4j2.version>2.20.0</log4j2.version>
         <slf4j.version>2.0.7</slf4j.version>
+        <genjavadoc-plugin.version>0.19</genjavadoc-plugin.version>
         <skipITs>false</skipITs>
       </properties>
       <modules>


### PR DESCRIPTION
### Change Logs

Currently, `javadoc:aggregate` couldn't be run at all. Fixed it in this MR. Proper versions for `genjavadoc-plugin_**` are taken from [this list of available versions](https://mvnrepository.com/artifact/com.typesafe.genjavadoc/genjavadoc-plugin).

Proper run is consist of two stages:
```bash
mvn clean install -DskipTests -Dspark* -Dflink* -T 1C
mvn javadoc:aggregate -DskipTests -Dspark* -Dflink* -T 1C -Pjavadocs
```

There are still many errors and warnings in `javadoc:aggregate` results, which require fixes in javadoc comments everywhere in the code. Created corresponding ticket HUDI-8872.

### Impact

No

### Risk level (write none, low medium or high below)

No risk

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
