### PR TITLE
[HUDI-8892] Introduce projection push down for payload mode

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
@@ -80,7 +80,7 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger, OperationMode
   public boolean isProjectionCompatible(HoodieTableConfig cfg, TypedProperties properties) {
     String payloadClass = cfg.getPayloadClass();
     ValidationUtils.checkArgument(payloadClass != null, "Payload class must be set in HoodieTableConfig for avro record merger");
-    HoodieRecordPayload dummyInstance = HoodieRecordUtils.loadPayload(payloadClass, new Object[] {new EmptyRecord(), 0}, GenericRecord.class, Comparable.class);
+    HoodieRecordPayload dummyInstance = HoodieRecordUtils.loadPayload(payloadClass, new Object[] {null, 0}, GenericRecord.class, Comparable.class);
     return dummyInstance.enableProjectionPushDown();
   }
 
@@ -91,7 +91,7 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger, OperationMode
   public String[] getMandatoryFieldsForMerging(Schema dataSchema, HoodieTableConfig cfg, TypedProperties properties) {
     String payloadClass = cfg.getPayloadClass();
     ValidationUtils.checkArgument(payloadClass != null, "Payload class must be set in HoodieTableConfig for avro record merger");
-    HoodieRecordPayload dummyInstance = HoodieRecordUtils.loadPayload(payloadClass, new Object[] {new EmptyRecord(), 0}, GenericRecord.class, Comparable.class);
+    HoodieRecordPayload dummyInstance = HoodieRecordUtils.loadPayload(payloadClass, new Object[] {null, 0}, GenericRecord.class, Comparable.class);
     String[] specifiedMandatoryFields = dummyInstance.mandatoryFields();
     String[] commonMandatoryFields = HoodieRecordMerger.super.getMandatoryFieldsForMerging(dataSchema, cfg, properties);
     List<String> allNeedMandatoryFields = Arrays.asList(commonMandatoryFields);
@@ -99,31 +99,4 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger, OperationMode
     return allNeedMandatoryFields.toArray(new String[0]);
   }
 
-  private static class EmptyRecord implements GenericRecord {
-    private EmptyRecord() {
-    }
-
-    @Override
-    public void put(int i, Object v) {
-    }
-
-    @Override
-    public Object get(int i) {
-      return null;
-    }
-
-    @Override
-    public Schema getSchema() {
-      return null;
-    }
-
-    @Override
-    public void put(String key, Object v) {
-    }
-
-    @Override
-    public Object get(String key) {
-      return null;
-    }
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -146,7 +146,7 @@ public interface HoodieRecordMerger extends Serializable {
    * If true, mor merging can be done without all columns. The columns required can be configured
    * by overriding getMandatoryFieldsForMerging
    */
-  default boolean isProjectionCompatible() {
+  default boolean isProjectionCompatible(HoodieTableConfig cfg, TypedProperties properties) {
     return false;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
@@ -146,6 +146,24 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
     return 0;
   }
 
+  /**
+   * This method can be used to enable projection push down for the payload to trim columns.
+   * @return true if projection push down is enabled, false otherwise.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  default boolean enableProjectionPushDown() {
+    return false;
+  }
+
+  /**
+   * This method can be used to specify the mandatory fields required for merging.
+   * @return the mandatory fields required for merging.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  default String[] mandatoryFields() {
+    return new String[]{};
+  }
+
   static String getAvroPayloadForMergeMode(RecordMergeMode mergeMode) {
     switch (mergeMode) {
       //TODO: After we have merge mode working for writing, we should have a dummy payload that will throw exception when used

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
@@ -282,4 +282,10 @@ public class PartialUpdateAvroPayload extends OverwriteNonDefaultsWithLatestAvro
     }
     return false;
   }
+
+  @Override
+  public boolean enableProjectionPushDown() {
+    return true;
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderSchemaHandler.java
@@ -156,7 +156,7 @@ public class HoodieFileGroupReaderSchemaHandler<T> {
     }
 
     if (hoodieTableConfig.getRecordMergeMode() == RecordMergeMode.CUSTOM) {
-      if (!recordMerger.get().isProjectionCompatible()) {
+      if (!recordMerger.get().isProjectionCompatible(hoodieTableConfig, properties)) {
         return dataSchema;
       }
     }


### PR DESCRIPTION
In many wide table scenarios, there may be thousands of columns in a table, and there are multiple tasks processing different columns. When reading, the downstream only cares about some dimension columns. But now the payload mode does not support columns trimming, resulting in great performance regression when perform snapshot read on file slices with log files exist. This is because all columns of the base file are read, even though most of the columns are not needed by the user

### Change Logs
1. support projection push down for payload mode

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
Improve mor read performance
### Risk level (write none, low medium or high below)
medium

### Documentation Update
none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
