### PR TITLE
[HUDI-7483] Disable flaky test dimension

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -153,8 +153,12 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
   }
 
   private static final List<Class> LOCK_PROVIDER_CLASSES = Arrays.asList(
-      InProcessLockProvider.class,
-      FileSystemBasedLockProvider.class);
+      // [HUDI-8887] Based on OS/docker container used, the underlying file system API might not support
+      // atomic operations which impairs the functionality of lock provider. Disable the test dimension to
+      // avoid false alarm in java CI.
+      // FileSystemBasedLockProvider.class,
+      InProcessLockProvider.class
+  );
 
   private static final List<ConflictResolutionStrategy> CONFLICT_RESOLUTION_STRATEGY_CLASSES = Arrays.asList(
       new SimpleConcurrentFileWritesConflictResolutionStrategy(),


### PR DESCRIPTION
### Change Logs

The filesystem based lock provider might not do atomic operations based on OS/docker container the test uses, which leads to lock provider not functioning correctly and leads to validation phase of OCC to run concurrently.

For more info please refer https://issues.apache.org/jira/browse/HUDI-8887.

### Impact

Get rid of flaky test.

### Risk level (write none, low medium or high below)

none
### Documentation Update
none
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
