### PR TITLE
[HUDI-8468] Honor merge mode in the expression payload

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.OperationModeAwareness;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 
+import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +113,10 @@ public class HoodieRecordUtils {
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new HoodieException("Unable to instantiate payload class ", e);
     }
+  }
+
+  public static <T extends HoodieRecordPayload> T loadPayload(String recordPayloadClass, GenericRecord record, Comparable orderingValue) {
+    return HoodieRecordUtils.loadPayload(recordPayloadClass, new Object[] {record, orderingValue}, GenericRecord.class, Comparable.class);
   }
 
   public static boolean recordTypeCompatibleEngine(HoodieRecordType recordType, EngineType engineType) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -474,6 +474,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
     )
 
+    // Append original payload class
+    writeParams ++= Seq(
+      PAYLOAD_ORIGINAL_AVRO_PAYLOAD -> hoodieCatalogTable.tableConfig.getPayloadClass
+    )
+
     val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, writeParams, sourceDF)
     if (!success) {
       throw new HoodieException("Merge into Hoodie table command failed")

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -186,8 +186,6 @@ class ExpressionPayload(@transient record: GenericRecord,
         val incomingRecordPayload = HoodieRecordUtils.loadPayload(originalPayload, incomingRecord,
           HoodieAvroUtils.getNestedFieldVal(incomingRecord, orderingField, true, consistentLogicalTimestampEnabled)
             .asInstanceOf[Comparable[_]]).asInstanceOf[HoodieRecordPayload[_ <: HoodieRecordPayload[_]]]
-        // if the PreCombine field value of targetRecord is greater
-        // than the new incoming record, just keep the old record value.
         incomingRecordPayload.combineAndGetUpdateValue(existingRecord, schema, properties)
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -70,7 +70,9 @@ class ExpressionPayload(@transient record: GenericRecord,
   }
 
   override def preCombine(oldValue: ExpressionPayload): ExpressionPayload = {
-    throw new IllegalStateException(s"Should not call this method for ${getClass.getCanonicalName}")
+    // used in HoodiePreCombineAvroRecordMerger when running insert for source table having dup key with preCombineField
+    // or when running merge into with insert * for non-matched records containing duplicates
+    this
   }
 
   override def combineAndGetUpdateValue(currentValue: IndexedRecord,

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -167,10 +167,10 @@ class ExpressionPayload(@transient record: GenericRecord,
                             existingRecord: IndexedRecord,
                             schema: Schema,
                             properties: Properties): HOption[IndexedRecord] = {
-    val originalPayload = properties.getProperty(PAYLOAD_ORIGINAL_AVRO_PAYLOAD)
-    if (originalPayload.equals(classOf[OverwriteWithLatestAvroPayload].getName)) {
+    val tablePayloadClass = properties.getProperty(PAYLOAD_ORIGINAL_AVRO_PAYLOAD)
+    if (tablePayloadClass.equals(classOf[OverwriteWithLatestAvroPayload].getName)) {
       HOption.of(incomingRecord)
-    } else if (originalPayload.equals(classOf[DefaultHoodieRecordPayload].getName)) {
+    } else if (tablePayloadClass.equals(classOf[DefaultHoodieRecordPayload].getName)) {
       if (needUpdatingPersistedRecord(existingRecord, incomingRecord, properties)) {
         HOption.of(incomingRecord)
       } else {
@@ -183,7 +183,7 @@ class ExpressionPayload(@transient record: GenericRecord,
       } else {
         val consistentLogicalTimestampEnabled = properties.getProperty(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key,
           KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue).toBoolean
-        val incomingRecordPayload = HoodieRecordUtils.loadPayload(originalPayload, incomingRecord,
+        val incomingRecordPayload = HoodieRecordUtils.loadPayload(tablePayloadClass, incomingRecord,
           HoodieAvroUtils.getNestedFieldVal(incomingRecord, orderingField, true, consistentLogicalTimestampEnabled)
             .asInstanceOf[Comparable[_]]).asInstanceOf[HoodieRecordPayload[_ <: HoodieRecordPayload[_]]]
         incomingRecordPayload.combineAndGetUpdateValue(existingRecord, schema, properties)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -1228,6 +1228,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
             ""
           }
           val sourceTable = generateTableName
+
           spark.sql(
             s"""
                |CREATE TABLE $sourceTable (
@@ -1238,6 +1239,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |) USING hudi
                |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
                |""".stripMargin)
+
           spark.sql(
             s"""
                | INSERT INTO $sourceTable
@@ -1295,7 +1297,6 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |VALUES
                |    (s.id, s.name, s.price, s.ts)
                |""".stripMargin)
-
 
           checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
             Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.COMMIT_TIME_ORDERING.name()) 1L else 1598886001L),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.hudi.dml
 
-import org.apache.hudi.AutoRecordKeyGenerationUtils.getClass
 import org.apache.hudi.{DataSourceWriteOptions, HoodieSparkUtils}
+import org.apache.hudi.common.config.RecordMergeMode
 import org.apache.hudi.config.HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
@@ -1215,5 +1215,84 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
         }
       }
     })
+  }
+
+  test("Test MergeInto with various payloads") {
+      withTempDir { tmp =>
+        Seq(RecordMergeMode.EVENT_TIME_ORDERING.name(),
+          RecordMergeMode.OVERWRITE_WITH_LATEST.name()).foreach { recordMergeMode =>
+          val sourceTable = generateTableName
+          spark.sql(
+            s"""
+               |CREATE TABLE $sourceTable (
+               |    id INT,
+               |    name STRING,
+               |    price INT,
+               |    ts BIGINT
+               |) USING hudi
+               |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
+               |""".stripMargin)
+          spark.sql(
+            s"""
+               | INSERT INTO $sourceTable
+               | VALUES (1, 'John Doe', 19, 1),
+               |        (4, 'Alice Johnson', 49, 2)
+               |""".stripMargin)
+
+          val targetTable = generateTableName
+          spark.sql(
+            s"""
+               |create table $targetTable (
+               |  id INT,
+               |  name STRING,
+               |  price INT,
+               |  ts BIGINT
+               |) using hudi
+               |TBLPROPERTIES (
+               |  type = 'cow',
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts',
+               |  recordMergeMode = '$recordMergeMode'
+               | )
+               |LOCATION '${tmp.getCanonicalPath}/$targetTable'
+               |""".stripMargin)
+
+          spark.sql(
+            s"""
+               |INSERT INTO $targetTable
+               |SELECT id, name, price, ts
+               |FROM (
+               |    SELECT 1 as id, 'John Doe' as name, 19 as price, 1598886001 as ts
+               |     UNION ALL
+               |     SELECT 2, 'Jane Doe', 24, 1598972400
+               |     UNION ALL
+               |     SELECT 3, 'Bob Smith', 14, 1599058800
+               |)
+               |""".stripMargin)
+
+          spark.sql(
+            s"""
+               |MERGE INTO $targetTable t
+               |USING $sourceTable s
+               |ON t.price = s.price
+               |WHEN MATCHED THEN UPDATE SET
+               |    t.id = s.id,
+               |    t.name = s.name,
+               |    t.price = s.price,
+               |    t.ts = s.ts
+               |WHEN NOT MATCHED THEN INSERT
+               |    (id, name, price, ts)
+               |VALUES
+               |    (s.id, s.name, s.price, s.ts)
+               |""".stripMargin)
+
+
+          checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
+            Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.EVENT_TIME_ORDERING.name()) 1598886001L else 1L),
+            Seq(2, "Jane Doe", 24, 1598972400L),
+            Seq(3, "Bob Smith", 14, 1599058800L),
+            Seq(4, "Alice Johnson", 49, 2L))
+        }
+      }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -1218,93 +1218,91 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
   }
 
   test("Test MergeInto with various payloads") {
+    withSQLConf("hoodie.merge.small.file.group.candidates.limit" -> "0") {
       withTempDir { tmp =>
         Seq(RecordMergeMode.EVENT_TIME_ORDERING.name(),
           RecordMergeMode.COMMIT_TIME_ORDERING.name(),
           RecordMergeMode.CUSTOM.name()).foreach { recordMergeMode =>
-          val payloadClassExtraString = if (recordMergeMode == RecordMergeMode.CUSTOM.name()) {
-            s" payloadClass = '${classOf[FirstValueAvroPayload].getName}',"
-          } else {
-            ""
+          Seq("cow", "mor").foreach { tableType =>
+            val payloadClassExtraString = if (recordMergeMode == RecordMergeMode.CUSTOM.name()) {
+              s" payloadClass = '${classOf[FirstValueAvroPayload].getName}',"
+            } else {
+              ""
+            }
+
+            val sourceTable = generateTableName
+            spark.sql(
+              s"""
+                 |CREATE TABLE $sourceTable (
+                 |    id INT,
+                 |    name STRING,
+                 |    price INT,
+                 |    ts BIGINT
+                 |) USING hudi
+                 |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
+                 |""".stripMargin)
+
+            spark.sql(
+              s"""
+                 | INSERT INTO $sourceTable
+                 | VALUES (1, 'John Doe', 19, 1),
+                 |        (4, 'Alice Johnson', 49, 2),
+                 |        (5, 'Baker Mayfield', 6, 10)
+                 |""".stripMargin)
+
+            val targetTable = generateTableName
+            spark.sql(
+              s"""
+                 |create table $targetTable (
+                 |  id INT,
+                 |  name STRING,
+                 |  price INT,
+                 |  ts BIGINT
+                 |) using hudi
+                 |TBLPROPERTIES (
+                 |  type = '$tableType',
+                 |  primaryKey = 'id',
+                 |  preCombineField = 'ts',
+                 |  $payloadClassExtraString
+                 |  recordMergeMode = '$recordMergeMode'
+                 | )
+                 |LOCATION '${tmp.getCanonicalPath}/$targetTable'
+                 |""".stripMargin)
+
+            spark.sql(
+              s"""
+                 | INSERT INTO $targetTable
+                 | VALUES (1, 'John Doe', 19, 1598886001),
+                 |        (2, 'Jane Doe', 24, 1598972400),
+                 |        (3, 'Bob Smith', 14, 1599058800),
+                 |        (5, 'Baker Mayfield', 60, 10)
+                 |""".stripMargin)
+
+            spark.sql(
+              s"""
+                 |MERGE INTO $targetTable t
+                 |USING $sourceTable s
+                 |ON t.price = s.price
+                 |WHEN MATCHED THEN UPDATE SET
+                 |    t.id = s.id,
+                 |    t.name = s.name,
+                 |    t.price = s.price,
+                 |    t.ts = s.ts
+                 |WHEN NOT MATCHED THEN INSERT
+                 |    (id, name, price, ts)
+                 |VALUES
+                 |    (s.id, s.name, s.price, s.ts)
+                 |""".stripMargin)
+
+            checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
+              Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.COMMIT_TIME_ORDERING.name()) 1L else 1598886001L),
+              Seq(2, "Jane Doe", 24, 1598972400L),
+              Seq(3, "Bob Smith", 14, 1599058800L),
+              Seq(4, "Alice Johnson", 49, 2L),
+              Seq(5, "Baker Mayfield", if (recordMergeMode == RecordMergeMode.CUSTOM.name()) 60 else 6, 10L))
           }
-          val sourceTable = generateTableName
-
-          spark.sql(
-            s"""
-               |CREATE TABLE $sourceTable (
-               |    id INT,
-               |    name STRING,
-               |    price INT,
-               |    ts BIGINT
-               |) USING hudi
-               |LOCATION '${tmp.getCanonicalPath}/$sourceTable'
-               |""".stripMargin)
-
-          spark.sql(
-            s"""
-               | INSERT INTO $sourceTable
-               | VALUES (1, 'John Doe', 19, 1),
-               |        (4, 'Alice Johnson', 49, 2),
-               |        (5, 'Baker Mayfield', 6, 10)
-               |""".stripMargin)
-
-          val targetTable = generateTableName
-          spark.sql(
-            s"""
-               |create table $targetTable (
-               |  id INT,
-               |  name STRING,
-               |  price INT,
-               |  ts BIGINT
-               |) using hudi
-               |TBLPROPERTIES (
-               |  type = 'cow',
-               |  primaryKey = 'id',
-               |  preCombineField = 'ts',
-               |  $payloadClassExtraString
-               |  recordMergeMode = '$recordMergeMode'
-               | )
-               |LOCATION '${tmp.getCanonicalPath}/$targetTable'
-               |""".stripMargin)
-
-          spark.sql(
-            s"""
-               |INSERT INTO $targetTable
-               |SELECT id, name, price, ts
-               |FROM (
-               |    SELECT 1 as id, 'John Doe' as name, 19 as price, 1598886001 as ts
-               |     UNION ALL
-               |     SELECT 2, 'Jane Doe', 24, 1598972400
-               |     UNION ALL
-               |     SELECT 3, 'Bob Smith', 14, 1599058800
-               |     UNION ALL
-               |     SELECT 5, 'Baker Mayfield', 60, 10
-               |)
-               |""".stripMargin)
-
-          spark.sql(
-            s"""
-               |MERGE INTO $targetTable t
-               |USING $sourceTable s
-               |ON t.price = s.price
-               |WHEN MATCHED THEN UPDATE SET
-               |    t.id = s.id,
-               |    t.name = s.name,
-               |    t.price = s.price,
-               |    t.ts = s.ts
-               |WHEN NOT MATCHED THEN INSERT
-               |    (id, name, price, ts)
-               |VALUES
-               |    (s.id, s.name, s.price, s.ts)
-               |""".stripMargin)
-
-          checkAnswer(s"select id, name, price, ts from $targetTable ORDER BY id")(
-            Seq(1, "John Doe", 19, if (recordMergeMode == RecordMergeMode.COMMIT_TIME_ORDERING.name()) 1L else 1598886001L),
-            Seq(2, "Jane Doe", 24, 1598972400L),
-            Seq(3, "Bob Smith", 14, 1599058800L),
-            Seq(4, "Alice Johnson", 49, 2L),
-            Seq(5, "Baker Mayfield", if (recordMergeMode == RecordMergeMode.CUSTOM.name()) 60 else 6, 10L))
         }
       }
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

- Use payload to do merging inside of expression payload.
- Change hierarchy - make ExpressionPayload extend from BaseAvroPayload instead of DefaultHoodieRecordPayload.
- Add test for merge into covering all merge modes.

NOTE: There is still per record overhead of reflection in case of CUSTOM merge mode. I am not sure how to avoid that given the construction of payload is tightly coupled to the record itself. Maybe we can use record merger API where merger can be instantiated upfront, and the merge methods take both old and new incoming record as arguments.

### Impact

MERGE INTO command honors different merge modes.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
