### PR TITLE
[HUDI-8696] Remove TestHoodieMultiTableDeltaStreamer#testInvalidIngestionProps

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -150,18 +150,7 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
         getStringWithAltKeys(streamer.getTableExecutionContexts().get(0).getProperties(),
             HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
   }
-
-  @Test
-  @Disabled
-  public void testInvalidIngestionProps() {
-    Exception e = assertThrows(Exception.class, () -> {
-      HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), true, true, null);
-      new HoodieMultiTableDeltaStreamer(cfg, jsc);
-    }, "Creation of execution object should fail without kafka topic");
-    LOG.debug("Creation of execution object failed with error: " + e.getMessage(), e);
-    assertTrue(e.getMessage().contains("Please provide valid table config arguments!"));
-  }
-
+  
   @Test //0 corresponds to fg
   public void testMultiTableExecutionWithKafkaSource() throws IOException {
     //create topics for each table

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -34,7 +34,6 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.streamer.TableExecutionContext;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
### Change Logs

The test was added in HUDI-288 but has always been in Ignored state. I have checked that the string being asserted `Please provide valid table config arguments` never existed in the codebase even duting the commit. I think it is ok to remove the test.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
