### PR TITLE
[HUDI-8850] Fix record merge mode related issues and improve test coverage in Spark SQL

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -257,17 +257,7 @@ trait ProvidesHoodieConfig extends Logging {
         Map()
     }
 
-    val inferredMergeConfigs = HoodieTableConfig.inferCorrectMergingBehavior(
-      tableConfig.getRecordMergeMode, tableConfig.getPayloadClass,
-      tableConfig.getRecordMergeStrategyId, preCombineField)
-    val recordMergeMode = inferredMergeConfigs.getLeft.name()
-    val deducedPayloadClassName = inferredMergeConfigs.getMiddle
-    val recordMergeStrategy = inferredMergeConfigs.getRight
-
     val defaultOpts = Map(
-      DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key -> deducedPayloadClassName,
-      DataSourceWriteOptions.RECORD_MERGE_MODE.key -> recordMergeMode,
-      DataSourceWriteOptions.RECORD_MERGE_STRATEGY_ID.key() -> recordMergeStrategy,
       // NOTE: By default insert would try to do deduplication in case that pre-combine column is specified
       //       for the table
       HoodieWriteConfig.COMBINE_BEFORE_INSERT.key -> String.valueOf(combineBeforeInsert),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -23,10 +23,12 @@ import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecord}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils
+import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
+import org.apache.hudi.storage.HoodieStorage
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
 
 import org.apache.hadoop.fs.Path
@@ -37,6 +39,7 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageConta
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 import org.slf4j.LoggerFactory
@@ -375,7 +378,15 @@ object HoodieSparkSqlTestBase {
       .getActiveTimeline.getInstantDetails(cleanInstant).get)
   }
 
+  def validateTableConfig(storage: HoodieStorage,
+                          basePath: String,
+                          expectedConfigs: Map[String, String]): Unit = {
+    val tableConfig = HoodieTableConfig.loadFromHoodieProps(storage, basePath)
+    expectedConfigs.foreach(e => {
+      assertEquals(e._2, tableConfig.getString(e._1))
+    })
+  }
+
   private def checkMessageContains(e: Throwable, text: String): Boolean =
     e.getMessage.trim.contains(text.trim)
