### PR TITLE
[HUDI-8785] Missed set of `POPULATE_META_FIELDS` parameter during table initialization by Flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.StringUtils;
@@ -373,6 +374,16 @@ public class OptionsResolver {
    */
   public static boolean readCDCFromChangelog(Configuration conf) {
     return conf.getBoolean(FlinkOptions.READ_CDC_FROM_CHANGELOG);
+  }
+
+  /**
+   * Returns whether to populate meta fields or not
+   */
+  public static boolean isPopulateMetaFields(Configuration conf) {
+    return Boolean.parseBoolean(
+        conf.getString(
+            HoodieTableConfig.POPULATE_META_FIELDS.key(),
+            HoodieTableConfig.POPULATE_META_FIELDS.defaultValue().toString()));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -270,6 +270,7 @@ public class StreamerUtil {
           .setUrlEncodePartitioning(conf.getBoolean(FlinkOptions.URL_ENCODE_PARTITIONING))
           .setCDCEnabled(conf.getBoolean(FlinkOptions.CDC_ENABLED))
           .setCDCSupplementalLoggingMode(conf.getString(FlinkOptions.SUPPLEMENTAL_LOGGING_MODE))
+          .setPopulateMetaFields(OptionsResolver.isPopulateMetaFields(conf))
           .initTable(HadoopFSUtils.getStorageConfWithCopy(hadoopConf), basePath);
       LOG.info("Table initialized under base path {}", basePath);
     } else {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -2450,9 +2450,8 @@ public class ITTestHoodieDataSource {
   private static Stream<Arguments> parametersForMetaColumnsSkip() {
     Object[][] data =
         new Object[][] {
-            {HoodieTableType.COPY_ON_WRITE, WriteOperationType.INSERT}
-            // add MOR upsert check after fixing of HUDI-8785
-            // {HoodieTableType.MERGE_ON_READ, WriteOperationType.UPSERT}
+            {HoodieTableType.COPY_ON_WRITE, WriteOperationType.INSERT},
+            {HoodieTableType.MERGE_ON_READ, WriteOperationType.UPSERT}
         };
     return Stream.of(data).map(Arguments::of);
   }


### PR DESCRIPTION
### Change Logs

Currently, the following queries execution by Flink:

```SQL
CREATE TABLE hudi_debug (
    id INT,
    part INT,
    desc STRING,
    PRIMARY KEY (id) NOT ENFORCED
) 
WITH (
    'connector' = 'hudi',
    'path' = '...',
    'table.type' = 'MERGE_ON_READ',
    'write.operation' = 'upsert',
    'hoodie.populate.meta.fields' = 'false'
); 

INSERT INTO hudi_debug VALUES 
    (1,100,'aaa'),
    (2,200,'bbb'); 

SELECT * FROM hudi_debug; 
```

would result in

```text
org.apache.hudi.exception.HoodieException: Exception when reading log file
```

The reason is missed configuration of `hoodie.populate.meta.fields` during table initialization by Flink.

Proposed changes allow to run successfully 
```SQL
SELECT * FROM hudi_debug
```

### Impact

Fixed read by Flink of data without Hudi metacolumns.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
