### PR TITLE
[HUDI-8898] Support INSERT SQL statement with a subset of columns in Spark 3.5

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -46,11 +46,6 @@ object HoodieAnalysis extends SparkAdapterSupport {
   def customResolutionRules: Seq[RuleBuilder] = {
     val rules: ListBuffer[RuleBuilder] = ListBuffer()
 
-    if (HoodieSparkUtils.gteqSpark3_5) {
-      rules += (_ => instantiateKlass(
-        "org.apache.spark.sql.hudi.analysis.HoodieSpark35ResolveColumnsForInsertInto"))
-    }
-
     // NOTE: This rule adjusts [[LogicalRelation]]s resolving into Hudi tables such that
     //       meta-fields are not affecting the resolution of the target columns to be updated by Spark (Except in the
     //       case of MergeInto. We leave the meta columns on the target table, and use other means to ensure resolution)
@@ -79,6 +74,11 @@ object HoodieAnalysis extends SparkAdapterSupport {
     // behavior of Spark's analysis phase (for ex, DataSource V2 to V1 fallback might not kick in before other rules,
     // leading to all relations resolving as V2 instead of current expectation of them being resolved as V1)
     rules ++= Seq(dataSourceV2ToV1Fallback, spark3ResolveReferences)
+
+    if (HoodieSparkUtils.gteqSpark3_5) {
+      rules += (_ => instantiateKlass(
+        "org.apache.spark.sql.hudi.analysis.HoodieSpark35ResolveColumnsForInsertInto"))
+    }
 
     val resolveAlterTableCommandsClass =
       if (HoodieSparkUtils.gteqSpark3_5) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -46,6 +46,11 @@ object HoodieAnalysis extends SparkAdapterSupport {
   def customResolutionRules: Seq[RuleBuilder] = {
     val rules: ListBuffer[RuleBuilder] = ListBuffer()
 
+    if (HoodieSparkUtils.gteqSpark3_5) {
+      rules += (_ => instantiateKlass(
+        "org.apache.spark.sql.hudi.analysis.HoodieSpark35ResolveColumnsForInsertInto"))
+    }
+
     // NOTE: This rule adjusts [[LogicalRelation]]s resolving into Hudi tables such that
     //       meta-fields are not affecting the resolution of the target columns to be updated by Spark (Except in the
     //       case of MergeInto. We leave the meta columns on the target table, and use other means to ensure resolution)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -46,10 +46,11 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   test("Test Insert Into with subset of columns") {
     // This is only supported by Spark 3.4 and above
     if (HoodieSparkUtils.gteqSpark3_4) {
-      Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
-        testInsertIntoWithSubsetOfColumns(
-          "hudi", s"${tmp.getCanonicalPath}/1", isPartitioned)
-      })
+      Seq("cow", "mor").foreach(tableType =>
+        Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
+          testInsertIntoWithSubsetOfColumns(
+            "hudi", tableType, s"${tmp.getCanonicalPath}/hudi_table", isPartitioned)
+        }))
     }
   }
 
@@ -60,12 +61,13 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       // INSERT INTO statements on Hudi tables
       Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
         testInsertIntoWithSubsetOfColumns(
-          "parquet", s"${tmp.getCanonicalPath}/1", isPartitioned)
+          "parquet", "", s"${tmp.getCanonicalPath}/parquet_table", isPartitioned)
       })
     }
   }
 
   private def testInsertIntoWithSubsetOfColumns(format: String,
+                                                tableType: String,
                                                 tablePath: String,
                                                 isPartitioned: Boolean): Unit = {
     val tableName = generateTableName
@@ -80,7 +82,10 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
          |  price double,
          |  ts long
          |) using $format
