### PR TITLE
[HUDI-8726] Test hollow commit handling for table version 8

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -29,7 +29,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.HoodieClientTestUtils;
@@ -126,7 +126,7 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
     // verify marker files for inflight commit exists
     for (String partitionPath : DEFAULT_PARTITION_PATHS) {
       assertEquals(1,
-          FileCreateUtils.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
+          FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
     }
 
     if (fromVersion != HoodieTableVersion.FIVE) {
@@ -140,7 +140,7 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
     if (toVersion == HoodieTableVersion.ZERO) {
       // verify marker files are non existent
       for (String partitionPath : DEFAULT_PARTITION_PATHS) {
-        assertEquals(0, FileCreateUtils.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
+        assertEquals(0, FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
       }
     }
   }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestMarkersCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestMarkersCommand.java
@@ -24,7 +24,7 @@ import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableVersion;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -71,16 +71,16 @@ public class ITTestMarkersCommand extends HoodieCLIIntegrationTestBase {
     // generate markers
     String instantTime1 = "101";
 
-    FileCreateUtils.createMarkerFile(tablePath, "partA", instantTime1, "f0", IOType.APPEND);
-    FileCreateUtils.createMarkerFile(tablePath, "partA", instantTime1, "f1", IOType.APPEND);
+    FileCreateUtilsLegacy.createMarkerFile(tablePath, "partA", instantTime1, "f0", IOType.APPEND);
+    FileCreateUtilsLegacy.createMarkerFile(tablePath, "partA", instantTime1, "f1", IOType.APPEND);
 
-    assertEquals(2, FileCreateUtils.getTotalMarkerFileCount(tablePath, "partA", instantTime1, IOType.APPEND));
+    assertEquals(2, FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "partA", instantTime1, IOType.APPEND));
 
     Object result = shell.evaluate(() ->
             String.format("marker delete --commit %s --sparkMaster %s", instantTime1, "local"));
 
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
 
-    assertEquals(0, FileCreateUtils.getTotalMarkerFileCount(tablePath, "partA", instantTime1, IOType.APPEND));
+    assertEquals(0, FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "partA", instantTime1, IOType.APPEND));
   }
 }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitMetadataGenerator.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitMetadataGenerator.java
@@ -22,7 +22,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.util.Option;
@@ -43,7 +43,7 @@ import java.util.UUID;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
 import static org.apache.hudi.common.util.CollectionUtils.createImmutableList;
 
 /**
@@ -143,8 +143,8 @@ public class HoodieTestCommitMetadataGenerator extends HoodieTestDataGenerator {
                                                             String fileId2, Option<Integer> writes,
                                                             Option<Integer> updates, Map<String, String> extraMetadata,
                                                             boolean setDefaultFileId) throws Exception {
-    FileCreateUtils.createBaseFile(basePath, DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId1);
-    FileCreateUtils.createBaseFile(basePath, DEFAULT_SECOND_PARTITION_PATH, commitTime, fileId2);
+    FileCreateUtilsLegacy.createBaseFile(basePath, DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId1);
+    FileCreateUtilsLegacy.createBaseFile(basePath, DEFAULT_SECOND_PARTITION_PATH, commitTime, fileId2);
     return generateCommitMetadata(new HashMap<String, List<String>>() {
       {
         put(DEFAULT_FIRST_PARTITION_PATH, createImmutableList(baseFileName(DEFAULT_FIRST_PARTITION_PATH, fileId1)));

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestReplaceCommitMetadataGenerator.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestReplaceCommitMetadataGenerator.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
 import static org.apache.hudi.common.util.CollectionUtils.createImmutableList;
 
 public class HoodieTestReplaceCommitMetadataGenerator extends HoodieTestCommitMetadataGenerator {
@@ -56,8 +56,8 @@ public class HoodieTestReplaceCommitMetadataGenerator extends HoodieTestCommitMe
 
   private static HoodieReplaceCommitMetadata generateReplaceCommitMetadata(String basePath, String commitTime, String fileId1, String fileId2, Option<Integer> writes, Option<Integer> updates)
       throws Exception {
-    FileCreateUtils.createBaseFile(basePath, DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId1);
-    FileCreateUtils.createBaseFile(basePath, DEFAULT_SECOND_PARTITION_PATH, commitTime, fileId2);
+    FileCreateUtilsLegacy.createBaseFile(basePath, DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId1);
+    FileCreateUtilsLegacy.createBaseFile(basePath, DEFAULT_SECOND_PARTITION_PATH, commitTime, fileId2);
     return generateReplaceCommitMetadata(new HashMap<String, List<String>>() {
       {
         put(DEFAULT_FIRST_PARTITION_PATH, createImmutableList(baseFileName(DEFAULT_FIRST_PARTITION_PATH, fileId1)));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -30,7 +30,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
@@ -252,7 +252,7 @@ public class TestConflictResolutionStrategyUtil {
     writeStat.setFileId("file-2");
     replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
     replaceMetadata.setOperationType(writeOperationType);
-    FileCreateUtils.createReplaceCommit(COMMIT_METADATA_SER_DE, metaClient.getBasePath().toString(), instantTime, replaceMetadata);
+    FileCreateUtilsLegacy.createReplaceCommit(COMMIT_METADATA_SER_DE, metaClient.getBasePath().toString(), instantTime, replaceMetadata);
   }
 
   public static void createPendingCompaction(String instantTime, HoodieTableMetaClient metaClient) throws Exception {
@@ -267,7 +267,7 @@ public class TestConflictResolutionStrategyUtil {
     compactionPlan.setOperations(Arrays.asList(operation));
     HoodieTestTable.of(metaClient)
         .addRequestedCompaction(instantTime, compactionPlan);
-    FileCreateUtils.createInflightCompaction(metaClient.getBasePath().toString(), instantTime);
+    FileCreateUtilsLegacy.createInflightCompaction(metaClient.getBasePath().toString(), instantTime);
   }
 
   public static void createCompleteCompaction(String instantTime, HoodieTableMetaClient metaClient) throws Exception {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
@@ -39,8 +39,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hudi.common.testutils.FileCreateUtils.createCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createDeltaCommit;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 
 /**

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestBaseTableServicePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestBaseTableServicePlanActionExecutor.java
@@ -35,7 +35,7 @@ import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
@@ -144,7 +144,7 @@ public class TestBaseTableServicePlanActionExecutor {
     prepareTimeline(metaClient, instants, Collections.emptyList());
     instants.keySet().forEach(instant -> {
       try {
-        FileCreateUtils.createPartitionMetaFile(tablePath, instant);
+        FileCreateUtilsLegacy.createPartitionMetaFile(tablePath, instant);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -193,7 +193,7 @@ public class TestBaseTableServicePlanActionExecutor {
     testTable.addCluster(clusteringRequestTime, replaceMetadata.getKey(), Option.empty(), replaceMetadata.getValue(), clusteringCompletionTIme);
 
     HoodieInstant clusteringInstant = metaClient.getActiveTimeline().filterCompletedInstants().getLastClusteringInstant().get();
-    FileCreateUtils.createPartitionMetaFile(tablePath, clusteringInstant.requestedTime());
+    FileCreateUtilsLegacy.createPartitionMetaFile(tablePath, clusteringInstant.requestedTime());
 
     // create empty commit 0003_004
     String emptyCommitRequestTime = "0003";
@@ -235,7 +235,7 @@ public class TestBaseTableServicePlanActionExecutor {
     requestInstants.forEach(instant -> {
       try {
         testTable.addRequestedCommit(instant);
-        FileCreateUtils.createPartitionMetaFile(metaClient.getBasePath().toString(), instant);
+        FileCreateUtilsLegacy.createPartitionMetaFile(metaClient.getBasePath().toString(), instant);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
@@ -35,7 +35,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -67,7 +67,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
 
 public class HoodieWriteableTestTable extends HoodieMetadataTestTable {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieWriteableTestTable.class);
@@ -110,7 +110,7 @@ public class HoodieWriteableTestTable extends HoodieMetadataTestTable {
 
   public StoragePath withInserts(String partition, String fileId, List<HoodieRecord> records,
                                  TaskContextSupplier contextSupplier) throws Exception {
-    FileCreateUtils.createPartitionMetaFile(basePath, partition);
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, partition);
     String fileName = baseFileName(currentInstantTime, fileId);
 
     StoragePath baseFilePath = new StoragePath(Paths.get(basePath, partition, fileName).toString());

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -64,7 +64,7 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -653,7 +653,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
                 HoodieTimeline.COMMIT_ACTION)
             .toUri());
     java.nio.file.Path tempFilePath =
-        FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
+        FileCreateUtilsLegacy.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
 
     metaClient.reloadActiveTimeline();
     testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
@@ -666,7 +666,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       doWriteOperation(testTable, metaClient.createNewInstantTime(), INSERT);
     } else {
       // let the compaction succeed in metadata and validation should succeed.
-      FileCreateUtils.renameTempToMetaFile(tempFilePath, metaFilePath);
+      FileCreateUtilsLegacy.renameTempToMetaFile(tempFilePath, metaFilePath);
     }
 
     validateMetadata(testTable);
@@ -688,7 +688,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
           new StoragePath(new StoragePath(metadataTableBasePath, METAFOLDER_NAME), HoodieTableMetaClient.TIMELINEFOLDER_NAME),
           metadataCompactionInstant.get(),
           HoodieTimeline.COMMIT_ACTION).toUri());
-      FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
+      FileCreateUtilsLegacy.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
 
       validateMetadata(testTable);
 
@@ -1856,7 +1856,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtilsLegacy.deleteReplaceCommit(basePath, clusteringCommitTime);
     HoodieWriteMetadata<List<WriteStatus>> updatedClusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     metaClient.reloadActiveTimeline();
@@ -1916,7 +1916,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieWriteMetadata<List<WriteStatus>> clusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtilsLegacy.deleteReplaceCommit(basePath, clusteringCommitTime);
 
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieWriteConfig updatedWriteConfig = HoodieWriteConfig.newBuilder().withProperties(initialConfig.getProps())
@@ -1950,8 +1950,8 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       assertNoWriteErrors(writeStatuses);
 
       // make all commits to inflight in metadata table. Still read should go through, just that it may not return any data.
-      FileCreateUtils.deleteDeltaCommit(basePath + "/.hoodie/metadata/", commitTimestamps[0]);
-      FileCreateUtils.deleteDeltaCommit(basePath + " /.hoodie/metadata/", HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP);
+      FileCreateUtilsLegacy.deleteDeltaCommit(basePath + "/.hoodie/metadata/", commitTimestamps[0]);
+      FileCreateUtilsLegacy.deleteDeltaCommit(basePath + " /.hoodie/metadata/", HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP);
       assertEquals(getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet()).size(), 0);
     }
   }
@@ -1988,18 +1988,18 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // mark each commit as incomplete and ensure files are not seen
       for (int i = 0; i < commitTimestamps.length; ++i) {
-        FileCreateUtils.deleteCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[i]);
         timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
         assertEquals(timelineTimestamps.size(), commitTimestamps.length - 1);
         for (int j = 0; j < commitTimestamps.length; ++j) {
           assertTrue(j == i || timelineTimestamps.contains(commitTimestamps[j]));
         }
-        FileCreateUtils.createCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.createCommit(basePath, commitTimestamps[i]);
       }
 
       // Test multiple incomplete commits
-      FileCreateUtils.deleteCommit(basePath, commitTimestamps[0]);
-      FileCreateUtils.deleteCommit(basePath, commitTimestamps[2]);
+      FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[0]);
+      FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[2]);
       timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
       assertEquals(timelineTimestamps.size(), commitTimestamps.length - 2);
       for (int j = 0; j < commitTimestamps.length; ++j) {
@@ -2008,7 +2008,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // Test no completed commits
       for (int i = 0; i < commitTimestamps.length; ++i) {
-        FileCreateUtils.deleteCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[i]);
       }
       timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
       assertEquals(timelineTimestamps.size(), 0);
@@ -2080,8 +2080,8 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         client.insert(records, newCommitTime);
         if (i == 0) {
           // Mark this commit inflight so compactions don't take place
-          FileCreateUtils.deleteCommit(basePath, newCommitTime);
-          FileCreateUtils.createInflightCommit(basePath, newCommitTime);
+          FileCreateUtilsLegacy.deleteCommit(basePath, newCommitTime);
+          FileCreateUtilsLegacy.createInflightCommit(basePath, newCommitTime);
           inflightCommitTime = newCommitTime;
         }
       }
@@ -2093,7 +2093,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
           ((2 * maxDeltaCommitsBeforeCompaction) + (maxDeltaCommitsBeforeCompaction /* clean from dataset */) + 1)/* clean in metadata table */);
 
       // Complete commit
-      FileCreateUtils.createCommit(basePath, inflightCommitTime);
+      FileCreateUtilsLegacy.createCommit(basePath, inflightCommitTime);
 
       // Next commit should lead to compaction
       newCommitTime = client.createNewInstantTime();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
