### PR TITLE
[HUDI-8880] Fix hive scan exception after new column is added

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/avro/HoodieTimestampAwareParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/avro/HoodieTimestampAwareParquetInputFormat.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.util.ContextUtil;
 
@@ -33,12 +35,18 @@ import java.io.IOException;
  * we need to handle timestamp types separately based on the parquet-avro approach.
  */
 public class HoodieTimestampAwareParquetInputFormat extends ParquetInputFormat<ArrayWritable> {
+  private final Option<InternalSchema> internalSchemaOption;
+
+  public HoodieTimestampAwareParquetInputFormat(Option<InternalSchema> internalSchemaOption) {
+    super();
+    this.internalSchemaOption = internalSchemaOption;
+  }
 
   @Override
   public RecordReader<Void, ArrayWritable> createRecordReader(
       InputSplit inputSplit,
       TaskAttemptContext taskAttemptContext) throws IOException {
     Configuration conf = ContextUtil.getConfiguration(taskAttemptContext);
-    return new HoodieAvroParquetReader(inputSplit, conf);
+    return new HoodieAvroParquetReader(inputSplit, conf, internalSchemaOption);
   }
 }


### PR DESCRIPTION
### Change Logs

Fix the exception happens when hive scan hudi table after new column is added.

### Impact

Consolidating hive scan to support more schema evolution scenarios.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
