### PR TITLE
[HUDI-8926] Fix precombine field value to be in the same type in TestMergeModeEventTimeOrdering

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeEventTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeEventTimeOrdering.scala
@@ -201,13 +201,13 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
           spark.sql(
             s"""
                | insert into $tableName
-               | select 0 as id, 'A0' as name, 0.0 as price, 100 as ts union all
-               | select 1, 'A', 10.0, 100 union all
-               | select 2, 'B', 20.0, 100 union all
-               | select 3, 'C', 30.0, 100 union all
-               | select 4, 'D', 40.0, 100 union all
-               | select 5, 'E', 50.0, 100 union all
-               | select 6, 'F', 60.0, 100
+               | select 0 as id, 'A0' as name, 0.0 as price, 100L as ts union all
+               | select 1, 'A', 10.0, 100L union all
+               | select 2, 'B', 20.0, 100L union all
+               | select 3, 'C', 30.0, 100L union all
+               | select 4, 'D', 40.0, 100L union all
+               | select 5, 'E', 50.0, 100L union all
+               | select 6, 'F', 60.0, 100L
              """.stripMargin)
 
           // Merge operation - delete with arbitrary ts value (lower, equal and higher). Lower ts won't take effect.
@@ -215,9 +215,9 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
             s"""
                | merge into $tableName t
                | using (
-               |   select 0 as id, 'B2' as name, 25.0 as price, 100 as ts union all
-               |   select 1 as id, 'B2' as name, 25.0 as price, 101 as ts union all
-               |   select 2 as id, 'B2' as name, 25.0 as price, 99 as ts
+               |   select 0 as id, 'B2' as name, 25.0 as price, 100L as ts union all
+               |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
+               |   select 2 as id, 'B2' as name, 25.0 as price, 99L as ts
                | ) s
                | on t.id = s.id
                | when matched then delete
@@ -228,9 +228,9 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
             s"""
                | merge into $tableName t
                | using (
-               |   select 4 as id, 'D2' as name, 45.0 as price, 101 as ts union all
-               |   select 5, 'E2', 55.0, 99 as ts union all
-               |   select 6, 'F2', 65.0, 100 as ts
+               |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
+               |   select 5, 'E2', 55.0, 99L as ts union all
+               |   select 6, 'F2', 65.0, 100L as ts
                | ) s
                | on t.id = s.id
                | when matched then update set *


### PR DESCRIPTION
### Change Logs

After #12452, we disallow the type change of precombine field to be safe (which wasn't supported before in 0.x releases).  In SQL, the input precombine values must match the type of the table schema, thus the fix on `TestMergeModeEventTimeOrdering`.

### Impact

Fix CI failure based on expected behavior.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
