### PR TITLE
[MINOR] Fix bloom index shuffle setup

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/BucketizedBloomCheckPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/BucketizedBloomCheckPartitioner.java
@@ -20,7 +20,6 @@ package org.apache.hudi.index.bloom;
 
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.util.NumericUtils;
-import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.spark.Partitioner;
 import org.slf4j.Logger;
@@ -31,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import scala.Tuple2;
 
 /**
  * Partitions bloom filter checks by spreading out comparisons across buckets of work.
@@ -143,11 +144,11 @@ public class BucketizedBloomCheckPartitioner extends Partitioner {
 
   @Override
   public int getPartition(Object key) {
-    final Pair<HoodieFileGroupId, String> parts = (Pair<HoodieFileGroupId, String>) key;
+    final Tuple2<HoodieFileGroupId, String> parts = (Tuple2<HoodieFileGroupId, String>) key;
     // TODO replace w/ more performant hash
-    final long hashOfKey = NumericUtils.getMessageDigestHash("MD5", parts.getRight());
-    final List<Integer> candidatePartitions = fileGroupToPartitions.get(parts.getLeft());
-    final int idx = (int) Math.floorMod((int) hashOfKey, candidatePartitions.size());
+    final long hashOfKey = NumericUtils.getMessageDigestHash("MD5", parts._2());
+    final List<Integer> candidatePartitions = fileGroupToPartitions.get(parts._1());
+    final int idx = Math.floorMod((int) hashOfKey, candidatePartitions.size());
     assert idx >= 0;
     return candidatePartitions.get(idx);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import scala.Tuple2;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,7 +98,7 @@ public class TestBucketizedBloomCheckPartitioner {
     BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(1000, comparisons1, 10);
 
     IntStream.range(0, 100000).forEach(f -> {
-      int partition = p.getPartition(Pair.of(new HoodieFileGroupId("p1", "f" + f), "value"));
+      int partition = p.getPartition(Tuple2.apply(new HoodieFileGroupId("p1", "f" + f), "value"));
       assertTrue(0 <= partition && partition <= 1000, "partition is out of range: " + partition);
     });
   }


### PR DESCRIPTION
### Change Logs

- The current code creates two copies of the data when only one is required. This will help reduce overhead. 

### Impact

- Reduces shuffle cost when using bloom index and fanning out the comparisons to different spark partitions

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
