### PR TITLE
[HUDI-8881] Fails fast in Flink append write function

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -459,6 +459,14 @@ public class FlinkOptions extends HoodieConfig {
           + "By default false. Turning this on, could hide the write status errors while the flink checkpoint moves ahead. \n"
           + "So, would recommend users to use this with caution.");
 
+  @AdvancedConfig
+  public static final ConfigOption<Boolean> WRITE_FAIL_FAST = ConfigOptions
+          .key("write.fail.fast")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Flag to indicate whether to fail job immediately when an error record is detected. \n"
+                  + "Currently, this option is only applied to Flink append write functions.");
+
   public static final ConfigOption<String> RECORD_KEY_FIELD = ConfigOptions
       .key(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key())
       .stringType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.util;
 
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.model.CommitTimeFlinkRecordMerger;
 import org.apache.hudi.client.model.EventTimeFlinkRecordMerger;
 import org.apache.hudi.client.model.PartialUpdateFlinkRecordMerger;
@@ -30,6 +31,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
@@ -88,6 +90,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.hudi.common.model.HoodieFileFormat.HOODIE_LOG;
@@ -97,6 +101,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_HISTORY_PA
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
+import static org.apache.hudi.configuration.FlinkOptions.WRITE_FAIL_FAST;
 
 /**
  * Utilities for Flink stream read and write.
@@ -672,5 +677,28 @@ public class StreamerUtil {
     properties.put(HoodieMetadataConfig.ENABLE.key(), conf.getBoolean(FlinkOptions.METADATA_ENABLED));
 
     return HoodieMetadataConfig.newBuilder().fromProperties(properties).build();
+  }
+
+  /**
+   * Validate against the given list of write statuses.
+   *
+   * @param config          The Flink conf
+   * @param currentInstant  The current instant
+   * @param writeStatusList The write status list
+   *
+   * @throws HoodieException if the {code WRITE_FAIL_FAST} is set up as true and there are writing errors
+   */
+  public static void validateWriteStatus(
+      Configuration config,
+      String currentInstant,
+      List<WriteStatus> writeStatusList) throws HoodieException {
+    if (config.get(WRITE_FAIL_FAST)) {
+      // It will early detect the write failures in each of task to prevent data loss caused by commit failure
+      // after a checkpoint has been triggered.
+      writeStatusList.stream().filter(ws -> !ws.getErrors().isEmpty()).findFirst().map(writeStatus -> {
+        Map.Entry<HoodieKey, Throwable> entry = writeStatus.getErrors().entrySet().iterator().next();
+        throw new HoodieException(String.format("Write failure occurs with hoodie key %s at Instant [%s] in append write function", entry.getKey(), currentInstant), entry.getValue());
+      });
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -91,7 +91,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.hudi.common.model.HoodieFileFormat.HOODIE_LOG;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test cases for {@link AppendWriteFunction}.
+ */
+public class TestAppendWriteFunction {
+  private static final String CURRENT_INSTANT = "123445";
+
+  @Test
+  void testRecordWriteNoFailure() {
+    WriteStatus writeStatus = new WriteStatus();
+    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+
+    Configuration configuration = new Configuration();
+    AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList);
+  }
+
+  @Test
+  void testRecordWriteFailureValidationWithoutFailFast() {
+    WriteStatus writeStatus = new WriteStatus();
+    writeStatus.markFailure(
+            "key1", "/partition1", new RuntimeException("test exception"));
+    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+
+    Configuration configuration = new Configuration();
+    AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList);
+  }
+
+  @Test
+  void testRecordWriteFailureValidationWithFailFast() {
+    WriteStatus writeStatus = new WriteStatus();
+    writeStatus.markFailure(
+            "key1", "/partition1", new RuntimeException("test exception"));
+    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+
+    Configuration configuration = new Configuration();
+    configuration.set(FlinkOptions.WRITE_FAIL_FAST, true);
+
+    // Verify that the failure was recorded in metrics
+    assertThrows(HoodieException.class, () -> AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList));
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
@@ -20,11 +20,14 @@ package org.apache.hudi.sink.append;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.util.StreamerUtil;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,15 +36,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test cases for {@link AppendWriteFunction}.
  */
 public class TestAppendWriteFunction {
-  private static final String CURRENT_INSTANT = "123445";
 
   @Test
   void testRecordWriteNoFailure() {
     WriteStatus writeStatus = new WriteStatus();
-    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+    List<WriteStatus> writeStatusList = Collections.singletonList(writeStatus);
 
     Configuration configuration = new Configuration();
-    AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList);
+    StreamerUtil.validateWriteStatus(configuration, HoodieInstantTimeGenerator.getCurrentInstantTimeStr(), writeStatusList);
   }
 
   @Test
@@ -49,10 +51,10 @@ public class TestAppendWriteFunction {
     WriteStatus writeStatus = new WriteStatus();
     writeStatus.markFailure(
             "key1", "/partition1", new RuntimeException("test exception"));
-    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+    List<WriteStatus> writeStatusList = Collections.singletonList(writeStatus);
 
     Configuration configuration = new Configuration();
-    AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList);
+    StreamerUtil.validateWriteStatus(configuration, HoodieInstantTimeGenerator.getCurrentInstantTimeStr(), writeStatusList);
   }
 
   @Test
@@ -60,12 +62,13 @@ public class TestAppendWriteFunction {
     WriteStatus writeStatus = new WriteStatus();
     writeStatus.markFailure(
             "key1", "/partition1", new RuntimeException("test exception"));
-    List<WriteStatus> writeStatusList = Arrays.asList(writeStatus);
+    List<WriteStatus> writeStatusList = Collections.singletonList(writeStatus);
 
     Configuration configuration = new Configuration();
     configuration.set(FlinkOptions.WRITE_FAIL_FAST, true);
 
     // Verify that the failure was recorded in metrics
-    assertThrows(HoodieException.class, () -> AppendWriteFunction.validateWriteStatus(configuration, CURRENT_INSTANT, writeStatusList));
+    assertThrows(HoodieException.class,
+        () -> StreamerUtil.validateWriteStatus(configuration, HoodieInstantTimeGenerator.getCurrentInstantTimeStr(), writeStatusList));
   }
 }


### PR DESCRIPTION
### Change Logs

Trigger failure when write failure is detected for flink hudi sink

### Impact

The early detection of write failure will prevent checkpoint to complete before hudi commit. Thus, prevent the data loss when checkpoint is completed, but hudi can't committed due the write failure.

### Risk level (write none, low medium or high below)

none

### Documentation Update
It is an improvement of existing functionality, no user facing feature is introduced. 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