@@ -34,7 +34,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -554,7 +554,7 @@ public class TestClientRollback extends HoodieClientTestBase {
       HoodieInstant rollbackInstant = rollbackInstants.get(0);
 
       // delete rollback completed meta file and retry rollback.
-      FileCreateUtils.deleteRollbackCommit(basePath, rollbackInstant.requestedTime());
+      FileCreateUtilsLegacy.deleteRollbackCommit(basePath, rollbackInstant.requestedTime());
 
       if (instantToRollbackExists) {
         // recreate actual commit files if needed
@@ -751,19 +751,19 @@ public class TestClientRollback extends HoodieClientTestBase {
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
       if (isRollbackPlanCorrupted) {
         // Add a corrupted requested rollback plan
-        FileCreateUtils.createRequestedRollbackFile(metaClient.getBasePath().toString(), rollbackInstantTime, new byte[] {0, 1, 2});
+        FileCreateUtilsLegacy.createRequestedRollbackFile(metaClient.getBasePath().toString(), rollbackInstantTime, new byte[] {0, 1, 2});
       } else {
         // Add a valid requested rollback plan to roll back commitTime3
         HoodieRollbackPlan rollbackPlan = new HoodieRollbackPlan();
         List<HoodieRollbackRequest> rollbackRequestList = partitionAndFileId3.keySet().stream()
             .map(partition -> new HoodieRollbackRequest(partition, EMPTY_STRING, EMPTY_STRING,
                 Collections.singletonList(metaClient.getBasePath() + "/" + partition + "/"
-                    + FileCreateUtils.baseFileName(commitTime3, partitionAndFileId3.get(p1))),
+                    + FileCreateUtilsLegacy.baseFileName(commitTime3, partitionAndFileId3.get(p1))),
                 Collections.emptyMap()))
             .collect(Collectors.toList());
         rollbackPlan.setRollbackRequests(rollbackRequestList);
         rollbackPlan.setInstantToRollback(new HoodieInstantInfo(commitTime3, HoodieTimeline.COMMIT_ACTION));
-        FileCreateUtils.createRequestedRollbackFile(metaClient.getBasePath().toString(), rollbackInstantTime, rollbackPlan);
+        FileCreateUtilsLegacy.createRequestedRollbackFile(metaClient.getBasePath().toString(), rollbackInstantTime, rollbackPlan);
       }
 
       // Rollback commit3

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -58,7 +58,7 @@ import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.FileFormatUtils;
@@ -1088,7 +1088,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     // delete rollback.completed instant to mimic failed rollback of clustering. and then trigger rollback of clustering again. same rollback instant should be used.
     HoodieInstant rollbackInstant = metaClient.getActiveTimeline().getRollbackTimeline().lastInstant().get();
-    FileCreateUtils.deleteRollbackCommit(metaClient.getBasePath().toString(), rollbackInstant.requestedTime());
+    FileCreateUtilsLegacy.deleteRollbackCommit(metaClient.getBasePath().toString(), rollbackInstant.requestedTime());
     metaClient.reloadActiveTimeline();
 
     // create replace commit requested meta file so that rollback will not throw FileNotFoundException
@@ -1098,7 +1098,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
 
-    FileCreateUtils.createRequestedClusterCommit(metaClient.getBasePath().toString(), pendingClusteringInstant.requestedTime(), requestedReplaceMetadata);
+    FileCreateUtilsLegacy.createRequestedClusterCommit(metaClient.getBasePath().toString(), pendingClusteringInstant.requestedTime(), requestedReplaceMetadata);
 
     // trigger clustering again. no new rollback instants should be generated.
     try {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -22,7 +22,7 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.config.HoodieArchivalConfig;
@@ -93,8 +93,8 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     doPreBootstrapWriteOperation(testTable, "0000005");
     // add few extra files to table. bootstrap should include those files.
     String fileName = UUID.randomUUID().toString();
-    Path baseFilePath = FileCreateUtils.getBaseFilePath(basePath, "p1", "0000006", fileName);
-    FileCreateUtils.createBaseFile(basePath, "p1", "0000006", fileName, 100);
+    Path baseFilePath = FileCreateUtilsLegacy.getBaseFilePath(basePath, "p1", "0000006", fileName);
+    FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000006", fileName, 100);
 
     writeConfig = getWriteConfig(true, true);
     initWriteConfigAndMetatableWriter(writeConfig, true);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -44,7 +44,7 @@ import org.apache.hudi.common.table.timeline.LSMTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -413,7 +413,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       partToFileId.forEach((key, value) -> {
         try {
           List<String> files = new ArrayList<>();
-          FileCreateUtils.createPartitionMetaFile(basePath, key);
+          FileCreateUtilsLegacy.createPartitionMetaFile(basePath, key);
           if (addBaseFiles) {
             files.addAll(testTable.withBaseFilesInPartition(key, value.toArray(new String[0])).getValue());
           }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestConsistencyGuard.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestConsistencyGuard.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.fs.FailSafeConsistencyGuard;
 import org.apache.hudi.common.fs.OptimisticConsistencyGuard;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
@@ -69,9 +69,9 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
   @ParameterizedTest
   @MethodSource("consistencyGuardType")
   public void testCheckPassingAppearAndDisAppear(String consistencyGuardType) throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f2");
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f3");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f2");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f3");
 
     ConsistencyGuardConfig config = getConsistencyGuardConfig(1, 1000, 1000);
     ConsistencyGuard passing = consistencyGuardType.equals(FailSafeConsistencyGuard.class.getName())
@@ -100,7 +100,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingAppearFailSafe() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(storage, getConsistencyGuardConfig());
     assertThrows(TimeoutException.class, () -> {
       passing.waitTillAllFilesAppear(basePath + "/partition/path", Arrays
@@ -111,7 +111,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingAppearTimedWait() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new OptimisticConsistencyGuard(storage, getConsistencyGuardConfig());
     passing.waitTillAllFilesAppear(basePath + "/partition/path", Arrays
           .asList(basePath + "/partition/path/f1_1-0-2_000" + BASE_FILE_EXTENSION,
@@ -120,7 +120,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingAppearsFailSafe() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(storage, getConsistencyGuardConfig());
     assertThrows(TimeoutException.class, () -> {
       passing.waitTillFileAppears(
@@ -130,7 +130,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingAppearsTimedWait() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new OptimisticConsistencyGuard(storage, getConsistencyGuardConfig());
     passing.waitTillFileAppears(
         new StoragePath(basePath + "/partition/path/f1_1-0-2_000" + BASE_FILE_EXTENSION));
@@ -138,7 +138,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingDisappearFailSafe() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(storage, getConsistencyGuardConfig());
     assertThrows(TimeoutException.class, () -> {
       passing.waitTillAllFilesDisappear(basePath + "/partition/path", Arrays
@@ -149,7 +149,7 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingDisappearTimedWait() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new OptimisticConsistencyGuard(storage, getConsistencyGuardConfig());
     passing.waitTillAllFilesDisappear(basePath + "/partition/path", Arrays
           .asList(basePath + "/partition/path/f1_1-0-1_000" + BASE_FILE_EXTENSION,
@@ -158,8 +158,8 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingDisappearsFailSafe() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(storage, getConsistencyGuardConfig());
     assertThrows(TimeoutException.class, () -> {
       passing.waitTillFileDisappears(
@@ -169,8 +169,8 @@ public class TestConsistencyGuard extends HoodieSparkClientTestHarness {
 
   @Test
   public void testCheckFailingDisappearsTimedWait() throws Exception {
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
-    FileCreateUtils.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
+    FileCreateUtilsLegacy.createBaseFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new OptimisticConsistencyGuard(storage, getConsistencyGuardConfig());
     passing.waitTillFileDisappears(
         new StoragePath(basePath + "/partition/path/f1_1-0-1_000" + BASE_FILE_EXTENSION));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/ClusteringTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/ClusteringTestUtils.java
@@ -51,8 +51,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createBaseFile;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION_PATHS;
 import static org.apache.hudi.utils.HoodieWriterClientTestHarness.getPropertiesForKeyGen;
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -31,7 +31,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.CompactionTestUtils;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -88,8 +88,8 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
         .withStorageConfig(HoodieStorageConfig.newBuilder().hfileMaxFileSize(1000 * 1024).parquetMaxFileSize(1000 * 1024).orcMaxFileSize(1000 * 1024).build())
         .build();
 
-    FileCreateUtils.createCommit(basePath, "001");
-    FileCreateUtils.createBaseFile(basePath, testPartitionPath, "001", "file1", fileSize);
+    FileCreateUtilsLegacy.createCommit(basePath, "001");
+    FileCreateUtilsLegacy.createBaseFile(basePath, testPartitionPath, "001", "file1", fileSize);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
 
@@ -223,7 +223,7 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(0)
             .insertSplitSize(totalInsertNum / 2).autoTuneInsertSplits(false).build()).build();
 
-    FileCreateUtils.createCommit(basePath, "001");
+    FileCreateUtilsLegacy.createCommit(basePath, "001");
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {testPartitionPath});
@@ -335,10 +335,10 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
 
     // This will generate initial commits and create a compaction plan which includes file groups created as part of this
     HoodieCompactionPlan plan = CompactionTestUtils.createCompactionPlan(metaClient, "001", "002", 1, true, false);
-    FileCreateUtils.createRequestedCompactionCommit(basePath, "002", plan);
+    FileCreateUtilsLegacy.createRequestedCompactionCommit(basePath, "002", plan);
     // Simulate one more commit so that inflight compaction is considered when building file groups in file system view
-    FileCreateUtils.createBaseFile(basePath, testPartitionPath, "003", "2", 1);
-    FileCreateUtils.createCommit(basePath, "003");
+    FileCreateUtilsLegacy.createBaseFile(basePath, testPartitionPath, "003", "2", 1);
+    FileCreateUtilsLegacy.createCommit(basePath, "003");
 
     // Partitioner will attempt to assign inserts to file groups including base file created by inflight compaction
     metaClient = HoodieTableMetaClient.reload(metaClient);
@@ -372,11 +372,11 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     // create requested replace commit
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
             .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    FileCreateUtils.createRequestedClusterCommit(basePath,"002", requestedReplaceMetadata);
+    FileCreateUtilsLegacy.createRequestedClusterCommit(basePath,"002", requestedReplaceMetadata);
 
     // create file slice 003
-    FileCreateUtils.createBaseFile(basePath, testPartitionPath, "003", "3", 1);
-    FileCreateUtils.createCommit(basePath, "003");
+    FileCreateUtilsLegacy.createBaseFile(basePath, testPartitionPath, "003", "3", 1);
+    FileCreateUtilsLegacy.createCommit(basePath, "003");
 
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
@@ -409,13 +409,13 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
             .build();
 
     // Create file group with only one log file
-    FileCreateUtils.createLogFile(basePath, testPartitionPath, "001", "fg1", 1);
-    FileCreateUtils.createDeltaCommit(basePath, "001");
+    FileCreateUtilsLegacy.createLogFile(basePath, testPartitionPath, "001", "fg1", 1);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "001");
     // Create another file group size set to max parquet file size so should not be considered during small file sizing
-    FileCreateUtils.createBaseFile(basePath, testPartitionPath, "002", "fg2", 1024);
-    FileCreateUtils.createCommit(basePath, "002");
-    FileCreateUtils.createLogFile(basePath, testPartitionPath, "003", "fg2", 1);
-    FileCreateUtils.createDeltaCommit(basePath, "003");
+    FileCreateUtilsLegacy.createBaseFile(basePath, testPartitionPath, "002", "fg2", 1024);
+    FileCreateUtilsLegacy.createCommit(basePath, "002");
+    FileCreateUtilsLegacy.createLogFile(basePath, testPartitionPath, "003", "fg2", 1);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "003");
 
     // Partitioner will attempt to assign inserts to file groups including base file created by inflight compaction
     metaClient = HoodieTableMetaClient.reload(metaClient);
@@ -449,11 +449,11 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
             .build();
 
     // Bootstrap base files ("small-file targets")
-    FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-1", 1024);
-    FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-2", 1024);
-    FileCreateUtils.createBaseFile(basePath, partitionPath, "002", "fg-3", 1024);
+    FileCreateUtilsLegacy.createBaseFile(basePath, partitionPath, "002", "fg-1", 1024);
+    FileCreateUtilsLegacy.createBaseFile(basePath, partitionPath, "002", "fg-2", 1024);
+    FileCreateUtilsLegacy.createBaseFile(basePath, partitionPath, "002", "fg-3", 1024);
 
-    FileCreateUtils.createCommit(basePath, "002");
+    FileCreateUtilsLegacy.createCommit(basePath, "002");
 
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {partitionPath});
     // Default estimated record size will be 1024 based on last file group created.

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
@@ -30,7 +30,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -190,7 +190,7 @@ public class HoodieCleanerTestBase extends HoodieClientTestBase {
     partToFileId.forEach((key, value) -> {
       try {
         List<String> files = new ArrayList<>();
-        FileCreateUtils.createPartitionMetaFile(basePath, key);
+        FileCreateUtilsLegacy.createPartitionMetaFile(basePath, key);
         if (addBaseFiles) {
           files.addAll(testTable.withBaseFilesInPartition(key, value.toArray(new String[0])).getValue());
         }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
@@ -48,10 +48,10 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createLogFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.logFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createBaseFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createLogFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.logFileName;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION_PATHS;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.createMetaClient;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -19,14 +19,9 @@
 
 package org.apache.hudi.common.testutils;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
-import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
-import org.apache.hudi.avro.model.HoodieRestoreMetadata;
-import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
-import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -34,61 +29,38 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.IOType;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
-import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StoragePathInfo;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanerPlan;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCompactionPlan;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRestoreMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackPlan;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Utils for creating dummy Hudi files in testing.
+ * ****************************************************
+ *      Use FileCreateUtilsV2 whenever possible!
+ * ****************************************************
  */
-public class FileCreateUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(FileCreateUtils.class);
-
-  private static final String WRITE_TOKEN = "1-0-1";
-  private static final String BASE_FILE_EXTENSION = HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().getFileExtension();
-  /** An empty byte array */
-  public static final byte[] EMPTY_BYTES = new byte[0];
+public class FileCreateUtils extends FileCreateUtilsBase {
 
   public static StoragePath getTimelinePath(StoragePath basePath) throws IOException {
     return new StoragePath(
@@ -96,63 +68,13 @@ public class FileCreateUtils {
         HoodieTableMetaClient.TIMELINEFOLDER_NAME);
   }
 
-  public static String baseFileName(String instantTime, String fileId) {
-    return baseFileName(instantTime, fileId, BASE_FILE_EXTENSION);
-  }
-
-  public static String baseFileName(String instantTime, String fileId, String fileExtension) {
-    return FSUtils.makeBaseFileName(instantTime, WRITE_TOKEN, fileId, fileExtension);
-  }
-
-  public static String logFileName(String instantTime, String fileId, int version) {
-    return logFileName(instantTime, fileId, version,
-        HoodieFileFormat.HOODIE_LOG.getFileExtension());
-  }
-
-  public static String logFileName(String instantTime, String fileId, int version,
-                                   String fileExtension) {
-    return FSUtils.makeLogFileName(fileId, fileExtension, instantTime, version, WRITE_TOKEN);
-  }
-
-  public static String markerFileName(String fileName, IOType ioType) {
-    return String.format("%s%s.%s", fileName, HoodieTableMetaClient.MARKER_EXTN, ioType.name());
-  }
-
-  public static String markerFileName(String instantTime, String fileId, IOType ioType,
-                                      String fileExtension) {
-    return markerFileName(instantTime, fileId, ioType, fileExtension, WRITE_TOKEN);
-  }
-
-  public static String markerFileName(String instantTime, String fileId, IOType ioType,
-                                      String fileExtension, String writeToken) {
-    return String.format("%s_%s_%s%s%s.%s", fileId, writeToken, instantTime, fileExtension,
-        HoodieTableMetaClient.MARKER_EXTN, ioType);
+  private static StoragePath getMetaPath(String basePath) {
+    return new StoragePath(basePath, HoodieTableMetaClient.METAFOLDER_NAME);
   }
 
   private static void createMetaFile(String basePath, String instantTime, String suffix,
                                      HoodieStorage storage) throws IOException {
-    createMetaFile(basePath, instantTime, suffix, storage, false);
-  }
-
-  private static void createMetaFile(String basePath, String instantTime, String suffix,
-                                     HoodieStorage storage, boolean preTableVersion8) throws IOException {
-    StoragePath parentPath = new StoragePath(basePath, HoodieTableMetaClient.METAFOLDER_NAME);
-    if (!storage.exists(parentPath)) {
-      storage.create(parentPath).close();
-    }
-
-    if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION)
-        || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
-      StoragePath metaFilePath = new StoragePath(parentPath, instantTime + suffix);
-      if (!storage.exists(metaFilePath)) {
-        storage.create(metaFilePath).close();
-      }
-    } else {
-      String instantTimeWithCompletionTime =
-          preTableVersion8 ? instantTime : instantTime + "_" + InProcessTimeGenerator.createNewInstantTime();
-      storage.create(new StoragePath(parentPath, instantTimeWithCompletionTime + suffix))
-          .close();
-    }
+    createMetaFileInMetaPath(getMetaPath(basePath), instantTime, suffix, storage, false);
   }
 
   private static void createMetaFile(String basePath, String instantTime, String suffix) throws IOException {
@@ -160,61 +82,7 @@ public class FileCreateUtils {
   }
 
   private static void createMetaFile(String basePath, String instantTime, String suffix, byte[] content) throws IOException {
-    createMetaFile(basePath, instantTime, InProcessTimeGenerator::createNewInstantTime, suffix, content);
-  }
-
-  private static void createMetaFile(String basePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
-    try {
-      Path parentPath = Paths.get(getTimelinePath(new StoragePath(basePath)).makeQualified(new URI("file:///")).toUri());
-
-      Files.createDirectories(parentPath);
-      if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
-        Path metaFilePath = parentPath.resolve(instantTime + suffix);
-        if (Files.notExists(metaFilePath)) {
-          if (content.length == 0) {
-            Files.createFile(metaFilePath);
-          } else {
-            Files.write(metaFilePath, content);
-          }
-        }
-      } else {
-        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(parentPath, instantTime + "*" + suffix)) {
-          // The instant file is not exist
-          if (!dirStream.iterator().hasNext()) {
-            // doesn't contains completion time
-            String instantTimeAndCompletionTime = instantTime + "_" + completionTimeSupplier.get();
-            Path metaFilePath = parentPath.resolve(instantTimeAndCompletionTime + suffix);
-            if (content.length == 0) {
-              Files.createFile(metaFilePath);
-            } else {
-              Files.write(metaFilePath, content);
-            }
-          }
-        }
-      }
-    } catch (URISyntaxException ex) {
-      throw new HoodieException(ex);
-    }
-  }
-
-  private static void deleteMetaFile(String basePath, String instantTime, String suffix,
-                                     HoodieStorage storage) throws IOException {
-    StoragePath parentPath = getTimelinePath(new StoragePath(basePath));
-
-    if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION)
-        || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
-      StoragePath metaFilePath = new StoragePath(parentPath, instantTime + suffix);
-      if (storage.exists(metaFilePath)) {
-        storage.deleteFile(metaFilePath);
-      }
-    } else {
-      StoragePath metaFilePath =
-          new StoragePath(parentPath, instantTime + "*" + suffix);
-      List<StoragePathInfo> pathInfoList = storage.globEntries(metaFilePath);
-      if (pathInfoList.size() != 0) {
-        storage.deleteFile(pathInfoList.get(0).getPath());
-      }
-    }
+    createMetaFileInTimelinePath(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, InProcessTimeGenerator::createNewInstantTime, suffix, content);
   }
 
   public static void createCommit(String basePath, String instantTime) throws IOException {
@@ -229,30 +97,20 @@ public class FileCreateUtils {
   public static void createCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath, String instantTime,
                                   Option<String> completionTime, Option<HoodieCommitMetadata> metadata) throws IOException {
     final Supplier<String> completionTimeSupplier = () -> completionTime.isPresent() ? completionTime.get() : InProcessTimeGenerator.createNewInstantTime();
+    String timelinePath = getTimelinePath(new StoragePath(basePath)).toUri().getPath();
     if (metadata.isPresent()) {
       HoodieCommitMetadata commitMetadata = metadata.get();
-      createMetaFile(basePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
+      createMetaFileInTimelinePath(timelinePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
           serializeCommitMetadata(commitMetadataSerDe, commitMetadata).get());
     } else {
-      createMetaFile(basePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
+      createMetaFileInTimelinePath(timelinePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
           getUTF8Bytes(""));
     }
-  }
-
-  public static void createSavepointCommit(String basePath, String instantTime,
-                                           HoodieSavepointMetadata savepointMetadata)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION,
-        TimelineMetadataUtils.serializeSavepointMetadata(savepointMetadata).get());
   }
 
   public static void createCommit(String basePath, String instantTime, HoodieStorage storage)
       throws IOException {
     createMetaFile(basePath, instantTime, HoodieTimeline.COMMIT_EXTENSION, storage);
-  }
-
-  public static void createRequestedCommit(String basePath, String instantTime) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
   }
 
   public static void createInflightCommit(String basePath, String instantTime) throws IOException {
@@ -276,17 +134,7 @@ public class FileCreateUtils {
 
   public static void createDeltaCommit(String basePath, String instantTime,
                                        HoodieStorage storage, boolean preTableVersion8) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage, preTableVersion8);
-  }
-
-  public static void createRequestedDeltaCommit(String basePath, String instantTime)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_DELTA_COMMIT_EXTENSION);
-  }
-
-  public static void createInflightDeltaCommit(String basePath, String instantTime)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
+    createMetaFileInMetaPath(getMetaPath(basePath), instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage, preTableVersion8);
   }
 
   public static void createInflightDeltaCommit(String basePath, String instantTime, HoodieStorage storage)
@@ -294,20 +142,10 @@ public class FileCreateUtils {
     createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION, storage);
   }
 
-  public static void createInflightReplaceCommit(String basePath, String instantTime)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
-  }
-
   public static void createReplaceCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath,
                                          String instantTime, HoodieReplaceCommitMetadata metadata) throws IOException {
     createMetaFile(basePath, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
         serializeCommitMetadata(commitMetadataSerDe, metadata).get());
-  }
-
-  public static void createReplaceCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath,
-                                         String instantTime, String completionTime, HoodieReplaceCommitMetadata metadata) throws IOException {
-    createMetaFile(basePath, instantTime, () -> completionTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION, serializeCommitMetadata(commitMetadataSerDe, metadata).get());
   }
 
   public static void createRequestedClusterCommit(String basePath, String instantTime,
@@ -317,83 +155,11 @@ public class FileCreateUtils {
         serializeRequestedReplaceMetadata(requestedReplaceMetadata).get());
   }
 
-  public static void createInflightClusterCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath,
-                                                 String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
-      throws IOException {
-    if (inflightReplaceMetadata.isPresent()) {
-      createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
-    } else {
-      createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION);
-    }
-  }
-
-  public static void createRequestedReplaceCommit(String basePath, String instantTime,
-                                                  Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata)
-      throws IOException {
-    if (requestedReplaceMetadata.isPresent()) {
-      createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION,
-          serializeRequestedReplaceMetadata(requestedReplaceMetadata.get()).get());
-    } else {
-      createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
-    }
-  }
-
-  public static void createInflightReplaceCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath,
-                                                 String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
-      throws IOException {
-    if (inflightReplaceMetadata.isPresent()) {
-      createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
-    } else {
-      createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
-    }
-  }
-
   public static void createRequestedCompactionCommit(String basePath, String instantTime,
                                                      HoodieCompactionPlan requestedCompactionPlan)
       throws IOException {
     createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION,
         serializeCompactionPlan(requestedCompactionPlan).get());
-  }
-
-  public static void createCleanFile(String basePath, String instantTime,
-                                     HoodieCleanMetadata metadata) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.CLEAN_EXTENSION,
-        serializeCleanMetadata(metadata).get());
-  }
-
-  public static void createCleanFile(String basePath, String instantTime,
-                                     HoodieCleanMetadata metadata, boolean isEmpty)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanMetadata(metadata).get());
-  }
-
-  public static void createRequestedCleanFile(String basePath, String instantTime,
-                                              HoodieCleanerPlan cleanerPlan) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
-        serializeCleanerPlan(cleanerPlan).get());
-  }
-
-  public static void createRequestedCleanFile(String basePath, String instantTime,
-                                              HoodieCleanerPlan cleanerPlan, boolean isEmpty)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
-  }
-
-  public static void createInflightCleanFile(String basePath, String instantTime,
-                                             HoodieCleanerPlan cleanerPlan) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
-        serializeCleanerPlan(cleanerPlan).get());
-  }
-
-  public static void createInflightCleanFile(String basePath, String instantTime,
-                                             HoodieCleanerPlan cleanerPlan, boolean isEmpty)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
   }
 
   public static void createRequestedRollbackFile(String basePath, String instantTime, HoodieRollbackPlan plan) throws IOException {
@@ -404,47 +170,8 @@ public class FileCreateUtils {
     createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, content);
   }
 
