### PR TITLE
[HUDI-8895] Ignoring PSI lookup for filters w/ nulls

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -23,9 +23,9 @@ import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.avro.model.{HoodieMetadataColumnStats, HoodieMetadataRecord}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieData
-import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
+import org.apache.hudi.common.model.{FileSlice, HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.util.ValidationUtils.checkState
+import org.apache.hudi.common.util.ValidationUtils.{checkArgument, checkState}
 import org.apache.hudi.common.util.hash.ColumnIndexID
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
@@ -33,6 +33,7 @@ import org.apache.hudi.util.JFunction
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.{And, DateAdd, DateFormatClass, DateSub, Expression, FromUnixTime, ParseToDate, ParseToTimestamp, RegExpExtract, RegExpReplace, StringSplit, StringTrim, StringTrimLeft, StringTrimRight, Substring, UnaryExpression, UnixTimestamp}
+import org.apache.spark.sql.hudi.DataSkippingUtils
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, SparkSession}
@@ -93,37 +94,40 @@ class PartitionStatsIndexSupport(spark: SparkSession,
         val readInMemory = shouldReadInMemory(fileIndex, queryReferencedColumns, inMemoryProjectionThreshold)
         loadTransposed(queryReferencedColumns, readInMemory, Option.empty, Option.empty) {
           transposedPartitionStatsDF => {
-            try {
-              transposedPartitionStatsDF.persist(StorageLevel.MEMORY_AND_DISK_SER)
-              val allPartitions = transposedPartitionStatsDF.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
-                .collect()
-                .map(_.getString(0))
-                .toSet
-              if (allPartitions.nonEmpty) {
-                // PARTITION_STATS index exist for all or some columns in the filters
-                // NOTE: [[translateIntoColumnStatsIndexFilterExpr]] has covered the case where the
-                //       column in a filter does not have the stats available, by making sure such a
-                //       filter does not prune any partition.
-                val indexSchema = transposedPartitionStatsDF.schema
-                val indexedCols: Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
-                // to be fixed. HUDI-8836.
-                val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols)).reduce(And)
-                if (indexFilter.equals(TrueLiteral)) {
-                  // if there are any non indexed cols or we can't translate source expr, we can prune partitions based on col stats lookup.
-                  Some(allPartitions)
+            val indexedCols: Seq[String] = metaClient.getIndexMetadata.get().getIndexDefinitions.get(PARTITION_NAME_COLUMN_STATS).getSourceFields.asScala.toSeq
+            if (canLookupInPSI(queryFilters, indexedCols)) {
+              try {
+                transposedPartitionStatsDF.persist(StorageLevel.MEMORY_AND_DISK_SER)
+                val allPartitions = transposedPartitionStatsDF.select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+                  .collect()
+                  .map(_.getString(0))
+                  .toSet
+                if (allPartitions.nonEmpty) {
+                  // PARTITION_STATS index exist for all or some columns in the filters
+                  // NOTE: [[translateIntoColumnStatsIndexFilterExpr]] has covered the case where the
+                  //       column in a filter does not have the stats available, by making sure such a
+                  //       filter does not prune any partition.
+                  // to be fixed. HUDI-8836.
+                  val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols)).reduce(And)
+                  if (indexFilter.equals(TrueLiteral)) {
+                    // if there are any non indexed cols or we can't translate source expr, we can prune partitions based on col stats lookup.
+                    Some(allPartitions)
+                  } else {
+                    Some(transposedPartitionStatsDF.where(new Column(indexFilter))
+                      .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+                      .collect()
+                      .map(_.getString(0))
+                      .toSet)
+                  }
                 } else {
-                  Some(transposedPartitionStatsDF.where(new Column(indexFilter))
-                    .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
-                    .collect()
-                    .map(_.getString(0))
-                    .toSet)
+                  // PARTITION_STATS index does not exist for any column in the filters, skip the pruning
+                  Option.empty
                 }
-              } else {
-                // PARTITION_STATS index does not exist for any column in the filters, skip the pruning
-                Option.empty
+              } finally {
+                transposedPartitionStatsDF.unpersist()
               }
-            } finally {
-              transposedPartitionStatsDF.unpersist()
+            } else { // for null filters, we can't look up in PSI.
+              Option.empty
             }
           }
         }
@@ -131,6 +135,10 @@ class PartitionStatsIndexSupport(spark: SparkSession,
     } else {
       Option.empty
     }
+  }
+
+  def canLookupInPSI(queryFilters: Seq[Expression], indexedCols: Seq[String]): Boolean = {
+    queryFilters.exists(DataSkippingUtils.containsNullOrValueCountBasedFilters(_, indexedCols = indexedCols))
   }
 
   private def containsAnySqlFunction(queryFilters: Seq[Expression]): Boolean = {


### PR DESCRIPTION
### Change Logs

Ignoring PSI lookup for filters w/ nulls. Null counts and value counts stored in PSI may not be reliable. Hence, avoiding the lookup for such filters. 

### Impact

Ignoring PSI lookup for filters w/ nulls. Null counts and value counts stored in PSI may not be reliable. Hence, avoiding the lookup for such filters. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