-
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageConta
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 import org.slf4j.LoggerFactory
@@ -380,11 +380,15 @@ object HoodieSparkSqlTestBase {
 
   def validateTableConfig(storage: HoodieStorage,
                           basePath: String,
-                          expectedConfigs: Map[String, String]): Unit = {
+                          expectedConfigs: Map[String, String],
+                          nonExistentConfigs: Seq[String]): Unit = {
     val tableConfig = HoodieTableConfig.loadFromHoodieProps(storage, basePath)
     expectedConfigs.foreach(e => {
-      assertEquals(e._2, tableConfig.getString(e._1))
+      assertEquals(e._2, tableConfig.getString(e._1),
+        s"Table config ${e._1} should be ${e._2} but is ${tableConfig.getString(e._1)}")
     })
+    nonExistentConfigs.foreach(e => assertFalse(
+      tableConfig.contains(e), s"$e should not be present in the table config"))
   }
 
   private def checkMessageContains(e: Throwable, text: String): Boolean =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -326,14 +326,22 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  protected def withSparkSqlSessionConfig(configNameValues: (String, String)*)(f: => Unit): Unit = {
+  protected def withSparkSqlSessionConfig(configNameValues: (String, String)*
+                                         )(f: => Unit): Unit = {
+    withSparkSqlSessionConfigWithCondition(configNameValues.map(e => (e, true)): _*)(f)
+  }
+
+  protected def withSparkSqlSessionConfigWithCondition(configNameValues: ((String, String), Boolean)*
+                                                      )(f: => Unit): Unit = {
     try {
-      configNameValues.foreach { case (configName, configValue) =>
-        spark.sql(s"set $configName=$configValue")
+      configNameValues.foreach { case ((configName, configValue), condition) =>
+        if (condition) {
+          spark.sql(s"set $configName=$configValue")
+        }
       }
       f
     } finally {
-      configNameValues.foreach { case (configName, _) =>
+      configNameValues.foreach { case ((configName, configValue), condition) =>
         spark.sql(s"reset $configName")
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeIntoTable2.scala
@@ -24,7 +24,6 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
-
 import org.slf4j.LoggerFactory
 
 class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
@@ -1254,7 +1253,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                |  ts BIGINT
                |) using hudi
                |TBLPROPERTIES (
-               |  type = 'cow',
+               |  type = '$tableType',
                |  primaryKey = 'id',
                |  preCombineField = 'ts',
                |  recordMergeMode = '$recordMergeMode'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -30,7 +30,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
   // "cow,false"
   // "cow,true",  "mor,true", "mor,false"
-  Seq("cow,false", "cow,true", "mor,false", "mor,true").foreach { args =>
+  //  "cow,true", "mor,false", "mor,true"
+  Seq("cow,false", "mor,false").foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val setRecordMergeMode = argList(1).toBoolean
@@ -42,8 +43,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     )
     val mergeConfigClause = if (setRecordMergeMode) {
       // with precombine, dedup automatically kick in
-      // ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
-      ",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      //",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
     } else {
       // By default, the COMMIT_TIME_ORDERING is used if not specified by the user
       ""

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -317,8 +317,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
               Seq(4, "D2", 45.0, 101),
               Seq(5, "E2", 55.0, 99),
               Seq(6, "F2", 65.0, 100)
-            )): _*,
-          )
+            )): _*)
 
           // Insert new records through merge
           spark.sql(
@@ -343,8 +342,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
               Seq(6, "F2", 65.0, 100),
               Seq(7, "D2", 45.0, 100),
               Seq(8, "E2", 55.0, 100)
-            )): _*
-          )
+            )): _*)
         })
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -30,15 +30,15 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
   // TODO(HUDI-8938): add "mor,true,true,6" after the fix
   Seq(
-    "cow,false,false,8", "cow,false,true,8", "cow,true,false,8",
-    "cow,true,false,6", "cow,true,true,6",
-    "mor,false,false,8", "mor,false,true,8", "mor,true,false,8",
-    "mor,true,false,6").foreach { args =>
+    "cow,8,false,false", "cow,8,false,true", "cow,8,true,false",
+    "cow,6,true,false", "cow,6,true,true",
+    "mor,8,false,false", "mor,8,false,true", "mor,8,true,false",
+    "mor,6,true,false").foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
-    val setRecordMergeConfigs = argList(1).toBoolean
-    val setUpsertOperation = argList(2).toBoolean
-    val tableVersion = argList(3)
+    val tableVersion = argList(1)
+    val setRecordMergeConfigs = argList(2).toBoolean
+    val setUpsertOperation = argList(3).toBoolean
     val isUpsert = setUpsertOperation || (tableVersion.toInt != 6 && setRecordMergeConfigs)
     val storage = HoodieTestUtils.getDefaultStorage
     val mergeConfigClause = if (setRecordMergeConfigs) {
@@ -86,7 +86,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
         ("hoodie.merge.small.file.group.candidates.limit" -> "0", true),
         ("hoodie.spark.sql.insert.into.operation" -> "upsert", setUpsertOperation),
         // TODO(HUDI-8820): enable MDT after supporting MDT with table version 6
-        ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6),
+        ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6)
       ) {
         withRecordType()(withTempDir { tmp =>
           val tableName = generateTableName
@@ -232,7 +232,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
         ("hoodie.merge.small.file.group.candidates.limit" -> "0", true),
         ("hoodie.spark.sql.insert.into.operation" -> "upsert", setUpsertOperation),
         // TODO(HUDI-8820): enable MDT after supporting MDT with table version 6
-        ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6),
+        ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6)
       ) {
         withRecordType()(withTempDir { tmp =>
           val tableName = generateTableName

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -17,14 +17,38 @@
 
 package org.apache.spark.sql.hudi.dml
 
+import org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING
+import org.apache.hudi.common.model.HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.testutils.HoodieTestUtils
+
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.validateTableConfig
 
 class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
-  Seq("mor").foreach { tableType =>
-    // [HUDI-8850] For COW commit time ordering does not work.
-    // Seq("cow", "mor").foreach { tableType =>
-    test(s"Test $tableType table with COMMIT_TIME_ORDERING merge mode") {
+  // "cow,false"
+  // "cow,true",  "mor,true", "mor,false"
+  Seq("cow,false", "cow,true", "mor,false", "mor,true").foreach { args =>
+    val argList = args.split(',')
+    val tableType = argList(0)
+    val setRecordMergeMode = argList(1).toBoolean
+    val storage = HoodieTestUtils.getDefaultStorage
+    val expectedMergeConfigs = Map(
+      HoodieTableConfig.RECORD_MERGE_MODE.key -> COMMIT_TIME_ORDERING.name(),
+      HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[OverwriteWithLatestAvroPayload].getName,
+      HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> COMMIT_TIME_BASED_MERGE_STRATEGY_UUID
+    )
+    val mergeConfigClause = if (setRecordMergeMode) {
+      // with precombine, dedup automatically kick in
+      // ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      ",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+    } else {
+      // By default, the COMMIT_TIME_ORDERING is used if not specified by the user
+      ""
+    }
+    test(s"Test $tableType table with COMMIT_TIME_ORDERING merge mode (explicitly set = $setRecordMergeMode)") {
       withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0"
       ) {
         withRecordType()(withTempDir { tmp =>
@@ -40,13 +64,12 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | ) using hudi
                | tblproperties (
                |  type = '$tableType',
-               |  primaryKey = 'id',
-               |  preCombineField = 'ts',
-               |  hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'
+               |  primaryKey = 'id'
+               |  $mergeConfigClause
                | )
                | location '${tmp.getCanonicalPath}'
              """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           // Insert initial records with ts=100
           spark.sql(
             s"""
@@ -64,7 +87,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
               | union all
               | select 2, 'B_equal', 70.0, 100
             """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(1, "A_equal", 60.0, 100),
             Seq(2, "B_equal", 70.0, 100)
@@ -77,7 +100,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | set price = 50.0, ts = 100
                | where id = 1
              """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(1, "A_equal", 50.0, 100),
             Seq(2, "B_equal", 70.0, 100)
@@ -141,7 +164,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
           // Delete record
           spark.sql(s"delete from $tableName where id = 1")
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           // Verify deletion
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(2, "B", 40.0, 101)
@@ -150,97 +173,104 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
       }
     }
 
-    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table") {
-      withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
-        withRecordType()(withTempDir { tmp =>
-          val tableName = generateTableName
-          // Create table with COMMIT_TIME_ORDERING
-          spark.sql(
-            s"""
-               | create table $tableName (
-               |  id int,
-               |  name string,
-               |  price double,
-               |  ts long
-               | ) using hudi
-               | tblproperties (
-               |  type = '$tableType',
-               |  primaryKey = 'id',
-               |  preCombineField = 'ts',
-               |  hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'
-               | )
-               | location '${tmp.getCanonicalPath}'
+    // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
+    if ("mor".equals(tableType)) {
+      test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+        + s"(explicitly set = $setRecordMergeMode)") {
+        withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
+          withRecordType()(withTempDir { tmp =>
+            val tableName = generateTableName
+            // Create table with COMMIT_TIME_ORDERING
+            spark.sql(
+              s"""
+                 | create table $tableName (
+                 |  id int,
+                 |  name string,
+                 |  price double,
+                 |  ts long
+                 | ) using hudi
+                 | tblproperties (
+                 |  type = '$tableType',
+                 |  primaryKey = 'id'
+                 |  $mergeConfigClause
+                 | )
+                 | location '${tmp.getCanonicalPath}'
+             """.stripMargin)
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+
+            // Insert initial records
+            spark.sql(
+              s"""
+                 | insert into $tableName
+                 | select 1 as id, 'A' as name, 10.0 as price, 100 as ts union all
+                 | select 0, 'X', 20.0, 100 union all
+                 | select 2, 'B', 20.0, 100 union all
+                 | select 3, 'C', 30.0, 100 union all
+                 | select 4, 'D', 40.0, 100 union all
+                 | select 5, 'E', 50.0, 100 union all
+                 | select 6, 'F', 60.0, 100
+             """.stripMargin)
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+
+            // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 1 as id, 'B2' as name, 25.0 as price, 101 as ts union all
+                 |   select 2, '', 55.0, 99 as ts union all
+                 |   select 0, '', 55.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when matched then delete
              """.stripMargin)
 
-          // Insert initial records
-          spark.sql(
-            s"""
-               | insert into $tableName
-               | select 1 as id, 'A' as name, 10.0 as price, 100 as ts union all
-               | select 0, 'X', 20.0, 100 union all
-               | select 2, 'B', 20.0, 100 union all
-               | select 3, 'C', 30.0, 100 union all
-               | select 4, 'D', 40.0, 100 union all
-               | select 5, 'E', 50.0, 100 union all
-               | select 6, 'F', 60.0, 100
+            // Merge operation - update with mixed ts values
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 4 as id, 'D2' as name, 45.0 as price, 101 as ts union all
+                 |   select 5, 'E2', 55.0, 99 as ts union all
+                 |   select 6, 'F2', 65.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when matched then update set *
              """.stripMargin)
 
-          // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 1 as id, 'B2' as name, 25.0 as price, 101 as ts union all
-               |   select 2, '', 55.0, 99 as ts union all
-               |   select 0, '', 55.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when matched then delete
+            // Verify state after merges
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+              Seq(3, "C", 30.0, 100),
+              Seq(4, "D2", 45.0, 101),
+              Seq(5, "E2", 55.0, 99),
+              Seq(6, "F2", 65.0, 100)
+            )
+
+            // Insert new records through merge
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 7 as id, 'D2' as name, 45.0 as price, 100 as ts union all
+                 |   select 8, 'E2', 55.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when not matched then insert *
              """.stripMargin)
 
-          // Merge operation - update with mixed ts values
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 4 as id, 'D2' as name, 45.0 as price, 101 as ts union all
-               |   select 5, 'E2', 55.0, 99 as ts union all
-               |   select 6, 'F2', 65.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when matched then update set *
-             """.stripMargin)
-
-          // Verify state after merges
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100)
-          )
-
-          // Insert new records through merge
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 7 as id, 'D2' as name, 45.0 as price, 100 as ts union all
-               |   select 8, 'E2', 55.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when not matched then insert *
-             """.stripMargin)
-
-          // Verify final state
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100),
-            Seq(7, "D2", 45.0, 100),
-            Seq(8, "E2", 55.0, 100)
-          )
-        })
+            // Verify final state
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+              Seq(3, "C", 30.0, 100),
+              Seq(4, "D2", 45.0, 101),
+              Seq(5, "E2", 55.0, 99),
+              Seq(6, "F2", 65.0, 100),
+              Seq(7, "D2", 45.0, 100),
+              Seq(8, "E2", 55.0, 100)
+            )
+          })
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -36,6 +36,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
    */
   //"cow,true,false,6",
   Seq(
+    "cow,false,false,8", "cow,false,true,8", "cow,true,false,8",
+    "cow,true,false,6", "cow,true,true,6",
     "mor,false,false,8", "mor,false,true,8", "mor,true,false,8",
     "mor,true,false,6", "mor,true,true,6").foreach { args =>
     val argList = args.split(',')
@@ -229,109 +231,107 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     }
 
     // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
-    if ("mor".equals(tableType)) {
-      test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
-        + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
-        + s"setUpsertOperation=$setUpsertOperation)") {
-        withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
-          withRecordType()(withTempDir { tmp =>
-            val tableName = generateTableName
-            // Create table with COMMIT_TIME_ORDERING
-            spark.sql(
-              s"""
-                 | create table $tableName (
-                 |  id int,
-                 |  name string,
-                 |  price double,
-                 |  ts long
-                 | ) using hudi
-                 | tblproperties (
-                 |  $writeTableVersionClause
-                 |  type = '$tableType',
-                 |  primaryKey = 'id'
-                 |  $mergeConfigClause
-                 | )
-                 | location '${tmp.getCanonicalPath}'
-             """.stripMargin)
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+      + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
+      + s"setUpsertOperation=$setUpsertOperation)") {
+      withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
+        withRecordType()(withTempDir { tmp =>
+          val tableName = generateTableName
+          // Create table with COMMIT_TIME_ORDERING
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts long
+               | ) using hudi
+               | tblproperties (
+               |  $writeTableVersionClause
+               |  type = '$tableType',
+               |  primaryKey = 'id'
+               |  $mergeConfigClause
+               | )
+               | location '${tmp.getCanonicalPath}'
+           """.stripMargin)
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
 
-            // Insert initial records
-            spark.sql(
-              s"""
-                 | insert into $tableName
-                 | select 1 as id, 'A' as name, 10.0 as price, 100L as ts union all
-                 | select 0, 'X', 20.0, 100L union all
-                 | select 2, 'B', 20.0, 100L union all
-                 | select 3, 'C', 30.0, 100L union all
-                 | select 4, 'D', 40.0, 100L union all
-                 | select 5, 'E', 50.0, 100L union all
-                 | select 6, 'F', 60.0, 100L
-             """.stripMargin)
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          // Insert initial records
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | select 1 as id, 'A' as name, 10.0 as price, 100L as ts union all
+               | select 0, 'X', 20.0, 100L union all
+               | select 2, 'B', 20.0, 100L union all
+               | select 3, 'C', 30.0, 100L union all
+               | select 4, 'D', 40.0, 100L union all
+               | select 5, 'E', 50.0, 100L union all
+               | select 6, 'F', 60.0, 100L
+           """.stripMargin)
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
 
-            // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
-                 |   select 2, '', 55.0, 99L as ts union all
-                 |   select 0, '', 55.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when matched then delete
-             """.stripMargin)
+          // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
+               |   select 2, '', 55.0, 99L as ts union all
+               |   select 0, '', 55.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when matched then delete
+           """.stripMargin)
 
-            // Merge operation - update with mixed ts values
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
-                 |   select 5, 'E2', 55.0, 99L as ts union all
-                 |   select 6, 'F2', 65.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when matched then update set *
-             """.stripMargin)
+          // Merge operation - update with mixed ts values
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
+               |   select 5, 'E2', 55.0, 99L as ts union all
+               |   select 6, 'F2', 65.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when matched then update set *
+           """.stripMargin)
 
-            // Verify state after merges
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(3, "C", 30.0, 100),
-              Seq(4, "D2", 45.0, 101),
-              Seq(5, "E2", 55.0, 99),
-              Seq(6, "F2", 65.0, 100)
-            )
+          // Verify state after merges
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+            Seq(3, "C", 30.0, 100),
+            Seq(4, "D2", 45.0, 101),
+            Seq(5, "E2", 55.0, 99),
+            Seq(6, "F2", 65.0, 100)
+          )
 
-            // Insert new records through merge
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 7 as id, 'D2' as name, 45.0 as price, 100L as ts union all
-                 |   select 8, 'E2', 55.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when not matched then insert *
-             """.stripMargin)
+          // Insert new records through merge
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 7 as id, 'D2' as name, 45.0 as price, 100L as ts union all
+               |   select 8, 'E2', 55.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when not matched then insert *
+           """.stripMargin)
 
-            // Verify final state
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(3, "C", 30.0, 100),
-              Seq(4, "D2", 45.0, 101),
-              Seq(5, "E2", 55.0, 99),
-              Seq(6, "F2", 65.0, 100),
-              Seq(7, "D2", 45.0, 100),
-              Seq(8, "E2", 55.0, 100)
-            )
-          })
-        }
+          // Verify final state
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+            Seq(3, "C", 30.0, 100),
+            Seq(4, "D2", 45.0, 101),
+            Seq(5, "E2", 55.0, 99),
+            Seq(6, "F2", 65.0, 100),
+            Seq(7, "D2", 45.0, 100),
+            Seq(8, "E2", 55.0, 100)
+          )
+        })
       }
     }
   }


### PR DESCRIPTION
### Change Logs

This PR fixes record merge mode related issues and improves test coverage in Spark SQL:
- Table version 6 does not have record merge mode in the table config.  The file group reader is changed to infer the record merge mode if it does not exist in the table config, so it can read Hudi table of version 6.
- For INSERT INTO in Spark SQL, the write config of record merge mode is not properly determined in `buildHoodieInsertConfig`.  The relevant logic is removed since the SQL writer can automatically get the correct write config of record merge mode from the table config.
- In MERGE INTO in Spark SQL, the record merge mode check is fixed to avoid NPE.
- More tests are added in `TestMergeModeCommitTimeOrdering` and `TestMergeModeEventTimeOrdering` to coverage different cases of merge modes and both table version 6 and 8.

### Impact

Bug fixes on record merge mode related issues and improvement on test coverage.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
