### PR TITLE
[HUDI-8901] Fix Timeline Server to process requests from multiple storage lakes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -26,8 +26,6 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.util.NetworkUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.storage.HoodieStorage;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
 
@@ -180,8 +178,7 @@ public class EmbeddedTimelineService {
 
     this.serviceConfig = timelineServiceConfBuilder.build();
 
-    server = timelineServiceCreator.create(context, storageConf.newInstance(), serviceConfig,
-        HoodieStorageUtils.getStorage(writeConfig.getBasePath(), storageConf.newInstance()), viewManager);
+    server = timelineServiceCreator.create(context, storageConf.newInstance(), serviceConfig, viewManager);
     serverPort = server.startService();
     LOG.info("Started embedded timeline server at " + hostAddr + ":" + serverPort);
   }
@@ -189,7 +186,7 @@ public class EmbeddedTimelineService {
   @FunctionalInterface
   interface TimelineServiceCreator {
     TimelineService create(HoodieEngineContext context, StorageConfiguration<?> storageConf, TimelineService.Config timelineServerConf,
-                           HoodieStorage storage, FileSystemViewManager globalFileSystemViewManager) throws IOException;
+                           FileSystemViewManager globalFileSystemViewManager) throws IOException;
   }
 
   private void setHostAddr(String embeddedTimelineServiceHostAddr) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
@@ -55,7 +55,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService = Mockito.mock(TimelineService.class);
-    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockCreator.create(any(), any(), any(), any())).thenReturn(mockService);
     when(mockService.startService()).thenReturn(123);
     EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
 
@@ -96,7 +96,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService = Mockito.mock(TimelineService.class);
-    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockCreator.create(any(), any(), any(), any())).thenReturn(mockService);
     when(mockService.startService()).thenReturn(321);
     EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
 
@@ -110,7 +110,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService2 = Mockito.mock(TimelineService.class);
-    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockCreator2.create(any(), any(), any(), any())).thenReturn(mockService2);
     when(mockService2.startService()).thenReturn(456);
     EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
     assertNotSame(service1, service2);
@@ -133,7 +133,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService = Mockito.mock(TimelineService.class);
-    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockCreator.create(any(), any(), any(), any())).thenReturn(mockService);
     when(mockService.startService()).thenReturn(789);
     EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
 
@@ -144,7 +144,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService2 = Mockito.mock(TimelineService.class);
-    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockCreator2.create(any(), any(), any(), any())).thenReturn(mockService2);
     when(mockService2.startService()).thenReturn(987);
     EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
     assertNotSame(service1, service2);
@@ -169,7 +169,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService = Mockito.mock(TimelineService.class);
-    when(mockCreator.create(any(), any(), any(), any(), any())).thenReturn(mockService);
+    when(mockCreator.create(any(), any(), any(), any())).thenReturn(mockService);
     when(mockService.startService()).thenReturn(555);
     EmbeddedTimelineService service1 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig1, mockCreator);
 
@@ -182,7 +182,7 @@ public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
         .build();
     EmbeddedTimelineService.TimelineServiceCreator mockCreator2 = Mockito.mock(EmbeddedTimelineService.TimelineServiceCreator.class);
     TimelineService mockService2 = Mockito.mock(TimelineService.class);
-    when(mockCreator2.create(any(), any(), any(), any(), any())).thenReturn(mockService2);
+    when(mockCreator2.create(any(), any(), any(), any())).thenReturn(mockService2);
     when(mockService2.startService()).thenReturn(111);
     EmbeddedTimelineService service2 = EmbeddedTimelineService.getOrStartEmbeddedTimelineService(engineContext, null, writeConfig2, mockCreator2);
     // a new service will be started since the original was shutdown already

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
@@ -160,7 +160,6 @@ public class TestTimelineServerBasedWriteMarkers extends TestWriteMarkersBase {
           hoodieEngineContext,
           (Configuration) storage.getConf().unwrap(),
           TimelineService.Config.builder().serverPort(0).enableMarkerRequests(true).build(),
-          (FileSystem) storage.getFileSystem(),
           FileSystemViewManager.createViewManager(
               hoodieEngineContext, metadataConfig, storageConf, HoodieCommonConfig.newBuilder().build()));
       timelineService.startService();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
@@ -37,7 +37,6 @@ import org.apache.hudi.timeline.service.TimelineService;
 import org.apache.hudi.timeline.service.TimelineServiceTestHarness;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -41,7 +41,6 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.storage.HoodieStorage;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
