### PR TITLE
[HUDI-8883] Add ability to configure HoodieCompactionPlanGenerator using reflection

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
+import org.apache.hudi.table.action.compact.plan.generators.HoodieCompactionPlanGenerator;
 import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
 import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 
@@ -198,9 +199,14 @@ public class HoodieCompactionConfig extends HoodieConfig {
       .withDocumentation("Log compaction can be scheduled if the no. of log blocks crosses this threshold value. "
           + "This is effective only when log compaction is enabled via " + INLINE_LOG_COMPACT.key());
 
-  /**
-   * @deprecated Use {@link #INLINE_COMPACT} and its methods instead
-   */
+  public static final ConfigProperty<String> COMPACTION_PLAN_GENERATOR = ConfigProperty
+      .key("hoodie.compaction.plan.generator")
+      .defaultValue(HoodieCompactionPlanGenerator.class.getName())
+      .markAdvanced()
+      .withDocumentation("Compaction plan generator for data files. Override with a custom plan generator "
+          + "if there's a need to use extraMetadata in the compaction plan for optimizations, ignore otherwise");
+
+  /** @deprecated Use {@link #INLINE_COMPACT} and its methods instead */
   @Deprecated
   public static final String INLINE_COMPACT_PROP = INLINE_COMPACT.key();
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
@@ -183,6 +183,7 @@ public abstract class BaseHoodieCompactionPlanGenerator<T extends HoodieRecordPa
     if (compactionPlan.getOperations().isEmpty()) {
       LOG.warn("After filtering, Nothing to compact for {} for table {}", metaClient.getBasePath(), hoodieTable.getConfig().getBasePath());
     }
+    compactionPlan.setExtraMetadata(getExtraMetadata(operations, compactionPlan));
     return compactionPlan;
   }
 
@@ -205,4 +206,7 @@ public abstract class BaseHoodieCompactionPlanGenerator<T extends HoodieRecordPa
     return Collections.emptyMap();
   }
 
+  protected Map<String, String> getExtraMetadata(List<HoodieCompactionOperation> operationsBeforeApplyingStrategy, HoodieCompactionPlan compactionPlan) {
+    return Collections.emptyMap();
+  }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/compact/TestScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/compact/TestScheduleCompactionActionExecutor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.compact;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.BaseTableServicePlanActionExecutor;
+import org.apache.hudi.table.action.compact.plan.generators.HoodieCompactionPlanGenerator;
+import org.apache.hudi.table.action.compact.strategy.LogFileNumBasedCompactionStrategy;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConf;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestScheduleCompactionActionExecutor extends HoodieCommonTestHarness {
+
+  private final HoodieEngineContext context = new HoodieLocalEngineContext(getStorageConf());
+  @Mock
+  private HoodieWriteConfig config;
+  @Mock
+  private HoodieTable table;
+
+  @Test
+  void testInitPlanGenerator() throws IOException {
+    initMetaClient();
+    TypedProperties properties = new TypedProperties();
+    properties.put(HoodieCompactionConfig.COMPACTION_PLAN_GENERATOR.key(), TestCompactionPlanGenerator.class.getName());
+    when(config.getProps()).thenReturn(properties);
+    when(config.getCompactionStrategy()).thenReturn(new LogFileNumBasedCompactionStrategy());
+    Assertions.assertDoesNotThrow(() -> new ScheduleCompactionActionExecutor(
+        context, config, table, "001", Option.empty(), WriteOperationType.COMPACT
+    ));
+    Assertions.assertEquals(1, TestCompactionPlanGenerator.getCount());
+  }
+
+  public static class TestCompactionPlanGenerator<T extends HoodieRecordPayload, I, K, O> extends HoodieCompactionPlanGenerator<T, I, K, O> {
+    private static int count = 0;
+
+    public TestCompactionPlanGenerator(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig writeConfig, BaseTableServicePlanActionExecutor executor) {
+      super(table, engineContext, writeConfig, executor);
+      count++;
+    }
+
+    public static int getCount() {
+      return count;
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

Compaction Planners can make use of extraMetadata to decide which partitions/file groups to compact, eg: extraMetadata can be used to keep track of previous compaction results.

### Impact

Provides ability to write compaction planner which can make use of extraMetadata to decide which partitions/file groups to compact. 

### Risk level (write none, low medium or high below)

Low

### Documentation Update

```
  public static final ConfigProperty<String> COMPACTION_PLAN_GENERATOR = ConfigProperty
      .key("hoodie.compaction.plan.generator")
      .defaultValue(HoodieCompactionPlanGenerator.class.getName())
      .markAdvanced()
      .withDocumentation("Compaction plan generator for data files. Override with a custom plan generator "
          + "if there's a need to use extraMetadata in the compaction plan for optimizations, ignore otherwise");
```

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
