### PR TITLE
[HUDI-5769] Ensure partitions created by async indexer are not deleted by regular writers

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -75,6 +75,7 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.metrics.datadog.DatadogHttpClient.ApiSite;
 import org.apache.hudi.storage.StoragePath;
@@ -2055,15 +2056,19 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public boolean isMetadataBloomFilterIndexEnabled() {
-    return isMetadataTableEnabled() && getMetadataConfig().isBloomFilterIndexEnabled();
+    return isMetadataTableEnabled() && getMetadataConfig().isBloomFilterIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
   }
 
   public boolean isMetadataColumnStatsIndexEnabled() {
-    return isMetadataTableEnabled() && getMetadataConfig().isColumnStatsIndexEnabled();
+    return isMetadataTableEnabled() && getMetadataConfig().isColumnStatsIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.COLUMN_STATS.getPartitionPath());
   }
 
   public boolean isPartitionStatsIndexEnabled() {
-    return isMetadataTableEnabled() && getMetadataConfig().isPartitionStatsIndexEnabled();
+    return isMetadataTableEnabled() && getMetadataConfig().isPartitionStatsIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.PARTITION_STATS.getPartitionPath());
+  }
+
+  public boolean isDropMetadataIndex(String indexName) {
+    return StringUtils.nonEmpty(getMetadataConfig().getMetadataIndexToDrop()) && getMetadataConfig().getMetadataIndexToDrop().equals(indexName);
   }
 
   public int getPartitionStatsIndexParallelism() {
@@ -2576,7 +2581,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public boolean isRecordIndexEnabled() {
-    return metadataConfig.isRecordIndexEnabled();
+    return metadataConfig.isRecordIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.RECORD_INDEX.getPartitionPath());
   }
 
   public int getRecordIndexMinFileGroupCount() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2055,18 +2055,78 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieIndexConfig.BLOOM_INDEX_BUCKETIZED_CHECKING);
   }
 
+  /**
+   * Determines if the metadata bloom filter index is enabled.
+   *
+   * <p>The bloom filter index is enabled if:
+   * <ul>
+   *   <li>The metadata table is enabled and bloom filter index is enabled in the metadata configuration, or</li>
+   *   <li>The bloom filter index is not explicitly marked for dropping in the metadata configuration.</li>
+   * </ul>
+   *
+   * @return {@code true} if the metadata bloom filter index is enabled, {@code false} otherwise.
+   */
   public boolean isMetadataBloomFilterIndexEnabled() {
     return isMetadataTableEnabled() && getMetadataConfig().isBloomFilterIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
   }
 
+  /**
+   * Determines if the metadata column stats index is enabled.
+   *
+   * <p>The column stats index is enabled if:
+   * <ul>
+   *   <li>The metadata table is enabled and column stats index is enabled in the metadata configuration, or</li>
+   *   <li>The column stats index is not explicitly marked for dropping in the metadata configuration.</li>
+   * </ul>
+   *
+   * @return {@code true} if the metadata column stats index is enabled, {@code false} otherwise.
+   */
   public boolean isMetadataColumnStatsIndexEnabled() {
     return isMetadataTableEnabled() && getMetadataConfig().isColumnStatsIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.COLUMN_STATS.getPartitionPath());
   }
 
+  /**
+   * Determines if the partition stats index is enabled.
+   *
+   * <p>The partition stats index is enabled if:
+   * <ul>
+   *   <li>The metadata table is enabled and partition stats index is enabled in the metadata configuration, or</li>
+   *   <li>The partition stats index is not explicitly marked for dropping in the metadata configuration.</li>
+   * </ul>
+   *
+   * @return {@code true} if the partition stats index is enabled, {@code false} otherwise.
+   */
   public boolean isPartitionStatsIndexEnabled() {
     return isMetadataTableEnabled() && getMetadataConfig().isPartitionStatsIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.PARTITION_STATS.getPartitionPath());
   }
 
