### PR TITLE
Revert "[HUDI-8621] Revert single file slice optimisation for getRecordsByKeys in MDT table (#12643)"

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -263,18 +263,23 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
     // Lookup keys from each file slice
-    // Parallel lookup for large sized partitions with many file slices
-    // Partition the keys by the file slice which contains it
-    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-    result = new HashMap<>(keys.size());
-    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-    getEngineContext().map(partitionedKeys, keysList -> {
-      if (keysList.isEmpty()) {
-        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-      }
-      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-      return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-    }, partitionedKeys.size()).forEach(result::putAll);
+    if (numFileSlices == 1) {
+      // Optimization for a single slice for smaller metadata table partitions
+      result = lookupKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
+    } else {
+      // Parallel lookup for large sized partitions with many file slices
+      // Partition the keys by the file slice which contains it
+      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+      result = new HashMap<>(keys.size());
+      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+      getEngineContext().map(partitionedKeys, keysList -> {
+        if (keysList.isEmpty()) {
+          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+        }
+        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+        return lookupKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+      }, partitionedKeys.size()).forEach(result::putAll);
+    }
 
     return result;
   }
@@ -305,18 +310,23 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     checkState(numFileSlices > 0, "Number of file slices for partition " + partitionName + " should be > 0");
 
     // Lookup keys from each file slice
-    // Parallel lookup for large sized partitions with many file slices
-    // Partition the keys by the file slice which contains it
-    ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
-    result = new HashMap<>(keys.size());
-    getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
-    getEngineContext().map(partitionedKeys, keysList -> {
-      if (keysList.isEmpty()) {
-        return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
-      }
-      int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
-      return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
-    }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
+    if (numFileSlices == 1) {
+      // Optimization for a single slice for smaller metadata table partitions
+      result = lookupAllKeysFromFileSlice(partitionName, keys, partitionFileSlices.get(0));
+    } else {
+      // Parallel lookup for large sized partitions with many file slices
+      // Partition the keys by the file slice which contains it
+      ArrayList<ArrayList<String>> partitionedKeys = partitionKeysByFileSlices(keys, numFileSlices);
+      result = new HashMap<>(keys.size());
+      getEngineContext().setJobStatus(this.getClass().getSimpleName(), "Reading keys from metadata table partition " + partitionName);
+      getEngineContext().map(partitionedKeys, keysList -> {
+        if (keysList.isEmpty()) {
+          return Collections.<String, HoodieRecord<HoodieMetadataPayload>>emptyMap();
+        }
+        int shardIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(keysList.get(0), numFileSlices);
+        return lookupAllKeysFromFileSlice(partitionName, keysList, partitionFileSlices.get(shardIndex));
+      }, partitionedKeys.size()).forEach(map -> result.putAll((Map<String, List<HoodieRecord<HoodieMetadataPayload>>>) map));
+    }
 
     return result;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
@@ -286,6 +286,6 @@ public abstract class TestBootstrapReadBase extends HoodieSparkClientTestBase {
     return df.withColumn("partpath" + n,
         functions.md5(functions.concat_ws("," + n + ",",
             df.col("partition_path"),
-            functions.hash(df.col("partition_path")).mod(n))));
+            functions.hash(df.col("_row_key")).mod(n))));
   }
 }


### PR DESCRIPTION
### Change Logs

This reverts commit 79e1730aea01dab80181fb10bd22c2d3f00204e7. Since this commit landed we see that the CI runtime has increased a lot. Reverting commit for HUDI-8621

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
