### PR TITLE
[HUDI-8851] Fix delete record generation in Prepped DELETE operation in Spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
@@ -242,7 +243,7 @@ public class DataSourceUtils {
       JavaRDD<HoodieRecord> records = hoodieKeysAndLocations.map(tuple -> {
         HoodieRecord record = recordType == HoodieRecord.HoodieRecordType.AVRO
             ? new HoodieAvroRecord(tuple._1, new EmptyHoodieRecordPayload())
-            : new HoodieSparkRecord(tuple._1, null, false);
+            : new HoodieEmptyRecord(tuple._1, HoodieRecord.HoodieRecordType.SPARK);
         record.setCurrentLocation(tuple._2.get());
         return record;
       });

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteFromTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteFromTable.scala
@@ -17,69 +17,86 @@
 
 package org.apache.spark.sql.hudi.dml
 
+import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
 class TestDeleteFromTable extends HoodieSparkSqlTestBase {
 
   test("Test deleting from table") {
-    withRecordType()(withTempDir { tmp =>
-      Seq("cow", "mor").foreach { tableType =>
-        val tableName = generateTableName
-        spark.sql(
-          s"""
-             |CREATE TABLE $tableName (
-             |  id int,
-             |  dt string,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) USING hudi
-             | tblproperties (
-             |    primaryKey = 'id',
-             |    tableType = '$tableType'
-             | )
-             | PARTITIONED BY (dt)
-             | LOCATION '${tmp.getCanonicalPath}/$tableName'
+    withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
+      withRecordType()(withTempDir { tmp =>
+        Seq("cow,COMMIT_TIME_ORDERING", "cow,EVENT_TIME_ORDERING",
+          "mor,COMMIT_TIME_ORDERING", "mor,EVENT_TIME_ORDERING").foreach { argString =>
+          val args = argString.split(',')
+          val tableType = args(0)
+          val mergeMode = args(1)
+          val preCombineClause =
+            if (RecordMergeMode.valueOf(mergeMode) == RecordMergeMode.EVENT_TIME_ORDERING) {
+              "preCombineField = 'ts',"
+            } else {
+              ""
+            }
+          val tableName = generateTableName
+          spark.sql(
+            s"""
+               |CREATE TABLE $tableName (
+               |  id int,
+               |  dt string,
+               |  name string,
+               |  price double,
+               |  ts long
+               |) USING hudi
+               | tblproperties (
+               |    primaryKey = 'id',
+               |    $preCombineClause
+               |    type = '$tableType',
+               |    recordMergeMode = '$mergeMode'
+               | )
+               | PARTITIONED BY (dt)
+               | LOCATION '${tmp.getCanonicalPath}/$tableName'
          """.stripMargin)
 
-        // NOTE: Do not write the field alias, the partition field must be placed last.
-        spark.sql(
-          s"""
-             | INSERT INTO $tableName VALUES
-             | (1, 'a1', 10, 1000, "2021-01-05"),
-             | (2, 'a2', 20, 2000, "2021-01-06"),
-             | (3, 'a3', 30, 3000, "2021-01-07")
+          // NOTE: Do not write the field alias, the partition field must be placed last.
+          spark.sql(
+            s"""
+               | INSERT INTO $tableName VALUES
+               | (1, 'a1', 10, 1000, "2021-01-05"),
+               | (2, 'a2', 20, 2000, "2021-01-06"),
+               | (3, 'a3', 30, 3000, "2021-01-07")
                 """.stripMargin)
 
-        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
-          Seq(1, "a1", 10.0, 1000, "2021-01-05"),
-          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
-          Seq(3, "a3", 30.0, 3000, "2021-01-07")
-        )
+          checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+            Seq(1, "a1", 10.0, 1000, "2021-01-05"),
+            Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+            Seq(3, "a3", 30.0, 3000, "2021-01-07")
+          )
 
-        // Delete single row
-        spark.sql(s"DELETE FROM $tableName WHERE id = 1")
+          // Delete single row
+          spark.sql(s"DELETE FROM $tableName WHERE id = 1")
 
-        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
-          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
-          Seq(3, "a3", 30.0, 3000, "2021-01-07")
-        )
+          checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+            Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+            Seq(3, "a3", 30.0, 3000, "2021-01-07")
+          )
 
-        // Try deleting non-existent row
-        spark.sql(s"DELETE FROM $tableName WHERE id = 1")
+          // Try deleting non-existent row
+          spark.sql(s"DELETE FROM $tableName WHERE id = 1")
 
-        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
-          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
-          Seq(3, "a3", 30.0, 3000, "2021-01-07")
-        )
+          checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+            Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+            Seq(3, "a3", 30.0, 3000, "2021-01-07")
+          )
 
-        // Delete record identified by some field other than the primary-key
-        spark.sql(s"DELETE FROM $tableName WHERE name = 'a2'")
+          // Delete record identified by some field other than the primary-key
+          spark.sql(s"DELETE FROM $tableName WHERE name = 'a2'")
 
-        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
-          Seq(3, "a3", 30.0, 3000, "2021-01-07")
-        )
-      }
-    })
+          checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+            Seq(3, "a3", 30.0, 3000, "2021-01-07")
+          )
+        }
+      })
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeEventTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeEventTimeOrdering.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.dml
 
 import org.apache.hudi.DataSourceWriteOptions
+
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
 class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
@@ -161,14 +162,11 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
             Seq(2, "B", 40.0, 101)
           )
           // Delete record with no ts.
-          // [HUDI-8851] For MOR we hit NPE
-          if (tableType.equals("cow")) {
-            spark.sql(s"delete from $tableName where id = 1")
-            // Verify deletion
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(2, "B", 40.0, 101)
-            )
-          }
+          spark.sql(s"delete from $tableName where id = 1")
+          // Verify deletion
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+            Seq(2, "B", 40.0, 101)
+          )
         })
       }
     }


### PR DESCRIPTION
### Change Logs

In the prepped DELETE operation in Spark, NPE was thrown from the `HoodieAppendHandle` for ecord merge mode of `EVENT_TIME_ORDERING` on MOR table (see stacktrace below).

The issue is that `HoodieEmptyRecord` should be generated for deletes instead of `HoodieSparkRecord` for `SPARK` record type on the write path.

New tests are added to guard DELETE SQL with different record merge modes and table types.

```
Caused by: java.lang.NullPointerException
at org.apache.spark.sql.HoodieUnsafeRowUtils$.getNestedInternalRowValue(HoodieUnsafeRowUtils.scala:69)
at org.apache.spark.sql.HoodieUnsafeRowUtils.getNestedInternalRowValue(HoodieUnsafeRowUtils.scala)
at org.apache.hudi.common.model.HoodieSparkRecord.getOrderingValue(HoodieSparkRecord.java:322)
at org.apache.hudi.io.HoodieAppendHandle.writeToBuffer(HoodieAppendHandle.java:608)
at org.apache.hudi.io.HoodieAppendHandle.doAppend(HoodieAppendHandle.java:465)
at org.apache.hudi.table.action.deltacommit.BaseSparkDeltaCommitActionExecutor.handleUpdate(BaseSparkDeltaCommitActionExecutor.java:83)
at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpsertPartition(BaseSparkCommitActionExecutor.java:312)
```

### Impact

Bug fix

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