-  public static void createRequestedRollbackFile(String basePath, String instantTime) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION);
-  }
-
-  public static void createInflightRollbackFile(String basePath, String instantTime) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_ROLLBACK_EXTENSION);
-  }
-
-  public static void createRollbackFile(String basePath, String instantTime, HoodieRollbackMetadata hoodieRollbackMetadata, boolean isEmpty) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.ROLLBACK_EXTENSION, isEmpty ? EMPTY_BYTES : serializeRollbackMetadata(hoodieRollbackMetadata).get());
-  }
-
-  public static void createRestoreFile(String basePath, String instantTime, HoodieRestoreMetadata hoodieRestoreMetadata) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.RESTORE_ACTION, serializeRestoreMetadata(hoodieRestoreMetadata).get());
-  }
-
-  public static void createRequestedCompaction(String basePath, String instantTime) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
-  }
-
   public static void createInflightCompaction(String basePath, String instantTime) throws IOException {
     createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
-  }
-
-  public static void createInflightSavepoint(String basePath, String instantTime) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION);
-  }
-
-  public static URI createPartitionMetaFile(String basePath, String partitionPath) throws IOException {
-    Path metaFilePath;
-    try {
-      Path parentPath = Paths.get(new URI(basePath).getPath(), partitionPath);
-      Files.createDirectories(parentPath);
-      metaFilePath = parentPath.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX);
-      if (Files.notExists(metaFilePath)) {
-        Files.createFile(metaFilePath);
-      }
-      return metaFilePath.toUri();
-    } catch (URISyntaxException e) {
-      throw new HoodieException("Error creating partition meta file", e);
-    }
   }
 
   public static String createBaseFile(String basePath, String partitionPath, String instantTime, String fileId)
@@ -521,54 +248,20 @@ public class FileCreateUtils {
     return markerFilePath.toAbsolutePath().toString();
   }
 
-  private static void removeMetaFile(String basePath, String instantTime, String suffix) throws IOException {
-    try {
-      Path parentPath = Paths.get(getTimelinePath(new StoragePath(basePath)).makeQualified(new URI("file:///")).toUri());
-
-      if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
-        Path metaFilePath = parentPath.resolve(instantTime + suffix);
-        if (Files.exists(metaFilePath)) {
-          Files.delete(metaFilePath);
-        }
-      } else {
-        if (Files.exists(parentPath)) {
-          try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(parentPath, instantTime + "*" + suffix)) {
-            Iterator<Path> iterator = dirStream.iterator();
-            // The instant file exists
-            if (iterator.hasNext()) {
-              // doesn't contains completion time
-              Files.delete(iterator.next());
-            }
-          }
-        }
-      }
-    } catch (Exception ex) {
-      throw new HoodieException(ex);
-    }
-  }
-
   public static void deleteCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.COMMIT_EXTENSION);
-  }
-
-  public static void deleteRequestedCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
-  }
-
-  public static void deleteInflightCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
+    removeMetaFileInTimelinePath(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, HoodieTimeline.COMMIT_EXTENSION);
   }
 
   public static void deleteDeltaCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION);
+    removeMetaFileInTimelinePath(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION);
   }
 
   public static void deleteReplaceCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