@@ -288,7 +287,6 @@ public class HoodieClientTestUtils {
       TimelineService timelineService = new TimelineService(context, HadoopFSUtils.getStorageConf(),
           TimelineService.Config.builder().enableMarkerRequests(true)
               .serverPort(config.getViewStorageConfig().getRemoteViewServerPort()).build(),
-          HoodieStorageUtils.getStorage(HoodieTestUtils.getDefaultStorageConf()),
           FileSystemViewManager.createViewManager(context, config.getMetadataConfig(), config.getViewStorageConfig(), config.getCommonConfig()));
       timelineService.startService();
       LOG.info("Timeline service server port: " + timelineServicePort);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -43,7 +43,6 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.metadata.HoodieBackedTestDelayedTableMetadata;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 import org.apache.hudi.timeline.service.TimelineService;
 
@@ -72,7 +71,6 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.view.FileSystemViewStorageConfig.REMOTE_PORT_NUM;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -115,7 +113,6 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
       timelineService = new TimelineService(localEngineContext, HadoopFSUtils.getStorageConf(),
           TimelineService.Config.builder().enableMarkerRequests(true)
               .serverPort(config.getViewStorageConfig().getRemoteViewServerPort()).build(),
-          HoodieStorageUtils.getStorage(getDefaultStorageConf()),
           FileSystemViewManager.createViewManager(
               context, config.getMetadataConfig(), config.getViewStorageConfig(),
               config.getCommonConfig(),

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -38,7 +38,6 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.handlers.BaseFileHandler;
 import org.apache.hudi.timeline.service.handlers.FileSliceHandler;
@@ -91,22 +90,22 @@ public class RequestHandler {
   private final ScheduledExecutorService asyncResultService;
 
   public RequestHandler(Javalin app, StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                        HoodieEngineContext hoodieEngineContext, HoodieStorage storage,
-                        FileSystemViewManager viewManager) throws IOException {
+                        HoodieEngineContext hoodieEngineContext,
+                        FileSystemViewManager viewManager) {
     this.timelineServiceConfig = timelineServiceConfig;
     this.viewManager = viewManager;
     this.app = app;
-    this.instantHandler = new TimelineHandler(conf, timelineServiceConfig, storage, viewManager);
-    this.sliceHandler = new FileSliceHandler(conf, timelineServiceConfig, storage, viewManager);
-    this.dataFileHandler = new BaseFileHandler(conf, timelineServiceConfig, storage, viewManager);
+    this.instantHandler = new TimelineHandler(conf, timelineServiceConfig, viewManager);
+    this.sliceHandler = new FileSliceHandler(conf, timelineServiceConfig, viewManager);
+    this.dataFileHandler = new BaseFileHandler(conf, timelineServiceConfig, viewManager);
     if (timelineServiceConfig.enableMarkerRequests) {
       this.markerHandler = new MarkerHandler(
-          conf, timelineServiceConfig, hoodieEngineContext, storage, viewManager, metricsRegistry);
+          conf, timelineServiceConfig, hoodieEngineContext, viewManager, metricsRegistry);
     } else {
       this.markerHandler = null;
     }
     if (timelineServiceConfig.enableInstantStateRequests) {
-      this.instantStateHandler = new InstantStateHandler(conf, timelineServiceConfig, storage, viewManager);
+      this.instantStateHandler = new InstantStateHandler(conf, timelineServiceConfig, viewManager);
     } else {
       this.instantStateHandler = null;
     }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -26,8 +26,6 @@ import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
-import org.apache.hudi.storage.HoodieStorage;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import com.beust.jcommander.JCommander;
@@ -56,7 +54,6 @@ public class TimelineService {
   private final Config timelineServerConf;
   private final StorageConfiguration<?> storageConf;
   private transient HoodieEngineContext context;
-  private transient HoodieStorage storage;
   private transient Javalin app = null;
   private transient FileSystemViewManager fsViewsManager;
   private transient RequestHandler requestHandler;
@@ -66,12 +63,11 @@ public class TimelineService {
   }
 
   public TimelineService(HoodieEngineContext context, StorageConfiguration<?> storageConf, Config timelineServerConf,
-                         HoodieStorage storage, FileSystemViewManager globalFileSystemViewManager) throws IOException {
+                         FileSystemViewManager globalFileSystemViewManager) {
     this.storageConf = storageConf;
     this.timelineServerConf = timelineServerConf;
     this.serverPort = timelineServerConf.serverPort;
     this.context = context;
-    this.storage = storage;
     this.fsViewsManager = globalFileSystemViewManager;
   }
 
@@ -370,7 +366,7 @@ public class TimelineService {
     return realServerPort;
   }
 
-  private void createApp() throws IOException {
+  private void createApp() {
     // if app needs to be recreated, stop the existing one
     if (app != null) {
       app.stop();
@@ -390,7 +386,7 @@ public class TimelineService {
     });
 
     requestHandler = new RequestHandler(
-        app, storageConf, timelineServerConf, context, storage, fsViewsManager);
+        app, storageConf, timelineServerConf, context, fsViewsManager);
     app.get("/", ctx -> ctx.result("Hello Hudi"));
     requestHandler.register();
   }
@@ -450,10 +446,6 @@ public class TimelineService {
     return storageConf;
   }
 
-  public HoodieStorage getStorage() {
-    return storage;
-  }
-
   public static void main(String[] args) throws Exception {
     final Config cfg = new Config();
     JCommander cmd = new JCommander(cfg, null, args);
@@ -469,7 +461,6 @@ public class TimelineService {
         new HoodieLocalEngineContext(storageConf.newInstance()),
         storageConf.newInstance(),
         cfg,
-        HoodieStorageUtils.getStorage(storageConf),
         viewManager);
     service.run();
   }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/BaseFileHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/BaseFileHandler.java
@@ -20,11 +20,9 @@ package org.apache.hudi.timeline.service.handlers;
 
 import org.apache.hudi.common.table.timeline.dto.BaseFileDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +34,8 @@ import java.util.stream.Collectors;
 public class BaseFileHandler extends Handler {
 
   public BaseFileHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                         HoodieStorage storage, FileSystemViewManager viewManager) throws IOException {
-    super(conf, timelineServiceConfig, storage, viewManager);
+                         FileSystemViewManager viewManager) {
+    super(conf, timelineServiceConfig, viewManager);
   }
 
   public List<BaseFileDTO> getLatestDataFiles(String basePath, String partitionPath) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
@@ -25,11 +25,9 @@ import org.apache.hudi.common.table.timeline.dto.DTOUtils;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,8 +40,8 @@ import java.util.stream.Collectors;
 public class FileSliceHandler extends Handler {
 
   public FileSliceHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                          HoodieStorage storage, FileSystemViewManager viewManager) throws IOException {
-    super(conf, timelineServiceConfig, storage, viewManager);
+                          FileSystemViewManager viewManager) {
+    super(conf, timelineServiceConfig, viewManager);
   }
 
   public List<FileSliceDTO> getAllFileSlices(String basePath, String partitionPath) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/Handler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/Handler.java
@@ -37,7 +37,7 @@ public abstract class Handler {
     this.viewManager = viewManager;
   }
 
-  public HoodieStorage getStorage(String path) {
+  protected HoodieStorage getStorage(String path) {
     return HoodieStorageUtils.getStorage(path, conf);
   }
 }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/Handler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/Handler.java
@@ -20,23 +20,24 @@ package org.apache.hudi.timeline.service.handlers;
 
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
-
-import java.io.IOException;
 
 public abstract class Handler {
 
   protected final StorageConfiguration<?> conf;
   protected final TimelineService.Config timelineServiceConfig;
-  protected final HoodieStorage storage;
   protected final FileSystemViewManager viewManager;
 
   public Handler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                 HoodieStorage storage, FileSystemViewManager viewManager) throws IOException {
-    this.conf = conf;
+                 FileSystemViewManager viewManager) {
+    this.conf = conf.newInstance();
     this.timelineServiceConfig = timelineServiceConfig;
-    this.storage = storage;
     this.viewManager = viewManager;
+  }
+
+  public HoodieStorage getStorage(String path) {
+    return HoodieStorageUtils.getStorage(path, conf);
   }
 }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/InstantStateHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/InstantStateHandler.java
@@ -76,9 +76,8 @@ public class InstantStateHandler extends Handler {
   private final AtomicLong requestCount;
 
   public InstantStateHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                             HoodieStorage storage,
-                             FileSystemViewManager viewManager) throws IOException {
-    super(conf, timelineServiceConfig, storage, viewManager);
+                             FileSystemViewManager viewManager) {
+    super(conf, timelineServiceConfig, viewManager);
     this.cachedInstantStates = new ConcurrentHashMap<>();
     this.requestCount = new AtomicLong();
   }
@@ -118,8 +117,9 @@ public class InstantStateHandler extends Handler {
   public List<InstantStateDTO> scanInstantState(StoragePath instantStatePath) {
     try {
       // Check instantStatePath exists before list status, see HUDI-5915
-      if (this.storage.exists(instantStatePath)) {
-        return this.storage.listDirectEntries(instantStatePath).stream()
+      HoodieStorage storage = getStorage(instantStatePath.toUri().toString());
+      if (storage.exists(instantStatePath)) {
+        return storage.listDirectEntries(instantStatePath).stream()
             .map(InstantStateDTO::fromStoragePathInfo).collect(Collectors.toList());
       } else {
         return Collections.emptyList();

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieEarlyConflictDetectionException;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
 import org.apache.hudi.timeline.service.handlers.marker.MarkerCreationDispatchingRunnable;
@@ -42,7 +41,6 @@ import io.javalin.http.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -103,10 +101,9 @@ public class MarkerHandler extends Handler {
   private TimelineServerBasedDetectionStrategy earlyConflictDetectionStrategy;
 
   public MarkerHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                       HoodieEngineContext hoodieEngineContext, HoodieStorage storage,
-                       FileSystemViewManager viewManager, Registry metricsRegistry) throws IOException {
-    super(conf, timelineServiceConfig, storage, viewManager);
-    LOG.debug("MarkerHandler FileSystem: " + this.storage.getScheme());
+                       HoodieEngineContext hoodieEngineContext,
+                       FileSystemViewManager viewManager, Registry metricsRegistry) {
+    super(conf, timelineServiceConfig, viewManager);
     LOG.debug("MarkerHandler batching params: batchNumThreads=" + timelineServiceConfig.markerBatchNumThreads
         + " batchIntervalMs=" + timelineServiceConfig.markerBatchIntervalMs + "ms");
     this.hoodieEngineContext = hoodieEngineContext;
@@ -221,7 +218,7 @@ public class MarkerHandler extends Handler {
                 timelineServiceConfig.asyncConflictDetectorInitialDelayMs,
                 timelineServiceConfig.asyncConflictDetectorPeriodMs,
                 markerDir, basePath, timelineServiceConfig.maxAllowableHeartbeatIntervalInMs,
-                storage, this, completedCommits);
+                getStorage(basePath), this, completedCommits);
           }
         }
 
@@ -297,7 +294,7 @@ public class MarkerHandler extends Handler {
                   ? Option.of(earlyConflictDetectionStrategy) : Option.empty();
           markerDirState = new MarkerDirState(
               markerDir, timelineServiceConfig.markerBatchNumThreads,
-              strategy, storage, metricsRegistry, hoodieEngineContext, parallelism);
+              strategy, getStorage(markerDir), metricsRegistry, hoodieEngineContext, parallelism);
           markerDirStateMap.put(markerDir, markerDirState);
         } else {
           markerDirState = markerDirStateMap.get(markerDir);

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/TimelineHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/TimelineHandler.java
@@ -21,11 +21,9 @@ package org.apache.hudi.timeline.service.handlers;
 import org.apache.hudi.common.table.timeline.dto.InstantDTO;
 import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,8 +34,8 @@ import java.util.List;
 public class TimelineHandler extends Handler {
 
   public TimelineHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
-                         HoodieStorage storage, FileSystemViewManager viewManager) throws IOException {
-    super(conf, timelineServiceConfig, storage, viewManager);
+                         FileSystemViewManager viewManager) {
+    super(conf, timelineServiceConfig, viewManager);
   }
 
   public List<InstantDTO> getLastInstant(String basePath) {

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
@@ -27,6 +27,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 
+/**
+ * A mock implementation of {@link HoodieHadoopStorage} that validates the storage scheme and authority
+ * before delegating operations to the superclass.
+ * <p>
+ * This class is primarily used for testing and ensures that all storage operations conform
+ * to the expected scheme and authority.
+ * </p>
+ */
 public class MockHoodieHadoopStorage extends HoodieHadoopStorage {
 
   private final String scheme;

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.timeline.service;
 
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -81,11 +82,10 @@ public class MockHoodieHadoopStorage extends HoodieHadoopStorage {
   }
 
   private StoragePath validateAndConvertPath(StoragePath path) {
-    assert scheme == null || scheme.equals(path.toUri().getScheme()) :
-        String.format("Invalid scheme, expected %s, found %s", scheme, path.toUri().getScheme());
-
-    assert authority == null || authority.equals(path.toUri().getAuthority()) :
-        String.format("Invalid authority, expected %s, found %s", authority, path.toUri().getAuthority());
+    ValidationUtils.checkArgument(scheme == null || scheme.equals(path.toUri().getScheme()),
+        String.format("Invalid scheme, expected %s, found %s", scheme, path.toUri().getScheme()));
+    ValidationUtils.checkArgument(authority == null || authority.equals(path.toUri().getAuthority()),
+        String.format("Invalid authority, expected %s, found %s", authority, path.toUri().getAuthority()));
 
     return convertToHadoopPath(path);
   }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/MockHoodieHadoopStorage.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.timeline.service;
+
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+public class MockHoodieHadoopStorage extends HoodieHadoopStorage {
+
+  private final String scheme;
+  private final String authority;
+
+  public MockHoodieHadoopStorage(StoragePath path, StorageConfiguration<?> conf) {
+    super(convertToHadoopPath(path), conf);
+    this.scheme = path.toUri().getScheme();
+    this.authority = path.toUri().getAuthority();
+  }
+
+  private static StoragePath convertToHadoopPath(StoragePath storagePath) {
+    return new StoragePath(storagePath.toUri().getPath());
+  }
+
+  @Override
+  public String getScheme() {
+    return super.getScheme();
+  }
+
+  @Override
+  public boolean exists(StoragePath path) throws IOException {
+    return super.exists(validateAndConvertPath(path));
+  }
+
+  @Override
+  public boolean createDirectory(StoragePath path) throws IOException {
+    return super.createDirectory(validateAndConvertPath(path));
+  }
+
+  @Override
+  public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
+    return super.create(validateAndConvertPath(path), overwrite);
+  }
+
+  @Override
+  public OutputStream create(StoragePath path) throws IOException {
+    return super.create(validateAndConvertPath(path));
+  }
+
+  @Override
+  public List<StoragePathInfo> listDirectEntries(StoragePath path) throws IOException {
+    return super.listDirectEntries(validateAndConvertPath(path));
+  }
+
+  private StoragePath validateAndConvertPath(StoragePath path) {
+    assert scheme == null || scheme.equals(path.toUri().getScheme()) :
+        String.format("Invalid scheme, expected %s, found %s", scheme, path.toUri().getScheme());
+
+    assert authority == null || authority.equals(path.toUri().getAuthority()) :
+        String.format("Invalid authority, expected %s, found %s", authority, path.toUri().getAuthority());
+
+    return convertToHadoopPath(path);
+  }
+}

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.timeline.service;
+
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.timeline.TimelineServiceClient;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.HOODIE_STORAGE_CLASS;
+import static org.apache.hudi.common.table.marker.MarkerOperation.CREATE_MARKER_URL;
+import static org.apache.hudi.common.table.marker.MarkerOperation.MARKER_DIR_PATH_PARAM;
+import static org.apache.hudi.common.table.marker.MarkerOperation.MARKER_NAME_PARAM;
+import static org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView.BASEPATH_PARAM;
+import static org.apache.hudi.timeline.TimelineServiceClientBase.RequestMethod.POST;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestRequestHandler extends HoodieCommonTestHarness {
+
+  public static final char SEPARATOR_CHAR = '/';
+  private static final String DEFAULT_FILE_SCHEME = "file:/";
+  private static final String DELIMITER_CHAR = ":";
+  private TimelineService server = null;
+  private TimelineServiceClient timelineServiceClient;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    metaClient = HoodieTestUtils.init(tempDir.toAbsolutePath().toString());
+    basePath = metaClient.getBasePath().toString();
+    FileSystemViewStorageConfig sConf =
+        FileSystemViewStorageConfig.newBuilder().withStorageType(FileSystemViewStorageType.SPILLABLE_DISK).build();
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().build();
+    HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().build();
+    HoodieLocalEngineContext localEngineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
+
+    try {
+      if (server != null) {
+        server.close();
+      }
+      TimelineServiceTestHarness.Builder builder = TimelineServiceTestHarness.newBuilder();
+      Configuration configuration = new Configuration();
+      configuration.set(HOODIE_STORAGE_CLASS.key(), MockHoodieHadoopStorage.class.getName());
+      server = builder.build(localEngineContext, configuration,
+          TimelineService.Config.builder().serverPort(0).enableMarkerRequests(true).build(),
+          FileSystemViewManager.createViewManager(localEngineContext, metadataConfig, sConf, commonConfig));
+      server.startService();
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+    FileSystemViewStorageConfig.Builder builder = FileSystemViewStorageConfig.newBuilder().withRemoteServerHost("localhost")
+        .withRemoteServerPort(server.getServerPort())
+        .withRemoteTimelineClientTimeoutSecs(60);
+    timelineServiceClient = new TimelineServiceClient(builder.build());
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.close();
+  }
+
+  @Test
+  void testCreateMarkerAPI() throws IOException {
+    assertMarkerCreation(tempDir.resolve("base-path-1").toUri().toString(), "test1:/", "marker-file-1");
+    assertMarkerCreation(tempDir.resolve("base-path-2").toUri().toString(), "test2:/", "marker-file-2");
+  }
+
+  private void assertMarkerCreation(String basePath, String schema, String markerFile) throws IOException {
+    Map<String, String> queryParameters = new HashMap<>();
+    String basePathScheme = getPathWithReplacedSchema(basePath, schema);
+    String markerDir = getPathWithReplacedSchema(metaClient.getMarkerFolderPath("101"), schema);
+
+    queryParameters.put(BASEPATH_PARAM, basePathScheme);
+    queryParameters.put(MARKER_DIR_PATH_PARAM, markerDir);
+    queryParameters.put(MARKER_NAME_PARAM, markerFile);
+
+    boolean content = timelineServiceClient.makeRequest(
+            TimelineServiceClient.Request.newBuilder(POST, CREATE_MARKER_URL)
+                .addQueryParams(queryParameters)
+                .build())
+        .getDecodedContent(new TypeReference<Boolean>() {});
+
+    assertTrue(content);
+  }
+
+  private String getPathWithReplacedSchema(String path, String schemaToUse) {
+    if (path.startsWith(DEFAULT_FILE_SCHEME)) {
+      return path.replace(DEFAULT_FILE_SCHEME, schemaToUse);
+    } else if (path.startsWith(String.valueOf(SEPARATOR_CHAR))) {
+      return schemaToUse + DELIMITER_CHAR + path;
+    }
+    throw new IllegalArgumentException("Invalid file provided");
+  }
+}

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
@@ -21,6 +21,7 @@ package org.apache.hudi.timeline.service;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
@@ -112,18 +113,19 @@ class TestRequestHandler extends HoodieCommonTestHarness {
 
   @Test
   void testCreateMarkerAPIWithDifferentSchemes() throws IOException {
-    assertMarkerCreation(tempDir.resolve("base-path-1").toUri().toString(), "test1:/", "marker-file-1");
-    assertMarkerCreation(tempDir.resolve("base-path-2").toUri().toString(), "test2:/", "marker-file-2");
+    assertMarkerCreation(tempDir.resolve("base-path-1").toUri().toString(), "test1:/");
+    assertMarkerCreation(tempDir.resolve("base-path-2").toUri().toString(), "test2:/");
   }
 
-  private void assertMarkerCreation(String basePath, String schema, String markerFile) throws IOException {
+  private void assertMarkerCreation(String basePath, String schema) throws IOException {
     Map<String, String> queryParameters = new HashMap<>();
     String basePathScheme = getPathWithReplacedSchema(basePath, schema);
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath, getTableType());
     String markerDir = getPathWithReplacedSchema(metaClient.getMarkerFolderPath("101"), schema);
 
     queryParameters.put(BASEPATH_PARAM, basePathScheme);
     queryParameters.put(MARKER_DIR_PATH_PARAM, markerDir);
-    queryParameters.put(MARKER_NAME_PARAM, markerFile);
+    queryParameters.put(MARKER_NAME_PARAM, "marker-file-1");
 
     boolean content = timelineServiceClient.makeRequest(
             TimelineServiceClient.Request.newBuilder(POST, CREATE_MARKER_URL)

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.timeline.TimelineServiceClient;
 
@@ -53,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestRequestHandler extends HoodieCommonTestHarness {
 
-  public static final char SEPARATOR_CHAR = '/';
   private static final String DEFAULT_FILE_SCHEME = "file:/";
 
   private TimelineService server = null;
@@ -139,8 +139,8 @@ class TestRequestHandler extends HoodieCommonTestHarness {
   private String getPathWithReplacedSchema(String path, String schemaToUse) {
     if (path.startsWith(DEFAULT_FILE_SCHEME)) {
       return path.replace(DEFAULT_FILE_SCHEME, schemaToUse);
-    } else if (path.startsWith(String.valueOf(SEPARATOR_CHAR))) {
-      return schemaToUse + SEPARATOR_CHAR + path;
+    } else if (path.startsWith(String.valueOf(StoragePath.SEPARATOR_CHAR))) {
+      return schemaToUse + StoragePath.SEPARATOR_CHAR + path;
     }
     throw new IllegalArgumentException("Invalid file provided");
   }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestRequestHandler.java
@@ -30,8 +30,6 @@ import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.timeline.TimelineServiceClient;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +94,7 @@ class TestRequestHandler extends HoodieCommonTestHarness {
   }
 
   @Test
-  void refreshTableAPI() throws IOException {
+  void testRefreshTableAPIWithDifferentSchemes() throws IOException {
     assertRefreshTable(tempDir.resolve("base-path-1").toUri().toString(), "test1:/");
     assertRefreshTable(tempDir.resolve("base-path-2").toUri().toString(), "test2:/");
   }
@@ -113,7 +111,7 @@ class TestRequestHandler extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testCreateMarkerAPI() throws IOException {
+  void testCreateMarkerAPIWithDifferentSchemes() throws IOException {
     assertMarkerCreation(tempDir.resolve("base-path-1").toUri().toString(), "test1:/", "marker-file-1");
     assertMarkerCreation(tempDir.resolve("base-path-2").toUri().toString(), "test2:/", "marker-file-2");
   }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestTimelineService.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TestTimelineService.java
@@ -50,12 +50,11 @@ class TestTimelineService {
       HoodieEngineContext engineContext = new HoodieLocalEngineContext(HoodieTestUtils.getDefaultStorageConf());
       int originalServerPort = 8888;
       TimelineService.Config config = TimelineService.Config.builder().enableMarkerRequests(true).serverPort(originalServerPort).build();
-      HoodieStorage storage = HoodieTestUtils.getDefaultStorage();
       FileSystemViewManager viewManager = mock(FileSystemViewManager.class);
-      timelineService = new TimelineService(engineContext, conf, config, storage, viewManager);
+      timelineService = new TimelineService(engineContext, conf, config, viewManager);
       assertEquals(originalServerPort, timelineService.startService());
       // Create second service with the same configs
-      secondTimelineService = new TimelineService(engineContext, conf, config, storage, viewManager);
+      secondTimelineService = new TimelineService(engineContext, conf, config, viewManager);
       assertNotEquals(originalServerPort, secondTimelineService.startService());
     } finally {
       if (timelineService != null) {
@@ -83,7 +82,7 @@ class TestTimelineService {
       FileSystemViewManager viewManager = mock(FileSystemViewManager.class);
       StorageConfiguration<Configuration> conf = HoodieTestUtils.getDefaultStorageConf();
       HoodieEngineContext engineContext = new HoodieLocalEngineContext(HoodieTestUtils.getDefaultStorageConf());
-      timelineService = new TimelineService(engineContext, conf, config, storage, viewManager);
+      timelineService = new TimelineService(engineContext, conf, config, viewManager);
       assertNotEquals(originalServerPort, timelineService.startService());
     } finally {
       if (timelineService != null) {

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
@@ -57,13 +57,11 @@ public class TimelineServiceTestHarness extends TimelineService {
   public TimelineServiceTestHarness(HoodieEngineContext context,
                                     Configuration hadoopConf,
                                     Config timelineServerConf,
-                                    FileSystem fileSystem,
                                     FileSystemViewManager globalFileSystemViewManager) throws IOException {
     super(
         context,
         new HadoopStorageConfiguration(hadoopConf),
         timelineServerConf,
-        new HoodieHadoopStorage(fileSystem),
         globalFileSystemViewManager);
     server = Option.empty();
     serverPort = 0;
@@ -131,10 +129,9 @@ public class TimelineServiceTestHarness extends TimelineService {
     public TimelineServiceTestHarness build(HoodieEngineContext context,
                                             Configuration hadoopConf,
                                             Config timelineServerConf,
-                                            FileSystem fileSystem,
                                             FileSystemViewManager globalFileSystemViewManager) throws IOException {
       TimelineServiceTestHarness timelineServiceTestHarness = new TimelineServiceTestHarness(
-          context, hadoopConf, timelineServerConf, fileSystem, globalFileSystemViewManager);
+          context, hadoopConf, timelineServerConf, globalFileSystemViewManager);
       timelineServiceTestHarness.setNumberOfSimulatedConnectionFailures(numberOfSimulatedConnectionFailures);
       return timelineServiceTestHarness;
     }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
@@ -22,10 +22,8 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
-import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.http.HttpResponse;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.utils.URIBuilder;

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -40,7 +40,6 @@ import org.apache.hudi.timeline.service.TimelineServiceTestHarness;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.slf4j.Logger;

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -35,7 +35,6 @@ import org.apache.hudi.common.table.view.TestHoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.exception.HoodieRemoteException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.timeline.service.TimelineService;
 import org.apache.hudi.timeline.service.TimelineServiceTestHarness;
 
@@ -53,7 +52,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -91,7 +89,6 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
           localEngineContext,
           HadoopFSUtils.getStorageConf().unwrap(),
           TimelineService.Config.builder().serverPort(0).build(),
-          (FileSystem) HoodieStorageUtils.getStorage(getDefaultStorageConf()).getFileSystem(),
           FileSystemViewManager.createViewManager(localEngineContext, metadataConfig, sConf, commonConfig));
       server.startService();
     } catch (Exception ex) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.storage.HoodieStorage;
-import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 import org.apache.hudi.timeline.service.TimelineService;
@@ -74,7 +73,7 @@ public class TimelineServerPerf implements Serializable {
   private final boolean useExternalTimelineServer;
   private String hostAddr;
 
-  public TimelineServerPerf(Config cfg) throws IOException {
+  public TimelineServerPerf(Config cfg) {
     this.cfg = cfg;
     useExternalTimelineServer = (cfg.serverHost != null);
     TimelineService.Config timelineServiceConf = cfg.getTimelineServerConfig();
@@ -82,7 +81,6 @@ public class TimelineServerPerf implements Serializable {
         new HoodieLocalEngineContext(HadoopFSUtils.getStorageConf()),
         HadoopFSUtils.getStorageConf(),
         timelineServiceConf,
-        HoodieStorageUtils.getStorage(HadoopFSUtils.getStorageConf()),
         TimelineService.buildFileSystemViewManager(timelineServiceConf, HadoopFSUtils.getStorageConf()));
   }
 


### PR DESCRIPTION
### Change Logs

Timeline server currently caches the hoodie storage which it further uses to process all the requests. When reuse timeline server is enabled, same timeline server can be used by different streams. If two streams are from two different lakes(or buckets) this would fail. 

`{
  "exception": {
    "stacktrace": "java.lang.IllegalArgumentException: Wrong FS s3a:/ABCD\/v1\/.hoodie\/.temp\/20250122111902624 -expected s3a:\/\/<lake2>l\n\tat org.apache.hadoop.fs.s3native.S3xLoginHelper.checkPath(S3xLoginHelper.java:224)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.checkPath(S3AFileSystem.java:1155)\n\tat org.apache.hadoop.fs.FileSystem.makeQualified(FileSystem.java:666)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.makeQualified(S3AFileSystem.java:1117)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.qualify(S3AFileSystem.java:1143)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.innerGetFileStatus(S3AFileSystem.java:3078)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:3053)\n\tat org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1760)\n\tat org.apache.hadoop.fs.s3a.S3AFileSystem.exists(S3AFileSystem.java:4263)\n\tat org.apache.hudi.common.util.MarkerUtils.readTimelineServerBasedMarkersFromFileSystem(MarkerUtils.java:188)\n\tat org.apache.hudi.timeline.service.handlers.marker.MarkerDirState.syncMarkersFromFileSystem(MarkerDirState.java:285)\n\tat org.apache.hudi.timeline.service.handlers.marker.MarkerDirState.<init>(MarkerDirState.java:108)\n\tat org.apache.hudi.timeline.service.handlers.MarkerHandler.getMarkerDirState(MarkerHandler.java:305)\n\tat org.apache.hudi.timeline.service.handlers.MarkerHandler.doesMarkerDirExist(MarkerHandler.java:180)\n\tat org.apache.hudi.timeline.service.RequestHandler.lambda$registerMarkerAPI$80(RequestHandler.java:551)\n\tat org.apache.hudi.timeline.service.RequestHandler$ViewHandler.handle(RequestHandler.java:615)\n\tat io.javalin.core.security.SecurityUtil.noopAccessManager(SecurityUtil.kt:20)\n\tat io.javalin.http.JavalinServlet.addHandler$lambda-0(JavalinServlet.kt:96)\n\tat io.javalin.http.JavalinServlet$lifecycle$2$1$1.invoke(JavalinServlet.kt:43)\n\tat io.javalin.http.JavalinServlet$lifecycle$2$1$1.invoke(JavalinServlet.kt:43)\n\tat io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:99)\n\tat io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85)\n\tat java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:995)\n\tat java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2137)\n\tat io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85)\n\tat io.javalin.http.JavalinServlet.service(JavalinServlet.kt:89)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:590)\n\tat io.javalin.jetty.JavalinJettyServlet.service(JavalinJettyServlet.kt:58)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:590)\n\tat org.apache.hudi.org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)\n\tat org.apache.hudi.org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:554)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)\n\tat org.apache.hudi.org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)\n\tat io.javalin.jetty.JettyServer$start$wsAndHttpHandler$1.doHandle(JettyServer.kt:52)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)\n\tat org.apache.hudi.org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505)\n\tat org.apache.hudi.org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)\n\tat org.apache.hudi.org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)\n\tat org.apache.hudi.org.eclipse.jetty.server.Server.handle(Server.java:516)\n\tat org.apache.hudi.org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)\n\tat org.apache.hudi.org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)\n\tat org.apache.hudi.org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)\n\tat org.apache.hudi.org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)\n\tat org.apache.hudi.org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)\n\tat org.apache.hudi.org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)\n\tat org.apache.hudi.org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)\n\tat org.apache.hudi.org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
`

### Impact

For createMarker and deleteMarkers apis, we'll be building HoodieStorage object per call. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
