### PR TITLE
[HUDI-8850] insert merge mode

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -257,17 +257,7 @@ trait ProvidesHoodieConfig extends Logging {
         Map()
     }
 
-    val inferredMergeConfigs = HoodieTableConfig.inferCorrectMergingBehavior(
-      tableConfig.getRecordMergeMode, tableConfig.getPayloadClass,
-      tableConfig.getRecordMergeStrategyId, preCombineField)
-    val recordMergeMode = inferredMergeConfigs.getLeft.name()
-    val deducedPayloadClassName = inferredMergeConfigs.getMiddle
-    val recordMergeStrategy = inferredMergeConfigs.getRight
-
     val defaultOpts = Map(
-      DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key -> deducedPayloadClassName,
-      DataSourceWriteOptions.RECORD_MERGE_MODE.key -> recordMergeMode,
-      DataSourceWriteOptions.RECORD_MERGE_STRATEGY_ID.key() -> recordMergeStrategy,
       // NOTE: By default insert would try to do deduplication in case that pre-combine column is specified
       //       for the table
       HoodieWriteConfig.COMBINE_BEFORE_INSERT.key -> String.valueOf(combineBeforeInsert),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -23,10 +23,12 @@ import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecord}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils
+import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
+import org.apache.hudi.storage.HoodieStorage
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
 
 import org.apache.hadoop.fs.Path
@@ -37,6 +39,7 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageConta
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 import org.slf4j.LoggerFactory
@@ -375,7 +378,15 @@ object HoodieSparkSqlTestBase {
       .getActiveTimeline.getInstantDetails(cleanInstant).get)
   }
 
+  def validateTableConfig(storage: HoodieStorage,
+                          basePath: String,
+                          expectedConfigs: Map[String, String]): Unit = {
+    val tableConfig = HoodieTableConfig.loadFromHoodieProps(storage, basePath)
+    expectedConfigs.foreach(e => {
+      assertEquals(e._2, tableConfig.getString(e._1))
+    })
+  }
+
   private def checkMessageContains(e: Throwable, text: String): Boolean =
     e.getMessage.trim.contains(text.trim)
-
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageConta
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 import org.slf4j.LoggerFactory
@@ -380,11 +380,15 @@ object HoodieSparkSqlTestBase {
 
   def validateTableConfig(storage: HoodieStorage,
                           basePath: String,
-                          expectedConfigs: Map[String, String]): Unit = {
+                          expectedConfigs: Map[String, String],
+                          nonExistentConfigs: Seq[String]): Unit = {
     val tableConfig = HoodieTableConfig.loadFromHoodieProps(storage, basePath)
     expectedConfigs.foreach(e => {
-      assertEquals(e._2, tableConfig.getString(e._1))
+      assertEquals(e._2, tableConfig.getString(e._1),
+        s"Table config ${e._1} should be ${e._2} but is ${tableConfig.getString(e._1)}")
     })
+    nonExistentConfigs.foreach(e => assertFalse(
+      tableConfig.contains(e), s"$e should not be present in the table config"))
   }
 
   private def checkMessageContains(e: Throwable, text: String): Boolean =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -30,7 +30,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
   // "cow,false"
   // "cow,true",  "mor,true", "mor,false"
-  Seq("cow,false", "cow,true", "mor,false", "mor,true").foreach { args =>
+  //  "cow,true", "mor,false", "mor,true"
+  Seq("cow,false", "mor,false").foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val setRecordMergeMode = argList(1).toBoolean
@@ -42,8 +43,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     )
     val mergeConfigClause = if (setRecordMergeMode) {
       // with precombine, dedup automatically kick in
-      // ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
-      ",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      //",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
     } else {
       // By default, the COMMIT_TIME_ORDERING is used if not specified by the user
       ""

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -36,10 +36,17 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
    */
   //"cow,true,false,6",
   Seq(
-    "cow,false,false,8", "cow,false,true,8", "cow,true,false,8",
-    "cow,true,false,6", "cow,true,true,6",
-    "mor,false,false,8", "mor,false,true,8", "mor,true,false,8",
-    "mor,true,false,6", "mor,true,true,6").foreach { args =>
+//    "cow,false,false,8",
+//    "cow,false,true,8",
+//    "cow,true,false,8",
+//    "cow,true,false,6",
+    "cow,true,true,6",
+//    "mor,false,false,8",
+//    "mor,false,true,8",
+//    "mor,true,false,8",
+//    "mor,true,false,6",
+//    "mor,true,true,6"
+  ).foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val setRecordMergeConfigs = argList(1).toBoolean
@@ -86,150 +93,6 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
       }
     }
 