+    removeMetaFileInTimelinePath(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
   }
 
   public static void deleteRollbackCommit(String basePath, String instantTime) throws IOException {
-    removeMetaFile(basePath, instantTime, HoodieTimeline.ROLLBACK_EXTENSION);
+    removeMetaFileInTimelinePath(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, HoodieTimeline.ROLLBACK_EXTENSION);
   }
 
   public static Path renameFileToTemp(Path sourcePath, String instantTime) throws IOException {
@@ -609,36 +302,8 @@ public class FileCreateUtils {
     return false;
   }
 
-  /**
-   * Find total basefiles for passed in paths.
-   */
-  public static Map<String, Long> getBaseFileCountsForPaths(String basePath, HoodieStorage storage,
-                                                            String... paths) {
-    Map<String, Long> toReturn = new HashMap<>();
-    try {
-      HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(
-          storage.getConf(), basePath);
-      for (String path : paths) {
-        TableFileSystemView.BaseFileOnlyView fileSystemView =
-            new HoodieTableFileSystemView(metaClient,
-                metaClient.getCommitsTimeline().filterCompletedInstants(),
-                storage.globEntries(new StoragePath(path)));
-        toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
-      }
-      return toReturn;
-    } catch (Exception e) {
-      throw new HoodieException("Error reading hoodie table as a dataframe", e);
-    }
-  }
-
   public static void deleteDeltaCommit(String basePath, String instantTime,
                                        HoodieStorage storage) throws IOException {
-    deleteMetaFile(basePath, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage);
-  }
-
-  public static void deleteSavepointCommit(String basePath, String instantTime,
-                                           HoodieStorage storage) throws IOException {
-    deleteMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION, storage);
-    deleteMetaFile(basePath, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION, storage);
+    deleteMetaFileInTimeline(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -252,9 +252,9 @@ public class FileCreateUtils extends FileCreateUtilsBase {
     return markerFilePath.toAbsolutePath().toString();
   }
 
-  private static void createMetaFile(String basePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
+  private static void createMetaFile(String timelinePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
     try {
-      Path parentPath = Paths.get(getTimelinePath(new StoragePath(basePath)).makeQualified(new URI("file:///")).toUri());
+      Path parentPath = Paths.get(new StoragePath(timelinePath).makeQualified(new URI("file:///")).toUri());
 
       Files.createDirectories(parentPath);
       if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -79,7 +79,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
  * TODO[Davis Zhang]: For all function calls with preTableVersion8, they should be derive directly by consulting metaClient. Remove the
  * parameter and revise all call sites properly.
  */
-public class FileCreateUtilsV2 extends FileCreateUtilsBase {
+public class FileCreateUtils extends FileCreateUtilsBase {
 
   private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
                                      HoodieStorage storage) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsBase.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.testutils;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.model.IOType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.table.view.TableFileSystemView;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Utils for creating dummy Hudi files in testing.
+ */
+public class FileCreateUtilsBase {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(FileCreateUtilsBase.class);
+
+  protected static final String WRITE_TOKEN = "1-0-1";
+  protected static final String BASE_FILE_EXTENSION = HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().getFileExtension();
+  /** An empty byte array */
+  public static final byte[] EMPTY_BYTES = new byte[0];
+
+  public static String baseFileName(String instantTime, String fileId) {
+    return baseFileName(instantTime, fileId, BASE_FILE_EXTENSION);
+  }
+
+  public static String baseFileName(String instantTime, String fileId, String fileExtension) {
+    return FSUtils.makeBaseFileName(instantTime, WRITE_TOKEN, fileId, fileExtension);
+  }
+
+  public static String logFileName(String instantTime, String fileId, int version) {
+    return logFileName(instantTime, fileId, version,
+        HoodieFileFormat.HOODIE_LOG.getFileExtension());
+  }
+
+  public static String logFileName(String instantTime, String fileId, int version,
+                                   String fileExtension) {
+    return FSUtils.makeLogFileName(fileId, fileExtension, instantTime, version, WRITE_TOKEN);
+  }
+
+  public static String markerFileName(String fileName, IOType ioType) {
+    return String.format("%s%s.%s", fileName, HoodieTableMetaClient.MARKER_EXTN, ioType.name());
+  }
+
+  public static String markerFileName(String instantTime, String fileId, IOType ioType,
+                                      String fileExtension) {
+    return markerFileName(instantTime, fileId, ioType, fileExtension, WRITE_TOKEN);
+  }
+
+  public static String markerFileName(String instantTime, String fileId, IOType ioType,
+                                      String fileExtension, String writeToken) {
+    return String.format("%s_%s_%s%s%s.%s", fileId, writeToken, instantTime, fileExtension,
+        HoodieTableMetaClient.MARKER_EXTN, ioType);
+  }
+
+  public static boolean isBaseOrLogFilename(String filename) {
+    for (HoodieFileFormat format : HoodieFileFormat.values()) {
+      if (filename.contains(format.getFileExtension())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static URI createPartitionMetaFile(String basePath, String partitionPath) throws IOException {
+    Path metaFilePath;
+    try {
+      Path parentPath = Paths.get(new URI(basePath).getPath(), partitionPath);
+      Files.createDirectories(parentPath);
+      metaFilePath = parentPath.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX);
+      if (Files.notExists(metaFilePath)) {
+        Files.createFile(metaFilePath);
+      }
+      return metaFilePath.toUri();
+    } catch (URISyntaxException e) {
+      throw new HoodieException("Error creating partition meta file", e);
+    }
+  }
+
+  protected static void createMetaFileInMetaPath(StoragePath metaPath, String instantTime, String suffix,
+                                                 HoodieStorage storage, boolean preTableVersion8) throws IOException {
+    if (!storage.exists(metaPath)) {
+      storage.create(metaPath).close();
+    }
+
+    if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION)
+        || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+      StoragePath metaFilePath = new StoragePath(metaPath, instantTime + suffix);
+      if (!storage.exists(metaFilePath)) {
+        storage.create(metaFilePath).close();
+      }
+    } else {
+      String instantTimeWithCompletionTime =
+          preTableVersion8 ? instantTime : instantTime + "_" + InProcessTimeGenerator.createNewInstantTime();
+      storage.create(new StoragePath(metaPath, instantTimeWithCompletionTime + suffix))
+          .close();
+    }
+  }
+
+  protected static void createMetaFileInTimelinePath(String timelinePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
+    try {
+      Path parentPath = Paths.get(new StoragePath(timelinePath).makeQualified(new URI("file:///")).toUri());
+      Files.createDirectories(parentPath);
+      if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        Path metaFilePath = parentPath.resolve(instantTime + suffix);
+        if (Files.notExists(metaFilePath)) {
+          if (content.length == 0) {
+            Files.createFile(metaFilePath);
+          } else {
+            Files.write(metaFilePath, content);
+          }
+        }
+      } else {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(parentPath, instantTime + "*" + suffix)) {
+          // The instant file is not exist
+          if (!dirStream.iterator().hasNext()) {
+            // doesn't contains completion time
+            String instantTimeAndCompletionTime = instantTime + "_" + completionTimeSupplier.get();
+            Path metaFilePath = parentPath.resolve(instantTimeAndCompletionTime + suffix);
+            if (content.length == 0) {
+              Files.createFile(metaFilePath);
+            } else {
+              Files.write(metaFilePath, content);
+            }
+          }
+        }
+      }
+    } catch (URISyntaxException ex) {
+      throw new HoodieException(ex);
+    }
+  }
+
+  protected static void removeMetaFileInTimelinePath(String timelinePath, String instantTime, String suffix) throws IOException {
+    try {
+      Path parentPath = Paths.get(new StoragePath(timelinePath).makeQualified(new URI("file:///")).toUri());
+
+      if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        Path metaFilePath = parentPath.resolve(instantTime + suffix);
+        if (Files.exists(metaFilePath)) {
+          Files.delete(metaFilePath);
+        }
+      } else {
+        if (Files.exists(parentPath)) {
+          try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(parentPath, instantTime + "*" + suffix)) {
+            Iterator<Path> iterator = dirStream.iterator();
+            // The instant file exists
+            if (iterator.hasNext()) {
+              // doesn't contains completion time
+              Files.delete(iterator.next());
+            }
+          }
+        }
+      }
+    } catch (Exception ex) {
+      throw new HoodieException(ex);
+    }
+  }
+
+  protected static void deleteMetaFileInTimeline(String timelinePath, String instantTime, String suffix,
+                                                 HoodieStorage storage) throws IOException {
+    StoragePath parentPath = new StoragePath(timelinePath);
+
+    if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION)
+        || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+      StoragePath metaFilePath = new StoragePath(parentPath, instantTime + suffix);
+      if (storage.exists(metaFilePath)) {
+        storage.deleteFile(metaFilePath);
+      }
+    } else {
+      StoragePath metaFilePath =
+          new StoragePath(parentPath, instantTime + "*" + suffix);
+      List<StoragePathInfo> pathInfoList = storage.globEntries(metaFilePath);
+      if (pathInfoList.size() != 0) {
+        storage.deleteFile(pathInfoList.get(0).getPath());
+      }
+    }
+  }
+
+  /**
+   * Find total basefiles for passed in paths.
+   */
+  public static Map<String, Long> getBaseFileCountsForPaths(String basePath, HoodieStorage storage,
+                                                            String... paths) {
+    Map<String, Long> toReturn = new HashMap<>();
+    try {
+      HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(
+          storage.getConf(), basePath);
+      for (String path : paths) {
+        TableFileSystemView.BaseFileOnlyView fileSystemView =
+            new HoodieTableFileSystemView(metaClient,
+                metaClient.getCommitsTimeline().filterCompletedInstants(),
+                storage.globEntries(new StoragePath(path)));
+        toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
+      }
+      return toReturn;
+    } catch (Exception e) {
+      throw new HoodieException("Error reading hoodie table as a dataframe", e);
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsBase.java
@@ -47,7 +47,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Utils for creating dummy Hudi files in testing.
@@ -135,39 +134,6 @@ public class FileCreateUtilsBase {
           preTableVersion8 ? instantTime : instantTime + "_" + InProcessTimeGenerator.createNewInstantTime();
       storage.create(new StoragePath(metaPath, instantTimeWithCompletionTime + suffix))
           .close();
-    }
-  }
-
-  protected static void createMetaFileInTimelinePath(String timelinePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
-    try {
-      Path parentPath = Paths.get(new StoragePath(timelinePath).makeQualified(new URI("file:///")).toUri());
-      Files.createDirectories(parentPath);
-      if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
-        Path metaFilePath = parentPath.resolve(instantTime + suffix);
-        if (Files.notExists(metaFilePath)) {
-          if (content.length == 0) {
-            Files.createFile(metaFilePath);
-          } else {
-            Files.write(metaFilePath, content);
-          }
-        }
-      } else {
-        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(parentPath, instantTime + "*" + suffix)) {
-          // The instant file is not exist
-          if (!dirStream.iterator().hasNext()) {
-            // doesn't contains completion time
-            String instantTimeAndCompletionTime = instantTime + "_" + completionTimeSupplier.get();
-            Path metaFilePath = parentPath.resolve(instantTimeAndCompletionTime + suffix);
-            if (content.length == 0) {
-              Files.createFile(metaFilePath);
-            } else {
-              Files.write(metaFilePath, content);
-            }
-          }
-        }
-      }
-    } catch (URISyntaxException ex) {
-      throw new HoodieException(ex);
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
@@ -61,7 +61,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 /**
  * Utils for creating dummy Hudi files in testing.
  * ****************************************************
- *      Use FileCreateUtilsV2 whenever possible!
+ *      Use FileCreateUtils whenever possible!
  * ****************************************************
  * [HUDI-8924]: Remove this class entirely.
  */

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
@@ -63,8 +63,9 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
  * ****************************************************
  *      Use FileCreateUtilsV2 whenever possible!
  * ****************************************************
+ * [HUDI-8924]: Remove this class entirely.
  */
-public class FileCreateUtils extends FileCreateUtilsBase {
+public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
 
   public static StoragePath getTimelinePath(StoragePath basePath) throws IOException {
     return new StoragePath(

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsV2.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
@@ -75,12 +76,14 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Utils for creating dummy Hudi files in testing.
+ * TODO[Davis Zhang]: For all function calls with preTableVersion8, they should be derive directly by consulting metaClient. Remove the
+ * parameter and revise all call sites properly.
  */
 public class FileCreateUtilsV2 extends FileCreateUtilsBase {
 
   private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
                                      HoodieStorage storage) throws IOException {
-    createMetaFile(metaClient, instantTime, suffix, storage, false);
+    createMetaFile(metaClient, instantTime, suffix, storage, metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT));
   }
 
   private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsV2.java
@@ -1,0 +1,483 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.testutils;
+
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRestoreMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
+import org.apache.hudi.avro.model.HoodieSavepointMetadata;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.IOType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.table.view.TableFileSystemView;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanMetadata;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanerPlan;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCompactionPlan;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRestoreMetadata;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackPlan;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+
+/**
+ * Utils for creating dummy Hudi files in testing.
+ */
+public class FileCreateUtilsV2 extends FileCreateUtilsBase {
+
+  private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
+                                     HoodieStorage storage) throws IOException {
+    createMetaFile(metaClient, instantTime, suffix, storage, false);
+  }
+
+  private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
+                                     HoodieStorage storage, boolean preTableVersion8) throws IOException {
+    createMetaFileInMetaPath(metaClient.getMetaPath(), instantTime, suffix, storage, preTableVersion8);
+  }
+
+  private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix) throws IOException {
+    createMetaFile(metaClient, instantTime, suffix, getUTF8Bytes(""));
+  }
+
+  private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix, byte[] content) throws IOException {
+    createMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, InProcessTimeGenerator::createNewInstantTime, suffix, content);
+  }
+
+  private static void deleteMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
+                                     HoodieStorage storage) throws IOException {
+    deleteMetaFileInTimeline(metaClient.getTimelinePath().toUri().getPath(), instantTime, suffix, storage);
+  }
+
+  public static void createCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe, String instantTime,
+                                  Option<HoodieCommitMetadata> metadata) throws IOException {
+    createCommit(metaClient, commitMetadataSerDe, instantTime, Option.empty(), metadata);
+  }
+
+  public static void createCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe, String instantTime,
+                                  Option<String> completionTime, Option<HoodieCommitMetadata> metadata) throws IOException {
+    final Supplier<String> completionTimeSupplier = () -> completionTime.isPresent() ? completionTime.get() : InProcessTimeGenerator.createNewInstantTime();
+    if (metadata.isPresent()) {
+      HoodieCommitMetadata commitMetadata = metadata.get();
+      createMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
+          serializeCommitMetadata(commitMetadataSerDe, commitMetadata).get());
+    } else {
+      createMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
+          getUTF8Bytes(""));
+    }
+  }
+
+  public static void createSavepointCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                           HoodieSavepointMetadata savepointMetadata)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION,
+        TimelineMetadataUtils.serializeSavepointMetadata(savepointMetadata).get());
+  }
+
+  public static void createCommit(HoodieTableMetaClient metaClient, String instantTime)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.COMMIT_EXTENSION);
+  }
+
+  public static void createRequestedCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
+  }
+
+  public static void createInflightCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
+  }
+
+  public static void createDeltaCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe, String instantTime,
+                                       HoodieCommitMetadata metadata) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION,
+        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+  }
+
+  public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION);
+  }
+
+  public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                       HoodieStorage storage) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage);
+  }
+
+  public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                       HoodieStorage storage, boolean preTableVersion8) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage, preTableVersion8);
+  }
+
+  public static void createRequestedDeltaCommit(HoodieTableMetaClient metaClient, String instantTime)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_DELTA_COMMIT_EXTENSION);
+  }
+
+  public static void createInflightDeltaCommit(HoodieTableMetaClient metaClient, String instantTime)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
+  }
+
+  public static void createInflightDeltaCommit(HoodieTableMetaClient metaClient, String instantTime, HoodieStorage storage)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION, storage);
+  }
+
+  public static void createInflightReplaceCommit(HoodieTableMetaClient metaClient, String instantTime)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
+  }
+
+  public static void createReplaceCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
+                                         String instantTime, HoodieReplaceCommitMetadata metadata) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
+        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+  }
+
+  public static void createReplaceCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
+                                         String instantTime, String completionTime, HoodieReplaceCommitMetadata metadata) throws IOException {
+    createMetaFileInTimelinePath(
+        metaClient.getTimelinePath().toUri().getPath(), instantTime, () -> completionTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
+        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+  }
+
+  public static void createRequestedClusterCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                                  HoodieRequestedReplaceMetadata requestedReplaceMetadata)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLUSTERING_COMMIT_EXTENSION,
+        serializeRequestedReplaceMetadata(requestedReplaceMetadata).get());
+  }
+
+  public static void createInflightClusterCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
+                                                 String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
+      throws IOException {
+    if (inflightReplaceMetadata.isPresent()) {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION,
+          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
+    } else {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION);
+    }
+  }
+
+  public static void createRequestedReplaceCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                                  Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata)
+      throws IOException {
+    if (requestedReplaceMetadata.isPresent()) {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION,
+          serializeRequestedReplaceMetadata(requestedReplaceMetadata.get()).get());
+    } else {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
+    }
+  }
+
+  public static void createInflightReplaceCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
+                                                 String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
+      throws IOException {
+    if (inflightReplaceMetadata.isPresent()) {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION,
+          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
+    } else {
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
+    }
+  }
+
+  public static void createRequestedCompactionCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                                     HoodieCompactionPlan requestedCompactionPlan)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION,
+        serializeCompactionPlan(requestedCompactionPlan).get());
+  }
+
+  public static void createCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                     HoodieCleanMetadata metadata) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.CLEAN_EXTENSION,
+        serializeCleanMetadata(metadata).get());
+  }
+
+  public static void createCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                     HoodieCleanMetadata metadata, boolean isEmpty)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.CLEAN_EXTENSION,
+        isEmpty ? EMPTY_BYTES : serializeCleanMetadata(metadata).get());
+  }
+
+  public static void createRequestedCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                              HoodieCleanerPlan cleanerPlan) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
+        serializeCleanerPlan(cleanerPlan).get());
+  }
+
+  public static void createRequestedCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                              HoodieCleanerPlan cleanerPlan, boolean isEmpty)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
+        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
+  }
+
+  public static void createInflightCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                             HoodieCleanerPlan cleanerPlan) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
+        serializeCleanerPlan(cleanerPlan).get());
+  }
+
+  public static void createInflightCleanFile(HoodieTableMetaClient metaClient, String instantTime,
+                                             HoodieCleanerPlan cleanerPlan, boolean isEmpty)
+      throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
+        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
+  }
+
+  public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRollbackPlan plan) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, serializeRollbackPlan(plan).get());
+  }
+
+  public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime, byte[] content) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, content);
+  }
+
+  public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION);
+  }
+
+  public static void createInflightRollbackFile(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_ROLLBACK_EXTENSION);
+  }
+
+  public static void createRollbackFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRollbackMetadata hoodieRollbackMetadata, boolean isEmpty) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.ROLLBACK_EXTENSION, isEmpty ? EMPTY_BYTES : serializeRollbackMetadata(hoodieRollbackMetadata).get());
+  }
+
+  public static void createRestoreFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRestoreMetadata hoodieRestoreMetadata) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.RESTORE_ACTION, serializeRestoreMetadata(hoodieRestoreMetadata).get());
+  }
+
+  public static void createRequestedCompaction(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
+  }
+
+  public static void createInflightCompaction(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
+  }
+
+  public static void createInflightSavepoint(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION);
+  }
+
+  public static String createBaseFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId)
+      throws Exception {
+    return createBaseFile(metaClient, partitionPath, instantTime, fileId, 1);
+  }
+
+  public static String createBaseFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId, long length)
+      throws Exception {
+    return createBaseFile(metaClient, partitionPath, instantTime, fileId, length, Instant.now().toEpochMilli());
+  }
+
+  public static String createBaseFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId, long length, long lastModificationTimeMilli)
+      throws Exception {
+    Path parentPath = Paths.get(metaClient.getBasePath().toUri().getPath(), partitionPath);
+    Files.createDirectories(parentPath);
+    Path baseFilePath = parentPath.resolve(baseFileName(instantTime, fileId));
+    if (Files.notExists(baseFilePath)) {
+      Files.createFile(baseFilePath);
+    }
+    try (RandomAccessFile raf = new RandomAccessFile(baseFilePath.toFile(), "rw")) {
+      raf.setLength(length);
+    }
+    Files.setLastModifiedTime(baseFilePath, FileTime.fromMillis(lastModificationTimeMilli));
+    return baseFilePath.toString();
+  }
+
+  public static Path getBaseFilePath(String basePath, String partitionPath, String instantTime, String fileId) {
+    Path parentPath = Paths.get(basePath, partitionPath);
+    return parentPath.resolve(baseFileName(instantTime, fileId));
+  }
+
+  public static String createLogFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId, int version)
+      throws Exception {
+    return createLogFile(metaClient, partitionPath, instantTime, fileId, version, 0);
+  }
+
+  public static String createLogFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId, int version, int length)
+      throws Exception {
+    Path parentPath = Paths.get(metaClient.getBasePath().toUri().getPath(), partitionPath);
+    Files.createDirectories(parentPath);
+    Path logFilePath = parentPath.resolve(logFileName(instantTime, fileId, version));
+    if (Files.notExists(logFilePath)) {
+      Files.createFile(logFilePath);
+    }
+    RandomAccessFile raf = new RandomAccessFile(logFilePath.toFile(), "rw");
+    raf.setLength(length);
+    raf.close();
+    return logFilePath.toString();
+  }
+
+  public static String createMarkerFile(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, String fileId, IOType ioType)
+      throws IOException {
+    if (IOType.APPEND == ioType) {
+      String logFileName = FSUtils.makeLogFileName(fileId, HoodieLogFile.DELTA_EXTENSION, instantTime, HoodieLogFile.LOGFILE_BASE_VERSION, WRITE_TOKEN);
+      String markerFileName = markerFileName(logFileName, ioType);
+      return createMarkerFile(metaClient, partitionPath, instantTime, markerFileName);
+    }
+    return createMarkerFile(metaClient, partitionPath, instantTime, instantTime, fileId, ioType, WRITE_TOKEN);
+  }
+
+  public static String createMarkerFile(HoodieTableMetaClient metaClient, String partitionPath, String commitInstant,
+                                        String instantTime, String fileId, IOType ioType, String writeToken) throws IOException {
+    return createMarkerFile(metaClient, partitionPath, commitInstant, markerFileName(instantTime, fileId, ioType, BASE_FILE_EXTENSION, writeToken));
+  }
+
+  public static String createMarkerFile(HoodieTableMetaClient metaClient, String partitionPath, String commitInstant, String markerFileName) throws IOException {
+    Path parentPath = Paths.get(metaClient.getTempFolderPath(), commitInstant, partitionPath);
+    Files.createDirectories(parentPath);
+    Path markerFilePath = parentPath.resolve(markerFileName);
+    if (Files.notExists(markerFilePath)) {
+      Files.createFile(markerFilePath);
+    }
+    return markerFilePath.toAbsolutePath().toString();
+  }
+
+  private static void removeMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, suffix);
+  }
+
+  public static void deleteCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.COMMIT_EXTENSION);
+  }
+
+  public static void deleteRequestedCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
+  }
+
+  public static void deleteInflightCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
+  }
+
+  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION);
+  }
+
+  public static void deleteReplaceCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
+  }
+
+  public static void deleteRollbackCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+    removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.ROLLBACK_EXTENSION);
+  }
+
+  public static Path renameFileToTemp(Path sourcePath, String instantTime) throws IOException {
+    Path dummyFilePath = sourcePath.getParent().resolve(instantTime + ".temp");
+    Files.move(sourcePath, dummyFilePath);
+    return dummyFilePath;
+  }
+
+  public static void renameTempToMetaFile(Path tempFilePath, Path destPath) throws IOException {
+    Files.move(tempFilePath, destPath);
+  }
+
+  public static long getTotalMarkerFileCount(HoodieTableMetaClient metaClient,String partitionPath, String instantTime, IOType ioType) throws IOException {
+    Path parentPath = Paths.get(metaClient.getTempFolderPath(), instantTime, partitionPath);
+    if (Files.notExists(parentPath)) {
+      return 0;
+    }
+    return Files.list(parentPath).filter(p -> p.getFileName().toString()
+        .endsWith(String.format("%s.%s", HoodieTableMetaClient.MARKER_EXTN, ioType))).count();
+  }
+
+  public static List<Path> getPartitionPaths(Path basePath) throws IOException {
+    if (Files.notExists(basePath)) {
+      return Collections.emptyList();
+    }
+    return Files.list(basePath).filter(entry -> !entry.getFileName().toString().equals(HoodieTableMetaClient.METAFOLDER_NAME)
+            && !isBaseOrLogFilename(entry.getFileName().toString())
+            && !entry.getFileName().toString().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX))
+        .collect(Collectors.toList());
+  }
+
+  public static boolean isBaseOrLogFilename(String filename) {
+    for (HoodieFileFormat format : HoodieFileFormat.values()) {
+      if (filename.contains(format.getFileExtension())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Find total basefiles for passed in paths.
+   */
+  public static Map<String, Long> getBaseFileCountsForPaths(HoodieTableMetaClient metaClient, HoodieStorage storage,
+                                                            String... paths) {
+    Map<String, Long> toReturn = new HashMap<>();
+    try {
+      for (String path : paths) {
+        TableFileSystemView.BaseFileOnlyView fileSystemView =
+            new HoodieTableFileSystemView(metaClient,
+                metaClient.getCommitsTimeline().filterCompletedInstants(),
+                storage.globEntries(new StoragePath(path)));
+        toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
+      }
+      return toReturn;
+    } catch (Exception e) {
+      throw new HoodieException("Error reading hoodie table as a dataframe", e);
+    }
+  }
+
+  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient,String instantTime,
+                                       HoodieStorage storage) throws IOException {
+    deleteMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage);
+  }
+
+  public static void deleteSavepointCommit(HoodieTableMetaClient metaClient, String instantTime,
+                                           HoodieStorage storage) throws IOException {
+    deleteMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION, storage);
+    deleteMetaFile(metaClient, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION, storage);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileSliceTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileSliceTestUtils.java
@@ -72,8 +72,8 @@ import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSIO
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.DELETE_BLOCK;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.PARQUET_DATA_BLOCK;
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
-import static org.apache.hudi.common.testutils.FileCreateUtils.logFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.logFileName;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.HoodieIndex.IndexType;
@@ -119,8 +119,8 @@ public class ITTestBucketStreamWrite {
       String partition = partitionFileNameSplit[0];
       String fileName = partitionFileNameSplit[1];
       try {
-        String markerFileName = FileCreateUtils.markerFileName(fileName, IOType.CREATE);
-        FileCreateUtils.createMarkerFile(tablePath, partition, commitInstant, markerFileName);
+        String markerFileName = FileCreateUtilsLegacy.markerFileName(fileName, IOType.CREATE);
+        FileCreateUtilsLegacy.createMarkerFile(tablePath, partition, commitInstant, markerFileName);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -51,7 +51,7 @@ import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HadoopMapRedUtils;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -713,10 +713,10 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     if (produceUncommittedLogBlocks) {
       List<IndexedRecord> toBeSkippedRecords = testUtil.generateHoodieTestRecords(0, 200);
       logFiles.addAll(writeLogFiles(partitionPath, schema, toBeSkippedRecords, 2, storage, "test-fileid1", "100", "150"));
-      FileCreateUtils.createInflightDeltaCommit(basePath, "150", storage);
+      FileCreateUtilsLegacy.createInflightDeltaCommit(basePath, "150", storage);
     }
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage, preTableVersion8);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage, preTableVersion8);
 
     // scan all log blocks (across multiple log files)
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
@@ -762,7 +762,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     List<HoodieLogFile> logFiles = writeLogFiles(partitionPath, schema, genRecords, 3, storage);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // scan all log blocks (across multiple log files)
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
@@ -850,7 +850,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     List<HoodieLogFile> logFiles = writeLogFiles(partitionPath, schema, genRecords, 3, storage);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // scan all log blocks (across multiple log files)
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
@@ -1165,7 +1165,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     copyOfRecords1.addAll(copyOfRecords2);
     Set<String> originalKeys =
@@ -1228,8 +1228,8 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
 
     copyOfRecords1.addAll(copyOfRecords3);
     Set<String> originalKeys =
@@ -1299,8 +1299,8 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "103", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "103", storage);
 
     copyOfRecords1.addAll(copyOfRecords3);
     Set<String> originalKeys =