-         | tblproperties (primaryKey = 'id')
+         | tblproperties (
+         | type = '$tableType',
+         | primaryKey = 'id'
+         | )
          | $createTablePartitionClause
          | location '$tablePath'
        """.stripMargin)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -44,8 +44,8 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 class TestInsertTable extends HoodieSparkSqlTestBase {
 
   test("Test Insert Into with subset of columns") {
-    // This is only supported by Spark 3.4 and above
-    if (HoodieSparkUtils.gteqSpark3_4) {
+    // This is only supported by Spark 3.5
+    if (HoodieSparkUtils.gteqSpark3_5) {
       Seq("cow", "mor").foreach(tableType =>
         Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
           testInsertIntoWithSubsetOfColumns(
@@ -55,8 +55,8 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   }
 
   test("Test Insert Into with subset of columns on Parquet table") {
-    // This is only supported by Spark 3.4 and above
-    if (HoodieSparkUtils.gteqSpark3_4) {
+    // This is only supported by Spark 3.5
+    if (HoodieSparkUtils.gteqSpark3_5) {
       // Make sure parquet tables are not affected by the custom rules for
       // INSERT INTO statements on Hudi tables
       Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -43,6 +43,117 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 class TestInsertTable extends HoodieSparkSqlTestBase {
 
+  test("Test Insert Into with subset of columns") {
+    // This is only supported by Spark 3.4 and above
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
+        testInsertIntoWithSubsetOfColumns(
+          "hudi", s"${tmp.getCanonicalPath}/1", isPartitioned)
+      })
+    }
+  }
+
+  test("Test Insert Into with subset of columns on Parquet table") {
+    // This is only supported by Spark 3.4 and above
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      // Make sure parquet tables are not affected by the custom rules for
+      // INSERT INTO statements on Hudi tables
+      Seq(true, false).foreach(isPartitioned => withTempDir { tmp =>
+        testInsertIntoWithSubsetOfColumns(
+          "parquet", s"${tmp.getCanonicalPath}/1", isPartitioned)
+      })
+    }
+  }
+
+  private def testInsertIntoWithSubsetOfColumns(format: String,
+                                                tablePath: String,
+                                                isPartitioned: Boolean): Unit = {
+    val tableName = generateTableName
+    val createTablePartitionClause = if (isPartitioned) "partitioned by (dt)" else ""
+    // Create a partitioned table
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  id int,
+         |  dt string,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) using $format
+         | tblproperties (primaryKey = 'id')
+         | $createTablePartitionClause
+         | location '$tablePath'
+       """.stripMargin)
+
+    // INSERT INTO with all columns
+    // Same ordering of columns as the schema
+    spark.sql(
+      s"""
+         | insert into $tableName (id, name, price, ts, dt)
+         | values (1, 'a1', 10, 1000, '2025-01-01'),
+         | (2, 'a2', 20, 2000, '2025-01-02')
+        """.stripMargin)
+    checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+      Seq(2, "a2", 20.0, 2000, "2025-01-02")
+    )
+
+    // Different ordering of columns compared to the schema
+    spark.sql(
+      s"""
+         | insert into $tableName (dt, name, id, price, ts)
+         | values ('2025-01-03', 'a3', 3, 30, 3000)
+        """.stripMargin)
+    checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+      Seq(2, "a2", 20.0, 2000, "2025-01-02"),
+      Seq(3, "a3", 30.0, 3000, "2025-01-03")
+    )
+
+    // INSERT INTO with a subset of columns
+    // Using different ordering of subset of columns in user-specified columns,
+    // and VALUES without column names
+    spark.sql(
+      s"""
+         | insert into $tableName (dt, ts, name, id)
+         | values ('2025-01-04', 4000, 'a4', 4)
+        """.stripMargin)
+    checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+      Seq(2, "a2", 20.0, 2000, "2025-01-02"),
+      Seq(3, "a3", 30.0, 3000, "2025-01-03"),
+      Seq(4, "a4", null, 4000, "2025-01-04")
+    )
+
+    spark.sql(
+      s"""
+         | insert into $tableName (id, price, ts, dt)
+         | values (5, 50.0, 5000, '2025-01-05')
+        """.stripMargin)
+    checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+      Seq(2, "a2", 20.0, 2000, "2025-01-02"),
+      Seq(3, "a3", 30.0, 3000, "2025-01-03"),
+      Seq(4, "a4", null, 4000, "2025-01-04"),
+      Seq(5, null, 50.0, 5000, "2025-01-05")
+    )
+
+    // Using a subset of columns in user-specified columns, and VALUES with column names
+    spark.sql(
+      s"""
+         | insert into $tableName (dt, ts, id, name)
+         | values ('2025-01-06' as dt, 6000 as ts, 6 as id, 'a6' as name)
+        """.stripMargin)
+    checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+      Seq(2, "a2", 20.0, 2000, "2025-01-02"),
+      Seq(3, "a3", 30.0, 3000, "2025-01-03"),
+      Seq(4, "a4", null, 4000, "2025-01-04"),
+      Seq(5, null, 50.0, 5000, "2025-01-05"),
+      Seq(6, "a6", null, 6000, "2025-01-06")
+    )
+  }
+
   test("Test table type name incase-sensitive test") {
     withTempDir { tmp =>
       val targetTable = generateTableName

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -157,6 +157,23 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       Seq(5, null, 50.0, 5000, "2025-01-05"),
       Seq(6, "a6", null, 6000, "2025-01-06")
     )
+
+    if (isPartitioned) {
+      spark.sql(
+        s"""
+           | insert into $tableName partition(dt='2025-01-07') (ts, id, name)
+           | values (7000, 7, 'a7')
+        """.stripMargin)
+      checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+        Seq(1, "a1", 10.0, 1000, "2025-01-01"),
+        Seq(2, "a2", 20.0, 2000, "2025-01-02"),
+        Seq(3, "a3", 30.0, 3000, "2025-01-03"),
+        Seq(4, "a4", null, 4000, "2025-01-04"),
+        Seq(5, null, 50.0, 5000, "2025-01-05"),
+        Seq(6, "a6", null, 6000, "2025-01-06"),
+        Seq(7, "a7", null, 7000, "2025-01-07")
+      )
+    }
   }
 
   test("Test table type name incase-sensitive test") {


### PR DESCRIPTION
### Change Logs

This PR fixes the issue that the INSERT SQL statement with a subset of columns fails on Hudi table in Spark 3.5. The same succeeds in Spark 3.4.

In Spark 3.5, the following Resolution rules are removed, `ResolveUserSpecifiedColumns` and `ResolveDefaultColumns` (see code changes in [[org.apache.spark.sql.catalyst.analysis.Analyzer]] from https://github.com/apache/spark/pull/41262). The same logic of resolving the user-specified columns and default values, which are required for a subset of columns as user-specified compared to the table schema to work properly, are deferred to `PreprocessTableInsertion` for v1 INSERT.
 
Note that `HoodieAnalysis` intercepts the `InsertIntoStatement` after Spark's built-in Resolution rules are applies, the logic of resolving the user specified columns and default values may no longer be applied. To make INSERT with a subset of columns specified by user to work, the custom resolution rule `HoodieSpark35ResolveColumnsForInsertInto` is added to achieve the same, before converting `InsertIntoStatement` into `InsertIntoHoodieTableCommand`.  Here's the behavior different before and after the fix on Spark 3.5, when `InsertIntoStatement` is intercepted

Before the fix, query in the relation for `InsertIntoStatement`
```
LocalRelation [col1#128, col2#129, col3#130, col4#131]
```
After the fix, query in the relation for `InsertIntoStatement`
```
Project [id#140, name#139, price#146, ts#147L, dt#137]
+- Project [null AS _hoodie_commit_time#141, null AS _hoodie_commit_seqno#142, null AS _hoodie_record_key#143, null AS _hoodie_partition_path#144, null AS _hoodie_file_name#145, id#140, name#139, null AS price#146, cast(ts#138 as bigint) AS ts#147L, dt#137]
   +- Project [col1#133 AS dt#137, col2#134 AS ts#138, col3#135 AS name#139, col4#136 AS id#140]
      +- LocalRelation [col1#133, col2#134, col3#135, col4#136]
```

New tests are added in `TestInsertTable`.`"Test Insert Into with subset of columns"` and `"Test Insert Into with subset of columns on Parquet table"`.  The test on Hudi table fails before the fix and passes after the fix.

Reproducing the failure in Spark 3.5 (this is added as tests in `TestInsertTable`.`"Test Insert Into with subset of columns"` and `"Test Insert Into with subset of columns on Parquet table"`):
Create table:
```
     create table $tableName (
       id int,
       dt string,
       name string,
       price double,
       ts long
     ) using hudi
     tblproperties (primaryKey = 'id')
     location '/tmp/table'
```
INSERT INTO with a subset of columns
```
         insert into $tableName (dt, ts, name, id)
         values ('2025-01-04', 4000, 'a4', 4)
```
It fails with
```
[INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS] Cannot write to `spark_catalog`.`default`.`h1`, the reason is not enough data columns:
Table columns: `id`, `name`, `price`, `ts`, `dt`.
Data columns: `dt`, `ts`, `name`, `id`.
org.apache.spark.sql.AnalysisException: [INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS] Cannot write to `spark_catalog`.`default`.`h1`, the reason is not enough data columns:
Table columns: `id`, `name`, `price`, `ts`, `dt`.
Data columns: `dt`, `ts`, `name`, `id`.
    at org.apache.spark.sql.errors.QueryCompilationErrors$.cannotWriteNotEnoughColumnsToTableError(QueryCompilationErrors.scala:2126)
    at org.apache.spark.sql.catalyst.analysis.TableOutputResolver$.resolveOutputColumns(TableOutputResolver.scala:70)
    at org.apache.spark.sql.HoodieSpark3CatalystPlanUtils.resolveOutputColumns(HoodieSpark3CatalystPlanUtils.scala:51)
    at org.apache.spark.sql.HoodieSpark3CatalystPlanUtils.resolveOutputColumns$(HoodieSpark3CatalystPlanUtils.scala:46)
    at org.apache.spark.sql.HoodieSpark35CatalystPlanUtils$.resolveOutputColumns(HoodieSpark35CatalystPlanUtils.scala:32)
    at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.coerceQueryOutputColumns(InsertIntoHoodieTableCommand.scala:168)
    at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.alignQueryOutput(InsertIntoHoodieTableCommand.scala:145)
    at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.run(InsertIntoHoodieTableCommand.scala:99)
    at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand.run(InsertIntoHoodieTableCommand.scala:62) 
```
### Impact

Fixes INSERT SQL statement with a subset of columns in Spark 3.5

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
