### PR TITLE
[HUDI-8930] Set transaction manager lock requirement based on config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -286,6 +286,20 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
   }
 
   /**
+   * Update the transaction manager lock requirement if necessary.
+   *
+   * @param oldLockRequired whether lock was required before.
+   * @return whether lock was disabled.
+   */
+  protected boolean updateTxnManagerLockRequirementIfNecessary(boolean oldLockRequired) {
+    boolean shouldDisableLock = oldLockRequired && !config.isLockRequired();
+    if (shouldDisableLock) {
+      txnManager.setIsLockRequired(false);
+    }
+    return shouldDisableLock;
+  }
+
+  /**
    * Updates the cols being indexed with column stats. This is for tracking purpose so that queries can leverage col stats
    * from MDT only for indexed columns.
    * @param metaClient instance of {@link HoodieTableMetaClient} of interest.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
@@ -37,7 +37,7 @@ public class TransactionManager implements Serializable {
 
   protected static final Logger LOG = LoggerFactory.getLogger(TransactionManager.class);
   protected final LockManager lockManager;
-  protected final boolean isLockRequired;
+  protected boolean isLockRequired;
   protected Option<HoodieInstant> currentTxnOwnerInstant = Option.empty();
   private Option<HoodieInstant> lastCompletedTxnOwnerInstant = Option.empty();
 
@@ -104,5 +104,13 @@ public class TransactionManager implements Serializable {
 
   public boolean isLockRequired() {
     return isLockRequired;
+  }
+
+  /**
+   * Lock requirement for transaction manager can change from within a transaction.
+   * For example, when a compaction is scheduled during upgrade, the lock requirement is set to false.
+   */
+  public void setIsLockRequired(boolean isLockRequired) {
+    this.isLockRequired = isLockRequired;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1242,7 +1242,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     this.commonConfig = HoodieCommonConfig.newBuilder().fromProperties(props).build();
     this.storageConfig = HoodieStorageConfig.newBuilder().fromProperties(props).build();
     this.timeGeneratorConfig = HoodieTimeGeneratorConfig.newBuilder().fromProperties(props)
-        .withDefaultLockProvider(!isLockRequired()).build();
+        // Instant time generation needs a lock. If lock provider is not set, use default lock provider
+        .withDefaultLockProvider(!isLockProviderSet()).build();
     this.indexingConfig = HoodieIndexingConfig.newBuilder().fromProperties(props).build();
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
@@ -191,7 +191,7 @@ public class UpgradeDowngradeUtils {
       try (BaseHoodieWriteClient writeClient = upgradeDowngradeHelper.getWriteClient(rollbackWriteConfig, context)) {
         writeClient.rollbackFailedWrites();
         if (shouldCompact) {
-          Option<String> compactionInstantOpt = writeClient.scheduleCompaction(Option.empty());
+          Option<String> compactionInstantOpt = writeClient.scheduleCompaction(Option.empty(), writeClient.getConfig().isLockRequired());
           if (compactionInstantOpt.isPresent()) {
             writeClient.compact(compactionInstantOpt.get());
           }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
@@ -19,9 +19,11 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider
 import org.apache.hudi.common.config.RecordMergeMode
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodieRecordMerger, HoodieTableType, OverwriteWithLatestAvroPayload}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+import org.apache.hudi.config.HoodieLockConfig
 import org.apache.hudi.keygen.constant.KeyGeneratorType
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 import org.apache.spark.sql.SaveMode
@@ -43,6 +45,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
       "hoodie.metadata.enable" -> "false",
       // "OverwriteWithLatestAvroPayload" is used to trigger merge mode upgrade/downgrade.
       DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key -> classOf[OverwriteWithLatestAvroPayload].getName,
+      HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key -> classOf[InProcessLockProvider].getName,
       DataSourceWriteOptions.RECORD_MERGE_MODE.key -> RecordMergeMode.COMMIT_TIME_ORDERING.name)
 
     doWriteAndValidateDataAndRecordIndex(hudiOpts,


### PR DESCRIPTION
### Change Logs

- After removing defaut lock provider in https://github.com/apache/hudi/commit/63ad659a672d9be23a87a1bc85731b66529cd3be, we need to still set a lock for instant time geenration. See changes in `HoodieWriteConfig`.
- Lock requirement for transaction manager can change from within a transaction. For example, when a compaction is scheduled during upgrade, the lock requirement is set to false. Make `isLockRequired` non-final and provide a setter.
- `TransacationManager`'s isLockRequired is set in `BaseHoodieClient#updateColumnsToIndexWithColStats` which is called before beginTransaction and then lock requirements are reset after the job within transaction is done.

### Impact

Set transaction manager lock requirement based on config

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
