### PR TITLE
[HUDI-7598] Remove duplicate methods in subclasses of HoodieSparkClientTestBase to enhance reusability

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions.{INSERT_OVERWRITE_OPERATION_OPT_VAL, INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL}
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.common.model.{ActionType, HoodieCommitMetadata, WriteOperationType}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, MetadataConversionUtils}
+import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.metadata.HoodieBackedTableMetadata
+import org.apache.hudi.storage.StoragePath
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.util.JavaConversions
+import org.apache.spark.sql.functions.{col, not}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.Collectors
+import scala.collection.JavaConverters._
+
+
+class HoodieStatsIndexTestBase extends HoodieSparkClientTestBase {
+  var spark: SparkSession = _
+  var instantTime: AtomicInteger = _
+  var metaClientReloaded = false
+  var mergedDfList: List[DataFrame] = List.empty
+
+  protected def getLatestCompactionInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(s => Option(
+        try {
+          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
+            .orElse(new HoodieCommitMetadata())
+          commitMetadata
+        } catch {
+          case _: Exception => new HoodieCommitMetadata()
+        })
+        .map(c => c.getOperationType == WriteOperationType.COMPACT)
+        .get))
+      .lastInstant()
+  }
+
+  protected def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
+    val lastInstant = HoodieInstantTimeGenerator.getLastInstantTime
+    if (enforce || metaClient.getActiveTimeline.lastInstant().isEmpty
+      || metaClient.getActiveTimeline.lastInstant().get().requestedTime.compareTo(lastInstant) < 0) {
+      println("Reloaded timeline")
+      metaClient.reloadActiveTimeline()
+      metaClient
+    }
+    metaClient
+  }
+
+  protected def getMetadataMetaClient(hudiOpts: Map[String, String]): HoodieTableMetaClient = {
+    getHoodieTable(metaClient, getWriteConfig(hudiOpts)).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+  }
+
+  protected def getLatestClusteringInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
+  }
+
+  protected def rollbackLastInstant(hudiOpts: Map[String, String]): HoodieInstant = {
+    val lastInstant = getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
+      .lastInstant().get()
+    if (getLatestCompactionInstant != getLatestMetaClient(false).getActiveTimeline.lastInstant()
+      && lastInstant.getAction != ActionType.replacecommit.name()
+      && lastInstant.getAction != ActionType.clean.name()) {
+      mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+    }
+    val writeConfig = getWriteConfig(hudiOpts)
+    new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), writeConfig)
+      .rollback(lastInstant.requestedTime)
+
+    if (lastInstant.getAction != ActionType.clean.name()) {
+      assertEquals(ActionType.rollback.name(), getLatestMetaClient(true).getActiveTimeline.lastInstant().get().getAction)
+    }
+    lastInstant
+  }
+
+  protected def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
+    val props = TypedProperties.fromMap(hudiOpts.asJava)
+    HoodieWriteConfig.newBuilder()
+      .withProps(props)
+      .withPath(basePath)
+      .build()
+  }
+
+  protected def getInstantTime(): String = {
+    String.format("%03d", new Integer(instantTime.incrementAndGet()))
+  }
+
+  protected def executeFunctionNTimes[T](function0: Function0[T], n: Int): Unit = {
+    for (_ <- 1 to n) {
+      function0.apply()
+    }
+  }
+
+  protected def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(getLatestMetaClient(false), writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
+    assertTrue(storage.deleteFile(new StoragePath(metaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(lastInstant))))
+    assertTrue(storage.deleteFile(new StoragePath(
+      metadataTableMetaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(metadataTableLastInstant))))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  protected def deleteLastCompletedCommitFromTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(getLatestMetaClient(false), writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    assertTrue(storage.deleteFile(new StoragePath(metaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(lastInstant))))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  /**
+   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
+   */
+  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String, globalIndexEnableUpdatePartitions: Boolean): DataFrame = {
+    val prevDfOpt = mergedDfList.lastOption
+    if (prevDfOpt.isEmpty) {
+      mergedDfList = mergedDfList :+ latestBatchDf
+      sparkSession.emptyDataFrame
+    } else {
+      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
+        mergedDfList = mergedDfList :+ latestBatchDf
+        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
+        prevDfOpt.get
+      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
+        val overwrittenPartitions = latestBatchDf.select("partition")
+          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
+        val prevDf = prevDfOpt.get
+        val latestSnapshot = prevDf
+          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
+          .union(latestBatchDf)
+        mergedDfList = mergedDfList :+ latestSnapshot
+
+        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
+        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
+      } else {
+        val prevDf = prevDfOpt.get
+        if (globalIndexEnableUpdatePartitions) {
+          val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key"), "leftanti")
+          val latestSnapshot = prevDfOld.union(latestBatchDf)
+          mergedDfList = mergedDfList :+ latestSnapshot
+        } else {
+          val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
+            && prevDf("partition") === latestBatchDf("partition"), "leftanti")
+          val latestSnapshot = prevDfOld.union(latestBatchDf)
+          mergedDfList = mergedDfList :+ latestSnapshot
+        }
+        sparkSession.emptyDataFrame
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/PartitionStatsIndexTestBase.scala
@@ -25,21 +25,10 @@ import org.apache.hudi.TestHoodieSparkUtils.dropMetaFields
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieInstant
-import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
-import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.functional.PartitionStatsIndexTestBase.checkIfOverlapped
-import org.apache.hudi.metadata.HoodieBackedTableMetadata
-import org.apache.hudi.storage.StoragePath
-import org.apache.hudi.util.JavaConversions
-
-import org.apache.spark.sql.functions.{col, not}
-import org.apache.spark.sql.{DataFrame, Row, SaveMode}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.{AfterEach, BeforeEach}
-
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.stream.Collectors
+import org.apache.spark.sql.{Column, DataFrame, SaveMode}
+import org.junit.jupiter.api.Assertions.assertEquals
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -49,7 +38,6 @@ import scala.util.matching.Regex
  * Common test setup and validation methods for partition stats index testing.
  */
 class PartitionStatsIndexTestBase extends HoodieStatsIndexTestBase {
-
   val targetColumnsToIndex: Seq[String] = Seq("rider", "driver")
   val metadataOpts: Map[String, String] = Map(
     HoodieMetadataConfig.ENABLE.key -> "true",
@@ -58,55 +46,18 @@ class PartitionStatsIndexTestBase extends HoodieStatsIndexTestBase {
     HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> targetColumnsToIndex.mkString(",")
   )
   val commonOpts: Map[String, String] = Map(
-    "hoodie.insert.shuffle.parallelism" -> "4",
-    "hoodie.upsert.shuffle.parallelism" -> "4",
-    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
-    RECORDKEY_FIELD.key -> "_row_key",
     PARTITIONPATH_FIELD.key -> "partition,trip_type",
-    HIVE_STYLE_PARTITIONING.key -> "true",
-    PRECOMBINE_FIELD.key -> "timestamp"
-  ) ++ metadataOpts
+    HIVE_STYLE_PARTITIONING.key -> "true"
+  ) ++ baseOpts ++ metadataOpts
 
-  @BeforeEach
-  override def setUp(): Unit = {
-    initPath()
-    initQueryIndexConf()
-    initSparkContexts()
-    initHoodieStorage()
-    initTestDataGenerator()
-
-    setTableName("hoodie_test")
-    initMetaClient()
-
-    instantTime = new AtomicInteger(1)
-
-    spark = sqlContext.sparkSession
+  override def createJoinCondition(prevDf: DataFrame, latestBatchDf: DataFrame): Column = {
+    prevDf("_row_key") === latestBatchDf("_row_key") &&
+      prevDf("partition") === latestBatchDf("partition") &&
+      prevDf("trip_type") === latestBatchDf("trip_type")
   }
 
-  @AfterEach
-  override def tearDown(): Unit = {
-    cleanupResources()
-    cleanupSparkContexts()
-  }
-
-  protected override def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
-    val lastInstant = String.format("%03d", new Integer(instantTime.incrementAndGet()))
-    if (enforce || metaClient.getActiveTimeline.lastInstant().get().requestedTime.compareTo(lastInstant) < 0) {
-      println("Reloaded timeline")
-      metaClient.reloadActiveTimeline()
-      metaClient
-    }
-    metaClient
-  }
-
-  protected override def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
-    val writeConfig = getWriteConfig(hudiOpts)
-    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
-    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
-    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
-    assertTrue(storage.deleteFile(new StoragePath(metaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(lastInstant))))
-    assertTrue(storage.deleteFile(new StoragePath(metadataTableMetaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(metadataTableLastInstant))))
-    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  protected override def getLastInstant(): String = {
+    String.format("%03d", new Integer(instantTime.incrementAndGet()))
   }
 
   protected def doWriteAndValidateDataAndPartitionStats(hudiOpts: Map[String, String],
@@ -151,39 +102,8 @@ class PartitionStatsIndexTestBase extends HoodieStatsIndexTestBase {
     latestBatchDf
   }
 
-  /**
-   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
-   */
   protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = synchronized {
-    val prevDfOpt = mergedDfList.lastOption
-    if (prevDfOpt.isEmpty) {
-      mergedDfList = mergedDfList :+ latestBatchDf
-      sparkSession.emptyDataFrame
-    } else {
-      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
-        mergedDfList = mergedDfList :+ latestBatchDf
-        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
-        prevDfOpt.get
-      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
-        val overwrittenPartitions = latestBatchDf.select("partition")
-          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
-        val prevDf = prevDfOpt.get
-        val latestSnapshot = prevDf
-          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
-          .union(latestBatchDf)
-        mergedDfList = mergedDfList :+ latestSnapshot
-
-        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
-        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
-      } else {
-        val prevDf = prevDfOpt.get
-        val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
-          && prevDf("partition") === latestBatchDf("partition") && prevDf("trip_type") === latestBatchDf("trip_type"), "leftanti")
-        val latestSnapshot = prevDfOld.union(latestBatchDf)
-        mergedDfList = mergedDfList :+ latestSnapshot
-        sparkSession.emptyDataFrame
-      }
-    }
+    calculateMergedDf(latestBatchDf, operation, globalIndexEnableUpdatePartitions = false)
   }
 
   protected def validateDataAndPartitionStats(inputDf: DataFrame = sparkSession.emptyDataFrame): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -28,9 +28,6 @@ import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataU
 
 import org.apache.spark.sql._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
-import org.junit.jupiter.api._
-
-import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 import scala.collection.{JavaConverters, mutable}
@@ -41,24 +38,19 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
     HoodieMetadataConfig.ENABLE.key -> "true",
     HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key -> "true"
   )
-  val commonOpts = Map(
-    "hoodie.insert.shuffle.parallelism" -> "4",
-    "hoodie.upsert.shuffle.parallelism" -> "4",
-    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
-    RECORDKEY_FIELD.key -> "_row_key",
+  val commonOpts: Map[String, String] = Map(
     PARTITIONPATH_FIELD.key -> "partition",
-    PRECOMBINE_FIELD.key -> "timestamp",
     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "15"
-  ) ++ metadataOpts
+  ) ++ baseOpts ++ metadataOpts
 
-  val secondaryIndexOpts = Map(
+  val secondaryIndexOpts: Map[String, String] = Map(
     HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key -> "true"
   )
 
-  val commonOptsWithSecondaryIndex = commonOpts ++ secondaryIndexOpts ++ metadataOpts
+  val commonOptsWithSecondaryIndex: Map[String, String] = commonOpts ++ secondaryIndexOpts ++ metadataOpts
 
-  val commonOptsNewTableSITest = Map(
+  val commonOptsNewTableSITest: Map[String, String] = Map(
     "hoodie.insert.shuffle.parallelism" -> "4",
     "hoodie.upsert.shuffle.parallelism" -> "4",
     HoodieWriteConfig.TBL_NAME.key -> "trips_table",
@@ -69,30 +61,7 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
   ) ++ metadataOpts
 
-  val commonOptsWithSecondaryIndexSITest = commonOptsNewTableSITest ++ secondaryIndexOpts
-
-  @BeforeEach
-  override def setUp() {
-    initPath()
-    initQueryIndexConf()
-    initSparkContexts()
-    initHoodieStorage()
-    initTestDataGenerator()
-
-    setTableName("hoodie_test")
-    initMetaClient()
-    metaClientReloaded = false
-
-    instantTime = new AtomicInteger(1)
-
-    spark = sqlContext.sparkSession
-  }
-
-  @AfterEach
-  override def tearDown() = {
-    cleanupFileSystem()
-    cleanupSparkContexts()
-  }
+  val commonOptsWithSecondaryIndexSITest: Map[String, String] = commonOptsNewTableSITest ++ secondaryIndexOpts
 
   protected def doWriteAndValidateDataAndRecordIndex(hudiOpts: Map[String, String],
                                                    operation: String,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -19,36 +19,25 @@ package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.DataSourceWriteOptions._
-import org.apache.hudi.client.SparkRDDWriteClient
-import org.apache.hudi.client.common.HoodieSparkEngineContext
-import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
-import org.apache.hudi.common.model._
+import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
-import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, MetadataConversionUtils}
-import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataUtil, MetadataPartitionType}
-import org.apache.hudi.storage.StoragePath
-import org.apache.hudi.testutils.HoodieSparkClientTestBase
-import org.apache.hudi.util.JavaConversions
+
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{col, not}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api._
 
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 import scala.collection.{JavaConverters, mutable}
 import scala.util.Using
 
-class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
-  var spark: SparkSession = _
-  var instantTime: AtomicInteger = _
-  val metadataOpts = Map(
+class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
+  val metadataOpts: Map[String, String] = Map(
     HoodieMetadataConfig.ENABLE.key -> "true",
     HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key -> "true"
   )
@@ -81,8 +70,6 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   ) ++ metadataOpts
 
   val commonOptsWithSecondaryIndexSITest = commonOptsNewTableSITest ++ secondaryIndexOpts
-  var mergedDfList: List[DataFrame] = List.empty
-  var metaClientReloaded = false
 
   @BeforeEach
   override def setUp() {
@@ -105,83 +92,6 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   override def tearDown() = {
     cleanupFileSystem()
     cleanupSparkContexts()
-  }
-
-  protected def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
-    val lastInsant = HoodieInstantTimeGenerator.getLastInstantTime
-    if (enforce || metaClient.getActiveTimeline.lastInstant().isEmpty
-      || metaClient.getActiveTimeline.lastInstant().get().requestedTime.compareTo(lastInsant) < 0) {
-      println("Reloaded timeline")
-      metaClient.reloadActiveTimeline()
-      metaClient
-    }
-    metaClient
-  }
-
-  protected def rollbackLastInstant(hudiOpts: Map[String, String]): HoodieInstant = {
-    val lastInstant = getLatestMetaClient(false).getActiveTimeline
-      .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
-      .lastInstant().get()
-    if (getLatestCompactionInstant() != getLatestMetaClient(false).getActiveTimeline.lastInstant()
-      && lastInstant.getAction != ActionType.replacecommit.name()
-      && lastInstant.getAction != ActionType.clean.name()) {
-      mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-    }
-    val writeConfig = getWriteConfig(hudiOpts)
-    new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), writeConfig)
-      .rollback(lastInstant.requestedTime)
-
-    if (lastInstant.getAction != ActionType.clean.name()) {
-      assertEquals(ActionType.rollback.name(), getLatestMetaClient(true).getActiveTimeline.lastInstant().get().getAction)
-    }
-    lastInstant
-  }
-
-  protected def executeFunctionNTimes[T](function0: Function0[T], n: Int): Unit = {
-    for (i <- 1 to n) {
-      function0.apply()
-    }
-  }
-
-  protected def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
-    val writeConfig = getWriteConfig(hudiOpts)
-    val lastInstant = getHoodieTable(getLatestMetaClient(false), writeConfig).getCompletedCommitsTimeline.lastInstant().get()
-    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
-    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
-    assertTrue(storage.deleteFile(new StoragePath(metaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(lastInstant))))
-    assertTrue(storage.deleteFile(new StoragePath(
-      metadataTableMetaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(metadataTableLastInstant))))
-    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-  }
-
-  protected def deleteLastCompletedCommitFromTimeline(hudiOpts: Map[String, String]): Unit = {
-    val writeConfig = getWriteConfig(hudiOpts)
-    val lastInstant = getHoodieTable(getLatestMetaClient(false), writeConfig).getCompletedCommitsTimeline.lastInstant().get()
-    assertTrue(storage.deleteFile(new StoragePath(metaClient.getTimelinePath, INSTANT_FILE_NAME_GENERATOR.getFileName(lastInstant))))
-    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-  }
-
-  protected def getMetadataMetaClient(hudiOpts: Map[String, String]): HoodieTableMetaClient = {
-    getHoodieTable(metaClient, getWriteConfig(hudiOpts)).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
-  }
-
-  protected def getLatestCompactionInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
-    getLatestMetaClient(false).getActiveTimeline
-      .filter(JavaConversions.getPredicate(s => Option(
-        try {
-          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
-            .orElse(new HoodieCommitMetadata())
-          commitMetadata
-        } catch {
-          case _: Exception => new HoodieCommitMetadata()
-        })
-        .map(c => c.getOperationType == WriteOperationType.COMPACT)
-        .get))
-      .lastInstant()
-  }
-
-  protected def getLatestClusteringInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
-    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
   }
 
   protected def doWriteAndValidateDataAndRecordIndex(hudiOpts: Map[String, String],
@@ -229,60 +139,7 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
   }
 
   protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = {
-    calculateMergedDf(latestBatchDf, operation, false)
-  }
-
-  /**
-   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
-   */
-  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String, globalIndexEnableUpdatePartitions: Boolean): DataFrame = {
-    val prevDfOpt = mergedDfList.lastOption
-    if (prevDfOpt.isEmpty) {
-      mergedDfList = mergedDfList :+ latestBatchDf
-      sparkSession.emptyDataFrame
-    } else {
-      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
-        mergedDfList = mergedDfList :+ latestBatchDf
-        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
-        prevDfOpt.get
-      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
-        val overwrittenPartitions = latestBatchDf.select("partition")
-          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
-        val prevDf = prevDfOpt.get
-        val latestSnapshot = prevDf
-          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
-          .union(latestBatchDf)
-        mergedDfList = mergedDfList :+ latestSnapshot
-
-        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
-        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
-      } else {
-        val prevDf = prevDfOpt.get
-        if (globalIndexEnableUpdatePartitions) {
-          val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key"), "leftanti")
-          val latestSnapshot = prevDfOld.union(latestBatchDf)
-          mergedDfList = mergedDfList :+ latestSnapshot
-        } else {
-          val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
-            && prevDf("partition") === latestBatchDf("partition"), "leftanti")
-          val latestSnapshot = prevDfOld.union(latestBatchDf)
-          mergedDfList = mergedDfList :+ latestSnapshot
-        }
-        sparkSession.emptyDataFrame
-      }
-    }
-  }
-
-  private def getInstantTime(): String = {
-    String.format("%03d", new Integer(instantTime.incrementAndGet()))
-  }
-
-  protected def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
-    val props = TypedProperties.fromMap(JavaConverters.mapAsJavaMapConverter(hudiOpts).asJava)
-    HoodieWriteConfig.newBuilder()
-      .withProps(props)
-      .withPath(basePath)
-      .build()
+    calculateMergedDf(latestBatchDf, operation, globalIndexEnableUpdatePartitions = false)
   }
 
   protected def getFileGroupCountForRecordIndex(writeConfig: HoodieWriteConfig): Long = {


### PR DESCRIPTION
### Change Logs

Reuse methods from subclasses HoodieSparkClientTestBase

### Impact

Enhance reusability

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