-    test(s"Test $tableType table with COMMIT_TIME_ORDERING (tableVersion=$tableVersion,"
-      + s"setRecordMergeConfigs=$setRecordMergeConfigs,setUpsertOperation=$setUpsertOperation)") {
-      withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0"
-      ) {
-        withRecordType()(withTempDir { tmp =>
-          if (setUpsertOperation) {
-            spark.sql(s"set hoodie.spark.sql.insert.into.operation=upsert")
-          }
-          val tableName = generateTableName
-          // Create table with COMMIT_TIME_ORDERING
-          spark.sql(
-            s"""
-               | create table $tableName (
-               |  id int,
-               |  name string,
-               |  price double,
-               |  ts long
-               | ) using hudi
-               | tblproperties (
-               |  $writeTableVersionClause
-               |  type = '$tableType',
-               |  primaryKey = 'id'
-               |  $mergeConfigClause
-               | )
-               | location '${tmp.getCanonicalPath}'
-             """.stripMargin)
-          validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-          // Insert initial records with ts=100
-          spark.sql(
-            s"""
-               | insert into $tableName
-               | select 1 as id, 'A' as name, 10.0 as price, 100 as ts
-               | union all
-               | select 2, 'B', 20.0, 100
-             """.stripMargin)
-
-          // Verify inserting records with the same ts value are visible (COMMIT_TIME_ORDERING)
-          spark.sql(
-            s"""
-               | insert into $tableName
-               | select 1 as id, 'A_equal' as name, 60.0 as price, 100 as ts
-               | union all
-               | select 2, 'B_equal', 70.0, 100
-            """.stripMargin)
-          validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            (if (isUpsert) {
-              // With UPSERT operation, there is no duplicate
-              Seq(
-                Seq(1, "A_equal", 60.0, 100),
-                Seq(2, "B_equal", 70.0, 100))
-            } else {
-              // With INSERT operation, there are duplicates
-              Seq(
-                Seq(1, "A", 10.0, 100),
-                Seq(1, "A_equal", 60.0, 100),
-                Seq(2, "B", 20.0, 100),
-                Seq(2, "B_equal", 70.0, 100))
-            }): _*)
-
-          if (isUpsert) {
-            // Verify updating records with the same ts value are visible (COMMIT_TIME_ORDERING)
-            spark.sql(
-              s"""
-                 | update $tableName
-                 | set price = 50.0, ts = 100
-                 | where id = 1
-             """.stripMargin)
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(1, "A_equal", 50.0, 100),
-              Seq(2, "B_equal", 70.0, 100))
-
-            // Verify inserting records with a lower ts value are visible (COMMIT_TIME_ORDERING)
-            spark.sql(
-              s"""
-                 | insert into $tableName
-                 | select 1 as id, 'A' as name, 30.0 as price, 99 as ts
-                 | union all
-                 | select 2, 'B', 40.0, 99
-             """.stripMargin)
-
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(1, "A", 30.0, 99),
-              Seq(2, "B", 40.0, 99))
-
-            // Verify updating records with a lower ts value are visible (COMMIT_TIME_ORDERING)
-            spark.sql(
-              s"""
-                 | update $tableName
-                 | set price = 50.0, ts = 98
-                 | where id = 1
-             """.stripMargin)
-
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(1, "A", 50.0, 98),
-              Seq(2, "B", 40.0, 99))
-
-            // Verify inserting records with a higher ts value are visible (COMMIT_TIME_ORDERING)
-            spark.sql(
-              s"""
-                 | insert into $tableName
-                 | select 1 as id, 'A' as name, 30.0 as price, 101 as ts
-                 | union all
-                 | select 2, 'B', 40.0, 101
-             """.stripMargin)
-
-            // Verify records with ts=101 are visible
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(1, "A", 30.0, 101),
-              Seq(2, "B", 40.0, 101)
-            )
-
-            // Verify updating records with a higher ts value are visible (COMMIT_TIME_ORDERING)
-            spark.sql(
-              s"""
-                 | update $tableName
-                 | set price = 50.0, ts = 102
-                 | where id = 1
-             """.stripMargin)
-
-            // Verify final state after all operations
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(1, "A", 50.0, 102),
-              Seq(2, "B", 40.0, 101)
-            )
-
-            // Delete record
-            spark.sql(s"delete from $tableName where id = 1")
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            // Verify deletion
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(2, "B", 40.0, 101)
-            )
-            spark.sql(s"RESET hoodie.spark.sql.insert.into.operation")
-          }
-        })
-      }
-    }
-
     // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
     test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
       + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