+  /**
+   * Determines if the record index is enabled.
+   *
+   * <p>The record index is enabled if:
+   * <ul>
+   *   <li>The record index is enabled in the metadata configuration, or</li>
+   *   <li>The record index is not explicitly marked for dropping in the metadata configuration.</li>
+   * </ul>
+   *
+   * @return {@code true} if the record index is enabled, {@code false} otherwise.
+   */
+  public boolean isRecordIndexEnabled() {
+    return metadataConfig.isRecordIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.RECORD_INDEX.getPartitionPath());
+  }
+
+  /**
+   * Checks if a specific metadata index is marked for dropping based on the metadata configuration.
+   *
+   * <p>An index is considered marked for dropping if:
+   * <ul>
+   *   <li>The metadata configuration specifies a non-empty index to drop, and</li>
+   *   <li>The specified index matches the given index name.</li>
+   * </ul>
+   *
+   * @param indexName the name of the metadata index to check
+   * @return {@code true} if the specified metadata index is marked for dropping, {@code false} otherwise.
+   */
   public boolean isDropMetadataIndex(String indexName) {
     return StringUtils.nonEmpty(getMetadataConfig().getMetadataIndexToDrop()) && getMetadataConfig().getMetadataIndexToDrop().equals(indexName);
   }
@@ -2578,10 +2638,6 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean isLogCompactionEnabledOnMetadata() {
     return getBoolean(HoodieMetadataConfig.ENABLE_LOG_COMPACTION_ON_METADATA_TABLE);
-  }
-
-  public boolean isRecordIndexEnabled() {
-    return metadataConfig.isRecordIndexEnabled() || !isDropMetadataIndex(MetadataPartitionType.RECORD_INDEX.getPartitionPath());
   }
 
   public int getRecordIndexMinFileGroupCount() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1096,7 +1096,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
 
       // Updates for record index are created by parsing the WriteStatus which is a hudi-client object. Hence, we cannot yet move this code
       // to the HoodieTableMetadataUtil class in hudi-common.
-      if (dataWriteConfig.isRecordIndexEnabled() && RECORD_INDEX.isMetadataPartitionAvailable(dataMetaClient)) {
+      if (getMetadataPartitionsToUpdate().contains(RECORD_INDEX.getPartitionPath())) {
         HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()), commitMetadata);
         partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()).union(additionalUpdates));
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1096,9 +1096,9 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
 
       // Updates for record index are created by parsing the WriteStatus which is a hudi-client object. Hence, we cannot yet move this code
       // to the HoodieTableMetadataUtil class in hudi-common.
-      if (dataWriteConfig.isRecordIndexEnabled()) {
-        HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(partitionToRecordMap.get(MetadataPartitionType.RECORD_INDEX.getPartitionPath()), commitMetadata);
-        partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), partitionToRecordMap.get(MetadataPartitionType.RECORD_INDEX.getPartitionPath()).union(additionalUpdates));
+      if (dataWriteConfig.isRecordIndexEnabled() && RECORD_INDEX.isMetadataPartitionAvailable(dataMetaClient)) {
+        HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()), commitMetadata);
+        partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()).union(additionalUpdates));
       }
       updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionToRecordMap);
       updateSecondaryIndexIfPresent(commitMetadata, partitionToRecordMap, instantTime);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -1051,7 +1051,8 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     if (isMetadataTable() || !config.isMetadataTableEnabled()) {
       return false;
     }
-    return !MetadataPartitionType.getEnabledPartitions(config.getProps(), metaClient).contains(partitionType);
+    boolean metadataIndexDisabled = !partitionType.isMetadataPartitionAvailable(metaClient);
+    return metadataIndexDisabled && metaClient.getTableConfig().getMetadataPartitions().contains(partitionType.getPartitionPath());
   }
 
   private boolean shouldExecuteMetadataTableDeletion() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -23,14 +23,17 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.MetadataPartitionType;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Configurations used by the HUDI Metadata Table.
@@ -391,6 +394,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Parallelism to use, when generating secondary index.");
 
