### PR TITLE
[HUDI-8897] Add a Scala retry API for running test multiple times

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
@@ -1,6 +1,7 @@
 package org.apache.hudi
 
 object ScalaTestUtils {
+  
   /**
    * Utility method to run a test multiple times. For using the test call the method on the test block.
    * Example:

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.hudi
 
 object ScalaTestUtils {

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
@@ -20,12 +20,12 @@
 package org.apache.hudi
 
 object ScalaTestUtils {
-  
+
   /**
    * Utility method to run a test multiple times. For using the test call the method on the test block.
    * Example:
    * repeatTest(5) {
-   *   ... // test code
+   * ... // test code
    * }
    *
    * @param numRuns Number of test runs

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/ScalaTestUtils.scala
@@ -1,0 +1,19 @@
+package org.apache.hudi
+
+object ScalaTestUtils {
+  /**
+   * Utility method to run a test multiple times. For using the test call the method on the test block.
+   * Example:
+   * repeatTest(5) {
+   *   ... // test code
+   * }
+   *
+   * @param numRuns Number of test runs
+   * @param test    Test to run
+   */
+  def repeatTest(numRuns: Int)(test: => Unit): Unit = {
+    for (_ <- 1 to numRuns) {
+      test
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

The jira aims to add an API for running a test multiple times. This is useful for assuring that the flaky tests are fixed.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