@@ -1365,9 +1365,9 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         FSUtils.getAllLogFiles(storage, partitionPath, "test-fileid1", HoodieLogFile.DELTA_EXTENSION, "100")
             .map(s -> s.getPath().toString()).collect(Collectors.toList());
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "101", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
 
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
@@ -1412,7 +1412,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieCommandBlock commandBlock = new HoodieCommandBlock(header);
     writer.appendBlock(commandBlock);
 
-    FileCreateUtils.deleteDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.deleteDeltaCommit(basePath, "101", storage);
 
     readKeys.clear();
     scanner.close();
@@ -1525,7 +1525,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     deleteBlock = new HoodieDeleteBlock(deleteRecordList, false, deleteBlockHeader);
     writer.appendBlock(deleteBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
 
     final List<String> readKeys = new ArrayList<>();
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
@@ -1648,11 +1648,11 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         FSUtils.getAllLogFiles(storage, partitionPath, "test-fileid1", HoodieLogFile.DELTA_EXTENSION, "100")
             .map(s -> s.getPath().toString()).collect(Collectors.toList());
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "101", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "103", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "104", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "103", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "104", storage);
 
     HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
@@ -1743,7 +1743,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieDeleteBlock deleteBlock = new HoodieDeleteBlock(deleteRecordList, false, header);
     writer.appendBlock(deleteBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Attempt 1 : Write rollback block for a failed write
     header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
@@ -1762,7 +1762,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     checkLogBlocksAndKeys("100", schema, diskMapType, isCompressionEnabled, enableOptimizedLogBlocksScan,
         0, 0, Option.empty());
-    FileCreateUtils.deleteDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.deleteDeltaCommit(basePath, "100", storage);
   }
 
   @ParameterizedTest
@@ -1805,7 +1805,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieDeleteBlock deleteBlock = new HoodieDeleteBlock(deleteRecordList, false, header);
     writer.appendBlock(deleteBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Write 2 rollback blocks (1 data block + 1 delete bloc) for a failed write
     header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
@@ -1817,7 +1817,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     checkLogBlocksAndKeys("100", schema, diskMapType, isCompressionEnabled, enableOptimizedLogBlocksScan,
         0, 0, Option.empty());
-    FileCreateUtils.deleteDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.deleteDeltaCommit(basePath, "100", storage);
   }
 
   @ParameterizedTest
@@ -1842,7 +1842,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieDataBlock dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, records1, header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Write invalid rollback for a failed write (possible for in-flight commits)
     header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, "101");
@@ -1898,7 +1898,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieDeleteBlock deleteBlock = new HoodieDeleteBlock(deleteRecordList, false, header);
     writer.appendBlock(deleteBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Write 1 rollback block for a failed write
     header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, "101");
@@ -1991,10 +1991,10 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         FSUtils.getAllLogFiles(storage, partitionPath, "test-fileid1", HoodieLogFile.DELTA_EXTENSION, "100")
             .map(s -> s.getPath().toString()).collect(Collectors.toList());
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "101", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
-    FileCreateUtils.createDeltaCommit(basePath, "103", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "103", storage);
 
     try (HoodieMergedLogRecordScanner scanner = HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
@@ -2059,7 +2059,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
     HoodieDataBlock dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, records1, header);
     writer.appendBlock(dataBlock);
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Write 2
     List<IndexedRecord> records2 = testUtil.generateHoodieTestRecords(100, 10);
@@ -2067,7 +2067,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, records2, header);
     writer.appendBlock(dataBlock);
-    FileCreateUtils.createDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "101", storage);
 
     // Should be able to read all 110 records
     checkLogBlocksAndKeys("101", schema, ExternalSpillableMap.DiskMapType.BITCASK, false,
@@ -2124,7 +2124,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
 
     writer.close();
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Append some arbitrary byte[] to the end of the log (mimics a partially written commit)
     FSDataOutputStream outputStream =
@@ -2186,7 +2186,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     checkLogBlocksAndKeys("101", schema, ExternalSpillableMap.DiskMapType.BITCASK, false,
         false, 0, 0, Option.empty());
-    FileCreateUtils.deleteDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.deleteDeltaCommit(basePath, "100", storage);
   }
 
   @ParameterizedTest
@@ -2219,7 +2219,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieDataBlock dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(records1), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Write 2nd data block
     List<IndexedRecord> records2 = testUtil.generateHoodieTestRecords(0, 100);
@@ -2232,7 +2232,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(records2), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "101", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "101", storage);
 
     // Write 3rd data block
     List<IndexedRecord> records3 = testUtil.generateHoodieTestRecords(0, 100);
@@ -2247,7 +2247,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
 
     writer.close();
-    FileCreateUtils.createDeltaCommit(basePath, "102", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "102", storage);
 
     // Append some arbitrary byte[] to the end of the log (mimics a partially written commit)
     FSDataOutputStream outputStream =
@@ -2291,7 +2291,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(compactedRecords), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "103", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "103", storage);
 
     // Create compacted block CB5
     List<IndexedRecord> secondCompactedRecords = Stream.of(compactedRecords, records3).flatMap(Collection::stream)
@@ -2303,7 +2303,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(secondCompactedRecords), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "104", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "104", storage);
 
     // Write 6th data block
     List<IndexedRecord> records6 = testUtil.generateHoodieTestRecords(0, 100);
@@ -2313,7 +2313,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(records6), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "105", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "105", storage);
 
     // Write 7th data block
     List<IndexedRecord> records7 = testUtil.generateHoodieTestRecords(0, 100);
@@ -2323,7 +2323,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(records7), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "106", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "106", storage);
 
     // Write 8th data block
     List<IndexedRecord> records8 = testUtil.generateHoodieTestRecords(0, 100);
@@ -2333,7 +2333,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, new ArrayList<>(records8), header);
     writer.appendBlock(dataBlock);
 
-    FileCreateUtils.createDeltaCommit(basePath, "107", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "107", storage);
 
     // Create compacted block CB9
     List<IndexedRecord> thirdCompactedBlockRecords = Stream.of(records7, records8).flatMap(Collection::stream)
@@ -2346,7 +2346,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "108", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "108", storage);
 
     List<String> allLogFiles =
         FSUtils.getAllLogFiles(storage, partitionPath, "test-fileid1", HoodieLogFile.DELTA_EXTENSION, "100")
@@ -2433,7 +2433,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       // Get the size of the block
       writer2.close();
 
-      FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+      FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
       // From the two log files generated, read the records
       List<String> allLogFiles = FSUtils.getAllLogFiles(storage, partitionPath, "test-fileid1",
@@ -2534,7 +2534,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     HoodieLogFile logFile = new HoodieLogFile(writer.getLogFile().getPath(), storage.getPathInfo(writer.getLogFile().getPath()).getLength());
     try (HoodieLogFileReader reader = new HoodieLogFileReader(storage, logFile, SchemaTestUtil.getSimpleSchema(), BUFFER_SIZE, true)) {
@@ -2587,7 +2587,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     // Append some arbitrary byte[] to the end of the log (mimics a partially written commit)
     FSDataOutputStream outputStream =
@@ -2659,7 +2659,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     writer.close();
 
-    FileCreateUtils.createDeltaCommit(basePath, "100", storage);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     HoodieLogFile logFile = new HoodieLogFile(writer.getLogFile().getPath(),
         storage.getPathInfo(writer.getLogFile().getPath()).getLength());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -22,7 +22,7 @@ import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
 import org.apache.hudi.common.table.timeline.versioning.v2.CompletionTimeQueryViewV2;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
@@ -85,7 +85,7 @@ public class TestHoodieFileGroup {
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i);
       fileGroup.addBaseFile(baseFile);
-      fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
+      fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
     }
 
     assertEquals(2, fileGroup.getAllFileSlices().count());
@@ -124,16 +124,16 @@ public class TestHoodieFileGroup {
     // when: building a file group with file slices like table version 6.
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "f1", activeTimeline);
 
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName("001", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName("001", "f1", 0))));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
 
-    fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtils.baseFileName("003", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
+    fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("003", "f1")));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
 
-    fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtils.baseFileName("006", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtils.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
+    fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("006", "f1")));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
+    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
 
     // then: assert that the file slices are in-tact.
     assertEquals(3, fileGroup.getAllFileSlices().count());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -34,23 +34,18 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.BaseTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
-import org.apache.hudi.common.testutils.HoodieTestTable;
-import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
@@ -63,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.COMPLETED;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
@@ -78,13 +72,10 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMI
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACTION;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineUtils.handleHollowCommitIfNeeded;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -593,40 +584,6 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         .setPartitionMetadata(partitionToFilesCleaned).build();
 
     return TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata);
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = HollowCommitHandling.class)
-  public void testHandleHollowCommitIfNeeded(HollowCommitHandling handlingMode) throws Exception {
-    HoodieTestTable.of(metaClient)
-        .addCommit("001")
-        .addInflightCommit("003")
-        .addCommit("005");
-    Stream<String> completed = Stream.of("001", "005");
-    HoodieTimeline completedTimeline = new MockHoodieTimeline(completed, Stream.empty());
-    switch (handlingMode) {
-      case FAIL:
-        HoodieException e = assertThrows(HoodieException.class, () ->
-            handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode));
-        assertTrue(e.getMessage().startsWith("Found hollow commit:"));
-        break;
-      case BLOCK: {
-        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
-        assertTrue(filteredTimeline.containsInstant("001"));
-        assertFalse(filteredTimeline.containsInstant("003"));
-        assertFalse(filteredTimeline.containsInstant("005"));
-        break;
-      }
-      case USE_TRANSITION_TIME: {
-        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
-        assertTrue(filteredTimeline.containsInstant("001"));
-        assertFalse(filteredTimeline.containsInstant("003"));
-        assertTrue(filteredTimeline.containsInstant("005"));
-        break;
-      }
-      default:
-        fail("should cover all handling mode.");
-    }
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtilsBackComp.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtilsBackComp.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
+import org.apache.hudi.exception.HoodieException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.table.timeline.TimelineUtils.handleHollowCommitIfNeeded;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestTimelineUtilsBackComp extends HoodieCommonTestHarness {
+  @BeforeEach
+  public void setUp() throws Exception {
+    initPath();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "FAIL, SIX, VERSION_1",
+      "FAIL, EIGHT, VERSION_2",
+      "BLOCK, SIX, VERSION_1",
+      "BLOCK, EIGHT, VERSION_2",
+      "USE_TRANSITION_TIME, SIX, VERSION_1",
+      "USE_TRANSITION_TIME, EIGHT, VERSION_2"
+  })
+  void testHandleHollowCommit(HollowCommitHandling handlingMode,
+                             HoodieTableVersion tableVersion,
+                             TimelineLayoutVersion timelineLayoutVersion) throws Exception {
+    metaClient =
+      HoodieTableMetaClient.newTableBuilder()
+        .setDatabaseName("dataset")
+        .setTableName("testTable")
+        .setTimelineLayoutVersion(timelineLayoutVersion)
+        .setTableVersion(tableVersion)
+        .setTableType(HoodieTableType.MERGE_ON_READ).initTable(getDefaultStorageConf(), basePath);
+    HoodieTestTable.of(metaClient)
+        .addCommit("001")
+        .addInflightCommit("003")
+        .addCommit("005");
+    verifyHollowCommitHandling(handlingMode);
+  }
+
+  private void verifyHollowCommitHandling(HollowCommitHandling handlingMode) {
+    Stream<String> completed = Stream.of("001", "005");
+    HoodieTimeline completedTimeline = new MockHoodieTimeline(completed, Stream.empty());
+    switch (handlingMode) {
+      case FAIL:
+        HoodieException e = assertThrows(HoodieException.class, () ->
+            handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode));
+        assertTrue(e.getMessage().startsWith("Found hollow commit:"));
+        break;
+      case BLOCK: {
+        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
+        assertTrue(filteredTimeline.containsInstant("001"));
+        assertFalse(filteredTimeline.containsInstant("003"));
+        assertFalse(filteredTimeline.containsInstant("005"));
+        break;
+      }
+      case USE_TRANSITION_TIME: {
+        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
+        assertTrue(filteredTimeline.containsInstant("001"));
+        assertFalse(filteredTimeline.containsInstant("003"));
+        assertTrue(filteredTimeline.containsInstant("005"));
+        break;
+      }
+      default:
+        fail("should cover all handling mode.");
+    }
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtilsBackComp.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtilsBackComp.java
@@ -20,7 +20,6 @@ package org.apache.hudi.common.table;
 
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -63,7 +62,7 @@ public class TestTimelineUtilsBackComp extends HoodieCommonTestHarness {
       HoodieTableMetaClient.newTableBuilder()
         .setDatabaseName("dataset")
         .setTableName("testTable")
-        .setTimelineLayoutVersion(timelineLayoutVersion)
+        .setTimelineLayoutVersion(timelineLayoutVersion.getVersion())
         .setTableVersion(tableVersion)
         .setTableType(HoodieTableType.MERGE_ON_READ).initTable(getDefaultStorageConf(), basePath);
     HoodieTestTable.of(metaClient)

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -109,31 +109,31 @@ import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.baseFileName;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightClusterCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCompaction;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightSavepoint;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createMarkerFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedClusterCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRestoreFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createSavepointCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.deleteSavepointCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtilsV2.logFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightClusterCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCompaction;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightSavepoint;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createMarkerFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedClusterCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRestoreFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createSavepointCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.deleteSavepointCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.logFileName;
 import static org.apache.hudi.common.testutils.HoodieCommonTestHarness.BASE_FILE_EXTENSION;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.util.CleanerUtils.convertCleanMetadata;
@@ -304,9 +304,9 @@ public class HoodieTestTable implements AutoCloseable {
 
   public void moveCompleteCommitToInflight(String instantTime) throws IOException {
     if (metaClient.getTableType() == HoodieTableType.COPY_ON_WRITE) {
-      FileCreateUtilsV2.deleteCommit(metaClient, instantTime);
+      FileCreateUtils.deleteCommit(metaClient, instantTime);
     } else {
-      FileCreateUtilsV2.deleteDeltaCommit(metaClient, instantTime);
+      FileCreateUtils.deleteDeltaCommit(metaClient, instantTime);
     }
   }
 
@@ -500,7 +500,7 @@ public class HoodieTestTable implements AutoCloseable {
         long rollbackLogFileSize = 50 + RANDOM.nextInt(500);
         String fileId = UUID.randomUUID().toString();
         String logFileName = logFileName(instantTimeToDelete, fileId, 0);
-        FileCreateUtilsV2.createLogFile(metaClient, entry.getKey(), instantTimeToDelete, fileId, 0, (int) rollbackLogFileSize);
+        FileCreateUtils.createLogFile(metaClient, entry.getKey(), instantTimeToDelete, fileId, 0, (int) rollbackLogFileSize);
         rollbackPartitionMetadata.setRollbackLogFiles(singletonMap(logFileName, rollbackLogFileSize));
       }
       partitionMetadataMap.put(entry.getKey(), rollbackPartitionMetadata);
@@ -673,14 +673,14 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable withPartitionMetaFiles(String... partitionPaths) throws IOException {
     for (String partitionPath : partitionPaths) {
-      FileCreateUtilsV2.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
     }
     return this;
   }
 
   public HoodieTestTable withPartitionMetaFiles(List<String> partitionPaths) throws IOException {
     for (String partitionPath : partitionPaths) {
-      FileCreateUtilsV2.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
     }
     return this;
   }
@@ -704,8 +704,8 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable withLogMarkerFile(String partitionPath, String fileId, IOType ioType) throws IOException {
     String logFileName = FSUtils.makeLogFileName(fileId, HoodieLogFile.DELTA_EXTENSION, currentInstantTime, HoodieLogFile.LOGFILE_BASE_VERSION, HoodieLogFormat.UNKNOWN_WRITE_TOKEN);
-    String markerFileName = FileCreateUtilsV2.markerFileName(logFileName, ioType);
-    FileCreateUtilsV2.createMarkerFile(metaClient, partitionPath, currentInstantTime, markerFileName);
+    String markerFileName = FileCreateUtils.markerFileName(logFileName, ioType);
+    FileCreateUtils.createMarkerFile(metaClient, partitionPath, currentInstantTime, markerFileName);
     return this;
   }
 
@@ -718,7 +718,7 @@ public class HoodieTestTable implements AutoCloseable {
     Map<String, String> partitionFileIdMap = new HashMap<>();
     for (String p : partitions) {
       String fileId = UUID.randomUUID().toString();
-      FileCreateUtilsV2.createBaseFile(metaClient, p, currentInstantTime, fileId);
+      FileCreateUtils.createBaseFile(metaClient, p, currentInstantTime, fileId);
       partitionFileIdMap.put(p, fileId);
     }
     return partitionFileIdMap;
@@ -735,7 +735,7 @@ public class HoodieTestTable implements AutoCloseable {
   public Pair<HoodieTestTable, List<String>> withBaseFilesInPartition(String partition, String... fileIds) throws Exception {
     List<String> files = new ArrayList<>();
     for (String f : fileIds) {
-      files.add(FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, f));
+      files.add(FileCreateUtils.createBaseFile(metaClient, partition, currentInstantTime, f));
     }
     return Pair.of(this, files);
   }
@@ -743,14 +743,14 @@ public class HoodieTestTable implements AutoCloseable {
   public HoodieTestTable withBaseFilesInPartition(String partition, int... lengths) throws Exception {
     for (int l : lengths) {
       String fileId = UUID.randomUUID().toString();
-      FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, fileId, l);
+      FileCreateUtils.createBaseFile(metaClient, partition, currentInstantTime, fileId, l);
     }
     return this;
   }
 
   public HoodieTestTable withBaseFilesInPartition(String partition, List<Pair<String, Integer>> fileInfos) throws Exception {
     for (Pair<String, Integer> fileInfo : fileInfos) {
-      FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue());
+      FileCreateUtils.createBaseFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue());
     }
     return this;
   }
@@ -768,14 +768,14 @@ public class HoodieTestTable implements AutoCloseable {
   public Pair<HoodieTestTable, List<String>> withLogFile(String partitionPath, String fileId, int... versions) throws Exception {
     List<String> logFiles = new ArrayList<>();
     for (int version : versions) {
-      logFiles.add(FileCreateUtilsV2.createLogFile(metaClient, partitionPath, currentInstantTime, fileId, version));
+      logFiles.add(FileCreateUtils.createLogFile(metaClient, partitionPath, currentInstantTime, fileId, version));
     }
     return Pair.of(this, logFiles);
   }
 
   public HoodieTestTable withLogFilesInPartition(String partition, List<Pair<String, Integer[]>> fileInfos) throws Exception {
     for (Pair<String, Integer[]> fileInfo : fileInfos) {
-      FileCreateUtilsV2.createLogFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue()[0], fileInfo.getValue()[1]);
+      FileCreateUtils.createLogFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue()[0], fileInfo.getValue()[1]);
     }
     return this;
   }
