### PR TITLE
[MINOR] Bump maven shade plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-    <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.4</maven-deploy-plugin.version>


### PR DESCRIPTION
### Change Logs

Bump maven shade plugin version from 3.4.0 to 3.5.1.

This is necessary to bump JDK version to 20+, as older versioned shade plugin won't support new JDK, sample error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.4.0:shade (default) on project hudi-examples-k8s: Error creating shaded jar: Problem shading JAR /home/release/.m2/repository/org/bouncycastle/bcprov-jdk18on/1.78.1/bcprov-jdk18on-1.78.1.jar entry META-INF/versions/21/org/bouncycastle/pqc/jcajce/provider/NTRU$Mappings.class: java.lang.IllegalArgumentException: Unsupported class file major version 65 -> [Help 1]
```

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
