### PR TITLE
[HUDI-8844] Support secondary and expression index creation through async indexer and write configs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -496,8 +496,8 @@ public class HoodieIndexUtils {
     }
   }
 
-  public static HoodieIndexDefinition getSecondaryOrExpressionIndexDefinition(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, Map<String, String>> columns,
-                                                                              Map<String, String> options, Map<String, String> tableProperties) throws Exception {
+  static HoodieIndexDefinition getSecondaryOrExpressionIndexDefinition(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, Map<String, String>> columns,
+                                                                       Map<String, String> options, Map<String, String> tableProperties) throws Exception {
     String fullIndexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX)
         ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + userIndexName
         : PARTITION_NAME_EXPRESSION_INDEX_PREFIX + userIndexName;
@@ -519,7 +519,7 @@ public class HoodieIndexUtils {
         .build();
   }
 
-  public static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
+  static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
     return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -38,6 +38,7 @@ import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.MetadataValues;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.HoodieTimer;
@@ -46,11 +47,13 @@ import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.exception.HoodieMetadataIndexException;
 import org.apache.hudi.io.HoodieMergedReadHandle;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
@@ -65,13 +68,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.hudi.common.config.HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP;
 import static org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+import static org.apache.hudi.index.expression.HoodieExpressionIndex.EXPRESSION_OPTION;
+import static org.apache.hudi.index.expression.HoodieExpressionIndex.IDENTITY_TRANSFORM;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.validateDataTypeForSecondaryIndex;
 import static org.apache.hudi.table.action.commit.HoodieDeleteHelper.createDeleteRecord;
 
 /**
@@ -483,5 +494,40 @@ public class HoodieIndexUtils {
         HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), metaClient.getTableConfig().getProps());
       }
     }
+  }
+
+  public static HoodieIndexDefinition getSecondaryOrExpressionIndexDefinition(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, Map<String, String>> columns,
+                                                                              Map<String, String> options, Map<String, String> tableProperties) throws Exception {
+    String fullIndexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX)
+        ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + userIndexName
+        : PARTITION_NAME_EXPRESSION_INDEX_PREFIX + userIndexName;
+    if (indexExists(metaClient, fullIndexName)) {
+      throw new HoodieMetadataIndexException("Index already exists: " + userIndexName);
+    }
+    checkArgument(columns.size() == 1, "Only one column can be indexed for functional or secondary index.");
+
+    if (!isEligibleForIndexing(metaClient, indexType, tableProperties, columns)) {
+      throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + userIndexName);
+    }
+
+    return new HoodieIndexDefinition(fullIndexName, indexType, options.getOrDefault(EXPRESSION_OPTION, IDENTITY_TRANSFORM),
+        new ArrayList<>(columns.keySet()), options);
+  }
+
+  public static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
+    return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
+  }
+
+  private static boolean isEligibleForIndexing(HoodieTableMetaClient metaClient, String indexType, Map<String, String> options, Map<String, Map<String, String>> columns) throws Exception {
+    if (!validateDataTypeForSecondaryIndex(new ArrayList<>(columns.keySet()), new TableSchemaResolver(metaClient).getTableAvroSchema())) {
+      return false;
+    }
+    // for secondary index, record index is a must
+    if (indexType.equals(PARTITION_NAME_SECONDARY_INDEX)) {
+      // either record index is enabled or record index partition is already present
+      return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(MetadataPartitionType.RECORD_INDEX.getPartitionPath()))
+          || Boolean.parseBoolean(options.getOrDefault(RECORD_INDEX_ENABLE_PROP.key(), RECORD_INDEX_ENABLE_PROP.defaultValue().toString()));
+    }
+    return true;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -510,8 +510,13 @@ public class HoodieIndexUtils {
       throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + userIndexName);
     }
 
-    return new HoodieIndexDefinition(fullIndexName, indexType, options.getOrDefault(EXPRESSION_OPTION, IDENTITY_TRANSFORM),
-        new ArrayList<>(columns.keySet()), options);
+    return HoodieIndexDefinition.newBuilder()
+        .withIndexName(fullIndexName)
+        .withIndexType(indexType)
+        .withIndexFunction(options.getOrDefault(EXPRESSION_OPTION, IDENTITY_TRANSFORM))
+        .withSourceFields(new ArrayList<>(columns.keySet()))
+        .withIndexOptions(options)
+        .build();
   }
 
   public static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -82,7 +82,7 @@ import static org.apache.hudi.index.expression.HoodieExpressionIndex.IDENTITY_TR
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.validateDataTypeForSecondaryIndex;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.validateDataTypeForSecondaryOrExpressionIndex;
 import static org.apache.hudi.table.action.commit.HoodieDeleteHelper.createDeleteRecord;
 
 /**
@@ -506,7 +506,7 @@ public class HoodieIndexUtils {
     }
     checkArgument(columns.size() == 1, "Only one column can be indexed for functional or secondary index.");
 
-    if (!isEligibleForIndexing(metaClient, indexType, tableProperties, columns)) {
+    if (!isEligibleForSecondaryOrExpressionIndex(metaClient, indexType, tableProperties, columns)) {
       throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + userIndexName);
     }
 
@@ -523,8 +523,11 @@ public class HoodieIndexUtils {
     return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
   }
 
-  private static boolean isEligibleForIndexing(HoodieTableMetaClient metaClient, String indexType, Map<String, String> options, Map<String, Map<String, String>> columns) throws Exception {
-    if (!validateDataTypeForSecondaryIndex(new ArrayList<>(columns.keySet()), new TableSchemaResolver(metaClient).getTableAvroSchema())) {
+  private static boolean isEligibleForSecondaryOrExpressionIndex(HoodieTableMetaClient metaClient,
+                                                                 String indexType,
+                                                                 Map<String, String> options,
+                                                                 Map<String, Map<String, String>> columns) throws Exception {
+    if (!validateDataTypeForSecondaryOrExpressionIndex(new ArrayList<>(columns.keySet()), new TableSchemaResolver(metaClient).getTableAvroSchema())) {
       return false;
     }
     // for secondary index, record index is a must

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1036,7 +1036,6 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
   }
 
   public void buildMetadataPartitions(HoodieEngineContext engineContext, List<HoodieIndexPartitionInfo> indexPartitionInfos, String instantTime) throws IOException {
-    // TODO: so we need to create an index definition in case we're coming via the indexer
     if (indexPartitionInfos.isEmpty()) {
       LOG.warn("No partition to index in the plan");
       return;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -427,10 +427,12 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
             break;
           case EXPRESSION_INDEX:
             Set<String> expressionIndexPartitionsToInit = getExpressionIndexPartitionsToInit(partitionType, dataWriteConfig.getMetadataConfig(), dataMetaClient);
-            if (expressionIndexPartitionsToInit == null) {
+            if (expressionIndexPartitionsToInit.size() != 1) {
+              if (expressionIndexPartitionsToInit.size() > 1) {
+                LOG.warn("Skipping expression index initialization as only one expression index bootstrap at a time is supported for now. Provided: {}", expressionIndexPartitionsToInit);
+              }
               continue;
             }
-            ValidationUtils.checkState(expressionIndexPartitionsToInit.size() == 1, "Only one expression index at a time is supported for now");
             partitionName = expressionIndexPartitionsToInit.iterator().next();
             fileGroupCountAndRecordsPair = initializeExpressionIndexPartition(partitionName, instantTimeForPartition);
             break;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -109,12 +109,12 @@ import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deseri
 import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createMetadataWriteConfig;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionLatestFileSlicesIncludingInflight;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
 import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
@@ -123,8 +123,6 @@ import static org.apache.hudi.metadata.MetadataPartitionType.PARTITION_STATS;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
 import static org.apache.hudi.metadata.MetadataPartitionType.getEnabledPartitions;
-import static org.apache.hudi.metadata.MetadataPartitionType.isNewExpressionIndexDefinitionRequired;
-import static org.apache.hudi.metadata.MetadataPartitionType.isNewSecondaryIndexDefinitionRequired;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices;
 
@@ -428,29 +426,9 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
             partitionName = RECORD_INDEX.getPartitionPath();
             break;
           case EXPRESSION_INDEX:
-            Set<String> expressionIndexPartitionsToInit = getIndexPartitionsToInit(partitionType);
-            if (expressionIndexPartitionsToInit.isEmpty()) {
-              if (isNewExpressionIndexDefinitionRequired(dataWriteConfig.getMetadataConfig(), dataMetaClient)) {
-                String indexedColumn  = dataWriteConfig.getMetadataConfig().getExpressionIndexColumn();
-                String indexName = dataWriteConfig.getMetadataConfig().getExpressionIndexName();
-                String indexType = dataWriteConfig.getMetadataConfig().getExpressionIndexType();
-                // Use a default index name if the indexed column is not specified
-                if (StringUtils.isNullOrEmpty(indexName) && StringUtils.nonEmpty(indexedColumn)) {
-                  indexName = PARTITION_NAME_EXPRESSION_INDEX_PREFIX + indexedColumn;
-                }
-                // Build and register the new index definition
-                HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
-                    .withIndexName(indexName)
-                    .withIndexType(indexType)
-                    .withSourceFields(Collections.singletonList(indexedColumn))
-                    .withIndexOptions(dataWriteConfig.getMetadataConfig().getExpressionIndexOptions())
-                    .build();
-                dataMetaClient.buildIndexDefinition(indexDefinition);
-                // Re-fetch the partitions after adding the new definition
-                expressionIndexPartitionsToInit = getIndexPartitionsToInit(partitionType);
-              } else {
-                continue;
-              }
+            Set<String> expressionIndexPartitionsToInit = getExpressionIndexPartitionsToInit(partitionType, dataWriteConfig.getMetadataConfig(), dataMetaClient);
+            if (expressionIndexPartitionsToInit == null) {
+              continue;
             }
             ValidationUtils.checkState(expressionIndexPartitionsToInit.size() == 1, "Only one expression index at a time is supported for now");
             partitionName = expressionIndexPartitionsToInit.iterator().next();
@@ -467,25 +445,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
             partitionName = PARTITION_STATS.getPartitionPath();
             break;
           case SECONDARY_INDEX:
-            Set<String> secondaryIndexPartitionsToInit = getIndexPartitionsToInit(partitionType);
-            // if no secondary index partition found, check if new secondary index definition need to be added based on metadata write configs
-            if (secondaryIndexPartitionsToInit.isEmpty() && isNewSecondaryIndexDefinitionRequired(dataWriteConfig.getMetadataConfig(), dataMetaClient)) {
-              String indexedColumn  = dataWriteConfig.getMetadataConfig().getSecondaryIndexColumn();
-              String indexName = dataWriteConfig.getMetadataConfig().getSecondaryIndexName();
-              // Use a default index name if the indexed column is not specified
-              if (StringUtils.isNullOrEmpty(indexName) && StringUtils.nonEmpty(indexedColumn)) {
-                indexName = PARTITION_NAME_SECONDARY_INDEX_PREFIX + indexedColumn;
-              }
-              // Build and register the new index definition
-              HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
-                  .withIndexName(indexName)
-                  .withIndexType(PARTITION_NAME_SECONDARY_INDEX)
-                  .withSourceFields(Collections.singletonList(indexedColumn))
-                  .build();
-              dataMetaClient.buildIndexDefinition(indexDefinition);
-              // Re-fetch the partitions after adding the new definition
-              secondaryIndexPartitionsToInit = getIndexPartitionsToInit(partitionType);
-            }
+            Set<String> secondaryIndexPartitionsToInit = getSecondaryIndexPartitionsToInit(partitionType, dataWriteConfig.getMetadataConfig(), dataMetaClient);
             if (secondaryIndexPartitionsToInit.size() != 1) {
               if (secondaryIndexPartitionsToInit.size() > 1) {
                 LOG.warn("Skipping secondary index initialization as only one secondary index bootstrap at a time is supported for now. Provided: {}", secondaryIndexPartitionsToInit);
@@ -654,22 +614,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     return HoodieTableMetadataUtil.getHoodieIndexDefinition(indexName, dataMetaClient);
   }
 
-  private Set<String> getIndexPartitionsToInit(MetadataPartitionType partitionType) {
-    if (dataMetaClient.getIndexMetadata().isEmpty()) {
-      return Collections.emptySet();
-    }
-
-    Set<String> indexPartitions = dataMetaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
-        .map(HoodieIndexDefinition::getIndexName)
-        .filter(indexName -> indexName.startsWith(partitionType.getPartitionPath()))
-        .collect(Collectors.toSet());
-    Set<String> completedMetadataPartitions = dataMetaClient.getTableConfig().getMetadataPartitions();
-    indexPartitions.removeAll(completedMetadataPartitions);
-    return indexPartitions;
-  }
-
   private Pair<Integer, HoodieData<HoodieRecord>> initializeSecondaryIndexPartition(String indexName) throws IOException {
-    // TODO:  does index definition already exist at this point, in case we're coming via the indexer?
     HoodieIndexDefinition indexDefinition = getIndexDefinition(indexName);
     ValidationUtils.checkState(indexDefinition != null, "Secondary Index definition is not present for index " + indexName);
     List<Pair<String, FileSlice>> partitionFileSlicePairs = getPartitionFileSlicePairs();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/BaseHoodieIndexClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/BaseHoodieIndexClient.java
@@ -17,58 +17,28 @@
  * under the License.
  */
 
-package org.apache.hudi.table.action.index.functional;
+package org.apache.hudi.table.action.index;
 
-import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.storage.StoragePath;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class BaseHoodieIndexClient {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BaseHoodieIndexClient.class);
-
   public BaseHoodieIndexClient() {
   }
 
   /**
-   * Register a expression index.
-   * Index definitions are stored in user-specified path or, by default, in .hoodie/.index_defs/index.json.
-   * For the first time, the index definition file will be created if not exists.
-   * For the second time, the index definition file will be updated if exists.
-   * Table Config is updated if necessary.
-   */
-  public void register(HoodieTableMetaClient metaClient, HoodieIndexDefinition indexDefinition) {
-    LOG.info("Registering index {} of using {}", indexDefinition.getIndexName(), indexDefinition.getIndexType());
-    // build HoodieIndexMetadata and then add to index definition file
-    boolean indexDefnUpdated = metaClient.buildIndexDefinition(indexDefinition);
-    if (indexDefnUpdated) {
-      String indexMetaPath = metaClient.getIndexDefinitionPath();
-      // update table config if necessary
-      if (!metaClient.getTableConfig().getProps().containsKey(HoodieTableConfig.RELATIVE_INDEX_DEFINITION_PATH.key())
-          || !metaClient.getTableConfig().getRelativeIndexDefinitionPath().isPresent()) {
-        metaClient.getTableConfig().setValue(HoodieTableConfig.RELATIVE_INDEX_DEFINITION_PATH, FSUtils.getRelativePartitionPath(metaClient.getBasePath(), new StoragePath(indexMetaPath)));
-        HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), metaClient.getTableConfig().getProps());
-      }
-    }
-  }
-
-  /**
-   * Create a expression index.
+   * Create a metadata index.
    */
   public abstract void create(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options,
                               Map<String, String> tableProperties) throws Exception;
 
   /**
    * Creates or updated the col stats index definition.
-   * @param metaClient data table's {@link HoodieTableMetaClient} instance.
+   *
+   * @param metaClient     data table's {@link HoodieTableMetaClient} instance.
    * @param columnsToIndex list of columns to index.
    */
   public abstract void createOrUpdateColumnStatsIndexDefinition(HoodieTableMetaClient metaClient, List<String> columnsToIndex);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -133,7 +133,6 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
 
   private HoodieIndexPartitionInfo buildIndexPartitionInfo(MetadataPartitionType partitionType, HoodieInstant indexUptoInstant) {
     // for expression index, we need to pass the index name as the partition name
-    // TODO: see the index partition info is built correctly. Should we register the index here?
     String partitionName = MetadataPartitionType.EXPRESSION_INDEX.equals(partitionType) || MetadataPartitionType.SECONDARY_INDEX.equals(partitionType)
         ? config.getIndexingConfig().getIndexName()
         : partitionType.getPartitionPath();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -133,6 +133,7 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
 
   private HoodieIndexPartitionInfo buildIndexPartitionInfo(MetadataPartitionType partitionType, HoodieInstant indexUptoInstant) {
     // for expression index, we need to pass the index name as the partition name
+    // TODO: see the index partition info is built correctly. Should we register the index here?
     String partitionName = MetadataPartitionType.EXPRESSION_INDEX.equals(partitionType) || MetadataPartitionType.SECONDARY_INDEX.equals(partitionType)
         ? config.getIndexingConfig().getIndexName()
         : partitionType.getPartitionPath();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.action.index;
 import org.apache.hudi.avro.model.HoodieIndexPartitionInfo;
 import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.client.transaction.TransactionManager;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
@@ -48,8 +49,11 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.model.WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL;
 import static org.apache.hudi.common.model.WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL;
 import static org.apache.hudi.config.HoodieWriteConfig.WRITE_CONCURRENCY_MODE;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataPartition;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightAndCompletedMetadataPartitions;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getSecondaryOrExpressionIndexName;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartitionExists;
 
 /**
@@ -96,10 +100,9 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
     requestedPartitions.removeAll(indexesInflightOrCompleted);
 
     if (!requestedPartitions.isEmpty()) {
-      LOG.warn(String.format("Following partitions already exist or inflight: %s. Going to schedule indexing of only these partitions: %s",
-          indexesInflightOrCompleted, requestedPartitions));
+      LOG.warn("Following partitions already exist or inflight: {}. Going to schedule indexing of only these partitions: {}", indexesInflightOrCompleted, requestedPartitions);
     } else {
-      LOG.error("All requested index types are inflight or completed: " + partitionIndexTypes);
+      LOG.error("All requested index types are inflight or completed: {}", partitionIndexTypes);
       return Option.empty();
     }
     List<MetadataPartitionType> finalPartitionsToIndex = partitionIndexTypes.stream()
@@ -132,10 +135,15 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
   }
 
   private HoodieIndexPartitionInfo buildIndexPartitionInfo(MetadataPartitionType partitionType, HoodieInstant indexUptoInstant) {
-    // for expression index, we need to pass the index name as the partition name
-    String partitionName = MetadataPartitionType.EXPRESSION_INDEX.equals(partitionType) || MetadataPartitionType.SECONDARY_INDEX.equals(partitionType)
-        ? config.getIndexingConfig().getIndexName()
-        : partitionType.getPartitionPath();
+    String partitionName = partitionType.getPartitionPath();
+    HoodieMetadataConfig metadataConfig = config.getMetadataConfig();
+    // for expression or secondary index, we need to pass the metadata config to derive the partition name
+    if (MetadataPartitionType.EXPRESSION_INDEX.equals(partitionType)) {
+      partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getExpressionIndexName, PARTITION_NAME_EXPRESSION_INDEX_PREFIX, metadataConfig.getExpressionIndexColumn());
+    }
+    if (MetadataPartitionType.SECONDARY_INDEX.equals(partitionType)) {
+      partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getSecondaryIndexName, PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataConfig.getSecondaryIndexColumn());
+    }
     return new HoodieIndexPartitionInfo(LATEST_INDEX_PLAN_VERSION, partitionName, indexUptoInstant.requestedTime(), Collections.emptyMap());
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -39,6 +39,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataIndexException;
+import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.StorageSchemes;
 import org.apache.hudi.table.action.index.BaseHoodieIndexClient;
@@ -60,17 +61,12 @@ import scala.collection.JavaConverters;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP;
-import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+import static org.apache.hudi.index.HoodieIndexUtils.indexExists;
 import static org.apache.hudi.index.HoodieIndexUtils.register;
-import static org.apache.hudi.index.expression.ExpressionIndexSparkFunctions.IDENTITY_FUNCTION;
-import static org.apache.hudi.index.expression.HoodieExpressionIndex.EXPRESSION_OPTION;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.validateDataTypeForSecondaryIndex;
 
 public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
 
@@ -142,35 +138,22 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
 
   private void createExpressionOrSecondaryIndex(HoodieTableMetaClient metaClient, String userIndexName, String indexType,
                                                 Map<String, Map<String, String>> columns, Map<String, String> options, Map<String, String> tableProperties) throws Exception {
-    String fullIndexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX)
-        ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + userIndexName
-        : PARTITION_NAME_EXPRESSION_INDEX_PREFIX + userIndexName;
-    if (indexExists(metaClient, fullIndexName)) {
-      throw new HoodieMetadataIndexException("Index already exists: " + userIndexName);
-    }
-    checkArgument(columns.size() == 1, "Only one column can be indexed for functional or secondary index.");
-
-    if (!isEligibleForIndexing(metaClient, indexType, tableProperties, columns)) {
-      throw new HoodieMetadataIndexException("Not eligible for indexing: " + indexType + ", indexName: " + userIndexName);
-    }
-
-    HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition(fullIndexName, indexType, options.getOrDefault(EXPRESSION_OPTION, IDENTITY_FUNCTION),
-        new ArrayList<>(columns.keySet()), options);
+    HoodieIndexDefinition indexDefinition = HoodieIndexUtils.getSecondaryOrExpressionIndexDefinition(metaClient, userIndexName, indexType, columns, options, tableProperties);
     if (!metaClient.getTableConfig().getRelativeIndexDefinitionPath().isPresent()
         || !metaClient.getIndexMetadata().isPresent()
-        || !metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(fullIndexName)) {
+        || !metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(indexDefinition.getIndexName())) {
       LOG.info("Index definition is not present. Registering the index first");
       register(metaClient, indexDefinition);
     }
 
     ValidationUtils.checkState(metaClient.getIndexMetadata().isPresent(), "Index definition is not present");
 
-    LOG.info("Creating index {} of using {}", fullIndexName, indexType);
+    LOG.info("Creating index {} of using {}", indexDefinition.getIndexName(), indexType);
     Option<HoodieIndexDefinition> expressionIndexDefinitionOpt = Option.ofNullable(indexDefinition);
     try (SparkRDDWriteClient writeClient = getWriteClient(metaClient, expressionIndexDefinitionOpt, Option.of(indexType))) {
       MetadataPartitionType partitionType = indexType.equals(PARTITION_NAME_SECONDARY_INDEX) ? MetadataPartitionType.SECONDARY_INDEX : MetadataPartitionType.EXPRESSION_INDEX;
       // generate index plan
-      Option<String> indexInstantTime = doSchedule(writeClient, metaClient, fullIndexName, partitionType);
+      Option<String> indexInstantTime = doSchedule(writeClient, metaClient, indexDefinition.getIndexName(), partitionType);
       if (indexInstantTime.isPresent()) {
         // build index
         writeClient.index(indexInstantTime.get());
@@ -178,7 +161,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
         throw new HoodieMetadataIndexException("Scheduling of index action did not return any instant.");
       }
     } catch (Throwable t) {
-      drop(metaClient, fullIndexName, Option.ofNullable(indexDefinition));
+      drop(metaClient, indexDefinition.getIndexName(), Option.ofNullable(indexDefinition));
       throw t;
     }
   }
@@ -248,10 +231,6 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     return client.scheduleIndexing(partitionTypes, Collections.singletonList(indexName));
   }
 
-  private static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
-    return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
-  }
-
   private static Map<String, String> buildWriteConfig(HoodieTableMetaClient metaClient, Option<HoodieIndexDefinition> indexDefinitionOpt,
                                                       Option<String> indexTypeOpt) {
     Map<String, String> writeConfig = new HashMap<>();
@@ -298,18 +277,5 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     } else {
       return Collections.emptyMap();
     }
-  }
-
-  private static boolean isEligibleForIndexing(HoodieTableMetaClient metaClient, String indexType, Map<String, String> options, Map<String, Map<String, String>> columns) throws Exception {
-    if (!validateDataTypeForSecondaryIndex(new ArrayList<>(columns.keySet()), new TableSchemaResolver(metaClient).getTableAvroSchema())) {
-      return false;
-    }
-    // for secondary index, record index is a must
-    if (indexType.equals(PARTITION_NAME_SECONDARY_INDEX)) {
-      // either record index is enabled or record index partition is already present
-      return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(MetadataPartitionType.RECORD_INDEX.getPartitionPath()))
-          || Boolean.parseBoolean(options.getOrDefault(RECORD_INDEX_ENABLE_PROP.key(), RECORD_INDEX_ENABLE_PROP.defaultValue().toString()));
-    }
-    return true;
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -130,8 +130,13 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
 
   @Override
   public void createOrUpdateColumnStatsIndexDefinition(HoodieTableMetaClient metaClient, List<String> columnsToIndex) {
-    HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition(PARTITION_NAME_COLUMN_STATS, PARTITION_NAME_COLUMN_STATS, PARTITION_NAME_COLUMN_STATS,
-        columnsToIndex, Collections.EMPTY_MAP);
+    HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(PARTITION_NAME_COLUMN_STATS)
+        .withIndexType(PARTITION_NAME_COLUMN_STATS)
+        .withIndexFunction(PARTITION_NAME_COLUMN_STATS)
+        .withSourceFields(columnsToIndex)
+        .withIndexOptions(Collections.EMPTY_MAP)
+        .build();
     LOG.info("Registering Or Updating the index " + PARTITION_NAME_COLUMN_STATS);
     register(metaClient, indexDefinition);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkIndexClient.java
@@ -41,7 +41,7 @@ import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataIndexException;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.StorageSchemes;
-import org.apache.hudi.table.action.index.functional.BaseHoodieIndexClient;
+import org.apache.hudi.table.action.index.BaseHoodieIndexClient;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -61,6 +61,7 @@ import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+import static org.apache.hudi.index.HoodieIndexUtils.register;
 import static org.apache.hudi.index.expression.ExpressionIndexSparkFunctions.IDENTITY_FUNCTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.EXPRESSION_OPTION;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.client;
 
-import org.apache.hudi.HoodieSparkIndexClient;
+import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.utils.SparkReleaseResources;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi;
+package org.apache.hudi.index;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
@@ -39,7 +39,6 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataIndexException;
-import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.StorageSchemes;
 import org.apache.hudi.table.action.index.BaseHoodieIndexClient;
@@ -166,6 +165,7 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
         throw new HoodieMetadataIndexException("Scheduling of index action did not return any instant.");
       }
     } catch (Throwable t) {
+      LOG.warn("Error while creating index: {}. So drop it.", indexDefinition.getIndexName(), t);
       drop(metaClient, indexDefinition.getIndexName(), Option.ofNullable(indexDefinition));
       throw t;
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/expression/ExpressionIndexSparkFunctions.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/expression/ExpressionIndexSparkFunctions.java
@@ -64,7 +64,7 @@ public class ExpressionIndexSparkFunctions {
   private static final String SPARK_REGEXP_REPLACE = "regexp_replace";
   private static final String SPARK_REGEXP_EXTRACT = "regexp_extract";
   private static final String SPARK_SPLIT = "split";
-  public static final String IDENTITY_FUNCTION = "identity";
+  public static final String IDENTITY_FUNCTION = HoodieExpressionIndex.IDENTITY_TRANSFORM;
 
   private static final Map<String, SparkFunction> SPARK_FUNCTION_MAP = new HashMap<>();
   static {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.metadata;
 
-import org.apache.hudi.HoodieSparkIndexClient;
+import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.table.action.commit;
 
-import org.apache.hudi.HoodieSparkIndexClient;
+import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.clustering.update.strategy.SparkAllowUpdateStrategy;
 import org.apache.hudi.client.utils.SparkValidatorUtils;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
@@ -140,7 +140,13 @@ public class TestHoodieSparkIndex extends HoodieClientTestBase {
   private HoodieIndexDefinition getIndexDefinition(String indexName, String indexType, String indexFunc, List<String> sourceFields,
                                                    Map<String, String> indexOptions) {
     String fullIndexName = getIndexFullName(indexName, indexType);
-    return new HoodieIndexDefinition(fullIndexName, indexType, indexFunc, sourceFields, indexOptions);
+    return HoodieIndexDefinition.newBuilder()
+        .withIndexName(fullIndexName)
+        .withIndexType(indexType)
+        .withIndexFunction(indexFunc)
+        .withSourceFields(sourceFields)
+        .withIndexOptions(indexOptions)
+        .build();
   }
 
   private String getIndexFullName(String indexName, String indexType) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -75,14 +76,14 @@ public class TestHoodieSparkIndex extends HoodieClientTestBase {
       String fieldName = fieldNamePrefix + "_" + i;
       HoodieIndexDefinition indexDefinition = getIndexDefinition(indexName,
           i % 2 == 0 ? PARTITION_NAME_SECONDARY_INDEX : PARTITION_NAME_EXPRESSION_INDEX, fieldName);
-      sparkIndexClient.register(metaClient, indexDefinition);
+      HoodieIndexUtils.register(metaClient, indexDefinition);
       readAndValidateIndexDefn(indexDefinition);
     }
 
     // add col stats index.
     HoodieIndexDefinition colStatsIndexDefinition = getIndexDefinition(PARTITION_NAME_COLUMN_STATS,
         PARTITION_NAME_COLUMN_STATS, fieldNamePrefix + "_5");
-    sparkIndexClient.register(metaClient, colStatsIndexDefinition);
+    HoodieIndexUtils.register(metaClient, colStatsIndexDefinition);
     readAndValidateIndexDefn(colStatsIndexDefinition);
 
     // drop one among sec index and expression index.
@@ -104,7 +105,7 @@ public class TestHoodieSparkIndex extends HoodieClientTestBase {
     List<String> colsToIndex = IntStream.range(0, 10).mapToObj(number -> fieldNamePrefix + "_" + number).collect(Collectors.toList());
     colStatsIndexDefinition = getIndexDefinition(PARTITION_NAME_COLUMN_STATS,
         PARTITION_NAME_COLUMN_STATS, PARTITION_NAME_COLUMN_STATS, colsToIndex, Collections.EMPTY_MAP);
-    sparkIndexClient.register(metaClient, colStatsIndexDefinition);
+    HoodieIndexUtils.register(metaClient, colStatsIndexDefinition);
     readAndValidateIndexDefn(colStatsIndexDefinition);
 
     // drop col stats

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.client;
 
-import org.apache.hudi.HoodieSparkIndexClient;
+import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
@@ -54,7 +54,7 @@ public class HoodieIndexingConfig extends HoodieConfig {
   public static final String INDEX_DEFINITION_FILE = "index.properties";
   public static final String INDEX_DEFINITION_FILE_BACKUP = "index.properties.backup";
   public static final ConfigProperty<String> INDEX_NAME = ConfigProperty
-      .key("hoodie.expression.index.name")
+      .key("hoodie.index.name")
       .noDefaultValue()
       .sinceVersion("1.0.0")
       .withDocumentation("Name of the expression index. This is also used for the partition name in the metadata table.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -364,26 +364,27 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".index.expression.column")
       .noDefaultValue()
       .markAdvanced()
-      .sinceVersion("1.0.0")
+      .sinceVersion("1.0.1")
       .withDocumentation("Column for which expression index will be built.");
+
   public static final ConfigProperty<String> EXPRESSION_INDEX_NAME = ConfigProperty
       .key(METADATA_PREFIX + ".index.expression.name")
       .defaultValue("")
       .markAdvanced()
-      .sinceVersion("1.0.0")
+      .sinceVersion("1.0.1")
       .withDocumentation("Name of the expression index. It is optional and default is the name of the column, prefixed by '" + PARTITION_NAME_EXPRESSION_INDEX_PREFIX + "'.");
 
   public static final ConfigProperty<String> EXPRESSION_INDEX_TYPE = ConfigProperty
       .key(METADATA_PREFIX + ".index.expression.type")
       .noDefaultValue()
       .markAdvanced()
-      .sinceVersion("1.0.0")
+      .sinceVersion("1.0.1")
       .withDocumentation("Index type i.e. column_stats aor bloom_filters, for which expression index will be built e.g. date_format(ts).");
   public static final ConfigProperty<String> EXPRESSION_INDEX_OPTIONS = ConfigProperty
       .key(METADATA_PREFIX + ".index.expression.options")
       .noDefaultValue()
       .markAdvanced()
-      .sinceVersion("1.0.0")
+      .sinceVersion("1.0.1")
       .withDocumentation("Options for the expression index, e.g. \"expr='from_unixtime', format='yyyy-MM-dd'\"");
 
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
+
 /**
  * Configurations used by the HUDI Metadata Table.
  */
@@ -394,6 +396,20 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Parallelism to use, when generating secondary index.");
 
+  public static final ConfigProperty<String> SECONDARY_INDEX_NAME = ConfigProperty
+      .key(METADATA_PREFIX + ".index.secondary.name")
+      .defaultValue("")
+      .markAdvanced()
+      .sinceVersion("1.0.1")
+      .withDocumentation("Name of the secondary index. It is optional and default is the name of the column, prefixed by '" + PARTITION_NAME_SECONDARY_INDEX_PREFIX + "'.");
+
+  public static final ConfigProperty<String> SECONDARY_INDEX_COLUMN = ConfigProperty
+      .key(METADATA_PREFIX + ".index.secondary.column")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("1.0.1")
+      .withDocumentation("Column for which secondary index will be built.");
+
   // Config to specify metadata index to delete
   public static final ConfigProperty<String> DROP_METADATA_INDEX = ConfigProperty
       .key(METADATA_PREFIX + ".index.drop")
@@ -563,6 +579,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public int getSecondaryIndexParallelism() {
     return getInt(SECONDARY_INDEX_PARALLELISM);
+  }
+
+  public String getSecondaryIndexColumn() {
+    return getString(SECONDARY_INDEX_COLUMN);
+  }
+
+  public String getSecondaryIndexName() {
+    return getString(SECONDARY_INDEX_NAME);
   }
 
   public String getMetadataIndexToDrop() {
@@ -769,6 +793,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withPartitionStatsIndexParallelism(int parallelism) {
       metadataConfig.setValue(PARTITION_STATS_INDEX_PARALLELISM, String.valueOf(parallelism));
+      return this;
+    }
+
+    public Builder withSecondaryIndexForColumn(String column) {
+      metadataConfig.setValue(SECONDARY_INDEX_COLUMN, column);
+      return this;
+    }
+
+    public Builder withSecondaryIndexName(String name) {
+      metadataConfig.setValue(SECONDARY_INDEX_NAME, name);
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -37,9 +37,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
-
 /**
  * Configurations used by the HUDI Metadata Table.
  */
@@ -367,19 +364,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.1")
       .withDocumentation("Column for which expression index will be built.");
 
-  public static final ConfigProperty<String> EXPRESSION_INDEX_NAME = ConfigProperty
-      .key(METADATA_PREFIX + ".index.expression.name")
-      .defaultValue("")
-      .markAdvanced()
-      .sinceVersion("1.0.1")
-      .withDocumentation("Name of the expression index. It is optional and default is the name of the column, prefixed by '" + PARTITION_NAME_EXPRESSION_INDEX_PREFIX + "'.");
+  public static final ConfigProperty<String> EXPRESSION_INDEX_NAME = HoodieIndexingConfig.INDEX_NAME;
 
-  public static final ConfigProperty<String> EXPRESSION_INDEX_TYPE = ConfigProperty
-      .key(METADATA_PREFIX + ".index.expression.type")
-      .noDefaultValue()
-      .markAdvanced()
-      .sinceVersion("1.0.1")
-      .withDocumentation("Index type i.e. column_stats aor bloom_filters, for which expression index will be built e.g. date_format(ts).");
+  public static final ConfigProperty<String> EXPRESSION_INDEX_TYPE = HoodieIndexingConfig.INDEX_TYPE;
+
   public static final ConfigProperty<String> EXPRESSION_INDEX_OPTIONS = ConfigProperty
       .key(METADATA_PREFIX + ".index.expression.options")
       .noDefaultValue()
@@ -426,12 +414,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Parallelism to use, when generating secondary index.");
 
-  public static final ConfigProperty<String> SECONDARY_INDEX_NAME = ConfigProperty
-      .key(METADATA_PREFIX + ".index.secondary.name")
-      .defaultValue("")
-      .markAdvanced()
-      .sinceVersion("1.0.1")
-      .withDocumentation("Name of the secondary index. It is optional and default is the name of the column, prefixed by '" + PARTITION_NAME_SECONDARY_INDEX_PREFIX + "'.");
+  public static final ConfigProperty<String> SECONDARY_INDEX_NAME = HoodieIndexingConfig.INDEX_NAME;
 
   public static final ConfigProperty<String> SECONDARY_INDEX_COLUMN = ConfigProperty
       .key(METADATA_PREFIX + ".index.secondary.column")

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexDefinition.java
@@ -63,8 +63,7 @@ public class HoodieIndexDefinition implements Serializable {
   public HoodieIndexDefinition() {
   }
 
-  public HoodieIndexDefinition(String indexName, String indexType, String indexFunction, List<String> sourceFields,
-                               Map<String, String> indexOptions) {
+  HoodieIndexDefinition(String indexName, String indexType, String indexFunction, List<String> sourceFields, Map<String, String> indexOptions) {
     this.indexName = indexName;
     this.indexType = indexType;
     this.indexFunction = nonEmpty(indexFunction) ? indexFunction : EMPTY_STRING;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexDefinition.java
@@ -22,6 +22,8 @@ package org.apache.hudi.common.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,10 +33,10 @@ import static org.apache.hudi.common.util.StringUtils.EMPTY_STRING;
 import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.DAYS_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.FORMAT_OPTION;
-import static org.apache.hudi.index.expression.HoodieExpressionIndex.REGEX_GROUP_INDEX_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.LENGTH_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.PATTERN_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.POSITION_OPTION;
+import static org.apache.hudi.index.expression.HoodieExpressionIndex.REGEX_GROUP_INDEX_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.REPLACEMENT_OPTION;
 import static org.apache.hudi.index.expression.HoodieExpressionIndex.TRIM_STRING_OPTION;
 
@@ -124,6 +126,53 @@ public class HoodieIndexDefinition implements Serializable {
 
   public String getIndexType() {
     return indexType;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private String indexName;
+    private String indexType;
+    private String indexFunction;
+    private List<String> sourceFields;
+    private Map<String, String> indexOptions;
+
+    public Builder() {
+      this.sourceFields = new ArrayList<>();
+      this.indexOptions = new HashMap<>();
+    }
+
+    public Builder withIndexName(String indexName) {
+      this.indexName = indexName;
+      return this;
+    }
+
+    public Builder withIndexType(String indexType) {
+      this.indexType = indexType;
+      return this;
+    }
+
+    public Builder withIndexFunction(String indexFunction) {
+      this.indexFunction = indexFunction;
+      return this;
+    }
+
+    public Builder withSourceFields(List<String> sourceFields) {
+      this.sourceFields = sourceFields;
+      return this;
+    }
+
+    public Builder withIndexOptions(Map<String, String> indexOptions) {
+      this.indexOptions = indexOptions;
+      return this;
+    }
+
+    public HoodieIndexDefinition build() {
+      return new HoodieIndexDefinition(indexName, indexType, indexFunction, sourceFields, indexOptions);
+    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -211,7 +211,7 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   /**
-   * Builds expression index definition and writes to index definition file.
+   * Builds index definition and writes to index definition file.
    * Support mutable and immutable index definition. Only col stats is mutable, while all others are immutable.
    * Inacse of immutable index definition, we could only create or delete the definition.
    * Incase of mutable (col stats), list of source columns (or list of columns to index) could also change.
@@ -293,7 +293,7 @@ public class HoodieTableMetaClient implements Serializable {
           return Option.of(new HoodieIndexMetadata());
         }
       } catch (IOException e) {
-        throw new HoodieIOException("Could not load expression index metadata at path: " + tableConfig.getRelativeIndexDefinitionPath().get(), e);
+        throw new HoodieIOException("Could not load index definition at path: " + tableConfig.getRelativeIndexDefinitionPath().get(), e);
       }
     }
     return Option.empty();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -91,7 +91,6 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.io.storage.HoodieIOFactory.getIOFactory;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 
 /**
  * <code>HoodieTableMetaClient</code> allows to access meta-data about a hoodie table It returns meta-data about
@@ -211,33 +210,28 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   /**
-   * Builds index definition and writes to index definition file.
-   * Support mutable and immutable index definition. Only col stats is mutable, while all others are immutable.
-   * Inacse of immutable index definition, we could only create or delete the definition.
-   * Incase of mutable (col stats), list of source columns (or list of columns to index) could also change.
+   * Builds index definition and writes to index definition file. Support mutable and immutable index definition.
+   * For instance, if index definition is mutable (like column stats), list of source columns (or list of columns to index) could also change.
+   * If an index definition is present for the index name, it will be updated only when there is difference between present and new index definition.
+   *
    * @return true if index definition is updated.
    */
   public boolean buildIndexDefinition(HoodieIndexDefinition indexDefinition) {
     String indexName = indexDefinition.getIndexName();
-    boolean isIndexDefnImmutable = !indexDefinition.getIndexName().equals(PARTITION_NAME_COLUMN_STATS); // only col stats is mutable.
     String indexMetaPath = getIndexDefinitionPath();
     boolean updateIndexDefn = true;
     if (indexMetadataOpt.isPresent()) {
-      if (isIndexDefnImmutable) {
-        indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
-      } else {
-        // if index defn is mutable, lets check for difference and only update if required.
-        if (indexMetadataOpt.get().getIndexDefinitions().containsKey(indexName)) {
-          if (!indexMetadataOpt.get().getIndexDefinitions().get(indexName).getSourceFields().equals(indexDefinition.getSourceFields())) {
-            LOG.info(String.format("List of columns to index is changing. Old value %s. New value %s",
-                indexMetadataOpt.get().getIndexDefinitions().get(indexName).getSourceFields(), indexDefinition.getSourceFields()));
-            indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
-          } else {
-            updateIndexDefn = false;
-          }
-        } else {
+      // if index definition is present, lets check for difference and only update if required.
+      if (indexMetadataOpt.get().getIndexDefinitions().containsKey(indexName)) {
+        if (!indexMetadataOpt.get().getIndexDefinitions().get(indexName).getSourceFields().equals(indexDefinition.getSourceFields())) {
+          LOG.info("List of columns to index is changing. Old value {}. New value {}", indexMetadataOpt.get().getIndexDefinitions().get(indexName).getSourceFields(),
+              indexDefinition.getSourceFields());
           indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
+        } else {
+          updateIndexDefn = false;
         }
+      } else {
+        indexMetadataOpt.get().getIndexDefinitions().put(indexName, indexDefinition);
       }
     } else {
       Map<String, HoodieIndexDefinition> indexDefinitionMap = new HashMap<>();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -220,11 +220,6 @@ public class HoodieTableMetaClient implements Serializable {
   public boolean buildIndexDefinition(HoodieIndexDefinition indexDefinition) {
     String indexName = indexDefinition.getIndexName();
     boolean isIndexDefnImmutable = !indexDefinition.getIndexName().equals(PARTITION_NAME_COLUMN_STATS); // only col stats is mutable.
-    if (isIndexDefnImmutable) {
-      checkState(
-          !indexMetadataOpt.isPresent() || (!indexMetadataOpt.get().getIndexDefinitions().containsKey(indexName)),
-          "Index metadata is already present");
-    }
     String indexMetaPath = getIndexDefinitionPath();
     boolean updateIndexDefn = true;
     if (indexMetadataOpt.isPresent()) {

--- a/hudi-common/src/main/java/org/apache/hudi/index/expression/HoodieExpressionIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/expression/HoodieExpressionIndex.java
@@ -46,6 +46,7 @@ public interface HoodieExpressionIndex<S, T> extends Serializable {
   String POSITION_OPTION = "pos";
   String DAYS_OPTION = "days";
   String FORMAT_OPTION = "format";
+  String IDENTITY_TRANSFORM = "identity";
 
   /**
    * Get the name of the index.

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -147,8 +147,8 @@ public class TestMetadataPartitionType {
     // Simulate the meta client having EXPRESSION_INDEX available
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
-    HoodieIndexMetadata expressionIndexMetadata =
-        new HoodieIndexMetadata(Collections.singletonMap("expr_index_dummy", new HoodieIndexDefinition("expr_index_dummy", null, null, null, null)));
+    HoodieIndexDefinition expressionIndexDefinition = createIndexDefinition(MetadataPartitionType.EXPRESSION_INDEX, "dummy", "column_stats", "lower", Collections.singletonList("name"), null);
+    HoodieIndexMetadata expressionIndexMetadata = new HoodieIndexMetadata(Collections.singletonMap("expr_index_dummy", expressionIndexDefinition));
     Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.of(expressionIndexMetadata));
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.EXPRESSION_INDEX)).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
@@ -198,22 +198,34 @@ public class TestMetadataPartitionType {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     String expressionIndexName = "dummyExpressionIndex";
     String secondaryIndexName = "dummySecondaryIndex";
-    Map<String, HoodieIndexDefinition> indexDefinitions = new HashMap<>();
-    indexDefinitions.put(
-        expressionIndexName,
-        new HoodieIndexDefinition("expr_index_dummyExpressionIndex", "column_stats", "lower", Collections.singletonList("name"), null));
-    indexDefinitions.put(
-        secondaryIndexName,
-        new HoodieIndexDefinition("secondary_index_dummySecondaryIndex", null, null, Collections.singletonList("name"), null));
-    HoodieIndexMetadata indexMetadata = new HoodieIndexMetadata(indexDefinitions);
+    HoodieIndexMetadata indexMetadata = getIndexMetadata(expressionIndexName, secondaryIndexName);
     when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
     if (partitionType == MetadataPartitionType.EXPRESSION_INDEX) {
-      assertEquals("expr_index_dummyExpressionIndex", partitionType.getPartitionPath(metaClient, expressionIndexName));
+      assertEquals(expressionIndexName, partitionType.getPartitionPath(metaClient, expressionIndexName));
     } else if (partitionType == MetadataPartitionType.SECONDARY_INDEX) {
-      assertEquals("secondary_index_dummySecondaryIndex", partitionType.getPartitionPath(metaClient, secondaryIndexName));
+      assertEquals(secondaryIndexName, partitionType.getPartitionPath(metaClient, secondaryIndexName));
     } else {
       assertEquals(partitionType.getPartitionPath(), partitionType.getPartitionPath(metaClient, null));
     }
+  }
+
+  private static HoodieIndexMetadata getIndexMetadata(String expressionIndexName, String secondaryIndexName) {
+    Map<String, HoodieIndexDefinition> indexDefinitions = new HashMap<>();
+    HoodieIndexDefinition expressionIndexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(expressionIndexName)
+        .withIndexType("column_stats")
+        .withIndexFunction("lower")
+        .withSourceFields(Collections.singletonList("name"))
+        .build();
+    indexDefinitions.put(expressionIndexName, expressionIndexDefinition);
+    HoodieIndexDefinition secondaryIndexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(secondaryIndexName)
+        .withIndexType(null)
+        .withIndexFunction(null)
+        .withSourceFields(Collections.singletonList("name"))
+        .build();
+    indexDefinitions.put(secondaryIndexName, secondaryIndexDefinition);
+    return new HoodieIndexMetadata(indexDefinitions);
   }
 
   @Test
@@ -230,19 +242,26 @@ public class TestMetadataPartitionType {
   public void testIndexNameWithoutPrefix() {
     for (MetadataPartitionType partitionType : MetadataPartitionType.getValidValues()) {
       String userIndexName = MetadataPartitionType.isExpressionOrSecondaryIndex(partitionType.getPartitionPath()) ? "idx" : "";
-      HoodieIndexDefinition indexDefinition = createIndexDefinition(partitionType, userIndexName);
+      HoodieIndexDefinition indexDefinition = createIndexDefinition(partitionType, userIndexName, null, null, null, null);
       assertEquals(partitionType.getIndexNameWithoutPrefix(indexDefinition), userIndexName);
     }
 
     assertThrows(IllegalArgumentException.class, () -> {
-      HoodieIndexDefinition indexDefinition = createIndexDefinition(MetadataPartitionType.RECORD_INDEX, "");
+      HoodieIndexDefinition indexDefinition = createIndexDefinition(MetadataPartitionType.RECORD_INDEX, "", null, null, null, null);
       MetadataPartitionType.EXPRESSION_INDEX.getIndexNameWithoutPrefix(indexDefinition);
     });
   }
 
-  private HoodieIndexDefinition createIndexDefinition(MetadataPartitionType partitionType, String userIndexName) {
+  private HoodieIndexDefinition createIndexDefinition(MetadataPartitionType partitionType, String userIndexName, String indexType, String indexFunction, List<String> sourceFields,
+                                                      Map<String, String> indexOptions) {
     String indexSuffix = StringUtils.nonEmpty(userIndexName) ? userIndexName : "";
-    return new HoodieIndexDefinition(partitionType.getPartitionPath() + indexSuffix, null, null, null, null);
+    return HoodieIndexDefinition.newBuilder()
+        .withIndexName(partitionType.getPartitionPath() + indexSuffix)
+        .withIndexType(indexType)
+        .withIndexFunction(indexFunction)
+        .withSourceFields(sourceFields)
+        .withIndexOptions(indexOptions)
+        .build();
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -262,8 +262,13 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     Map<String, Map<String, String>> columnsMap = new HashMap<>();
     columnsMap.put("c1", Collections.emptyMap());
     String indexName = MetadataPartitionType.EXPRESSION_INDEX.getPartitionPath() + "idx";
-    HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition(indexName, "column_stats", "identity",
-        new ArrayList<>(columnsMap.keySet()), Collections.emptyMap());
+    HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(indexName)
+        .withIndexType("column_stats")
+        .withIndexFunction("identity")
+        .withSourceFields(new ArrayList<>(columnsMap.keySet()))
+        .withIndexOptions(Collections.emptyMap())
+        .build();
     metaClient.buildIndexDefinition(indexDefinition);
     assertTrue(metaClient.getIndexMetadata().get().getIndexDefinitions().containsKey(indexName));
     assertTrue(metaClient.getStorage().exists(new StoragePath(metaClient.getIndexDefinitionPath())));

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -19,12 +19,12 @@
 
 package org.apache.spark.sql.hudi.command
 
-import org.apache.hudi.HoodieSparkIndexClient
 import org.apache.hudi.common.model.HoodieIndexDefinition
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.util.{StringUtils, ValidationUtils}
 import org.apache.hudi.exception.HoodieIndexException
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.index.HoodieSparkIndexClient
 import org.apache.hudi.index.expression.ExpressionIndexSparkFunctions
 import org.apache.hudi.index.expression.HoodieExpressionIndex.EXPRESSION_OPTION
 import org.apache.hudi.metadata.{HoodieTableMetadataUtil, MetadataPartitionType}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -318,7 +318,13 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       // assert SI records from 1st commit
       List<String> expectedSecondaryIndexKeys = records1.stream().map(TestMetadataUtilRLIandSIRecordGeneration::getSecondaryIndexKey).collect(Collectors.toList());
       String firstCommitTime = commitTime;
-      HoodieIndexDefinition indexDefinition = new HoodieIndexDefinition("secondary_index_idx_rider", "", "", Collections.singletonList("rider"), Collections.emptyMap());
+      HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
+          .withIndexName("secondary_index_idx_rider")
+          .withIndexType("")
+          .withIndexFunction("")
+          .withSourceFields(Collections.singletonList("rider"))
+          .withIndexOptions(Collections.emptyMap())
+          .build();
       HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).withSecondaryIndexParallelism(2).build();
       HoodieMetadataFileSystemView metadataView = new HoodieMetadataFileSystemView(engineContext, metaClient, metaClient.getActiveTimeline(), metadataConfig);
       metadataView.loadAllPartitions();

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -32,13 +32,12 @@ import org.apache.hudi.common.util.Option
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.functional.TestCOWDataSource.convertColumnsToNullable
 import org.apache.hudi.index.HoodieIndex.IndexType
-import org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartitionExists
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.{PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataPartitionExists}
 import org.apache.hudi.metadata.MetadataPartitionType.SECONDARY_INDEX
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieSparkClientTestBase}
 import org.apache.hudi.util.JFunction
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
@@ -50,7 +49,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
 
 import java.util.function.Consumer
-
 import scala.collection.JavaConverters._
 
 /**
@@ -1552,18 +1550,18 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     initMetaClient(HoodieTableType.MERGE_ON_READ)
     // Create a MOR table and add 10 records to the table.
     val records = recordsToStrings(dataGen.generateInserts("000", 3)).asScala.toSeq
-    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 10))
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
     inputDF.write.format("org.apache.hudi")
       .options(writeOpts)
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
     val snapshotDF = spark.read.format("org.apache.hudi").options(readOpts).load(basePath)
-    assertEquals(10, snapshotDF.count())
+    assertEquals(3, snapshotDF.count())
 
     // Upsert another batch with secondary index configs
-    val secondaryIndexName = "idx_name"
-    val secondaryIndexColumn = "name"
+    val secondaryIndexName = "idx_rider"
+    val secondaryIndexColumn = "rider"
     writeOpts = writeOpts ++ Map(
       HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key -> "true",
       HoodieMetadataConfig.SECONDARY_INDEX_NAME.key -> secondaryIndexName,
@@ -1578,8 +1576,28 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
 
     // validate that secondary index is created
     metaClient = HoodieTableMetaClient.reload(metaClient)
-    // validate the secondary index is built
-    assertTrue(metadataPartitionExists(basePath, context, SECONDARY_INDEX.getPartitionPath(metaClient, secondaryIndexName)))
-    assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(SECONDARY_INDEX.getPartitionPath(metaClient, secondaryIndexName)))
+    assertTrue(metadataPartitionExists(basePath, context, PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName))
+    assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName))
+
+    // let us create one more index
+    val secondaryIndexName2 = "idx_driver"
+    val secondaryIndexColumn2 = "driver"
+    writeOpts = writeOpts ++ Map(
+      HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key -> "true",
+      HoodieMetadataConfig.SECONDARY_INDEX_NAME.key -> secondaryIndexName2,
+      HoodieMetadataConfig.SECONDARY_INDEX_COLUMN.key -> secondaryIndexColumn2
+    )
+    val records3 = recordsToStrings(dataGen.generateInserts("002", 3)).asScala.toSeq
+    val inputDF3 = spark.read.json(spark.sparkContext.parallelize(records3, 10))
+    inputDF3.write.format("org.apache.hudi")
+      .options(writeOpts)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // validate that secondary index is created
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertTrue(metadataPartitionExists(basePath, context, PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
+    assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
+
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -1598,6 +1598,5 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertTrue(metadataPartitionExists(basePath, context, PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
     assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
-
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
@@ -187,6 +187,7 @@ public class HoodieIndexer {
       if (PARTITION_NAME_RECORD_INDEX.equals(p)) {
         props.setProperty(RECORD_INDEX_ENABLE_PROP.key(), "true");
       }
+      // TODO: check if we need to set other indexes as well
     });
 
     return UtilHelpers.retry(retry, () -> {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
@@ -324,8 +324,7 @@ public class HoodieIndexer {
       return false;
     }
     List<HoodieIndexPartitionInfo> indexPartitionInfos = commitMetadata.get().getIndexPartitionInfos();
-    LOG.info(String.format("Indexing complete for partitions: %s",
-        indexPartitionInfos.stream().map(HoodieIndexPartitionInfo::getMetadataPartitionPath).collect(Collectors.toList())));
+    LOG.info("Indexing complete for partitions: {}", indexPartitionInfos.stream().map(HoodieIndexPartitionInfo::getMetadataPartitionPath).collect(Collectors.toList()));
     return isIndexBuiltForAllRequestedTypes(indexPartitionInfos);
   }
 
@@ -335,7 +334,11 @@ public class HoodieIndexer {
     Set<String> requestedPartitions = getRequestedPartitionTypes(cfg.indexTypes, Option.empty()).stream()
         .map(MetadataPartitionType::getPartitionPath).collect(Collectors.toSet());
     requestedPartitions.removeAll(indexedPartitions);
-    return requestedPartitions.isEmpty();
+    if (requestedPartitions.isEmpty()) {
+      return true;
+    }
+    metaClient.reloadTableConfig();
+    return metaClient.getTableConfig().getMetadataPartitions().containsAll(indexedPartitions);
   }
 
   List<MetadataPartitionType> getRequestedPartitionTypes(String indexTypes, Option<HoodieMetadataConfig> metadataConfig) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
@@ -187,7 +187,6 @@ public class HoodieIndexer {
       if (PARTITION_NAME_RECORD_INDEX.equals(p)) {
         props.setProperty(RECORD_INDEX_ENABLE_PROP.key(), "true");
       }
-      // TODO: check if we need to set other indexes as well
     });
 
     return UtilHelpers.retry(retry, () -> {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -144,7 +144,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertTrue(reload(metaClient).getTableConfig().getMetadataPartitions().contains(BLOOM_FILTERS.getPartitionPath()));
 
     // build indexer config which has only column_stats enabled (files and bloom filter is already enabled)
-    indexMetadataPartitionsAndAssert(COLUMN_STATS, Arrays.asList(new MetadataPartitionType[] {FILES, BLOOM_FILTERS}), Collections.emptyList(), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Arrays.asList(new MetadataPartitionType[] {FILES, BLOOM_FILTERS}), Collections.emptyList(), tableName, "streamer-config/indexer.properties");
   }
 
   @Test
@@ -158,7 +158,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(reload(metaClient).getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
     // build indexer config which has only files enabled
-    indexMetadataPartitionsAndAssert(FILES, Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
   }
 
   /**
@@ -177,7 +177,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertTrue(reload(metaClient).getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
     // build indexer config which has only files enabled
-    indexMetadataPartitionsAndAssert(RECORD_INDEX, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+    indexMetadataPartitionsAndAssert(RECORD_INDEX.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
         "streamer-config/indexer-record-index.properties");
   }
 
@@ -187,7 +187,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   @Test
   public void testIndexerForSecondaryIndex() {
     String tableName = "indexer_test_rli_si";
-    // enable files and bloom_filters only with the regular write client
+    // enable files only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder = HoodieMetadataConfig.newBuilder()
         .enable(true)
         .withAsyncIndex(false).withMetadataIndexColumnStats(false);
@@ -197,15 +197,15 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     metaClient = reload(metaClient);
     assertTrue(metaClient.getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
-    // build RLI
-    indexMetadataPartitionsAndAssert(RECORD_INDEX, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+    // build RLI with the indexer
+    indexMetadataPartitionsAndAssert(RECORD_INDEX.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
         "streamer-config/indexer-record-index.properties");
-    // build SI
+    // build SI with the indexer
     String indexName = "idx_name";
-    indexMetadataPartitionsAndAssert(SECONDARY_INDEX, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}),
+    indexMetadataPartitionsAndAssert(SECONDARY_INDEX.getPartitionPath() + indexName, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}),
         Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer-secondary-index.properties");
     // validate the secondary index is built
-    assertTrue(metadataPartitionExists(basePath(), context(), SECONDARY_INDEX.getPartitionPath(metaClient, indexName)));
+    assertTrue(metadataPartitionExists(basePath(), context(), SECONDARY_INDEX.getPartitionPath() + indexName));
   }
 
   /**
@@ -224,7 +224,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     upsertToTable(metadataConfigBuilder.build(), tableName);
 
     // Step 2: build indexer config which has only RECORD_INDEX enabled
-    indexMetadataPartitionsAndAssert(RECORD_INDEX, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}),
+    indexMetadataPartitionsAndAssert(RECORD_INDEX.getPartitionPath(), Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}),
         tableName, "streamer-config/indexer-record-index.properties");
     // validate table config and metadata partitions actually exist
     assertTrue(reload(metaClient).getTableConfig().getMetadataPartitions().contains(RECORD_INDEX.getPartitionPath()));
@@ -243,8 +243,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
    */
   @Test
   public void testIndexerForExpressionIndex() {
-    String tableName = "indexer_test_expr_si";
-    // enable files and bloom_filters only with the regular write client
+    String tableName = "indexer_test_expr_ei";
+    // enable files only with the regular write client
     HoodieMetadataConfig.Builder metadataConfigBuilder = HoodieMetadataConfig.newBuilder()
         .enable(true)
         .withAsyncIndex(false).withMetadataIndexColumnStats(false);
@@ -254,17 +254,17 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     metaClient = reload(metaClient);
     assertTrue(metaClient.getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
-    // build RLI
-    indexMetadataPartitionsAndAssert(RECORD_INDEX, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+    // build RLI with the indexer
+    indexMetadataPartitionsAndAssert(RECORD_INDEX.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
         "streamer-config/indexer-record-index.properties");
 
     // rebuild metadata config with expression index name and indexed column
     String indexName = "idx_ts";
-    // build expression index
-    indexMetadataPartitionsAndAssert(EXPRESSION_INDEX, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}),
+    // build expression index with the indexer
+    indexMetadataPartitionsAndAssert(EXPRESSION_INDEX.getPartitionPath() + indexName, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}),
         Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer-expression-index.properties");
     // validate the expression index is built
-    assertTrue(metadataPartitionExists(basePath(), context(), EXPRESSION_INDEX.getPartitionPath(metaClient, indexName)));
+    assertTrue(metadataPartitionExists(basePath(), context(), EXPRESSION_INDEX.getPartitionPath() + indexName));
   }
 
   @Test
@@ -422,10 +422,10 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(reload(metaClient).getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
     // build indexer config which has only files enabled
-    indexMetadataPartitionsAndAssert(FILES, Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
 
     // build indexer config which has only col stats enabled
-    indexMetadataPartitionsAndAssert(COLUMN_STATS, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder()
         .setConf(metaClient.getStorageConf().newInstance()).setBasePath(metaClient.getMetaPath() + "/metadata").build();
@@ -472,10 +472,10 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(metadataPartitionExists(basePath(), context(), FILES.getPartitionPath()));
 
     // trigger FILES partition and indexing should succeed.
-    indexMetadataPartitionsAndAssert(FILES, Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
 
     // build indexer config which has only col stats enabled
-    indexMetadataPartitionsAndAssert(COLUMN_STATS, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder()
         .setConf(metaClient.getStorageConf().newInstance()).setBasePath(metaClient.getMetaPath() + "/metadata").build();
@@ -518,18 +518,19 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     metaClient = reload(metaClient);
   }
 
-  private void indexMetadataPartitionsAndAssert(MetadataPartitionType partitionTypeToIndex, List<MetadataPartitionType> alreadyCompletedPartitions, List<MetadataPartitionType> nonExistentPartitions,
+  private void indexMetadataPartitionsAndAssert(String indexPartitionPath, List<MetadataPartitionType> alreadyCompletedPartitions, List<MetadataPartitionType> nonExistentPartitions,
                                                 String tableName, String propsFilePath) {
-    scheduleAndExecuteIndexing(partitionTypeToIndex, tableName, propsFilePath);
+    scheduleAndExecuteIndexing(MetadataPartitionType.fromPartitionPath(indexPartitionPath), tableName, propsFilePath);
 
     // validate table config
+    metaClient.reloadTableConfig();
     Set<String> completedPartitions = metaClient.getTableConfig().getMetadataPartitions();
-    assertTrue(completedPartitions.contains(partitionTypeToIndex.getPartitionPath()));
+    assertTrue(completedPartitions.contains(indexPartitionPath));
     alreadyCompletedPartitions.forEach(entry -> assertTrue(completedPartitions.contains(entry.getPartitionPath())));
     nonExistentPartitions.forEach(entry -> assertFalse(completedPartitions.contains(entry.getPartitionPath())));
 
     // validate metadata partitions actually exist
-    assertTrue(metadataPartitionExists(basePath(), context(), partitionTypeToIndex.getPartitionPath()));
+    assertTrue(metadataPartitionExists(basePath(), context(), indexPartitionPath));
     alreadyCompletedPartitions.forEach(entry -> assertTrue(metadataPartitionExists(basePath(), context(), entry.getPartitionPath())));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -200,16 +200,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // build RLI
     indexMetadataPartitionsAndAssert(RECORD_INDEX, Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
         "streamer-config/indexer-record-index.properties");
-    // rebuild metadata config with secondary index name and indexed column
-    String indexName = "idx_name";
-    /*metadataConfigBuilder = HoodieMetadataConfig.newBuilder()
-        .enable(true)
-        .withAsyncIndex(false).withMetadataIndexColumnStats(false)
-        .withSecondaryIndexName(indexName)
-        .withSecondaryIndexForColumn("name");
-    upsertToTable(metadataConfigBuilder.build(), tableName);*/
-
     // build SI
+    String indexName = "idx_name";
     indexMetadataPartitionsAndAssert(SECONDARY_INDEX, Arrays.asList(new MetadataPartitionType[] {FILES, RECORD_INDEX}),
         Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer-secondary-index.properties");
     // validate the secondary index is built

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -144,7 +144,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertTrue(reload(metaClient).getTableConfig().getMetadataPartitions().contains(BLOOM_FILTERS.getPartitionPath()));
 
     // build indexer config which has only column_stats enabled (files and bloom filter is already enabled)
-    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Arrays.asList(new MetadataPartitionType[] {FILES, BLOOM_FILTERS}), Collections.emptyList(), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Arrays.asList(new MetadataPartitionType[] {FILES, BLOOM_FILTERS}), Collections.emptyList(), tableName,
+        "streamer-config/indexer.properties");
   }
 
   @Test
@@ -158,7 +159,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(reload(metaClient).getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
     // build indexer config which has only files enabled
-    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+        "streamer-config/indexer.properties");
   }
 
   /**
@@ -422,10 +424,12 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(reload(metaClient).getTableConfig().getMetadataPartitions().contains(FILES.getPartitionPath()));
 
     // build indexer config which has only files enabled
-    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+        "streamer-config/indexer.properties");
 
     // build indexer config which has only col stats enabled
-    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName,
+        "streamer-config/indexer.properties");
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder()
         .setConf(metaClient.getStorageConf().newInstance()).setBasePath(metaClient.getMetaPath() + "/metadata").build();
@@ -458,7 +462,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     config.propsFilePath = propsPath;
     // start the indexer and validate index building fails
     HoodieIndexer indexer = new HoodieIndexer(jsc(), config);
-    Throwable cause = assertThrows(RuntimeException.class, () ->  indexer.start(0))
+    Throwable cause = assertThrows(RuntimeException.class, () -> indexer.start(0))
         .getCause();
     assertTrue(cause instanceof HoodieException);
     assertTrue(cause.getMessage().contains("Metadata table is not yet initialized"));
@@ -472,10 +476,12 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     assertFalse(metadataPartitionExists(basePath(), context(), FILES.getPartitionPath()));
 
     // trigger FILES partition and indexing should succeed.
-    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(FILES.getPartitionPath(), Collections.emptyList(), Arrays.asList(new MetadataPartitionType[] {COLUMN_STATS, BLOOM_FILTERS}), tableName,
+        "streamer-config/indexer.properties");
 
     // build indexer config which has only col stats enabled
-    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName, "streamer-config/indexer.properties");
+    indexMetadataPartitionsAndAssert(COLUMN_STATS.getPartitionPath(), Collections.singletonList(FILES), Arrays.asList(new MetadataPartitionType[] {BLOOM_FILTERS}), tableName,
+        "streamer-config/indexer.properties");
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder()
         .setConf(metaClient.getStorageConf().newInstance()).setBasePath(metaClient.getMetaPath() + "/metadata").build();

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
@@ -18,10 +18,11 @@
 #
 hoodie.metadata.enable=true
 hoodie.metadata.index.async=true
+hoodie.metadata.index.expression.enable=true
 hoodie.metadata.index.expression.name=idx_ts
-hoodie.metadata.index.expression.column=ts
+hoodie.metadata.index.expression.column=timestamp
 hoodie.metadata.index.expression.type=column_stats
-hoodie.metadata.index.expression.options=expr='from_unixtime', format='yyyy-MM-dd'
+hoodie.metadata.index.expression.options=expr=from_unixtime,format='yyyy-MM-dd'
 hoodie.metadata.index.check.timeout.seconds=60
 hoodie.write.concurrency.mode=optimistic_concurrency_control
 hoodie.write.lock.provider=org.apache.hudi.client.transaction.lock.InProcessLockProvider

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+hoodie.metadata.enable=true
+hoodie.metadata.index.async=true
+hoodie.metadata.index.expression.name=idx_ts
+hoodie.metadata.index.expression.column=ts
+hoodie.metadata.index.expression.type=column_stats
+hoodie.metadata.index.expression.options=expr='from_unixtime', format='yyyy-MM-dd'
+hoodie.metadata.index.check.timeout.seconds=60
+hoodie.write.concurrency.mode=optimistic_concurrency_control
+hoodie.write.lock.provider=org.apache.hudi.client.transaction.lock.InProcessLockProvider

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-expression-index.properties
@@ -19,9 +19,9 @@
 hoodie.metadata.enable=true
 hoodie.metadata.index.async=true
 hoodie.metadata.index.expression.enable=true
-hoodie.metadata.index.expression.name=idx_ts
+hoodie.index.name=idx_ts
 hoodie.metadata.index.expression.column=timestamp
-hoodie.metadata.index.expression.type=column_stats
+hoodie.expression.index.type=column_stats
 hoodie.metadata.index.expression.options=expr=from_unixtime,format='yyyy-MM-dd'
 hoodie.metadata.index.check.timeout.seconds=60
 hoodie.write.concurrency.mode=optimistic_concurrency_control

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
@@ -18,6 +18,7 @@
 #
 hoodie.metadata.enable=true
 hoodie.metadata.index.async=true
+hoodie.metadata.index.secondary.enable=true
 hoodie.metadata.index.secondary.name=idx_name
 hoodie.metadata.index.secondary.column=name
 hoodie.metadata.index.check.timeout.seconds=60

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+hoodie.metadata.enable=true
+hoodie.metadata.index.async=true
+hoodie.metadata.index.secondary.name=idx_name
+hoodie.metadata.index.secondary.column=name
+hoodie.metadata.index.check.timeout.seconds=60
+hoodie.write.concurrency.mode=optimistic_concurrency_control
+hoodie.write.lock.provider=org.apache.hudi.client.transaction.lock.InProcessLockProvider

--- a/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
+++ b/hudi-utilities/src/test/resources/streamer-config/indexer-secondary-index.properties
@@ -19,7 +19,7 @@
 hoodie.metadata.enable=true
 hoodie.metadata.index.async=true
 hoodie.metadata.index.secondary.enable=true
-hoodie.metadata.index.secondary.name=idx_name
+hoodie.index.name=idx_name
 hoodie.metadata.index.secondary.column=name
 hoodie.metadata.index.check.timeout.seconds=60
 hoodie.write.concurrency.mode=optimistic_concurrency_control


### PR DESCRIPTION
### Change Logs

- Added new write configs for secondary index (SI) and expression index (EI) conformant to sql syntax for create index.
- Use those configs to check if we need to update new SI/EI definition in index definition file.
- Initialize SI/EI if a new one is being created through write configs.
- Add asyn indexer and spark datasource to validate index gets built successfully.

### Impact

Support secondary and expression index creation through async indexer and write configs.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
