### PR TITLE
[HUDI-8553] Support writing record positions to log blocks from Spark SQL UPDATE and DELETE statements

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -239,4 +239,9 @@ trait SparkAdapter extends Serializable {
   def sqlExecutionWithNewExecutionId[T](sparkSession: SparkSession,
                                         queryExecution: QueryExecution,
                                         name: Option[String] = None)(body: => T): T
+
+  /**
+   * Returns temporary row index column name used in Spark
+   */
+  def getTemporaryRowIndexColumnName(): String
 }

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -25,12 +25,12 @@ import org.apache.hudi.exception.InvalidUnionTypeException;
 import org.apache.hudi.exception.MissingSchemaFieldException;
 import org.apache.hudi.exception.SchemaBackwardsCompatibilityException;
 import org.apache.hudi.exception.SchemaCompatibilityException;
-
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaCompatibility;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.action.TableChanges;
 import org.apache.hudi.internal.schema.utils.SchemaChangeUtils;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaCompatibility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -597,6 +597,22 @@ public class AvroSchemaUtils {
     return String.format("%s\nwriterSchema: %s\ntableSchema: %s", errorMessage, writerSchema, tableSchema);
   }
 
+  public static Schema projectSchema(Schema schema, List<String> fieldNames, Schema.Field newField) {
+    List<Schema.Field> fieldList = fieldNames.stream().map(name -> {
+      Schema.Field originalField = schema.getField(name);
+      return new Schema.Field(
+          originalField.name(),
+          originalField.schema(),
+          originalField.doc(),
+          originalField.defaultVal());
+    }).collect(Collectors.toList());
+    fieldList.add(newField);
+    Schema newSchema = Schema.createRecord(
+        schema.getName(), "", schema.getNamespace(), false);
+    newSchema.setFields(fieldList);
+    return newSchema;
+  }
+
   /**
    * Create a new schema by force changing all the fields as nullable.
    *
@@ -605,14 +621,14 @@ public class AvroSchemaUtils {
    */
   public static Schema asNullable(Schema schema) {
     List<String> filterCols = schema.getFields().stream()
-            .filter(f -> !f.schema().isNullable()).map(Schema.Field::name).collect(Collectors.toList());
+        .filter(f -> !f.schema().isNullable()).map(Schema.Field::name).collect(Collectors.toList());
     if (filterCols.isEmpty()) {
       return schema;
     }
     InternalSchema internalSchema = convert(schema);
     TableChanges.ColumnUpdateChange schemaChange = TableChanges.ColumnUpdateChange.get(internalSchema);
     schemaChange = reduce(filterCols, schemaChange,
-            (change, field) -> change.updateColumnNullability(field, true));
+        (change, field) -> change.updateColumnNullability(field, true));
     return convert(SchemaChangeUtils.applyTableChanges2Schema(internalSchema, schemaChange), schema.getFullName());
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -352,6 +352,12 @@ object DataSourceWriteOptions {
    * operations are already prepped.
    */
   val SPARK_SQL_WRITES_PREPPED_KEY = "_hoodie.spark.sql.writes.prepped";
+  val ROW_POSITION_META_COLUMN = "_hoodie_row_position"
+  val SPARK_READ_ATTACH_ROW_POSITION: ConfigProperty[Boolean] = ConfigProperty
+    .key("_hoodie.spark.read.attach.row.position")
+    .defaultValue(false)
+    .withDocumentation("When enabled, the datasource read and SQL query return the results with "
+      + s"row position column, $ROW_POSITION_META_COLUMN, attached.")
 
   /**
    * May be derive partition path from incoming df if not explicitly set.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCatalystUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCatalystUtils.scala
@@ -21,6 +21,8 @@ package org.apache.hudi
 import org.apache.hudi.common.data.HoodieData
 
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
 
@@ -61,6 +63,13 @@ object HoodieCatalystUtils extends SparkAdapterSupport {
       f
     } finally {
       data.unpersist()
+    }
+  }
+
+  def toUnresolved(e: Expression): Expression = {
+    e transform {
+      case AttributeReference(name, _, _, _) =>
+        UnresolvedAttribute(name)
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
@@ -226,8 +226,8 @@ object HoodieCreateRecordUtils {
     else {
       None
     }
-    val recordPosition: Option[Long] = if (fetchRecordLocationFromMetaFields) {
-      Option(avroRec.get(ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME)).map(_.asInstanceOf[Long])
+    val recordPosition: Option[Long] = if (fetchRecordLocationFromMetaFields && avroRec.hasField(SparkAdapterSupport.sparkAdapter.getTemporaryRowIndexColumnName())) {
+      Option(avroRec.get(SparkAdapterSupport.sparkAdapter.getTemporaryRowIndexColumnName())).map(_.asInstanceOf[Long])
     } else {
       None
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -18,18 +18,26 @@
 package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.DataSourceWriteOptions.{SPARK_SQL_OPTIMIZED_WRITES, SPARK_SQL_WRITES_PREPPED_KEY}
+import org.apache.hudi.HoodieBaseRelation.convertToAvroSchema
 import org.apache.hudi.SparkAdapterSupport
-
-import org.apache.spark.sql.HoodieCatalystExpressionUtils.attributeEquals
+import org.apache.hudi.avro.AvroSchemaUtils
+import org.apache.hudi.HoodieCatalystUtils.toUnresolved
+import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.spark.sql._
+import org.apache.spark.sql.HoodieCatalystExpressionUtils.attributeEquals
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
-import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, LogicalPlan, Project, UpdateTable}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, UpdateTable}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.failAnalysis
+import org.apache.spark.sql.types.LongType
+
+import scala.jdk.CollectionConverters.{mapAsJavaMapConverter, seqAsJavaListConverter}
 
 case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableCommand
   with SparkAdapterSupport with ProvidesHoodieConfig {
@@ -81,6 +89,11 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
       case Assignment(attr: AttributeReference, value) => attr -> value
     }
 
+    val rowIndexAttr = AttributeReference(
+      ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME, LongType, nullable = true)()
+
+    val attributeSeq = ut.table.output
+
     // We don't support update queries changing partition column value.
     validateNoAssignmentsToTargetTableAttr(
       sparkSession.sessionState.conf.resolver,
@@ -101,9 +114,9 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
 
     val filteredOutput = if (sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
       , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true") {
-      ut.table.output
+      attributeSeq
     } else {
-      removeMetaFields(ut.table.output)
+      removeMetaFields(attributeSeq)
     }
 
     val targetExprs = filteredOutput.map { targetAttr =>
@@ -116,7 +129,22 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
     }
 
     val condition = ut.condition.getOrElse(TrueLiteral)
-    val filteredPlan = Filter(condition, Project(targetExprs, ut.table))
+
+    val x = convertToAvroSchema(catalogTable.tableSchema, catalogTable.tableName)
+    val schema = AvroSchemaUtils.projectSchema(
+      convertToAvroSchema(catalogTable.tableSchema, catalogTable.tableName),
+      attributeSeq.map(e => e.name).asJava,
+      new Schema.Field(
+        ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME,
+        Schema.createUnion(
+          Schema.create(Schema.Type.NULL), SchemaBuilder.builder().longType())
+      ))
+    val options = Map(
+      "hoodie.datasource.query.type" -> "snapshot",
+      "path" -> catalogTable.metaClient.getBasePath.toString)
+    val relation = sparkAdapter.createRelation(
+      sparkSession.sqlContext, catalogTable.metaClient, schema, Array.empty, options.asJava)
+    val filteredPlan = Filter(toUnresolved(condition), LogicalRelation(relation))
 
     val config = if (sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
       , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.hudi.HoodieSparkUtils.gteqSpark3_4
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,8 +33,8 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
 
   test("Test Update Table") {
     withRecordType()(withTempDir { tmp =>
-      Seq(true, false).foreach { sparkSqlOptimizedWrites =>
-        Seq("cow", "mor").foreach { tableType =>
+      Seq(true).foreach { sparkSqlOptimizedWrites =>
+        Seq("mor").foreach { tableType =>
           val tableName = generateTableName
           // create table
           spark.sql(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -33,8 +33,8 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
 
   test("Test Update Table") {
     withRecordType()(withTempDir { tmp =>
-      Seq(true).foreach { sparkSqlOptimizedWrites =>
-        Seq("mor").foreach { tableType =>
+      Seq(true, false).foreach { sparkSqlOptimizedWrites =>
+        Seq("mor", "cow").foreach { tableType =>
           val tableName = generateTableName
           // create table
           spark.sql(

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -104,4 +104,8 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
                                                  name: Option[String])(body: => T): T = {
       SQLExecution.withNewExecutionId(queryExecution, name)(body)
   }
+
+  override def getTemporaryRowIndexColumnName(): String = {
+    "_tmp_metadata_row_index"
+  }
 }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -148,4 +148,8 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
                                        hadoopConf: Configuration): SparkParquetReader = {
     Spark35ParquetReader.build(vectorized, sqlConf, options, hadoopConf)
   }
+
+  override def getTemporaryRowIndexColumnName(): String = {
+    ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME
+  }
 }


### PR DESCRIPTION
### Change Logs

Spark SQL UPDATE and DELETE do not write record positions to the log files. The PR aims to add the metadata in log files so that it can be used for faster merge operations.

### Impact

Spark SQL UPDATE and DELETE would write record positions to the log files now and it is useful for merging records.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
