### PR TITLE
[HUDI-8910] Fix Unstable UT TestHoodieCompactionStrategy

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -95,7 +95,7 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> returned = resPair.getLeft();
     List<String> missingPartitions = resPair.getRight();
     if (enableIncrTableService) {
-      assertEquals(1, missingPartitions.stream().distinct().count());
+      assertTrue(missingPartitions.stream().distinct().count() > 0);
     }
     assertTrue(returned.size() < operations.size(), "BoundedIOCompaction should have resulted in fewer compactions");
     assertEquals(2, returned.size(), "BoundedIOCompaction should have resulted in 2 compactions being chosen");


### PR DESCRIPTION
### Change Logs

TestHoodieCompactionStrategy.testBoundedIOSimple is Unstable because of random compactions based on ` .map(e -> Pair.of(e, partitionPaths[RANDOM.nextInt(partitionPaths.length - 1)]))`


### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