+  // Config to specify metadata index to delete
+  public static final ConfigProperty<String> DROP_METADATA_INDEX = ConfigProperty
+      .key(METADATA_PREFIX + ".index.drop")
+      .noDefaultValue()
+      .sinceVersion("1.0.1")
+      .withDocumentation("Drop the specified index. "
+          + "The value should be the name of the index to delete. You can check index names using `SHOW INDEXES` command. "
+          + "The index name either starts with or matches exactly can be one of the following: "
+          + StringUtils.join(Arrays.stream(MetadataPartitionType.values()).map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList()), ", "));
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -550,6 +563,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public int getSecondaryIndexParallelism() {
     return getInt(SECONDARY_INDEX_PARALLELISM);
+  }
+
+  public String getMetadataIndexToDrop() {
+    return getString(DROP_METADATA_INDEX);
   }
 
   public static class Builder {
@@ -757,6 +774,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withSecondaryIndexParallelism(int parallelism) {
       metadataConfig.setValue(SECONDARY_INDEX_PARALLELISM, String.valueOf(parallelism));
+      return this;
+    }
+
+    public Builder withDropMetadataIndex(String indexName) {
+      metadataConfig.setValue(DROP_METADATA_INDEX, indexName);
       return this;
     }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -43,6 +43,7 @@ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
 import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestParams
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS
+import org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions, config}
 import org.apache.spark.sql._
@@ -163,6 +164,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     val metadataOpts3 = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false",
+      HoodieMetadataConfig.DROP_METADATA_INDEX.key -> COLUMN_STATS.getPartitionPath,
       HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "c1,c2,c3,c5,c7" // ignore c4,c5,c8.
     )
     // disable col stats


### PR DESCRIPTION
### Change Logs

Ensure partitions created by async indexer are not deleted by regular writers.

- Add a new metadata config to declare what metadata partitions to delete.
- Fix the condition for checking whether MDT partition needs to be deleted in `HoodieTable`
- Add a test in `TestHoodieIndexer`

Let's understand the interplay between index enable/disable boolean flag and the new config. For illustration prupose, we will assume, `files` and column_stats` are enabled by ingestion writer, and `record_index` is created using async indexer. 

Existing boolean configs: `hoodie.metadata.enable`, `hoodie.metadata.index.column.stats.enable` and `hoodie.metadata.record.index.enable`.
New string config: `hoodie.metadata.index.drop` (this takes the index name/MDT partition name as value)

1. Regular ingestion writer has `hoodie.metadata.enable` and `hoodie.metadata.index.column.stats.enable` set to true. And, `files` and `column_stats` index are present.
2. Async indexer starts with setting only `hoodie.metadata.enable` and `hoodie.metadata.record.index.enable` to true. It checks the available partitions and automatically sets the columns stats config to true as well - https://github.com/apache/hudi/blob/c049e9befcbbc056aa8cdebe3c59cd8dbbfee7cf/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java#L182
3. Indexer continues to build the record_index and that is now part of inflight metadata partitions in table config.
4. Ingestion writer continue to log updates for files, column_stats, and record_index (which is already inflight a this point), while indexer catches up with ingestion writer commit. Note that at this point, regular ingestion writer does not set `hoodie.metadata.index.drop` config, so even though the `hoodie.metadata.record.index.enable` is false in ingestion writer config, the record_index is not deleted.
5. Indexer has caught up. Ingestion writer notices that in addition to files and column_stats, we have record_index fully available (not inflight) in the table config. It logs updates for all 3 indexes now.
6. In case users want to delete record_index in future, they need to set not only `hoodie.metadata.record.index.enable=false` but also `hoodie.metadata.index.drop=record_index`.

To summarise, there is a boolean flag for enabling.disabling an index, and there is a string config to explicitly specify what index to delete. The interplay between these two decides finally, whether index needs to be disabled/dropped or not.
```
(boolean, string) -> enabled
true, null or non-matching -> true
false, null or no-matching -> true
true, record_index -> true
false, record_index -> false
```

### Impact

Ensure partitions created by async indexer are not deleted by regular writers.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
