### PR TITLE
[HUDI-8921] Switch from `HoodieRecord` to `HoodieFlinkRecord` for Flink write, simple bucket index

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
+import org.apache.flink.types.BooleanValue;
+
+import static org.apache.flink.api.java.typeutils.ValueTypeInfo.BOOLEAN_VALUE_TYPE_INFO;
+
+/**
+ * Flink {@link RowData} with added Hudi metadata in data structure based on Flink {@link Tuple}.
+ * Strict ordering and fixed arity are expected.
+ */
+public class HoodieFlinkRecord extends Tuple {
+
+  private static final long serialVersionUID = 1L;
+  // Arity shouldn't exceed 25, because tuples in Flink are limited by Tuple25.
+  // But if it will be needed in the future, then nested structure could be used.
+  private static final int ARITY = 7;
+
+  private StringData recordKey;
+  private StringData partitionPath;
+  private StringData fileId;
+  private StringData instantTime;
+  /**
+   * {@link HoodieOperation}
+   */
+  private StringData operationType;
+  private BooleanValue isIndexRecord;
+  private RowData rowData;
+
+  public HoodieFlinkRecord(String recordKey, String partitionPath, RowData rowData) {
+    this(recordKey, partitionPath, "", "", "", false, rowData);
+  }
+
+  public HoodieFlinkRecord(String recordKey, String partitionPath, boolean isIndexRecord, RowData rowData) {
+    this(recordKey, partitionPath, "", "", "", isIndexRecord, rowData);
+  }
+
+  public HoodieFlinkRecord(String recordKey,
+                           String partitionPath,
+                           String fileId,
+                           String instantTime,
+                           String operationType,
+                           boolean isIndexRecord,
+                           RowData rowData) {
+    this.recordKey = StringData.fromString(recordKey);
+    this.partitionPath = StringData.fromString(partitionPath);
+    this.fileId = StringData.fromString(fileId);
+    this.instantTime = StringData.fromString(instantTime);
+    this.operationType = StringData.fromString(operationType);
+    this.isIndexRecord = new BooleanValue(isIndexRecord);
+    this.rowData = rowData;
+  }
+
+  public <T extends Tuple> HoodieFlinkRecord(T tuple) {
+    if (tuple.getArity() == ARITY) {
+      for (int i = 0;  i < ARITY; i++) {
+        setField(tuple.getField(i), i);
+      }
+    } else {
+      throw new HoodieException("Tuple with arity " + tuple.getArity() + " is not reconciled with 'HoodieFlinkRecord', for which arity " + ARITY + " is expected");
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T getField(int pos) {
+    switch (pos) {
+      case 0:
+        return (T) this.recordKey;
+      case 1:
+        return (T) this.partitionPath;
+      case 2:
+        return (T) this.fileId;
+      case 3:
+        return (T) this.instantTime;
+      case 4:
+        return (T) this.operationType;
+      case 5:
+        return (T) this.isIndexRecord;
+      case 6:
+        return (T) this.rowData;
+      default:
+        throw new IndexOutOfBoundsException("There is no corresponding object in 'HoodieFlinkRecord' for position '" + pos + "'");
+    }
+  }
+
+  @Override
+  public <T> void setField(T value, int pos) {
+    switch (pos) {
+      case 0:
+        this.recordKey = (StringData) value;
+        break;
+      case 1:
+        this.partitionPath = (StringData) value;
+        break;
+      case 2:
+        this.fileId = (StringData) value;
+        break;
+      case 3:
+        this.instantTime = (StringData) value;
+        break;
+      case 4:
+        this.operationType = (StringData) value;
+        break;
+      case 5:
+        this.isIndexRecord = (BooleanValue) value;
+        break;
+      case 6:
+        this.rowData = (RowData) value;
+        break;
+      default:
+        throw new IndexOutOfBoundsException("There is no corresponding object in 'HoodieFlinkRecord' for position '" + pos + "'");
+    }
+  }
+
+  @Override
+  public int getArity() {
+    return ARITY;
+  }
+
+  @Override
+  public HoodieFlinkRecord copy() {
+    return new HoodieFlinkRecord(
+        this.recordKey.toString(),
+        this.partitionPath.toString(),
+        this.fileId.toString(),
+        this.instantTime.toString(),
+        this.operationType.toString(),
+        this.isIndexRecord.getValue(),
+        this.rowData);
+  }
+
+  /**
+   * Returns {@link TypeInformation} for proper serde with forced use of {@link TupleSerializer}.
+   */
+  public static TupleTypeInfo getTypeInfo(TypeInformation<RowData> rowDataInfo) {
+    return new TupleTypeInfo<>(
+        StringDataTypeInfo.INSTANCE,
+        StringDataTypeInfo.INSTANCE,
+        StringDataTypeInfo.INSTANCE,
+        StringDataTypeInfo.INSTANCE,
+        StringDataTypeInfo.INSTANCE,
+        BOOLEAN_VALUE_TYPE_INFO,
+        rowDataInfo);
+  }
+
+  public String getRecordKey() {
+    return String.valueOf(recordKey);
+  }
+
+  public String getPartitionPath() {
+    return String.valueOf(partitionPath);
+  }
+
+  public RowData getRowData() {
+    return rowData;
+  }
+
+  public void setFileId(String fileId) {
+    this.fileId = StringData.fromString(fileId);
+  }
+
+  public String getFileId() {
+    return String.valueOf(fileId);
+  }
+
+  public void setInstantTime(String instantTime) {
+    this.instantTime = StringData.fromString(instantTime);
+  }
+
+  public String getInstantTime() {
+    return String.valueOf(instantTime);
+  }
+
+  public void setOperationType(String operationType) {
+    this.operationType = StringData.fromString(operationType);
+  }
+
+  public String getOperationType() {
+    return String.valueOf(operationType);
+  }
+
+  public boolean isIndexRecord() {
+    return isIndexRecord.getValue();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -675,6 +675,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(ClientIds.INIT_CLIENT_ID)
       .withDescription("Unique identifier used to distinguish different writer pipelines for concurrent mode");
 
+  @AdvancedConfig
+  public static final ConfigOption<Boolean> WRITE_FAST_MODE = ConfigOptions
+      .key("write.fast.mode")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Optimized Flink write into Hudi table, which uses customized serialization/deserialization. "
+          + "Note, that only SIMPLE BUCKET index is supported for now.");
+
   // ------------------------------------------------------------------------
   //  Compaction Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteRowDataFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteRowDataFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.client.model.HoodieFlinkRecord;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.sink.utils.PayloadCreation;
+import org.apache.hudi.util.RowDataToAvroConverters;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Collector;
+
+import java.io.IOException;
+
+/**
+ * A stream write function with simple bucket hash index for processing of {@link HoodieFlinkRecord},
+ * which places records into buffer of {@link StreamWriteFunction}.
+ */
+final class BucketStreamWriteRowDataFunction<T extends Tuple> extends BucketStreamWriteFunction<T> {
+
+  private final RowType rowType;
+  private transient Schema avroSchema;
+  private transient RowDataToAvroConverters.RowDataToAvroConverter converter;
+  private transient PayloadCreation payloadCreation;
+
+  BucketStreamWriteRowDataFunction(Configuration config, RowType rowType) {
+    super(config);
+    this.rowType = rowType;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws IOException {
+    super.open(parameters);
+    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
+    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
+    try {
+      this.payloadCreation = PayloadCreation.instance(config);
+    } catch (Exception ex) {
+      throw new HoodieException("Failed payload creation in BucketStreamWriteRowDataFunction", ex);
+    }
+  }
+
+  @Override
+  public void processElement(T income,
+                             ProcessFunction<T, Object>.Context context,
+                             Collector<Object> collector) throws Exception {
+    HoodieFlinkRecord hoodieFlinkRecord = new HoodieFlinkRecord(income);
+    String recordKey = hoodieFlinkRecord.getRecordKey();
+    String partition = hoodieFlinkRecord.getPartitionPath();
+    RowData row = hoodieFlinkRecord.getRowData();
+
+    final HoodieKey hoodieKey = new HoodieKey(recordKey, partition);
+    HoodieRecordPayload payload = payloadCreation.createPayload(
+        (GenericRecord) this.converter.convert(this.avroSchema, row));
+    HoodieOperation operation = HoodieOperation.fromValue(row.getRowKind().toByteValue());
+    HoodieRecord record = new HoodieAvroRecord<>(hoodieKey, payload, operation);
+
+    record.unseal();
+    record.setCurrentLocation(defineRecordLocation(hoodieKey, partition));
+    record.seal();
+    bufferRecord(record);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteRowDataOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteRowDataOperator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.client.model.HoodieFlinkRecord;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.sink.common.AbstractWriteOperator;
+import org.apache.hudi.sink.common.WriteOperatorFactory;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Operator for switching between different types of bucket index.
+ */
+public final class BucketStreamWriteRowDataOperator extends AbstractWriteOperator<HoodieFlinkRecord> {
+
+  BucketStreamWriteRowDataOperator(Configuration conf, RowType rowType) {
+    super(new BucketStreamWriteRowDataFunction<>(conf, rowType));
+  }
+
+  public static WriteOperatorFactory<HoodieFlinkRecord> getFactory(Configuration conf, RowType rowType) throws HoodieNotSupportedException {
+    if (!OptionsResolver.isConsistentHashingBucketIndexType(conf)) {
+      return WriteOperatorFactory.instance(conf, new BucketStreamWriteRowDataOperator(conf, rowType));
+    } else {
+      throw new HoodieNotSupportedException("Currently, only simple bucket index is supported with enabled '" + FlinkOptions.WRITE_FAST_MODE.key() + "'");
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.client.model.HoodieFlinkRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
+import org.apache.hudi.util.RowDataToAvroConverters;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Function that converts Flink {@link RowData} into {@link HoodieFlinkRecord}, which extends Flink {@link Tuple}.
+ */
+class RowDataEnrichFunction<I extends RowData, O extends Tuple> extends RichMapFunction<I, O> {
+  private final Configuration config;
+  private final RowType rowType;
+  private transient Schema avroSchema;
+  private transient RowDataToAvroConverters.RowDataToAvroConverter converter;
+  private transient KeyGenerator keyGenerator;
+
+  RowDataEnrichFunction(Configuration config, RowType rowType) {
+    this.config = config;
+    this.rowType = rowType;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
+    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
+    this.keyGenerator = HoodieAvroKeyGeneratorFactory.createKeyGenerator(StreamerUtil.flinkConf2TypedProperties(this.config));
+  }
+
+  @Override
+  public O map(I record) throws Exception {
+    GenericRecord gr = (GenericRecord) this.converter.convert(this.avroSchema, record);
+    final HoodieKey hoodieKey = keyGenerator.getKey(gr);
+    return (O) new HoodieFlinkRecord(hoodieKey.getRecordKey(), hoodieKey.getPartitionPath(), record);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctionWithRateLimit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctionWithRateLimit.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.common.util.RateLimiter;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link RowDataEnrichFunction} with rate limiting according to {@link FlinkOptions#WRITE_RATE_LIMIT}.
+ */
+final class RowDataEnrichFunctionWithRateLimit<I extends RowData, O extends Tuple> extends RowDataEnrichFunction<I, O> {
+  /**
+   * Total rate limit per second for the whole job set by config
+   */
+  private final double totalLimit;
+
+  /**
+   * Rate limit per second for the subtask, which depends on parallelism
+   */
+  private transient RateLimiter rateLimiter;
+
+  RowDataEnrichFunctionWithRateLimit(Configuration config, RowType rowType) {
+    super(config, rowType);
+    this.totalLimit = config.getLong(FlinkOptions.WRITE_RATE_LIMIT);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    this.rateLimiter =
+        RateLimiter.create((int) totalLimit / getRuntimeContext().getNumberOfParallelSubtasks(), TimeUnit.SECONDS);
+  }
+
+  @Override
+  public O map(I record) throws Exception {
+    rateLimiter.acquire(1);
+    return super.map(record);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctions.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.client.model.HoodieFlinkRecord;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Utilities for {@link RowDataEnrichFunction} to handle rate limit if it was set.
+ */
+public abstract class RowDataEnrichFunctions {
+  private RowDataEnrichFunctions() {
+  }
+
+  /**
+   * Creates {@link RowDataEnrichFunctions} instance based on the given configuration.
+   */
+  public static RichMapFunction<RowData, HoodieFlinkRecord> create(Configuration conf, RowType rowType) {
+    if (conf.getLong(FlinkOptions.WRITE_RATE_LIMIT) > 0) {
+      return new RowDataEnrichFunctionWithRateLimit<>(conf, rowType);
+    } else {
+      return new RowDataEnrichFunction<>(conf, rowType);
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

Changes in Flink stream write into Hudi table with simple bucket index corresponding to [RFC-84](https://github.com/apache/hudi/pull/12697).

#### Benchmark description

`Lineitem` table from TPC-H benchmark was used. 60 mln rows, from which 20 mln rows are unique.

#### Perfomance estimation results

|                                         | current with Kryo | switched to Tuple | Optimization |
| --------------------------- | ------------------ | -------------------- | -------------- |
| CPU samples, serialize     | 37 842                 |  7 584                   | **79.9%**      |
| CPU samples, deserialize | 72 440                 |  3 072                   | **95.8%**      |
| **Data passed, GB**        | **19.4**               | **13.6**                 | **29.9%**     |
| **Total time, s**               | **344**                | **237**                  | **31.1%**     |

Note, that for serialization costs estimation, we search for `KryoSerializer::serialize` and `TupleSerializer::serialize` correspondingly in the first Flink operator. For deserialization costs, we search for `KryoSerializer::deserialize` and `TupleSerializer::deserialize` in the second Flink operator.

#### Flink operators

Current with Kryo:

![0 operators - 1 usual](https://github.com/user-attachments/assets/2718464f-b971-46d0-b0dd-984452edeeb8)

After switch to `HoodieFlinkRecord`:

![0 operators - 3 HoodieFlinkRecord](https://github.com/user-attachments/assets/12d407d1-5c55-43f1-ad7c-7bf3ff27f927)

#### Flame graph

Current with Kryo:

![1 flame graph - 1 usual](https://github.com/user-attachments/assets/9c0c21eb-68de-41ef-83fc-e6e534c87cd8)


After switch to `HoodieFlinkRecord`:

![1 flame graph - 3 HoodieFlinkRecord](https://github.com/user-attachments/assets/3f69c5b8-f68f-4ae2-ab99-ef7327eb3b75)

#### Extra conversion

There is an additional intermediate conversion into Avro `GenericRecord` in `RowDataEnrichFunction::enrichRowData` to support all current key generators, because they are hardly coupled with `GenericRecord`. These costs could be accepted for now due to acceptable values: 5 798 CPU samples from 183 236 in total, which is about 3%.

![4 extra cost - 3 HoodieFlinkRecord](https://github.com/user-attachments/assets/2b9b370d-6cd5-4158-8e2e-017bdf8cdd1a)

![5 all cost - 3 HoodieFlinkRecord](https://github.com/user-attachments/assets/03000c57-1f17-48cc-b95b-5a67cd84079d)

### Impact

Improved performance for Flink stream write into Hudi table with simple bucket index if `write.fast.mode` is enabled.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Corresponding updates will be done after merge.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