@@ -249,6 +112,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | tblproperties (
                |  $writeTableVersionClause
                |  type = '$tableType',
+               |  hoodie.metadata.enable = 'false',
                |  primaryKey = 'id'
                |  $mergeConfigClause
                | )
@@ -261,13 +125,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
           spark.sql(
             s"""
                | insert into $tableName
-               | select 1 as id, 'A' as name, 10.0 as price, 100L as ts union all
-               | select 0, 'X', 20.0, 100L union all
-               | select 2, 'B', 20.0, 100L union all
-               | select 3, 'C', 30.0, 100L union all
-               | select 4, 'D', 40.0, 100L union all
-               | select 5, 'E', 50.0, 100L union all
-               | select 6, 'F', 60.0, 100L
+               | select 1 as id, 'A' as name, 10.0 as price, 100L as ts
            """.stripMargin)
           validateTableConfig(
             storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
@@ -277,60 +135,16 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
             s"""
                | merge into $tableName t
                | using (
-               |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
-               |   select 2, '', 55.0, 99L as ts union all
-               |   select 0, '', 55.0, 100L as ts
+               |   select 1 as id, 'A' as name, 10.0 as price, 101L as ts
                | ) s
                | on t.id = s.id
                | when matched then delete
            """.stripMargin)
 
-          // Merge operation - update with mixed ts values
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
-               |   select 5, 'E2', 55.0, 99L as ts union all
-               |   select 6, 'F2', 65.0, 100L as ts
-               | ) s
-               | on t.id = s.id
-               | when matched then update set *
-           """.stripMargin)
-
           // Verify state after merges
           validateTableConfig(
             storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100)
-          )
-
-          // Insert new records through merge
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 7 as id, 'D2' as name, 45.0 as price, 100L as ts union all
-               |   select 8, 'E2', 55.0, 100L as ts
-               | ) s
-               | on t.id = s.id
-               | when not matched then insert *
-           """.stripMargin)
-
-          // Verify final state
-          validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100),
-            Seq(7, "D2", 45.0, 100),
-            Seq(8, "E2", 55.0, 100)
-          )
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")()
         })
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -17,14 +17,38 @@
 
 package org.apache.spark.sql.hudi.dml
 
+import org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING
+import org.apache.hudi.common.model.HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.testutils.HoodieTestUtils
+
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.validateTableConfig
 
 class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