@@ -846,7 +846,7 @@ public class HoodieTestTable implements AutoCloseable {
 
   public List<java.nio.file.Path> getAllPartitionPaths() throws IOException {
     java.nio.file.Path basePathPath = Paths.get(basePath);
-    return FileCreateUtilsV2.getPartitionPaths(basePathPath);
+    return FileCreateUtils.getPartitionPaths(basePathPath);
   }
 
   public Path getBaseFilePath(String partition, String fileId) {
@@ -942,7 +942,7 @@ public class HoodieTestTable implements AutoCloseable {
           String filePath = entry.getPath().toString();
           String fileName = entry.getPath().getName();
           if (fileName.startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)
-              || !FileCreateUtilsV2.isBaseOrLogFilename(fileName)
+              || !FileCreateUtils.isBaseOrLogFilename(fileName)
               || filePath.contains("metadata")) {
             toReturn = false;
           } else {
@@ -1368,7 +1368,7 @@ public class HoodieTestTable implements AutoCloseable {
       for (Pair<String, Integer> fileIdInfo : entry.getValue()) {
         HoodieWriteStat writeStat = new HoodieWriteStat();
         String fileName = bootstrap ? fileIdInfo.getKey() :
-            FileCreateUtilsV2.baseFileName(commitTime, fileIdInfo.getKey());
+            FileCreateUtils.baseFileName(commitTime, fileIdInfo.getKey());
         writeStat.setFileId(fileName);
         writeStat.setPartitionPath(partition);
         writeStat.setPath(StringUtils.isNullOrEmpty(partition) ? fileName : partition + "/" + fileName);
@@ -1394,7 +1394,7 @@ public class HoodieTestTable implements AutoCloseable {
       for (Pair<String, Integer[]> fileIdInfo : entry.getValue()) {
         HoodieWriteStat writeStat = new HoodieWriteStat();
         String fileName = bootstrap ? fileIdInfo.getKey() :
-            FileCreateUtilsV2.logFileName(commitTime, fileIdInfo.getKey(), fileIdInfo.getValue()[0]);
+            FileCreateUtils.logFileName(commitTime, fileIdInfo.getKey(), fileIdInfo.getValue()[0]);
         writeStat.setFileId(fileName);
         writeStat.setPartitionPath(partition);
         writeStat.setPath(StringUtils.isNullOrEmpty(partition) ? fileName : partition + "/" + fileName);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -109,31 +109,31 @@ import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightClusterCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCompaction;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightSavepoint;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createMarkerFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCleanFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedClusterCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedDeltaCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedReplaceCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRestoreFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createRollbackFile;
-import static org.apache.hudi.common.testutils.FileCreateUtils.createSavepointCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.deleteSavepointCommit;
-import static org.apache.hudi.common.testutils.FileCreateUtils.logFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightClusterCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightCompaction;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createInflightSavepoint;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createMarkerFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedCleanFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedClusterCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedDeltaCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedReplaceCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRequestedRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRestoreFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createRollbackFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.createSavepointCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.deleteSavepointCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtilsV2.logFileName;
 import static org.apache.hudi.common.testutils.HoodieCommonTestHarness.BASE_FILE_EXTENSION;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.util.CleanerUtils.convertCleanMetadata;
@@ -215,22 +215,22 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieTestTable addRequestedCommit(String instantTime) throws Exception {
-    createRequestedCommit(basePath, instantTime);
+    createRequestedCommit(metaClient, instantTime);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightCommit(String instantTime) throws Exception {
-    createRequestedCommit(basePath, instantTime);
-    createInflightCommit(basePath, instantTime);
+    createRequestedCommit(metaClient, instantTime);
+    createInflightCommit(metaClient, instantTime);
     inflightCommits.add(instantTime);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightDeltaCommit(String instantTime) throws Exception {
-    createRequestedDeltaCommit(basePath, instantTime);
-    createInflightDeltaCommit(basePath, instantTime);
+    createRequestedDeltaCommit(metaClient, instantTime);
+    createInflightDeltaCommit(metaClient, instantTime);
     inflightCommits.add(instantTime);
     currentInstantTime = instantTime;
     return this;
@@ -245,16 +245,16 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieTestTable addCommit(String instantTime, Option<String> completionTime, Option<HoodieCommitMetadata> metadata) throws Exception {
-    createRequestedCommit(basePath, instantTime);
-    createInflightCommit(basePath, instantTime);
-    createCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, completionTime, metadata);
+    createRequestedCommit(metaClient, instantTime);
+    createInflightCommit(metaClient, instantTime);
+    createCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, completionTime, metadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addSavepointCommit(String instantTime, HoodieSavepointMetadata savepointMetadata) throws IOException {
-    createInflightSavepoint(basePath, instantTime);
-    createSavepointCommit(basePath, instantTime, savepointMetadata);
+    createInflightSavepoint(metaClient, instantTime);
+    createSavepointCommit(metaClient, instantTime, savepointMetadata);
     return this;
   }
 
@@ -293,9 +293,9 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable moveInflightCommitToComplete(String instantTime, HoodieCommitMetadata metadata) throws IOException {
     if (metaClient.getTableType() == HoodieTableType.COPY_ON_WRITE) {
-      createCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, Option.of(metadata));
+      createCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, Option.of(metadata));
     } else {
-      createDeltaCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, metadata);
+      createDeltaCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, metadata);
     }
     inflightCommits.remove(instantTime);
     currentInstantTime = instantTime;
@@ -304,24 +304,24 @@ public class HoodieTestTable implements AutoCloseable {
 
   public void moveCompleteCommitToInflight(String instantTime) throws IOException {
     if (metaClient.getTableType() == HoodieTableType.COPY_ON_WRITE) {
-      FileCreateUtils.deleteCommit(basePath, instantTime);
+      FileCreateUtilsV2.deleteCommit(metaClient, instantTime);
     } else {
-      FileCreateUtils.deleteDeltaCommit(basePath, instantTime);
+      FileCreateUtilsV2.deleteDeltaCommit(metaClient, instantTime);
     }
   }
 
   public HoodieTestTable addDeltaCommit(String instantTime) throws Exception {
-    createRequestedDeltaCommit(basePath, instantTime);
-    createInflightDeltaCommit(basePath, instantTime);
-    createDeltaCommit(basePath, instantTime);
+    createRequestedDeltaCommit(metaClient, instantTime);
+    createInflightDeltaCommit(metaClient, instantTime);
+    createDeltaCommit(metaClient, instantTime);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addDeltaCommit(String instantTime, HoodieCommitMetadata metadata) throws Exception {
-    createRequestedDeltaCommit(basePath, instantTime);
-    createInflightDeltaCommit(basePath, instantTime);
-    createDeltaCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, metadata);
+    createRequestedDeltaCommit(metaClient, instantTime);
+    createInflightDeltaCommit(metaClient, instantTime);
+    createDeltaCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, metadata);
     currentInstantTime = instantTime;
     return this;
   }
@@ -331,35 +331,35 @@ public class HoodieTestTable implements AutoCloseable {
       Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata,
       Option<HoodieCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
-    createRequestedReplaceCommit(basePath, instantTime, requestedReplaceMetadata);
-    createInflightReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
-    createReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, completeReplaceMetadata);
+    createRequestedReplaceCommit(metaClient, instantTime, requestedReplaceMetadata);
+    createInflightReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
+    createReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, completeReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addPendingReplace(String instantTime, Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
-    createRequestedReplaceCommit(basePath, instantTime, requestedReplaceMetadata);
-    createInflightReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
+    createRequestedReplaceCommit(metaClient, instantTime, requestedReplaceMetadata);
+    createInflightReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addPendingCluster(String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
-    createRequestedClusterCommit(basePath, instantTime, requestedReplaceMetadata);
-    createInflightClusterCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
+    createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
+    createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addRequestedCluster(String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata) throws Exception {
-    createRequestedClusterCommit(basePath, instantTime, requestedReplaceMetadata);
+    createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightCluster(String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
-    createInflightClusterCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
+    createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
@@ -369,9 +369,9 @@ public class HoodieTestTable implements AutoCloseable {
       HoodieRequestedReplaceMetadata requestedReplaceMetadata,
       Option<HoodieCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
-    createRequestedClusterCommit(basePath, instantTime, requestedReplaceMetadata);
-    createInflightClusterCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
-    createReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, completeReplaceMetadata);
+    createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
+    createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
+    createReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, completeReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
@@ -382,28 +382,28 @@ public class HoodieTestTable implements AutoCloseable {
       Option<HoodieCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata,
       String completionTime) throws Exception {
-    createRequestedClusterCommit(basePath, instantTime, requestedReplaceMetadata);
-    createInflightClusterCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
-    createReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, completionTime, completeReplaceMetadata);
+    createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
+    createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
+    createReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, completionTime, completeReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addRequestedReplace(String instantTime, Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata) throws Exception {
-    createRequestedReplaceCommit(basePath, instantTime, requestedReplaceMetadata);
+    createRequestedReplaceCommit(metaClient, instantTime, requestedReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightReplace(String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
-    createInflightReplaceCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, inflightReplaceMetadata);
+    createInflightReplaceCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightClean(String instantTime, HoodieCleanerPlan cleanerPlan) throws IOException {
-    createRequestedCleanFile(basePath, instantTime, cleanerPlan);
-    createInflightCleanFile(basePath, instantTime, cleanerPlan);
+    createRequestedCleanFile(metaClient, instantTime, cleanerPlan);
+    createInflightCleanFile(metaClient, instantTime, cleanerPlan);
     currentInstantTime = instantTime;
     return this;
   }
@@ -413,9 +413,9 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieTestTable addClean(String instantTime, HoodieCleanerPlan cleanerPlan, HoodieCleanMetadata metadata, boolean isEmptyForAll, boolean isEmptyCompleted) throws IOException {
-    createRequestedCleanFile(basePath, instantTime, cleanerPlan, isEmptyForAll);
-    createInflightCleanFile(basePath, instantTime, cleanerPlan, isEmptyForAll);
-    createCleanFile(basePath, instantTime, metadata, isEmptyCompleted);
+    createRequestedCleanFile(metaClient, instantTime, cleanerPlan, isEmptyForAll);
+    createInflightCleanFile(metaClient, instantTime, cleanerPlan, isEmptyForAll);
+    createCleanFile(metaClient, instantTime, metadata, isEmptyCompleted);
     currentInstantTime = instantTime;
     return this;
   }
@@ -447,13 +447,13 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieTestTable addRequestedRollback(String instantTime, HoodieRollbackPlan plan) throws IOException {
-    createRequestedRollbackFile(basePath, instantTime, plan);
+    createRequestedRollbackFile(metaClient, instantTime, plan);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addInflightRollback(String instantTime) throws IOException {
-    createInflightRollbackFile(basePath, instantTime);
+    createInflightRollbackFile(metaClient, instantTime);
     currentInstantTime = instantTime;
     return this;
   }
@@ -464,24 +464,24 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable addRollback(String instantTime, HoodieRollbackMetadata rollbackMetadata, boolean isEmpty, HoodieRollbackPlan rollbackPlan) throws IOException {
     if (rollbackPlan != null) {
-      createRequestedRollbackFile(basePath, instantTime, rollbackPlan);
+      createRequestedRollbackFile(metaClient, instantTime, rollbackPlan);
     } else {
-      createRequestedRollbackFile(basePath, instantTime);
+      createRequestedRollbackFile(metaClient, instantTime);
     }
-    createInflightRollbackFile(basePath, instantTime);
-    // createRollbackFile(basePath, instantTime, rollbackMetadata, isEmpty);
+    createInflightRollbackFile(metaClient, instantTime);
+    // createRollbackFile(metaClient, instantTime, rollbackMetadata, isEmpty);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addRollbackCompleted(String instantTime, HoodieRollbackMetadata rollbackMetadata, boolean isEmpty) throws IOException {
-    createRollbackFile(basePath, instantTime, rollbackMetadata, isEmpty);
+    createRollbackFile(metaClient, instantTime, rollbackMetadata, isEmpty);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addRestore(String instantTime, HoodieRestoreMetadata restoreMetadata) throws IOException {
-    createRestoreFile(basePath, instantTime, restoreMetadata);
+    createRestoreFile(metaClient, instantTime, restoreMetadata);
     currentInstantTime = instantTime;
     return this;
   }
@@ -500,7 +500,7 @@ public class HoodieTestTable implements AutoCloseable {
         long rollbackLogFileSize = 50 + RANDOM.nextInt(500);
         String fileId = UUID.randomUUID().toString();
         String logFileName = logFileName(instantTimeToDelete, fileId, 0);
-        FileCreateUtils.createLogFile(basePath, entry.getKey(), instantTimeToDelete, fileId, 0, (int) rollbackLogFileSize);
+        FileCreateUtilsV2.createLogFile(metaClient, entry.getKey(), instantTimeToDelete, fileId, 0, (int) rollbackLogFileSize);
         rollbackPartitionMetadata.setRollbackLogFiles(singletonMap(logFileName, rollbackLogFileSize));
       }
       partitionMetadataMap.put(entry.getKey(), rollbackPartitionMetadata);
@@ -584,7 +584,7 @@ public class HoodieTestTable implements AutoCloseable {
       }
     }
     this.addRequestedCompaction(instantTime, fileSlices.toArray(new FileSlice[0]));
-    createInflightCompaction(basePath, instantTime);
+    createInflightCompaction(metaClient, instantTime);
     inflightCommits.add(instantTime);
     currentInstantTime = instantTime;
     return this;
@@ -593,7 +593,7 @@ public class HoodieTestTable implements AutoCloseable {
   public HoodieTestTable addCompaction(String instantTime, HoodieCommitMetadata commitMetadata) throws Exception {
     addInflightCompaction(instantTime, commitMetadata);
     this.inflightCommits.remove(instantTime);
-    createCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, Option.of(commitMetadata));
+    createCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, Option.of(commitMetadata));
     return this;
   }
 
@@ -639,20 +639,20 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public HoodieTestTable moveInflightCompactionToComplete(String instantTime, HoodieCommitMetadata metadata) throws IOException {
-    createCommit(COMMIT_METADATA_SER_DE, basePath, instantTime, Option.of(metadata));
+    createCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, Option.of(metadata));
     inflightCommits.remove(instantTime);
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable addSavepoint(String instantTime, HoodieSavepointMetadata savepointMetadata) throws IOException {
-    createInflightSavepoint(basePath, instantTime);
-    createSavepointCommit(basePath, instantTime, savepointMetadata);
+    createInflightSavepoint(metaClient, instantTime);
+    createSavepointCommit(metaClient, instantTime, savepointMetadata);
     return this;
   }
 
   public HoodieTestTable deleteSavepoint(String instantTime) throws IOException {
-    deleteSavepointCommit(basePath, instantTime, storage);
+    deleteSavepointCommit(metaClient, instantTime, storage);
     return this;
   }
 
@@ -673,20 +673,20 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable withPartitionMetaFiles(String... partitionPaths) throws IOException {
     for (String partitionPath : partitionPaths) {
-      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtilsV2.createPartitionMetaFile(basePath, partitionPath);
     }
     return this;
   }
 
   public HoodieTestTable withPartitionMetaFiles(List<String> partitionPaths) throws IOException {
     for (String partitionPath : partitionPaths) {
-      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtilsV2.createPartitionMetaFile(basePath, partitionPath);
     }
     return this;
   }
 
   public HoodieTestTable withMarkerFile(String partitionPath, String fileId, IOType ioType) throws IOException {
-    createMarkerFile(basePath, partitionPath, currentInstantTime, fileId, ioType);
+    createMarkerFile(metaClient, partitionPath, currentInstantTime, fileId, ioType);
     return this;
   }
 
@@ -697,15 +697,15 @@ public class HoodieTestTable implements AutoCloseable {
 
   public HoodieTestTable withMarkerFiles(String partitionPath, String[] fileIds, IOType ioType) throws IOException {
     for (String fileId : fileIds) {
-      createMarkerFile(basePath, partitionPath, currentInstantTime, fileId, ioType);
+      createMarkerFile(metaClient, partitionPath, currentInstantTime, fileId, ioType);
     }
     return this;
   }
 
   public HoodieTestTable withLogMarkerFile(String partitionPath, String fileId, IOType ioType) throws IOException {
     String logFileName = FSUtils.makeLogFileName(fileId, HoodieLogFile.DELTA_EXTENSION, currentInstantTime, HoodieLogFile.LOGFILE_BASE_VERSION, HoodieLogFormat.UNKNOWN_WRITE_TOKEN);
-    String markerFileName = FileCreateUtils.markerFileName(logFileName, ioType);
-    FileCreateUtils.createMarkerFile(basePath, partitionPath, currentInstantTime, markerFileName);
+    String markerFileName = FileCreateUtilsV2.markerFileName(logFileName, ioType);
+    FileCreateUtilsV2.createMarkerFile(metaClient, partitionPath, currentInstantTime, markerFileName);
     return this;
   }
 
@@ -718,7 +718,7 @@ public class HoodieTestTable implements AutoCloseable {
     Map<String, String> partitionFileIdMap = new HashMap<>();
     for (String p : partitions) {
       String fileId = UUID.randomUUID().toString();
-      FileCreateUtils.createBaseFile(basePath, p, currentInstantTime, fileId);
+      FileCreateUtilsV2.createBaseFile(metaClient, p, currentInstantTime, fileId);
       partitionFileIdMap.put(p, fileId);
     }
     return partitionFileIdMap;
@@ -735,7 +735,7 @@ public class HoodieTestTable implements AutoCloseable {
   public Pair<HoodieTestTable, List<String>> withBaseFilesInPartition(String partition, String... fileIds) throws Exception {
     List<String> files = new ArrayList<>();
     for (String f : fileIds) {
-      files.add(FileCreateUtils.createBaseFile(basePath, partition, currentInstantTime, f));
+      files.add(FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, f));
     }
     return Pair.of(this, files);
   }
@@ -743,14 +743,14 @@ public class HoodieTestTable implements AutoCloseable {
   public HoodieTestTable withBaseFilesInPartition(String partition, int... lengths) throws Exception {
     for (int l : lengths) {
       String fileId = UUID.randomUUID().toString();
-      FileCreateUtils.createBaseFile(basePath, partition, currentInstantTime, fileId, l);
+      FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, fileId, l);
     }
     return this;
   }
 
   public HoodieTestTable withBaseFilesInPartition(String partition, List<Pair<String, Integer>> fileInfos) throws Exception {
     for (Pair<String, Integer> fileInfo : fileInfos) {
-      FileCreateUtils.createBaseFile(basePath, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue());
+      FileCreateUtilsV2.createBaseFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue());
     }
     return this;
   }
@@ -768,14 +768,14 @@ public class HoodieTestTable implements AutoCloseable {
   public Pair<HoodieTestTable, List<String>> withLogFile(String partitionPath, String fileId, int... versions) throws Exception {
     List<String> logFiles = new ArrayList<>();
     for (int version : versions) {
-      logFiles.add(FileCreateUtils.createLogFile(basePath, partitionPath, currentInstantTime, fileId, version));
+      logFiles.add(FileCreateUtilsV2.createLogFile(metaClient, partitionPath, currentInstantTime, fileId, version));
     }
     return Pair.of(this, logFiles);
   }
 
   public HoodieTestTable withLogFilesInPartition(String partition, List<Pair<String, Integer[]>> fileInfos) throws Exception {
     for (Pair<String, Integer[]> fileInfo : fileInfos) {
-      FileCreateUtils.createLogFile(basePath, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue()[0], fileInfo.getValue()[1]);
+      FileCreateUtilsV2.createLogFile(metaClient, partition, currentInstantTime, fileInfo.getKey(), fileInfo.getValue()[0], fileInfo.getValue()[1]);
     }
     return this;
   }
@@ -827,17 +827,16 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public Path getInflightCommitFilePath(String instantTime) {
-    return new Path(Paths.get(basePath, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableMetaClient.TIMELINEFOLDER_NAME,
+    return new Path(Paths.get(metaClient.getTimelinePath().toUri().getPath(),
         instantTime + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION).toUri());
   }
 
   public StoragePath getCommitFilePath(String instantTime) {
-    return HoodieTestUtils.getCompleteInstantPath(storage, new StoragePath(new StoragePath(basePath,
-        HoodieTableMetaClient.METAFOLDER_NAME), HoodieTableMetaClient.TIMELINEFOLDER_NAME), instantTime, HoodieTimeline.COMMIT_ACTION);
+    return HoodieTestUtils.getCompleteInstantPath(storage, metaClient.getTimelinePath(), instantTime, HoodieTimeline.COMMIT_ACTION);
   }
 
   public Path getRequestedCompactionFilePath(String instantTime) {
-    return new Path(Paths.get(basePath, HoodieTableMetaClient.AUXILIARYFOLDER_NAME,
+    return new Path(Paths.get(metaClient.getMetaAuxiliaryPath(),
         instantTime + HoodieTimeline.REQUESTED_COMPACTION_EXTENSION).toUri());
   }
 
@@ -847,7 +846,7 @@ public class HoodieTestTable implements AutoCloseable {
 
   public List<java.nio.file.Path> getAllPartitionPaths() throws IOException {
     java.nio.file.Path basePathPath = Paths.get(basePath);
-    return FileCreateUtils.getPartitionPaths(basePathPath);
+    return FileCreateUtilsV2.getPartitionPaths(basePathPath);
   }
 
   public Path getBaseFilePath(String partition, String fileId) {
@@ -943,7 +942,7 @@ public class HoodieTestTable implements AutoCloseable {
           String filePath = entry.getPath().toString();
           String fileName = entry.getPath().getName();
           if (fileName.startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)
-              || !FileCreateUtils.isBaseOrLogFilename(fileName)
+              || !FileCreateUtilsV2.isBaseOrLogFilename(fileName)
               || filePath.contains("metadata")) {
             toReturn = false;
           } else {
@@ -959,7 +958,7 @@ public class HoodieTestTable implements AutoCloseable {
   }
 
   public FileStatus[] listAllFilesInTempFolder() throws IOException {
-    return listRecursive(fs, new Path(Paths.get(basePath, HoodieTableMetaClient.TEMPFOLDER_NAME).toString())).toArray(new FileStatus[0]);
+    return listRecursive(fs, new Path(metaClient.getTempFolderPath())).toArray(new FileStatus[0]);
   }
 
   public void deleteFilesInPartition(String partitionPath, List<String> filesToDelete) throws IOException {
@@ -1369,7 +1368,7 @@ public class HoodieTestTable implements AutoCloseable {
       for (Pair<String, Integer> fileIdInfo : entry.getValue()) {
         HoodieWriteStat writeStat = new HoodieWriteStat();
         String fileName = bootstrap ? fileIdInfo.getKey() :
-            FileCreateUtils.baseFileName(commitTime, fileIdInfo.getKey());
+            FileCreateUtilsV2.baseFileName(commitTime, fileIdInfo.getKey());
         writeStat.setFileId(fileName);
         writeStat.setPartitionPath(partition);
         writeStat.setPath(StringUtils.isNullOrEmpty(partition) ? fileName : partition + "/" + fileName);
@@ -1395,7 +1394,7 @@ public class HoodieTestTable implements AutoCloseable {
       for (Pair<String, Integer[]> fileIdInfo : entry.getValue()) {
         HoodieWriteStat writeStat = new HoodieWriteStat();
         String fileName = bootstrap ? fileIdInfo.getKey() :
-            FileCreateUtils.logFileName(commitTime, fileIdInfo.getKey(), fileIdInfo.getValue()[0]);
+            FileCreateUtilsV2.logFileName(commitTime, fileIdInfo.getKey(), fileIdInfo.getValue()[0]);
         writeStat.setFileId(fileName);
         writeStat.setPartitionPath(partition);
         writeStat.setPath(StringUtils.isNullOrEmpty(partition) ? fileName : partition + "/" + fileName);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -33,7 +33,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -127,7 +127,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     // Generate 10 inserts for each partition and populate partitionBaseFilePairs and recordKeys.
     DATE_PARTITIONS.forEach(p -> {
       try {
-        URI partitionMetaFile = FileCreateUtils.createPartitionMetaFile(basePath, p);
+        URI partitionMetaFile = FileCreateUtilsLegacy.createPartitionMetaFile(basePath, p);
         StoragePath partitionMetadataPath = new StoragePath(partitionMetaFile);
         String fileId1 = UUID.randomUUID().toString();
         FileSlice fileSlice1 = new FileSlice(p, instant1, fileId1);
@@ -239,7 +239,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     // Generate 10 inserts for each partition and populate partitionBaseFilePairs and recordKeys.
     DATE_PARTITIONS.forEach(p -> {
       try {
-        URI partitionMetaFile = FileCreateUtils.createPartitionMetaFile(basePath, p);
+        URI partitionMetaFile = FileCreateUtilsLegacy.createPartitionMetaFile(basePath, p);
         StoragePath partitionMetadataPath = new StoragePath(partitionMetaFile);
         String fileId1 = UUID.randomUUID().toString();
         // add only one parquet file in first file slice

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -32,7 +32,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -203,7 +203,7 @@ public class TestHoodieParquetInputFormat {
         true, schema);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), "100", Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), "100", Option.of(commitMetadata));
 
     // Add the paths
     FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
@@ -673,7 +673,7 @@ public class TestHoodieParquetInputFormat {
 
     // add more files
     InputFormatTestUtil.simulateInserts(partitionDir, baseFileExtension, "fileId2-", 5, "200");
-    FileCreateUtils.createInflightCommit(basePath.toString(), "200");
+    FileCreateUtilsLegacy.createInflightCommit(basePath.toString(), "200");
 
     // Verify that validate mode reads uncommitted files
     InputFormatTestUtil.setupSnapshotIncludePendingCommits(jobConf, "200");
@@ -714,7 +714,7 @@ public class TestHoodieParquetInputFormat {
 
     // create inflight commit add more files with same file_id.
     InputFormatTestUtil.simulateInserts(partitionDir, baseFileExtension, "fileId1", 5, "100");
-    FileCreateUtils.createInflightCommit(basePath.toString(), "100");
+    FileCreateUtilsLegacy.createInflightCommit(basePath.toString(), "100");
 
     // Create another commit without datafiles.
     createCommitFile(basePath, "200", "2016/05/01");

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
@@ -24,7 +24,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -134,14 +134,14 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     // mock the latest schema to the commit metadata
     InternalSchema internalSchema = AvroInternalSchemaConverter.convert(schema);
     commitMetadataOne.addMetadata(SerDeHelper.LATEST_SCHEMA, SerDeHelper.toJson(internalSchema));
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, path1.toString(), commitTime, Option.of(commitMetadataOne));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, path1.toString(), commitTime, Option.of(commitMetadataOne));
     // Create 3 parquet files with 10 records each for partition 2
     File partitionDirTwo = InputFormatTestUtil.prepareParquetTable(path2, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadataTwo = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
     // Mock the latest schema to the commit metadata
     commitMetadataTwo.addMetadata(SerDeHelper.LATEST_SCHEMA, SerDeHelper.toJson(internalSchema));
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, path2.toString(), commitTime, Option.of(commitMetadataTwo));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, path2.toString(), commitTime, Option.of(commitMetadataTwo));
 
     // Enable schema evolution
     conf.set("hoodie.schema.on.read.enable", "true");
@@ -209,7 +209,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
         .prepareMultiPartitionedParquetTable(tempDir, schema, 3, numRecords, commitTime, HoodieTableType.MERGE_ON_READ);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
 
     TableDesc tblDesc = Utilities.defaultTd;
     // Set the input format
@@ -291,7 +291,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     File partitionDir = InputFormatTestUtil.prepareParquetTable(tempDir, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
 
     TableDesc tblDesc = Utilities.defaultTd;
     // Set the input format
@@ -374,7 +374,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     File partitionDir = InputFormatTestUtil.prepareParquetTable(tempDir, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
 
     String newCommitTime = "101";
     // to trigger the bug of HUDI-1772, only update fileid2
@@ -445,7 +445,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     File partitionDir = InputFormatTestUtil.prepareParquetTable(tempDir, schema, 3, numRecords, commitTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, tempDir.toString(), commitTime, Option.of(commitMetadata));
 
     // insert 1000 update records to log file 0
     String newCommitTime = "101";

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
@@ -31,7 +31,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.CommitUtils;
@@ -125,7 +125,7 @@ public class TestHoodieMergeOnReadSnapshotReader {
 
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), baseInstant, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), baseInstant, commitMetadata);
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
 
@@ -164,7 +164,7 @@ public class TestHoodieMergeOnReadSnapshotReader {
         long size = writer.getCurrentSize();
         writer.close();
         assertTrue(size > 0, "block - size should be > 0");
-        FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+        FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
         fileSlice.addLogFile(writer.getLogFile());
 
         HoodieMergeOnReadSnapshotReader snapshotReader = new HoodieMergeOnReadSnapshotReader(

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -35,7 +35,7 @@ import org.apache.hudi.common.table.log.HoodieLogFormat.Writer;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -205,7 +205,7 @@ public class TestHoodieRealtimeRecordReader {
 
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), baseInstant, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), baseInstant, commitMetadata);
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
 
@@ -242,7 +242,7 @@ public class TestHoodieRealtimeRecordReader {
         long size = writer.getCurrentSize();
         writer.close();
         assertTrue(size > 0, "block - size should be > 0");
-        FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+        FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
 
         // create a split with baseFile (parquet file written earlier) and new log file(s)
         fileSlice.addLogFile(writer.getLogFile());
@@ -317,7 +317,7 @@ public class TestHoodieRealtimeRecordReader {
         HoodieTableType.MERGE_ON_READ);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
 
@@ -330,7 +330,7 @@ public class TestHoodieRealtimeRecordReader {
     long size = writer.getCurrentSize();
     writer.close();
     assertTrue(size > 0, "block - size should be > 0");
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, commitMetadata);
 
     // create a split with baseFile (parquet file written earlier) and new log file(s)
     HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
@@ -401,7 +401,7 @@ public class TestHoodieRealtimeRecordReader {
 
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
 
@@ -414,7 +414,7 @@ public class TestHoodieRealtimeRecordReader {
     assertTrue(size > 0, "block - size should be > 0");
     commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, commitMetadata);
 
     // create a split with baseFile (parquet file written earlier) and new log file(s)
     HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
@@ -542,7 +542,7 @@ public class TestHoodieRealtimeRecordReader {
             instantTime, HoodieTableType.MERGE_ON_READ);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
     List<Field> firstSchemaFields = schema.getFields();
@@ -572,7 +572,7 @@ public class TestHoodieRealtimeRecordReader {
         CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(),
             WriteOperationType.UPSERT,
             schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
-    FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+    FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
 
     // create a split with baseFile (parquet file written earlier) and new log file(s)
     HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
@@ -633,7 +633,7 @@ public class TestHoodieRealtimeRecordReader {
             instantTime, HoodieTableType.MERGE_ON_READ);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         schema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, Option.of(commitMetadata));
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
     List<Field> firstSchemaFields = schema.getFields();
@@ -647,7 +647,7 @@ public class TestHoodieRealtimeRecordReader {
             instantTime, HoodieTableType.MERGE_ON_READ, "2017", "05", "01");
     HoodieCommitMetadata commitMetadata1 = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
         evolvedSchema.toString(), HoodieTimeline.COMMIT_ACTION);
-    FileCreateUtils.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, Option.of(commitMetadata1));
+    FileCreateUtilsLegacy.createCommit(COMMIT_METADATA_SER_DE, basePath.toString(), newCommitTime, Option.of(commitMetadata1));
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir1.getPath());
 
@@ -860,7 +860,7 @@ public class TestHoodieRealtimeRecordReader {
     String baseInstant = "100";
     File partitionDir = InputFormatTestUtil.prepareNonPartitionedParquetTable(basePath, schema, 1, 100, baseInstant,
         HoodieTableType.MERGE_ON_READ);
-    FileCreateUtils.createDeltaCommit(basePath.toString(), baseInstant);
+    FileCreateUtilsLegacy.createDeltaCommit(basePath.toString(), baseInstant);
     // Add the paths
     FileInputFormat.setInputPaths(baseJobConf, partitionDir.toURI().toString());
 
@@ -881,7 +881,7 @@ public class TestHoodieRealtimeRecordReader {
           CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(),
               WriteOperationType.UPSERT,
               schema.toString(), HoodieTimeline.COMMIT_ACTION);
-      FileCreateUtils.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+      FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
       // create a split with new log file(s)
       fileSlice.addLogFile(new HoodieLogFile(writer.getLogFile().getPath(), size));
       RealtimeFileStatus realtimeFileStatus = new RealtimeFileStatus(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -67,7 +67,7 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -1006,7 +1006,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
             metadataCompactionInstant.get(), HoodieTimeline.COMMIT_ACTION)
         .toUri());
     java.nio.file.Path tempFilePath =
-        FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
+        FileCreateUtilsLegacy.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
     metaClient.reloadActiveTimeline();
     testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter, Option.of(context));
     // this validation will exercise the code path where a compaction is inflight in metadata table, but still metadata based file listing should match non
@@ -1018,7 +1018,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       doWriteOperation(testTable, metaClient.createNewInstantTime(), INSERT);
     } else {
       // let the compaction succeed in metadata and validation should succeed.
-      FileCreateUtils.renameTempToMetaFile(tempFilePath, metaFilePath);
+      FileCreateUtilsLegacy.renameTempToMetaFile(tempFilePath, metaFilePath);
     }
 
     validateMetadata(testTable);
@@ -1041,7 +1041,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
               new StoragePath(new StoragePath(metadataTableBasePath, METAFOLDER_NAME), TIMELINEFOLDER_NAME),
               metadataCompactionInstant.get(), HoodieTimeline.COMMIT_ACTION)
           .toUri());
-      FileCreateUtils.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
+      FileCreateUtilsLegacy.renameFileToTemp(metaFilePath, metadataCompactionInstant.get());
 
       validateMetadata(testTable);
 
@@ -2348,7 +2348,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtilsLegacy.deleteReplaceCommit(basePath, clusteringCommitTime);
     HoodieWriteMetadata<JavaRDD<WriteStatus>> updatedClusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     metaClient.reloadActiveTimeline();
@@ -2405,7 +2405,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieWriteMetadata<JavaRDD<WriteStatus>> clusterMetadata = newClient.cluster(clusteringCommitTime, true);
 
     // manually remove clustering completed instant from .hoodie folder and to mimic succeeded clustering in metadata table, but failed in data table.
-    FileCreateUtils.deleteReplaceCommit(basePath, clusteringCommitTime);
+    FileCreateUtilsLegacy.deleteReplaceCommit(basePath, clusteringCommitTime);
 
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieWriteConfig updatedWriteConfig = HoodieWriteConfig.newBuilder().withProperties(initialConfig.getProps())
@@ -2438,8 +2438,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       assertNoWriteErrors(writeStatuses);
 
       // make all commits to inflight in metadata table. Still read should go through, just that it may not return any data.
-      FileCreateUtils.deleteDeltaCommit(basePath + "/.hoodie/metadata/", commitTimestamps[0]);
-      FileCreateUtils.deleteDeltaCommit(basePath + " /.hoodie/metadata/", SOLO_COMMIT_TIMESTAMP);
+      FileCreateUtilsLegacy.deleteDeltaCommit(basePath + "/.hoodie/metadata/", commitTimestamps[0]);
+      FileCreateUtilsLegacy.deleteDeltaCommit(basePath + " /.hoodie/metadata/", SOLO_COMMIT_TIMESTAMP);
       assertEquals(getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet()).size(), 0);
     }
   }
@@ -2476,18 +2476,18 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // mark each commit as incomplete and ensure files are not seen
       for (int i = 0; i < commitTimestamps.length; ++i) {
-        FileCreateUtils.deleteCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[i]);
         timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
         assertEquals(timelineTimestamps.size(), commitTimestamps.length - 1);
         for (int j = 0; j < commitTimestamps.length; ++j) {
           assertTrue(j == i || timelineTimestamps.contains(commitTimestamps[j]));
         }
-        FileCreateUtils.createCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.createCommit(basePath, commitTimestamps[i]);
       }
 
       // Test multiple incomplete commits
-      FileCreateUtils.deleteCommit(basePath, commitTimestamps[0]);
-      FileCreateUtils.deleteCommit(basePath, commitTimestamps[2]);
+      FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[0]);
+      FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[2]);
       timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
       assertEquals(timelineTimestamps.size(), commitTimestamps.length - 2);
       for (int j = 0; j < commitTimestamps.length; ++j) {
@@ -2496,7 +2496,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // Test no completed commits
       for (int i = 0; i < commitTimestamps.length; ++i) {
-        FileCreateUtils.deleteCommit(basePath, commitTimestamps[i]);
+        FileCreateUtilsLegacy.deleteCommit(basePath, commitTimestamps[i]);
       }
       timelineTimestamps = getAllFiles(metadata(client)).stream().map(p -> p.getName()).map(n -> FSUtils.getCommitTime(n)).collect(Collectors.toSet());
       assertEquals(timelineTimestamps.size(), 0);
@@ -2568,8 +2568,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
         if (i == 0) {
           // Mark this commit inflight so compactions don't take place
-          FileCreateUtils.deleteCommit(basePath, newCommitTime);
-          FileCreateUtils.createInflightCommit(basePath, newCommitTime);
+          FileCreateUtilsLegacy.deleteCommit(basePath, newCommitTime);
+          FileCreateUtilsLegacy.createInflightCommit(basePath, newCommitTime);
           inflightCommitTime = newCommitTime;
         }
       }
@@ -2581,7 +2581,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
           ((2 * maxDeltaCommitsBeforeCompaction) + (maxDeltaCommitsBeforeCompaction /* clean from dataset */) + 1)/* clean in metadata table */);
 
       // Complete commit
-      FileCreateUtils.createCommit(basePath, inflightCommitTime);
+      FileCreateUtilsLegacy.createCommit(basePath, inflightCommitTime);
 
       // Next commit should lead to compaction
       newCommitTime = client.createNewInstantTime();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
@@ -36,7 +36,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.RawTripTestPayload;
@@ -258,9 +258,9 @@ public class TestOrcBootstrap extends HoodieSparkClientTestBase {
 
     // Rollback Bootstrap
     if (deltaCommit) {
-      FileCreateUtils.deleteDeltaCommit(metaClient.getBasePath().toString(), bootstrapCommitInstantTs);
+      FileCreateUtilsLegacy.deleteDeltaCommit(metaClient.getBasePath().toString(), bootstrapCommitInstantTs);
     } else {
-      FileCreateUtils.deleteCommit(metaClient.getBasePath().toString(), bootstrapCommitInstantTs);
+      FileCreateUtilsLegacy.deleteCommit(metaClient.getBasePath().toString(), bootstrapCommitInstantTs);
     }
     client.getTableServiceClient().rollbackFailedBootstrap();
     metaClient.reloadActiveTimeline();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -45,7 +45,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
@@ -249,7 +249,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
       // verify that there is no new rollback instant generated
       HoodieInstant rollbackInstant = metaClient.getActiveTimeline().getRollbackTimeline().lastInstant().get();
       String basePathStr = metaClient.getBasePath().toString();
-      FileCreateUtils.deleteRollbackCommit(basePathStr.substring(basePathStr.indexOf(":") + 1),
+      FileCreateUtilsLegacy.deleteRollbackCommit(basePathStr.substring(basePathStr.indexOf(":") + 1),
           rollbackInstant.requestedTime());
       metaClient.reloadActiveTimeline();
       try (SparkRDDWriteClient client1 = getHoodieWriteClient(cfg)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallProcedure.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hudi.procedure
 
 import org.apache.hudi.common.model.IOType
-import org.apache.hudi.common.testutils.FileCreateUtils
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy
 
 class TestCallProcedure extends HoodieSparkProcedureTestBase {
 
@@ -196,15 +196,15 @@ class TestCallProcedure extends HoodieSparkProcedureTestBase {
         s"Argument: instant_time is required")
 
       val instantTime = "101"
-      FileCreateUtils.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
+      FileCreateUtilsLegacy.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
       assertResult(1) {
-        FileCreateUtils.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
+        FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
       }
 
       checkAnswer(s"""call delete_marker(table => '$tableName', instant_time => '$instantTime')""")(Seq(true))
 
       assertResult(0) {
-        FileCreateUtils.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
+        FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
       }
     }
   }
@@ -234,21 +234,21 @@ class TestCallProcedure extends HoodieSparkProcedureTestBase {
         s"Argument: instant_time is required")
 
       var instantTime = "101"
-      FileCreateUtils.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
+      FileCreateUtilsLegacy.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
       assertResult(1) {
-        FileCreateUtils.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
+        FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
       }
       instantTime = "102"
-      FileCreateUtils.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
+      FileCreateUtilsLegacy.createMarkerFile(tablePath, "", instantTime, "f0", IOType.APPEND)
       assertResult(1) {
-        FileCreateUtils.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
+        FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
       }
 
       instantTime = "101,102"
       checkAnswer(s"""call delete_marker(table => '$tableName', instant_time => '$instantTime')""")(Seq(true))
 
       assertResult(0) {
-        FileCreateUtils.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
+        FileCreateUtilsLegacy.getTotalMarkerFileCount(tablePath, "", instantTime, IOType.APPEND)
       }
     }
   }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.model.HoodieSyncTableStrategy;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.testutils.NetworkTestUtils;
@@ -345,8 +345,8 @@ public class TestHiveSyncTool {
     assertEquals(5, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "No new partition should be added");
     hiveClient.addPartitionsToTable(HiveTestUtil.TABLE_NAME, newPartition);
-    FileCreateUtils.createPartitionMetaFile(basePath, "2050/01/01");
-    FileCreateUtils.createPartitionMetaFile(basePath, "2040/02/01");
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, "2050/01/01");
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, "2040/02/01");
     assertEquals(7, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "New partition should be added");
 
@@ -1393,7 +1393,7 @@ public class TestHiveSyncTool {
     assertEquals(1, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "No new partition should be added");
     hiveClient.addPartitionsToTable(HiveTestUtil.TABLE_NAME, newPartition);
-    FileCreateUtils.createPartitionMetaFile(basePath, "2050/01/01");
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, "2050/01/01");
     assertEquals(2, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "New partition should be added");
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -43,7 +43,7 @@ import org.apache.hudi.common.table.log.HoodieLogFormat.Writer;
 import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
-import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -398,7 +398,7 @@ public class HiveTestUtil {
     Path partPath = new Path(basePath + "/" + partitionPath);
     fileSystem.makeQualified(partPath);
     fileSystem.mkdirs(partPath);
-    FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, partitionPath);
     List<HoodieWriteStat> writeStats = new ArrayList<>();
     String fileId = UUID.randomUUID().toString();
     Path filePath = new Path(partPath.toString() + "/"
@@ -562,7 +562,7 @@ public class HiveTestUtil {
       Path partPath = new Path(basePath + "/" + partitionPath);
       fileSystem.makeQualified(partPath);
       fileSystem.mkdirs(partPath);
-      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtilsLegacy.createPartitionMetaFile(basePath, partitionPath);
       List<HoodieWriteStat> writeStats = createTestData(partPath, isParquetSchemaSimple, instantTime);
       startFrom = startFrom.minusDays(1);
       writeStats.forEach(s -> commitMetadata.addWriteStat(partitionPath, s));
@@ -578,7 +578,7 @@ public class HiveTestUtil {
       Path partPath = new Path(basePath + "/" + partitionPath);
       fileSystem.makeQualified(partPath);
       fileSystem.mkdirs(partPath);
-      FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+      FileCreateUtilsLegacy.createPartitionMetaFile(basePath, partitionPath);
       List<HoodieWriteStat> writeStats = createTestData(partPath, schemaPath, dataPath, instantTime);
       writeStats.forEach(s -> commitMetadata.addWriteStat(partitionPath, s));
     }
@@ -594,7 +594,7 @@ public class HiveTestUtil {
     Path partPath = new Path(basePath + "/" + partitionPath);
     fileSystem.makeQualified(partPath);
     fileSystem.mkdirs(partPath);
-    FileCreateUtils.createPartitionMetaFile(basePath, partitionPath);
+    FileCreateUtilsLegacy.createPartitionMetaFile(basePath, partitionPath);
     List<HoodieWriteStat> writeStats = createTestData(partPath, isParquetSchemaSimple, instantTime);
     writeStats.forEach(s -> commitMetadata.addWriteStat(partitionPath, s));
     addSchemaToCommitMetadata(commitMetadata, isParquetSchemaSimple, useSchemaFromCommitMetadata);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.createBaseFile;
 import static org.apache.hudi.utilities.config.DFSPathSelectorConfig.ROOT_INPUT_PATH;
 import static org.apache.hudi.utilities.config.DatePartitionPathSelectorConfig.PARTITIONS_LIST_PARALLELISM;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
### Change Logs

1st commit
Revised the test utils so it can work in both table version 6 timeline
layout 1 and table version 8 and timeline layout 2 mode. Previously as
all the metafolder path and the completion instant file names are are
hard coded, so they cannot accommodate based on the given version.

FileCreateUtilsV2 is introduced which takes metaClient as input to solve
this issue. We should use this as opposed to old FileCreateUtilsV2 in
the future.

2nd commit
Test hollow commit handling in both old and new table version and
timeline layout version.


### Impact

better test coverage
### Risk level (write none, low medium or high below)

none
### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
