### PR TITLE
[HUDI-8805]  Upgrade commons-io version to 2.14.0 to fix CVE-2024-47554

### DIFF
--- a/dependencies/hudi-flink-bundle_2.11.txt
+++ b/dependencies/hudi-flink-bundle_2.11.txt
@@ -59,7 +59,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.0.1//commons-httpclient-3.0.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-flink-bundle_2.12.txt
+++ b/dependencies/hudi-flink-bundle_2.12.txt
@@ -59,7 +59,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.0.1//commons-httpclient-3.0.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-hadoop-mr-bundle.txt
+++ b/dependencies/hudi-hadoop-mr-bundle.txt
@@ -34,7 +34,7 @@ commons-configuration/commons-configuration/1.6//commons-configuration-1.6.jar
 commons-daemon/commons-daemon/1.0.13//commons-daemon-1.0.13.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar
 commons-math/org.apache.commons/2.2//commons-math-2.2.jar

--- a/dependencies/hudi-hive-sync-bundle.txt
+++ b/dependencies/hudi-hive-sync-bundle.txt
@@ -34,7 +34,7 @@ commons-configuration/commons-configuration/1.6//commons-configuration-1.6.jar
 commons-daemon/commons-daemon/1.0.13//commons-daemon-1.0.13.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar
 commons-math/org.apache.commons/2.2//commons-math-2.2.jar

--- a/dependencies/hudi-integ-test-bundle.txt
+++ b/dependencies/hudi-integ-test-bundle.txt
@@ -70,7 +70,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/dependencies/hudi-kafka-connect-bundle.txt
+++ b/dependencies/hudi-kafka-connect-bundle.txt
@@ -53,7 +53,7 @@ commons-crypto/org.apache.commons/1.0.0//commons-crypto-1.0.0.jar
 commons-daemon/commons-daemon/1.0.13//commons-daemon-1.0.13.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.3.2//commons-lang3-3.3.2.jar
 commons-logging/commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/dependencies/hudi-presto-bundle.txt
+++ b/dependencies/hudi-presto-bundle.txt
@@ -34,7 +34,7 @@ commons-configuration/commons-configuration/1.6//commons-configuration-1.6.jar
 commons-daemon/commons-daemon/1.0.13//commons-daemon-1.0.13.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar
 commons-math/org.apache.commons/2.2//commons-math-2.2.jar

--- a/dependencies/hudi-spark-bundle_2.11.txt
+++ b/dependencies/hudi-spark-bundle_2.11.txt
@@ -50,7 +50,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-spark-bundle_2.12.txt
+++ b/dependencies/hudi-spark-bundle_2.12.txt
@@ -50,7 +50,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-spark3-bundle_2.12.txt
+++ b/dependencies/hudi-spark3-bundle_2.12.txt
@@ -50,7 +50,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-timeline-server-bundle.txt
+++ b/dependencies/hudi-timeline-server-bundle.txt
@@ -33,7 +33,7 @@ commons-configuration/commons-configuration/1.6//commons-configuration-1.6.jar
 commons-daemon/commons-daemon/1.0.13//commons-daemon-1.0.13.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar
 commons-math/org.apache.commons/2.2//commons-math-2.2.jar

--- a/dependencies/hudi-utilities-bundle_2.11.txt
+++ b/dependencies/hudi-utilities-bundle_2.11.txt
@@ -64,7 +64,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/dependencies/hudi-utilities-bundle_2.12.txt
+++ b/dependencies/hudi-utilities-bundle_2.12.txt
@@ -64,7 +64,7 @@ commons-dbcp/commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/commons-digester/1.8//commons-digester-1.8.jar
 commons-el/commons-el/1.0//commons-el-1.0.jar
 commons-httpclient/commons-httpclient/3.1//commons-httpclient-3.1.jar
-commons-io/commons-io/2.4//commons-io-2.4.jar
+commons-io/commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/org.apache.commons/3.1//commons-lang3-3.1.jar
 commons-logging/commons-logging/1.2//commons-logging-1.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <avro.version>1.11.4</avro.version>
     <bijection-avro.version>0.9.8</bijection-avro.version>
     <caffeine.version>2.9.1</caffeine.version>
-    <commons.io.version>2.11.0</commons.io.version>
+    <commons.io.version>2.14.0</commons.io.version>
     <scala12.version>2.12.15</scala12.version>
     <scala13.version>2.13.8</scala13.version>
     <scala.version>${scala12.version}</scala.version>


### PR DESCRIPTION
### Change Logs

Upgrade commons-io to fix https://github.com/advisories/GHSA-78wr-2p64-hpwj

### Impact

https://github.com/advisories/GHSA-78wr-2p64-hpwj:

Uncontrolled Resource Consumption vulnerability in Apache Commons IO. The org.apache.commons.io.input.XmlStreamReader class may excessively consume CPU resources when processing maliciously crafted input.

### Risk level (write none, low medium or high below)

HIGH

### Documentation Update

Upgrade commons-io to 2.14.0 version


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