-  Seq("mor").foreach { tableType =>
-    // [HUDI-8850] For COW commit time ordering does not work.
-    // Seq("cow", "mor").foreach { tableType =>
-    test(s"Test $tableType table with COMMIT_TIME_ORDERING merge mode") {
+  // "cow,false"
+  // "cow,true",  "mor,true", "mor,false"
+  Seq("cow,false", "cow,true", "mor,false", "mor,true").foreach { args =>
+    val argList = args.split(',')
+    val tableType = argList(0)
+    val setRecordMergeMode = argList(1).toBoolean
+    val storage = HoodieTestUtils.getDefaultStorage
+    val expectedMergeConfigs = Map(
+      HoodieTableConfig.RECORD_MERGE_MODE.key -> COMMIT_TIME_ORDERING.name(),
+      HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[OverwriteWithLatestAvroPayload].getName,
+      HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> COMMIT_TIME_BASED_MERGE_STRATEGY_UUID
+    )
+    val mergeConfigClause = if (setRecordMergeMode) {
+      // with precombine, dedup automatically kick in
+      // ", preCombineField = 'ts',\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+      ",\nhoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'"
+    } else {
+      // By default, the COMMIT_TIME_ORDERING is used if not specified by the user
+      ""
+    }
+    test(s"Test $tableType table with COMMIT_TIME_ORDERING merge mode (explicitly set = $setRecordMergeMode)") {
       withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0"
       ) {
         withRecordType()(withTempDir { tmp =>
@@ -40,13 +64,12 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | ) using hudi
                | tblproperties (
                |  type = '$tableType',
-               |  primaryKey = 'id',
-               |  preCombineField = 'ts',
-               |  hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'
+               |  primaryKey = 'id'
+               |  $mergeConfigClause
                | )
                | location '${tmp.getCanonicalPath}'
              """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           // Insert initial records with ts=100
           spark.sql(
             s"""
@@ -64,7 +87,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
               | union all
               | select 2, 'B_equal', 70.0, 100
             """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(1, "A_equal", 60.0, 100),
             Seq(2, "B_equal", 70.0, 100)
@@ -77,7 +100,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | set price = 50.0, ts = 100
                | where id = 1
              """.stripMargin)
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(1, "A_equal", 50.0, 100),
             Seq(2, "B_equal", 70.0, 100)
@@ -141,7 +164,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
           // Delete record
           spark.sql(s"delete from $tableName where id = 1")
-
+          validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
           // Verify deletion
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             Seq(2, "B", 40.0, 101)
@@ -150,97 +173,104 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
       }
     }
 
-    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table") {
-      withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
-        withRecordType()(withTempDir { tmp =>
-          val tableName = generateTableName
-          // Create table with COMMIT_TIME_ORDERING
-          spark.sql(
-            s"""
-               | create table $tableName (
-               |  id int,
-               |  name string,
-               |  price double,
-               |  ts long
-               | ) using hudi
-               | tblproperties (
-               |  type = '$tableType',
-               |  primaryKey = 'id',
-               |  preCombineField = 'ts',
-               |  hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING'
-               | )
-               | location '${tmp.getCanonicalPath}'
+    // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
+    if ("mor".equals(tableType)) {
+      test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+        + s"(explicitly set = $setRecordMergeMode)") {
+        withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
+          withRecordType()(withTempDir { tmp =>
+            val tableName = generateTableName
+            // Create table with COMMIT_TIME_ORDERING
+            spark.sql(
+              s"""
+                 | create table $tableName (
+                 |  id int,
+                 |  name string,
+                 |  price double,
+                 |  ts long
+                 | ) using hudi
+                 | tblproperties (
+                 |  type = '$tableType',
+                 |  primaryKey = 'id'
+                 |  $mergeConfigClause
+                 | )
+                 | location '${tmp.getCanonicalPath}'
+             """.stripMargin)
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+
+            // Insert initial records
+            spark.sql(
+              s"""
+                 | insert into $tableName
+                 | select 1 as id, 'A' as name, 10.0 as price, 100 as ts union all
+                 | select 0, 'X', 20.0, 100 union all
+                 | select 2, 'B', 20.0, 100 union all
+                 | select 3, 'C', 30.0, 100 union all
+                 | select 4, 'D', 40.0, 100 union all
+                 | select 5, 'E', 50.0, 100 union all
+                 | select 6, 'F', 60.0, 100
+             """.stripMargin)
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+
+            // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 1 as id, 'B2' as name, 25.0 as price, 101 as ts union all
+                 |   select 2, '', 55.0, 99 as ts union all
+                 |   select 0, '', 55.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when matched then delete
              """.stripMargin)
 
-          // Insert initial records
-          spark.sql(
-            s"""
-               | insert into $tableName
-               | select 1 as id, 'A' as name, 10.0 as price, 100 as ts union all
-               | select 0, 'X', 20.0, 100 union all
-               | select 2, 'B', 20.0, 100 union all
-               | select 3, 'C', 30.0, 100 union all
-               | select 4, 'D', 40.0, 100 union all
-               | select 5, 'E', 50.0, 100 union all
-               | select 6, 'F', 60.0, 100
+            // Merge operation - update with mixed ts values
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 4 as id, 'D2' as name, 45.0 as price, 101 as ts union all
+                 |   select 5, 'E2', 55.0, 99 as ts union all
+                 |   select 6, 'F2', 65.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when matched then update set *
              """.stripMargin)
 
-          // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 1 as id, 'B2' as name, 25.0 as price, 101 as ts union all
-               |   select 2, '', 55.0, 99 as ts union all
-               |   select 0, '', 55.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when matched then delete
+            // Verify state after merges
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+              Seq(3, "C", 30.0, 100),
+              Seq(4, "D2", 45.0, 101),
+              Seq(5, "E2", 55.0, 99),
+              Seq(6, "F2", 65.0, 100)
+            )
+
+            // Insert new records through merge
+            spark.sql(
+              s"""
+                 | merge into $tableName t
+                 | using (
+                 |   select 7 as id, 'D2' as name, 45.0 as price, 100 as ts union all
+                 |   select 8, 'E2', 55.0, 100 as ts
+                 | ) s
+                 | on t.id = s.id
+                 | when not matched then insert *
              """.stripMargin)
 
-          // Merge operation - update with mixed ts values
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 4 as id, 'D2' as name, 45.0 as price, 101 as ts union all
-               |   select 5, 'E2', 55.0, 99 as ts union all
-               |   select 6, 'F2', 65.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when matched then update set *
-             """.stripMargin)
-
-          // Verify state after merges
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100)
-          )
-
-          // Insert new records through merge
-          spark.sql(
-            s"""
-               | merge into $tableName t
-               | using (
-               |   select 7 as id, 'D2' as name, 45.0 as price, 100 as ts union all
-               |   select 8, 'E2', 55.0, 100 as ts
-               | ) s
-               | on t.id = s.id
-               | when not matched then insert *
-             """.stripMargin)
-
-          // Verify final state
-          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-            Seq(3, "C", 30.0, 100),
-            Seq(4, "D2", 45.0, 101),
-            Seq(5, "E2", 55.0, 99),
-            Seq(6, "F2", 65.0, 100),
-            Seq(7, "D2", 45.0, 100),
-            Seq(8, "E2", 55.0, 100)
-          )
-        })
+            // Verify final state
+            validateTableConfig(storage, tmp.getCanonicalPath, expectedMergeConfigs)
+            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+              Seq(3, "C", 30.0, 100),
+              Seq(4, "D2", 45.0, 101),
+              Seq(5, "E2", 55.0, 99),
+              Seq(6, "F2", 65.0, 100),
+              Seq(7, "D2", 45.0, 100),
+              Seq(8, "E2", 55.0, 100)
+            )
+          })
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -36,6 +36,8 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
    */
   //"cow,true,false,6",
   Seq(
+    "cow,false,false,8", "cow,false,true,8", "cow,true,false,8",
+    "cow,true,false,6", "cow,true,true,6",
     "mor,false,false,8", "mor,false,true,8", "mor,true,false,8",
     "mor,true,false,6", "mor,true,true,6").foreach { args =>
     val argList = args.split(',')
@@ -229,109 +231,107 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     }
 
     // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
-    if ("mor".equals(tableType)) {
-      test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
-        + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
-        + s"setUpsertOperation=$setUpsertOperation)") {
-        withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
-          withRecordType()(withTempDir { tmp =>
-            val tableName = generateTableName
-            // Create table with COMMIT_TIME_ORDERING
-            spark.sql(
-              s"""
-                 | create table $tableName (
-                 |  id int,
-                 |  name string,
-                 |  price double,
-                 |  ts long
-                 | ) using hudi
-                 | tblproperties (
-                 |  $writeTableVersionClause
-                 |  type = '$tableType',
-                 |  primaryKey = 'id'
-                 |  $mergeConfigClause
-                 | )
-                 | location '${tmp.getCanonicalPath}'
-             """.stripMargin)
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+      + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
+      + s"setUpsertOperation=$setUpsertOperation)") {
+      withSparkSqlSessionConfig("hoodie.merge.small.file.group.candidates.limit" -> "0") {
+        withRecordType()(withTempDir { tmp =>
+          val tableName = generateTableName
+          // Create table with COMMIT_TIME_ORDERING
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts long
+               | ) using hudi
+               | tblproperties (
+               |  $writeTableVersionClause
+               |  type = '$tableType',
+               |  primaryKey = 'id'
+               |  $mergeConfigClause
+               | )
+               | location '${tmp.getCanonicalPath}'
+           """.stripMargin)
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
 
-            // Insert initial records
-            spark.sql(
-              s"""
-                 | insert into $tableName
-                 | select 1 as id, 'A' as name, 10.0 as price, 100L as ts union all
-                 | select 0, 'X', 20.0, 100L union all
-                 | select 2, 'B', 20.0, 100L union all
-                 | select 3, 'C', 30.0, 100L union all
-                 | select 4, 'D', 40.0, 100L union all
-                 | select 5, 'E', 50.0, 100L union all
-                 | select 6, 'F', 60.0, 100L
-             """.stripMargin)
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          // Insert initial records
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | select 1 as id, 'A' as name, 10.0 as price, 100L as ts union all
+               | select 0, 'X', 20.0, 100L union all
+               | select 2, 'B', 20.0, 100L union all
+               | select 3, 'C', 30.0, 100L union all
+               | select 4, 'D', 40.0, 100L union all
+               | select 5, 'E', 50.0, 100L union all
+               | select 6, 'F', 60.0, 100L
+           """.stripMargin)
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
 
-            // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
-                 |   select 2, '', 55.0, 99L as ts union all
-                 |   select 0, '', 55.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when matched then delete
-             """.stripMargin)
+          // Merge operation - delete with higher, lower and equal ordering field value, all should take effect.
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 1 as id, 'B2' as name, 25.0 as price, 101L as ts union all
+               |   select 2, '', 55.0, 99L as ts union all
+               |   select 0, '', 55.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when matched then delete
+           """.stripMargin)
 
-            // Merge operation - update with mixed ts values
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
-                 |   select 5, 'E2', 55.0, 99L as ts union all
-                 |   select 6, 'F2', 65.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when matched then update set *
-             """.stripMargin)
+          // Merge operation - update with mixed ts values
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 4 as id, 'D2' as name, 45.0 as price, 101L as ts union all
+               |   select 5, 'E2', 55.0, 99L as ts union all
+               |   select 6, 'F2', 65.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when matched then update set *
+           """.stripMargin)
 
-            // Verify state after merges
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(3, "C", 30.0, 100),
-              Seq(4, "D2", 45.0, 101),
-              Seq(5, "E2", 55.0, 99),
-              Seq(6, "F2", 65.0, 100)
-            )
+          // Verify state after merges
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+            Seq(3, "C", 30.0, 100),
+            Seq(4, "D2", 45.0, 101),
+            Seq(5, "E2", 55.0, 99),
+            Seq(6, "F2", 65.0, 100)
+          )
 
-            // Insert new records through merge
-            spark.sql(
-              s"""
-                 | merge into $tableName t
-                 | using (
-                 |   select 7 as id, 'D2' as name, 45.0 as price, 100L as ts union all
-                 |   select 8, 'E2', 55.0, 100L as ts
-                 | ) s
-                 | on t.id = s.id
-                 | when not matched then insert *
-             """.stripMargin)
+          // Insert new records through merge
+          spark.sql(
+            s"""
+               | merge into $tableName t
+               | using (
+               |   select 7 as id, 'D2' as name, 45.0 as price, 100L as ts union all
+               |   select 8, 'E2', 55.0, 100L as ts
+               | ) s
+               | on t.id = s.id
+               | when not matched then insert *
+           """.stripMargin)
 
-            // Verify final state
-            validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
-            checkAnswer(s"select id, name, price, ts from $tableName order by id")(
-              Seq(3, "C", 30.0, 100),
-              Seq(4, "D2", 45.0, 101),
-              Seq(5, "E2", 55.0, 99),
-              Seq(6, "F2", 65.0, 100),
-              Seq(7, "D2", 45.0, 100),
-              Seq(8, "E2", 55.0, 100)
-            )
-          })
-        }
+          // Verify final state
+          validateTableConfig(
+            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+          checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+            Seq(3, "C", 30.0, 100),
+            Seq(4, "D2", 45.0, 101),
+            Seq(5, "E2", 55.0, 99),
+            Seq(6, "F2", 65.0, 100),
+            Seq(7, "D2", 45.0, 100),
+            Seq(8, "E2", 55.0, 100)
+          )
+        })
       }
     }
   }


### PR DESCRIPTION
### Change Logs

MIT delete does not take effect. Run test class TestMergeModeCommitTimeOrdering.


COW, Override payload.
(id 1, ts 100)
incoming record
(id 1, ts 101)

MIT on match id column then delete

We end up with (id 1, ts 100).

--------
# Investigation findings

Investigation found that:
shouldIgnore(Schema, Properties):173, for the incoming record returns true. So it is completely not processed.
```
isDeleteRecord(GenericRecord):87, BaseAvroPayload (org.apache.hudi.common.model), BaseAvroPayload.java
getInsertValue(Schema, Properties):270, ExpressionPayload (org.apache.spark.sql.hudi.command.payload), ExpressionPayload.scala
shouldIgnore(Schema, Properties):173, HoodieAvroRecord (org.apache.hudi.common.model), HoodieAvroRecord.java
writeInsertRecord(HoodieRecord):303, HoodieMergeHandle (org.apache.hudi.io), HoodieMergeHandle.java
writeIncomingRecords():120, HoodieConcatHandle (org.apache.hudi.io), HoodieConcatHandle.java
close():452, HoodieMergeHandle (org.apache.hudi.io), HoodieMergeHandle.java
finish():59, BaseMergeHelper$UpdateHandler (org.apache.hudi.table.action.commit), BaseMergeHelper.java
finish():44, BaseMergeHelper$UpdateHandler (org.apache.hudi.table.action.commit), BaseMergeHelper.java
execute():72, SimpleExecutor (org.apache.hudi.common.util.queue), SimpleExecutor.java
runMerge(HoodieTable, HoodieMergeHandle):149, HoodieMergeHelper (org.apache.hudi.table.action.commit), HoodieMergeHelper.java
runMerge(HoodieMergeHandle, String, String):147, HoodieSparkTable (org.apache.hudi.table), HoodieSparkTable.java
handleUpdateInternal(HoodieMergeHandle, String):351, BaseSparkCommitActionExecutor (org.apache.hudi.table.action.commit), BaseSparkCommitActionExecutor.java
handleUpdate(String, String, Iterator):346, BaseSparkCommitActionExecutor (org.apache.hudi.table.action.commit), BaseSparkCommitActionExecutor.java
handleUpsertPartition(String, Integer, Iterator, Partitioner):312, BaseSparkCommitActionExecutor (org.apache.hudi.table.action.commit), BaseSparkCommitActionExecutor.java
handleInsertPartition(String, Integer, Iterator, Partitioner):325, BaseSparkCommitActionExecutor (org.apache.hudi.table.action.commit), BaseSparkCommitActionExecutor.java
```

Because "getInsertValue"
```

  override def getInsertValue(schema: Schema, properties: Properties): HOption[IndexedRecord] = {
    val recordSchema = getRecordSchema(properties)
    val incomingRecord = ConvertibleRecord(bytesToAvro(recordBytes, recordSchema))

    if (super.isDeleteRecord(incomingRecord.asAvro)) {
      HOption.empty[IndexedRecord]()
    } else if (isMORTable(properties)) {
      ...
    } else {
      // For COW table, only the not-matched record will step into the getInsertValue method, So just call
      // the processNotMatchedRecord() here.
      processNotMatchedRecord(incomingRecord, properties) <== returns HOption.of(HoodieRecord.SENTINEL), an indicator that it should be ignored.
    }
  }
```

# Questions
I'm confused by the logic, here we have the incoming record matching with the existing record, yet we are calling getInsertValue, which is a branch intended for " the not-matched record ". It internally poke into the assignment clause and for MIT delete it is totally garbage info and we end up with HoodieRecord.SENTINEL.

I need to learn the right flow of MIT delete first to figure out the problem.



### Impact


### Risk level (write none, low medium or high below)


### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
