### PR TITLE
[HUDI-8940] Fix Bloom Index Partitioner to distribute keys uniformly across partitions

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -147,6 +147,14 @@ public class HoodieIndexConfig extends HoodieConfig {
           + "When true, bucketized bloom filtering is enabled. "
           + "This reduces skew seen in sort based bloom index lookup");
 
+  public static final ConfigProperty<String> BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER = ConfigProperty
+      .key("hoodie.bloom.index.fileId.key.sort.partitioner")
+      .defaultValue("false")
+      .markAdvanced()
+      .withDocumentation("Only applies if index type is BLOOM. "
+          + "When true, fileId and key sort based partitioning is enabled "
+          + "This reduces skew seen in bucket based bloom index lookup");
+
   public static final ConfigProperty<String> SIMPLE_INDEX_USE_CACHING = ConfigProperty
       .key("hoodie.simple.index.use.caching")
       .defaultValue("true")
@@ -617,6 +625,11 @@ public class HoodieIndexConfig extends HoodieConfig {
 
     public Builder bloomIndexBucketizedChecking(boolean bucketizedChecking) {
       hoodieIndexConfig.setValue(BLOOM_INDEX_BUCKETIZED_CHECKING, String.valueOf(bucketizedChecking));
+      return this;
+    }
+
+    public Builder bloomIndexFileGroupIdKeySortPartitioner(boolean fileGroupIdKeySortPartitioner) {
+      hoodieIndexConfig.setValue(BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER, String.valueOf(fileGroupIdKeySortPartitioner));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -147,13 +147,14 @@ public class HoodieIndexConfig extends HoodieConfig {
           + "When true, bucketized bloom filtering is enabled. "
           + "This reduces skew seen in sort based bloom index lookup");
 
-  public static final ConfigProperty<String> BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER = ConfigProperty
-      .key("hoodie.bloom.index.fileId.key.sort.partitioner")
+  public static final ConfigProperty<String> BLOOM_INDEX_FILE_GROUP_ID_KEY_SORTING = ConfigProperty
+      .key("hoodie.bloom.index.fileid.key.sorting.enable")
       .defaultValue("false")
       .markAdvanced()
+      .sinceVersion("1.1.0")
       .withDocumentation("Only applies if index type is BLOOM. "
-          + "When true, fileId and key sort based partitioning is enabled "
-          + "This reduces skew seen in bucket based bloom index lookup");
+          + "When true, the global sorting based on the fileId and key is enabled during key lookup. "
+          + "This reduces skew in the key lookup in the bloom index.");
 
   public static final ConfigProperty<String> SIMPLE_INDEX_USE_CACHING = ConfigProperty
       .key("hoodie.simple.index.use.caching")
@@ -628,8 +629,8 @@ public class HoodieIndexConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder bloomIndexFileGroupIdKeySortPartitioner(boolean fileGroupIdKeySortPartitioner) {
-      hoodieIndexConfig.setValue(BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER, String.valueOf(fileGroupIdKeySortPartitioner));
+    public Builder enableBloomIndexFileGroupIdKeySorting(boolean fileGroupIdKeySorting) {
+      hoodieIndexConfig.setValue(BLOOM_INDEX_FILE_GROUP_ID_KEY_SORTING, String.valueOf(fileGroupIdKeySorting));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2105,8 +2105,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieIndexConfig.BLOOM_INDEX_BUCKETIZED_CHECKING);
   }
 
-  public boolean useBloomIndexFileGroupIdKeySortPartitioner() {
-    return getBoolean(HoodieIndexConfig.BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER);
+  public boolean isBloomIndexFileGroupIdKeySortingEnabled() {
+    return getBoolean(HoodieIndexConfig.BLOOM_INDEX_FILE_GROUP_ID_KEY_SORTING);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2105,6 +2105,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieIndexConfig.BLOOM_INDEX_BUCKETIZED_CHECKING);
   }
 
+  public boolean useBloomIndexFileGroupIdKeySortPartitioner() {
+    return getBoolean(HoodieIndexConfig.BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER);
+  }
+
   /**
    * Determines if the metadata bloom filter index is enabled.
    *

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -616,14 +616,15 @@ public class TestHoodieWriteConfig {
   }
 
   @Test
-  void testBloomIndexFileIdKeySortPartitionerConfig() {
+  void testBloomIndexFileIdKeySortingConfig() {
     Properties props = new Properties();
     props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
-        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).withIndexType(HoodieIndex.IndexType.BLOOM)
-            .bloomIndexFileGroupIdKeySortPartitioner(true).build())
+        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props)
+            .withIndexType(HoodieIndex.IndexType.BLOOM)
+            .enableBloomIndexFileGroupIdKeySorting(true).build())
         .build();
-    assertTrue(writeConfig.useBloomIndexFileGroupIdKeySortPartitioner());
+    assertTrue(writeConfig.isBloomIndexFileGroupIdKeySortingEnabled());
   }
   
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -616,6 +616,17 @@ public class TestHoodieWriteConfig {
   }
 
   @Test
+  void testBloomIndexFileIdKeySortPartitionerConfig() {
+    Properties props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).withIndexType(HoodieIndex.IndexType.BLOOM)
+            .bloomIndexFileGroupIdKeySortPartitioner(true).build())
+        .build();
+    assertTrue(writeConfig.useBloomIndexFileGroupIdKeySortPartitioner());
+  }
+  
+  @Test
   public void testAutoAdjustCleanPolicyForNonBlockingConcurrencyControl() {
     TypedProperties props = new TypedProperties();
     props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.MERGE_ON_READ.name());

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -170,6 +170,11 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
           .repartitionAndSortWithinPartitions(partitioner, new FileGroupIdComparator())
           .map(Tuple2::_1)
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
+    } else if (config.useBloomIndexFileGroupIdKeySortPartitioner()) {
+      keyLookupResultRDD = fileComparisonsRDD.map(fileGroupAndRecordKey -> fileGroupAndRecordKey)
+          .sortBy(fileGroupAndRecordKey -> fileGroupAndRecordKey._1
+              + "+" + fileGroupAndRecordKey._2, true, targetParallelism
+          ).mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
     } else {
       keyLookupResultRDD = fileComparisonsRDD.sortByKey(true, targetParallelism)
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -170,7 +170,7 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
           .repartitionAndSortWithinPartitions(partitioner, new FileGroupIdComparator())
           .map(Tuple2::_1)
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
-    } else if (config.useBloomIndexFileGroupIdKeySortPartitioner()) {
+    } else if (config.isBloomIndexFileGroupIdKeySortingEnabled()) {
       keyLookupResultRDD = fileComparisonsRDD.mapToPair(fileGroupAndRecordKey -> new Tuple2<>(fileGroupAndRecordKey, false))
           .sortByKey(new FileGroupIdAndRecordKeyComparator(), true, targetParallelism)
           .map(Tuple2::_1)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
@@ -82,20 +82,24 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
   private static final Schema SCHEMA = getSchemaFromResource(TestHoodieBloomIndex.class, "/exampleSchema.avsc", true);
   private static final String TEST_NAME_WITH_PARAMS =
-      "[{index}] Test with rangePruning={0}, treeFiltering={1}, bucketizedChecking={2}, useMetadataTable={3}";
+      "[{index}] Test with rangePruning={0}, treeFiltering={1}, bucketizedChecking={2}, useMetadataTable={3}, useFileGroupIDKeySortPartitioner={4}";
   private static final Random RANDOM = new Random(0xDEED);
 
   public static Stream<Arguments> configParams() {
-    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable
+    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner
     Object[][] data = new Object[][] {
-        {true, true, true, false},
-        {false, true, true, false},
-        {true, true, false, false},
-        {true, false, true, false},
-        {true, true, true, true},
-        {false, true, true, true},
-        {true, true, false, true},
-        {true, false, true, true}
+        {true, true, true, false, false},
+        {false, true, true, false, false},
+        {true, true, false, false, false},
+        {true, false, true, false, false},
+        {true, true, true, true, false},
+        {false, true, true, true, false},
+        {true, true, false, true, false},
+        {true, false, true, true, false},
+        {true, true, false, false, true},
+        {true, false, false, false, true},
+        {false, false, false, false, true},
+        {false, true, false, false, true}
     };
     return Stream.of(data).map(Arguments::of);
   }
@@ -120,7 +124,8 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   }
 
   private HoodieWriteConfig makeConfig(
-      boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking, boolean useMetadataTable) {
+      boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
     // For the bloom index to use column stats and bloom filters from metadata table,
     // the following configs must be set to true:
     // "hoodie.bloom.index.use.metadata"
@@ -134,6 +139,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
             .bloomIndexBucketizedChecking(bucketizedChecking)
             .bloomIndexKeysPerBucket(2)
             .bloomIndexUseMetadata(useMetadataTable)
+            .bloomIndexFileGroupIdKeySortPartitioner(useFileGroupIDKeySortPartitioner)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .withMetadataIndexBloomFilter(useMetadataTable)
@@ -146,9 +152,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testLoadInvolvedFiles(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) throws Exception {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
@@ -249,9 +255,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testRangePruning(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
 
     final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo = new HashMap<>();
@@ -352,12 +358,12 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationWithEmptyRDD(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
     // We have some records to be tagged (two different partitions)
     JavaRDD<HoodieRecord> recordRDD = jsc.emptyRDD();
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkTable table = HoodieSparkTable.create(config, context, metaClient);
 
@@ -373,7 +379,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnPartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) throws Exception {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -398,7 +404,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Arrays.asList(record1, record2, record3, record4));
 
     // Also create the metadata and config
-    HoodieWriteConfig config = makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+    HoodieWriteConfig config = makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -473,7 +479,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnNonpartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) throws Exception {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -497,7 +503,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -566,7 +572,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testCheckExists(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) throws Exception {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
     // We have some records to be tagged (two different partitions)
 
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
@@ -593,7 +599,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -681,7 +687,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testBloomFilterFalseError(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable) throws Exception {
+      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
     // We have two hoodie records
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
         + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
@@ -707,7 +713,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     // We do the tag
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Arrays.asList(record1, record2));
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
@@ -82,11 +82,12 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
   private static final Schema SCHEMA = getSchemaFromResource(TestHoodieBloomIndex.class, "/exampleSchema.avsc", true);
   private static final String TEST_NAME_WITH_PARAMS =
-      "[{index}] Test with rangePruning={0}, treeFiltering={1}, bucketizedChecking={2}, useMetadataTable={3}, useFileGroupIDKeySortPartitioner={4}";
+      "[{index}] Test with rangePruning={0}, treeFiltering={1}, bucketizedChecking={2}, "
+          + "useMetadataTable={3}, enableFileGroupIDKeySorting={4}";
   private static final Random RANDOM = new Random(0xDEED);
 
   public static Stream<Arguments> configParams() {
-    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner
+    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting
     Object[][] data = new Object[][] {
         {true, true, true, false, false},
         {false, true, true, false, false},
@@ -125,7 +126,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
   private HoodieWriteConfig makeConfig(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
     // For the bloom index to use column stats and bloom filters from metadata table,
     // the following configs must be set to true:
     // "hoodie.bloom.index.use.metadata"
@@ -139,7 +140,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
             .bloomIndexBucketizedChecking(bucketizedChecking)
             .bloomIndexKeysPerBucket(2)
             .bloomIndexUseMetadata(useMetadataTable)
-            .bloomIndexFileGroupIdKeySortPartitioner(useFileGroupIDKeySortPartitioner)
+            .enableBloomIndexFileGroupIdKeySorting(enableFileGroupIDKeySorting)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .withMetadataIndexBloomFilter(useMetadataTable)
@@ -152,9 +153,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testLoadInvolvedFiles(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
@@ -255,9 +256,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testRangePruning(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
 
     final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo = new HashMap<>();
@@ -358,12 +359,12 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationWithEmptyRDD(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
     // We have some records to be tagged (two different partitions)
     JavaRDD<HoodieRecord> recordRDD = jsc.emptyRDD();
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkTable table = HoodieSparkTable.create(config, context, metaClient);
 
@@ -379,7 +380,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnPartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -404,7 +405,8 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Arrays.asList(record1, record2, record3, record4));
 
     // Also create the metadata and config
-    HoodieWriteConfig config = makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+    HoodieWriteConfig config =
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -479,7 +481,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnNonpartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -503,7 +505,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -572,7 +574,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testCheckExists(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
 
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
@@ -599,7 +601,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -687,7 +689,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testBloomFilterFalseError(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean useFileGroupIDKeySortPartitioner) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
     // We have two hoodie records
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
         + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
@@ -713,7 +715,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     // We do the tag
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Arrays.asList(record1, record2));
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, useFileGroupIDKeySortPartitioner);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
@@ -83,11 +83,11 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   private static final Schema SCHEMA = getSchemaFromResource(TestHoodieBloomIndex.class, "/exampleSchema.avsc", true);
   private static final String TEST_NAME_WITH_PARAMS =
       "[{index}] Test with rangePruning={0}, treeFiltering={1}, bucketizedChecking={2}, "
-          + "useMetadataTable={3}, enableFileGroupIDKeySorting={4}";
+          + "useMetadataTable={3}, enableFileGroupIdKeySorting={4}";
   private static final Random RANDOM = new Random(0xDEED);
 
   public static Stream<Arguments> configParams() {
-    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting
+    // rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting
     Object[][] data = new Object[][] {
         {true, true, true, false, false},
         {false, true, true, false, false},
@@ -126,7 +126,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
   private HoodieWriteConfig makeConfig(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) {
     // For the bloom index to use column stats and bloom filters from metadata table,
     // the following configs must be set to true:
     // "hoodie.bloom.index.use.metadata"
@@ -140,7 +140,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
             .bloomIndexBucketizedChecking(bucketizedChecking)
             .bloomIndexKeysPerBucket(2)
             .bloomIndexUseMetadata(useMetadataTable)
-            .enableBloomIndexFileGroupIdKeySorting(enableFileGroupIDKeySorting)
+            .enableBloomIndexFileGroupIdKeySorting(enableFileGroupIdKeySorting)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .withMetadataIndexBloomFilter(useMetadataTable)
@@ -153,9 +153,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testLoadInvolvedFiles(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) throws Exception {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
@@ -256,9 +256,9 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testRangePruning(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) {
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
 
     final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo = new HashMap<>();
@@ -359,12 +359,12 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationWithEmptyRDD(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) {
     // We have some records to be tagged (two different partitions)
     JavaRDD<HoodieRecord> recordRDD = jsc.emptyRDD();
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkTable table = HoodieSparkTable.create(config, context, metaClient);
 
@@ -380,7 +380,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnPartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -406,7 +406,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -481,7 +481,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testTagLocationOnNonpartitionedTable(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
     String rowKey1 = genRandomUUID();
     String rowKey2 = genRandomUUID();
@@ -505,7 +505,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -574,7 +574,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testCheckExists(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) throws Exception {
     // We have some records to be tagged (two different partitions)
 
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
@@ -601,7 +601,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
 
     // Also create the metadata and config
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
@@ -689,7 +689,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
   @MethodSource("configParams")
   public void testBloomFilterFalseError(
       boolean rangePruning, boolean treeFiltering, boolean bucketizedChecking,
-      boolean useMetadataTable, boolean enableFileGroupIDKeySorting) throws Exception {
+      boolean useMetadataTable, boolean enableFileGroupIdKeySorting) throws Exception {
     // We have two hoodie records
     String recordStr1 = "{\"_row_key\":\"1eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
         + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
@@ -715,7 +715,7 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     // We do the tag
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Arrays.asList(record1, record2));
     HoodieWriteConfig config =
-        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIDKeySorting);
+        makeConfig(rangePruning, treeFiltering, bucketizedChecking, useMetadataTable, enableFileGroupIdKeySorting);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
 


### PR DESCRIPTION
### Change Logs

Bloom Index causes data skew when bucketized partitioning is used, during repartition and sorting stage when there are hollow buckets created. This happens when there are lot of writes to one partition and few writes to other partitions.

In this pr, we're partitioning based on the fileId + recordKey sort partitioner which distributes the keys equally while keeping same fileIds together.

![Screenshot 2025-01-17 at 9 29 00 PM (1)](https://github.com/user-attachments/assets/362f0321-033f-44ca-b1d2-0a2f64b10032)


### Impact

Bloom Index can now use fileId and recordkey based partitioner to distribute the comparisons equally across partitions where bucketized partitioning is causing data skew.


### Risk level (write none, low medium or high below)

Medium

Added Functional Tests

### Documentation Update

```java
public static final ConfigProperty<String> BLOOM_INDEX_FILE_GROUP_ID_KEY_SORT_PARTITIONER = ConfigProperty
      .key("hoodie.bloom.index.fileId.key.sort.partitioner")
      .defaultValue("false")
      .markAdvanced()
      .withDocumentation("Only applies if index type is BLOOM. "
          + "When true, fileId and key sort based partitioning is enabled "
          + "This reduces skew seen in bucket based bloom index lookup");
``` 
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
