### PR TITLE
[HUDI-8941] Stop spark context with proper exit code in HoodieStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -640,10 +640,15 @@ public class HoodieStreamer implements Serializable {
       LOG.warn("--enable-hive-sync will be deprecated in a future release; please use --enable-sync instead for Hive syncing");
     }
 
+    int exitCode = 0;
     try {
       new HoodieStreamer(cfg, jssc).sync();
+    } catch (Exception e) {
+      LOG.error("Failed to execute HoodieStreamer : {}", e.getMessage());
+      exitCode = 1;
+      throw e;
     } finally {
-      jssc.stop();
+      jssc.sc().stop(exitCode);
     }
   }
 


### PR DESCRIPTION
### Change Logs

Currently in Hoodiestreamer, jssc.stop();  is being called which always stops the application with exit code 0 even in case of any exception is raised.

With new spark versions, exit code can be passed while stopping spark context.
For reference : https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L2306

This PR enables spark context to shutdown with proper exit code


### Impact

NA


### Risk level (write none, low medium or high below)

NA

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
