### PR TITLE
[HUDI-8947] Fixing log file naming with MOR table writes using table version 6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleWithChangeLog.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleWithChangeLog.java
@@ -62,7 +62,7 @@ public class HoodieMergeHandleWithChangeLog<T, I, K, O> extends HoodieMergeHandl
         partitionPath,
         storage,
         getWriterSchema(),
-        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX),
+        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX, Option.empty()),
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 
@@ -80,7 +80,7 @@ public class HoodieMergeHandleWithChangeLog<T, I, K, O> extends HoodieMergeHandl
         partitionPath,
         storage,
         getWriterSchema(),
-        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX),
+        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX, Option.empty()),
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.testutils.providers;
 
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -35,6 +36,8 @@ import java.util.Properties;
 public interface HoodieMetaClientProvider {
 
   HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException;
+
+  HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props, HoodieTableType tableType) throws IOException;
 
   default HoodieTableFileSystemView getHoodieTableFileSystemView(
       HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandleWithChangeLog.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandleWithChangeLog.java
@@ -64,7 +64,7 @@ public class FlinkMergeAndReplaceHandleWithChangeLog<T, I, K, O>
         partitionPath,
         getStorage(),
         getWriterSchema(),
-        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX),
+        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX, Option.empty()),
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeHandleWithChangeLog.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeHandleWithChangeLog.java
@@ -62,7 +62,7 @@ public class FlinkMergeHandleWithChangeLog<T, I, K, O>
         partitionPath,
         getStorage(),
         getWriterSchema(),
-        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX),
+        createLogWriter(instantTime, HoodieCDCUtils.CDC_LOGFILE_SUFFIX, Option.empty()),
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -122,13 +123,19 @@ public class FunctionalTestHarness implements SparkProvider, DFSProvider, Hoodie
   }
 
   @Override
-  public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
+  public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props,
+      HoodieTableType tableType) throws IOException {
     return HoodieTableMetaClient.newTableBuilder()
       .setTableName(RAW_TRIPS_TEST_NAME)
-      .setTableType(COPY_ON_WRITE)
+      .setTableType(tableType)
       .setPayloadClass(HoodieAvroPayload.class)
       .fromProperties(props)
       .initTable(storageConf.newInstance(), basePath);
+  }
+
+  @Override
+  public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
+    return getHoodieMetaClient(storageConf, basePath, props, COPY_ON_WRITE);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -192,9 +192,15 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
 
   @Override
   public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props) throws IOException {
+    return getHoodieMetaClient(storageConf, basePath, props, COPY_ON_WRITE);
+  }
+
+  @Override
+  public HoodieTableMetaClient getHoodieMetaClient(StorageConfiguration<?> storageConf, String basePath, Properties props,
+                                                   HoodieTableType tableType) throws IOException {
     return HoodieTableMetaClient.newTableBuilder()
         .setTableName(RAW_TRIPS_TEST_NAME)
-        .setTableType(COPY_ON_WRITE)
+        .setTableType(tableType)
         .setPayloadClass(HoodieAvroPayload.class)
         .setTableVersion(ConfigUtils.getIntWithAltKeys(new TypedProperties(props), WRITE_TABLE_VERSION))
         .fromProperties(props)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -79,10 +79,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -435,5 +437,30 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     // to avoid port reuse causing failures
     timelineServicePort = (timelineServicePort + 1 - 1024) % (65536 - 1024) + 1024;
     return timelineServicePort;
+  }
+
+  /**
+   * Check if two dataframes are equal.
+   *
+   * @param expectedDf      expected dataframe
+   * @param actualDf        actual dataframe
+   * @param validateColumns columns to validate
+   * @return true if dataframes are equal, false otherwise
+   */
+  public static boolean areDataframesEqual(Dataset<Row> expectedDf, Dataset<Row> actualDf, Set<String> validateColumns) {
+    // Normalize schema order
+    String[] sortedColumnNames = Arrays.stream(expectedDf.columns())
+        .filter(validateColumns::contains).sorted().toArray(String[]::new);
+
+    // Reorder columns in both datasets
+    Dataset<Row> df1Normalized = expectedDf.selectExpr(sortedColumnNames);
+    Dataset<Row> df2Normalized = actualDf.selectExpr(sortedColumnNames);
+
+    // Sort rows
+    Dataset<Row> df1Sorted = df1Normalized.sort("_row_key");
+    Dataset<Row> df2Sorted = df2Normalized.sort("_row_key");
+
+    // Check for differences
+    return df1Sorted.except(df2Sorted).isEmpty() && df2Sorted.except(df1Sorted).isEmpty();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -256,6 +256,7 @@ public interface HoodieLogFormat {
           if (versionAndWriteToken.isPresent()) {
             logVersion = versionAndWriteToken.get().getKey();
             logWriteToken = versionAndWriteToken.get().getValue();
+            //logVersion++; // bump up the version so the new file has the next log version.
           } else {
             // this is the case where there is no existing log-file.
             logVersion = HoodieLogFile.LOGFILE_BASE_VERSION;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -256,7 +256,6 @@ public interface HoodieLogFormat {
           if (versionAndWriteToken.isPresent()) {
             logVersion = versionAndWriteToken.get().getKey();
             logWriteToken = versionAndWriteToken.get().getValue();
-            //logVersion++; // bump up the version so the new file has the next log version.
           } else {
             // this is the case where there is no existing log-file.
             logVersion = HoodieLogFile.LOGFILE_BASE_VERSION;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -102,8 +102,11 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       boolean created = false;
       while (!created) {
         try {
+          if (storage.exists(logFile.getPath())) {
+            rollOver();
+          }
           // Block size does not matter as we will always manually auto-flush
-          createNewFile();
+          createNewFile(); // if file already exists, we end up creating a marker, but no data file.
           LOG.info("Created a new log file: {}", logFile);
           created = true;
         } catch (FileAlreadyExistsException ignored) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -106,7 +106,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
             rollOver();
           }
           // Block size does not matter as we will always manually auto-flush
-          createNewFile(); // if file already exists, we end up creating a marker, but no data file.
+          createNewFile();
           LOG.info("Created a new log file: {}", logFile);
           created = true;
         } catch (FileAlreadyExistsException ignored) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -333,8 +333,10 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
     // assert that the dataframe is equal to the expected dataframe
     // NOTE: we have excluded some columns from comparison such as map, date and array type fields as they were incompatible
     // For example below is what data generated looks like vs what is read from the table (check `city_to_state` map: [CA] vs Map(LA -> CA))
-    //  [false,029c1e56-3c03-42e3-a2eb-a45addd5b671,0.5550830309956531,0.013823731501093062,[CA],15,1322460250,1053705246,driver-002,0.8563083971473885,0.7050871729430999,[39.649862113946796,USD],WrappedArray(0, 0, 8, 19, -72),Canada,2015/03/17,rider-002,-5190452608208752867,0,WrappedArray([88.29247239885966,USD]),BLACK,0.7458226]
-    //  [false,029c1e56-3c03-42e3-a2eb-a45addd5b671,0.5550830309956531,0.013823731501093062,Map(LA -> CA),1970-01-16,1322460250,1053705246,driver-002,0.8563083971473885,0.7050871729430999,[39.649862113946796,USD],0.529336,[B@372d7420,2015/03/17,rider-002,-5190452608208752867,0,WrappedArray([88.29247239885966,USD]),BLACK,0.7458226]
+    //  [false,029c1e56-3c03-42e3-a2eb-a45addd5b671,0.5550830309956531,0.013823731501093062,[CA],15,1322460250,1053705246,driver-002,0.8563083971473885,0.7050871729430999,
+    //         [39.649862113946796,USD], WrappedArray(0, 0, 8, 19, -72),Canada,2015/03/17,rider-002,-5190452608208752867,0,WrappedArray([88.29247239885966,USD]),BLACK,0.7458226]
+    //  [false,029c1e56-3c03-42e3-a2eb-a45addd5b671,0.5550830309956531,0.013823731501093062,Map(LA -> CA),1970-01-16,1322460250,1053705246,driver-002,0.8563083971473885,0.7050871729430999,
+    //         [39.649862113946796,USD],0.529336,[B@372d7420,2015/03/17,rider-002,-5190452608208752867,0,WrappedArray([88.29247239885966,USD]),BLACK,0.7458226]
     assertTrue(areDataframesEqual(inputDf, outputDf, new HashSet<>(Arrays.asList("_hoodie_is_deleted", "_row_key", "begin_lat", "begin_lon",
         "current_ts", "distance_in_meters", "driver", "end_lat", "end_lon", "fare"))), "Dataframe mismatch");
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
@@ -172,9 +172,20 @@ public class DataSourceTestUtils {
         .getLatestCompletionTime().orElse(null);
   }
 
+  public static String latestCommitRequestTime(HoodieStorage storage, String basePath) {
+    return HoodieDataSourceHelpers.allCompletedCommitsCompactions(storage, basePath)
+        .lastInstant().map(instant -> instant.requestedTime()).orElse(null);
+  }
+
   public static String latestDeltaCommitCompletionTime(HoodieStorage storage, String basePath) {
     return HoodieDataSourceHelpers.allCompletedCommitsCompactions(storage, basePath)
         .filter(instant -> HoodieTimeline.DELTA_COMMIT_ACTION.equals(instant.getAction()))
         .getLatestCompletionTime().orElse(null);
+  }
+
+  public static String latestDeltaCommitRequest(HoodieStorage storage, String basePath) {
+    return HoodieDataSourceHelpers.allCompletedCommitsCompactions(storage, basePath)
+        .filter(instant -> HoodieTimeline.DELTA_COMMIT_ACTION.equals(instant.getAction()))
+        .lastInstant().map(instant -> instant.requestedTime()).orElse(null);
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -114,7 +114,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     "AVRO, AVRO, avro, true,timestamp,EVENT_TIME_ORDERING,6",
     "AVRO, AVRO, avro, true,timestamp,COMMIT_TIME_ORDERING,6"))
   def testCount(readType: HoodieRecordType, writeType: HoodieRecordType, logType: String,
-                hasPreCombineField: Boolean, precombineField: String, recordMergeMode: String, tableVersion: String = "8") {
+                hasPreCombineField: Boolean, precombineField: String, recordMergeMode: String, tableVersion: String = "8"): Unit = {
     var (_, readOpts) = getWriterReaderOpts(readType)
     var (writeOpts, _) = getWriterReaderOpts(writeType)
     readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.config.{HoodieMemoryConfig, HoodieMetadataConfig, 
 import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TIMEZONE_FORMAT, TIMESTAMP_TYPE_FIELD}
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.util.Option
@@ -33,7 +33,7 @@ import org.apache.hudi.common.util.StringUtils.isNullOrEmpty
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.functional.TestCOWDataSource.convertColumnsToNullable
 import org.apache.hudi.index.HoodieIndex.IndexType
-import org.apache.hudi.metadata.HoodieTableMetadataUtil.{metadataPartitionExists, PARTITION_NAME_SECONDARY_INDEX_PREFIX}
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.{PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataPartitionExists}
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieSparkClientTestBase}
@@ -99,22 +99,22 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
   @ParameterizedTest
   @CsvSource(Array(
     // Inferred as COMMIT_TIME_ORDERING
-    "AVRO, AVRO, avro, false,,", "AVRO, SPARK, parquet, false,,",
-    "SPARK, AVRO, parquet, false,,", "SPARK, SPARK, parquet, false,,",
+    "AVRO, AVRO, avro, false,,,EIGHT", "AVRO, SPARK, parquet, false,,,EIGHT",
+    "SPARK, AVRO, parquet, false,,,EIGHT", "SPARK, SPARK, parquet, false,,,EIGHT",
     // EVENT_TIME_ORDERING without precombine field
-    "AVRO, AVRO, avro, false,,EVENT_TIME_ORDERING", "AVRO, SPARK, parquet, false,,EVENT_TIME_ORDERING",
-    "SPARK, AVRO, parquet, false,,EVENT_TIME_ORDERING", "SPARK, SPARK, parquet, false,,EVENT_TIME_ORDERING",
+    "AVRO, AVRO, avro, false,,EVENT_TIME_ORDERING,EIGHT", "AVRO, SPARK, parquet, false,,EVENT_TIME_ORDERING,EIGHT",
+    "SPARK, AVRO, parquet, false,,EVENT_TIME_ORDERING,EIGHT", "SPARK, SPARK, parquet, false,,EVENT_TIME_ORDERING,EIGHT",
     // EVENT_TIME_ORDERING with empty precombine field
-    "AVRO, AVRO, avro, true,,EVENT_TIME_ORDERING", "AVRO, SPARK, parquet, true,,EVENT_TIME_ORDERING",
-    "SPARK, AVRO, parquet, true,,EVENT_TIME_ORDERING", "SPARK, SPARK, parquet, true,,EVENT_TIME_ORDERING",
+    "AVRO, AVRO, avro, true,,EVENT_TIME_ORDERING,EIGHT", "AVRO, SPARK, parquet, true,,EVENT_TIME_ORDERING,EIGHT",
+    "SPARK, AVRO, parquet, true,,EVENT_TIME_ORDERING,EIGHT", "SPARK, SPARK, parquet, true,,EVENT_TIME_ORDERING,EIGHT",
     // Inferred as EVENT_TIME_ORDERING
-    "AVRO, AVRO, avro, true, timestamp,", "AVRO, SPARK, parquet, true, timestamp,",
-    "SPARK, AVRO, parquet, true, timestamp,", "SPARK, SPARK, parquet, true, timestamp,",
+    "AVRO, AVRO, avro, true, timestamp,,EIGHT", "AVRO, SPARK, parquet, true, timestamp,,EIGHT",
+    "SPARK, AVRO, parquet, true, timestamp,,EIGHT", "SPARK, SPARK, parquet, true, timestamp,,EIGHT",
     // test table version 6
-    "AVRO, AVRO, avro, true,timestamp,EVENT_TIME_ORDERING,6",
-    "AVRO, AVRO, avro, true,timestamp,COMMIT_TIME_ORDERING,6"))
+    "AVRO, AVRO, avro, true,timestamp,EVENT_TIME_ORDERING,SIX",
+    "AVRO, AVRO, avro, true,timestamp,COMMIT_TIME_ORDERING,SIX"))
   def testCount(readType: HoodieRecordType, writeType: HoodieRecordType, logType: String,
-                hasPreCombineField: Boolean, precombineField: String, recordMergeMode: String, tableVersion: String = "8"): Unit = {
+                hasPreCombineField: Boolean, precombineField: String, recordMergeMode: String, tableVersion: String): Unit = {
     var (_, readOpts) = getWriterReaderOpts(readType)
     var (writeOpts, _) = getWriterReaderOpts(writeType)
     readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)
@@ -126,15 +126,14 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       writeOpts = writeOpts ++ Map(DataSourceWriteOptions.PRECOMBINE_FIELD.key ->
         (if (isNullOrEmpty(precombineField)) "" else precombineField))
     }
-    //val firstWriteOpts =
     if (!isNullOrEmpty(recordMergeMode)) {
       writeOpts = writeOpts ++ Map(HoodieWriteConfig.RECORD_MERGE_MODE.key -> recordMergeMode)
     }
     if (isNullOrEmpty(recordMergeMode)) {
       assertFalse(writeOpts.contains(HoodieWriteConfig.RECORD_MERGE_MODE.key))
     }
-    val firstWriteOpts = if (tableVersion.equals("6")) {
-      writeOpts = writeOpts ++ Map(HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> "6")
+    val firstWriteOpts = if (tableVersion.equals("SIX")) {
+      writeOpts = writeOpts ++ Map(HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> HoodieTableVersion.SIX.versionCode().toString)
       writeOpts = writeOpts - HoodieWriteConfig.RECORD_MERGE_MODE.key
       if (recordMergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING.name)) {
         writeOpts = writeOpts ++ Map(DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName)
@@ -170,24 +169,24 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       recordMergeMode
     }
     val expectedConfigs = (
-      if (tableVersion.equals("8")) {
-        Map(HoodieTableConfig.RECORD_MERGE_MODE.key -> expectedMergeMode)
+      if (tableVersion.equals("EIGHT")) {
+        Map(HoodieTableConfig.RECORD_MERGE_MODE.key -> expectedMergeMode,
+          HoodieTableConfig.VERSION.key -> HoodieTableVersion.EIGHT.versionCode().toString)
       } else {
-        Map()
+        Map(HoodieTableConfig.VERSION.key -> HoodieTableVersion.SIX.versionCode().toString)
       } ++
       (if (hasPreCombineField && !isNullOrEmpty(precombineField)) {
         Map(HoodieTableConfig.PRECOMBINE_FIELD.key -> precombineField)
       } else {
         Map()
-      }) ++ Map(HoodieTableConfig.VERSION.key -> tableVersion)).asJava
+      })).asJava
     val nonExistentConfigs: java.util.List[String] = (if (hasPreCombineField) {
       Seq[String]()
     } else {
       Seq(HoodieTableConfig.PRECOMBINE_FIELD.key)
     }).asJava
     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
-    val commit1CompletionTime = if (tableVersion.equals("8"))
-    {
+    val commit1CompletionTime = if (tableVersion.equals("EIGHT")) {
       DataSourceTestUtils.latestCommitCompletionTime(storage, basePath)
     } else {
       DataSourceTestUtils.latestCommitRequestTime(storage, basePath)
@@ -209,7 +208,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .mode(SaveMode.Append)
       .save(basePath)
     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
-    val commit2CompletionTime = if (tableVersion.equals("8")) {
+    val commit2CompletionTime = if (tableVersion.equals("EIGHT")) {
       DataSourceTestUtils.latestCommitCompletionTime(storage, basePath)
     } else {
       DataSourceTestUtils.latestCommitRequestTime(storage, basePath)
@@ -226,49 +225,54 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     assertEquals(100, hudiSnapshotDF2.join(hudiSnapshotDF1, Seq("_hoodie_record_key"), "left").count())
 
     // incremental view
-    // base file only
-    val hudiIncDF1 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
-      .option(DataSourceReadOptions.END_COMMIT.key, commit1CompletionTime)
-      .load(basePath)
-    assertEquals(100, hudiIncDF1.count())
-    assertEquals(1, hudiIncDF1.select("_hoodie_commit_time").distinct().count())
-    assertEquals(commit1Time, hudiIncDF1.select("_hoodie_commit_time").head().get(0).toString)
-    hudiIncDF1.show(1)
-    // log file only
-    val hudiIncDF2 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit2CompletionTime)
-      .option(DataSourceReadOptions.END_COMMIT.key, commit2CompletionTime)
-      .load(basePath)
-    assertEquals(100, hudiIncDF2.count())
-    assertEquals(1, hudiIncDF2.select("_hoodie_commit_time").distinct().count())
-    assertEquals(commit2Time, hudiIncDF2.select("_hoodie_commit_time").head().get(0).toString)
-    hudiIncDF2.show(1)
+    // validate incremental queries only for table version 8
+    // 1.0 reader (table version 8) supports incremental query reads using completion time
+    if (tableVersion.equals("EIGHT")) {
+      // base file only
+      val hudiIncDF1 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
+        .option(DataSourceReadOptions.END_COMMIT.key, commit1CompletionTime)
+        .load(basePath)
+      assertEquals(100, hudiIncDF1.count())
+      assertEquals(1, hudiIncDF1.select("_hoodie_commit_time").distinct().count())
+      assertEquals(commit1Time, hudiIncDF1.select("_hoodie_commit_time").head().get(0).toString)
+      hudiIncDF1.show(1)
 
-    // base file + log file
-    val hudiIncDF3 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
-      .option(DataSourceReadOptions.END_COMMIT.key, commit2CompletionTime)
-      .load(basePath)
-    assertEquals(100, hudiIncDF3.count())
-    // log file being load
-    assertEquals(1, hudiIncDF3.select("_hoodie_commit_time").distinct().count())
-    assertEquals(commit2Time, hudiIncDF3.select("_hoodie_commit_time").head().get(0).toString)
+      // log file only
+      val hudiIncDF2 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit2CompletionTime)
+        .option(DataSourceReadOptions.END_COMMIT.key, commit2CompletionTime)
+        .load(basePath)
+      assertEquals(100, hudiIncDF2.count())
+      assertEquals(1, hudiIncDF2.select("_hoodie_commit_time").distinct().count())
+      assertEquals(commit2Time, hudiIncDF2.select("_hoodie_commit_time").head().get(0).toString)
+      hudiIncDF2.show(1)
 
-    // Test incremental query has no instant in range
-    val emptyIncDF = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, "000")
-      .option(DataSourceReadOptions.END_COMMIT.key, "001")
-      .load(basePath)
-    assertEquals(0, emptyIncDF.count())
+      // base file + log file
+      val hudiIncDF3 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
+        .option(DataSourceReadOptions.END_COMMIT.key, commit2CompletionTime)
+        .load(basePath)
+      assertEquals(100, hudiIncDF3.count())
+      // log file being load
+      assertEquals(1, hudiIncDF3.select("_hoodie_commit_time").distinct().count())
+      assertEquals(commit2Time, hudiIncDF3.select("_hoodie_commit_time").head().get(0).toString)
+
+      // Test incremental query has no instant in range
+      val emptyIncDF = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, "000")
+        .option(DataSourceReadOptions.END_COMMIT.key, "001")
+        .load(basePath)
+      assertEquals(0, emptyIncDF.count())
+    }
 
     // Unmerge
     val hudiSnapshotSkipMergeDF2 = spark.read.format("org.apache.hudi")
@@ -297,7 +301,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .mode(SaveMode.Append)
       .save(basePath)
     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
-    val commit3CompletionTime = if (tableVersion.equals("8")) {
+    val commit3CompletionTime = if (tableVersion.equals("EIGHT")) {
       DataSourceTestUtils.latestCommitCompletionTime(storage, basePath)
     } else {
       DataSourceTestUtils.latestCommitRequestTime(storage, basePath)
@@ -316,22 +320,26 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       hudiSnapshotDF3.join(hudiSnapshotDF2, Seq("_hoodie_record_key", "_hoodie_commit_time"), "inner").count())
 
     // incremental query from commit2Time
-    val hudiIncDF4 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit3CompletionTime)
-      .load(basePath)
-    assertEquals(50, hudiIncDF4.count())
+    // validate incremental queries only for table version 8
+    // 1.0 reader (table version 8) supports incremental query reads using completion time
+    if (tableVersion.equals("EIGHT")) {
+      val hudiIncDF4 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit3CompletionTime)
+        .load(basePath)
+      assertEquals(50, hudiIncDF4.count())
 
-    // skip merge incremental view
-    // including commit 2 and commit 3
-    val hudiIncDF4SkipMerge = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
-      .option(DataSourceReadOptions.REALTIME_MERGE.key, DataSourceReadOptions.REALTIME_SKIP_MERGE_OPT_VAL)
-      .load(basePath)
-    assertEquals(250, hudiIncDF4SkipMerge.count())
+      // skip merge incremental view
+      // including commit 2 and commit 3
+      val hudiIncDF4SkipMerge = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit1CompletionTime)
+        .option(DataSourceReadOptions.REALTIME_MERGE.key, DataSourceReadOptions.REALTIME_SKIP_MERGE_OPT_VAL)
+        .load(basePath)
+      assertEquals(250, hudiIncDF4SkipMerge.count())
+    }
 
     // Fourth Operation:
     // Insert records to a new partition. Produced a new parquet file.
@@ -356,12 +364,16 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       hudiSnapshotDF1.join(hudiSnapshotDF4, Seq("_hoodie_record_key"), "inner").count())
 
     // Incremental query, 50 from log file, 100 from base file of the new partition.
-    val hudiIncDF5 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit3CompletionTime)
-      .load(basePath)
-    assertEquals(150, hudiIncDF5.count())
+    // validate incremental queries only for table version 8
+    // 1.0 reader (table version 8) supports incremental query reads using completion time
+    if (tableVersion.equals("EIGHT")) {
+      val hudiIncDF5 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit3CompletionTime)
+        .load(basePath)
+      assertEquals(150, hudiIncDF5.count())
+    }
 
     // Fifth Operation:
     // Upsert records to the new partition. Produced a newer version of parquet file.
@@ -390,7 +402,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .mode(SaveMode.Append)
       .save(basePath)
     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
-    val commit6CompletionTime = if (tableVersion.equals("8")) {
+    val commit6CompletionTime = if (tableVersion.equals("EIGHT")) {
       DataSourceTestUtils.latestCommitCompletionTime(storage, basePath)
     } else {
       DataSourceTestUtils.latestCommitRequestTime(storage, basePath)
@@ -400,15 +412,19 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
       .load(basePath + "/2020/01/10/*")
     assertEquals(102, hudiSnapshotDF6.count())
-    val hudiIncDF6 = spark.read.format("org.apache.hudi")
-      .options(readOpts)
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-      .option(DataSourceReadOptions.START_COMMIT.key, commit6CompletionTime)
-      .option(DataSourceReadOptions.END_COMMIT.key, commit6CompletionTime)
-      .load(basePath)
-    // even though compaction updated 150 rows, since preserve commit metadata is true, they won't be part of incremental query.
-    // inserted 2 new row
-    assertEquals(2, hudiIncDF6.count())
+    // validate incremental queries only for table version 8
+    // 1.0 reader (table version 8) supports incremental query reads using completion time
+    if (tableVersion.equals("EIGHT")) {
+      val hudiIncDF6 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, commit6CompletionTime)
+        .option(DataSourceReadOptions.END_COMMIT.key, commit6CompletionTime)
+        .load(basePath)
+      // even though compaction updated 150 rows, since preserve commit metadata is true, they won't be part of incremental query.
+      // inserted 2 new row
+      assertEquals(2, hudiIncDF6.count())
+    }
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -30,10 +30,11 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
   // TODO(HUDI-8938): add "mor,true,true,6" after the fix
   Seq(
-    "cow,8,false,false", "cow,8,false,true", "cow,8,true,false",
+    /*"cow,8,false,false", "cow,8,false,true", "cow,8,true,false",
     "cow,6,true,false", "cow,6,true,true",
-    "mor,8,false,false", "mor,8,false,true", "mor,8,true,false",
-    "mor,6,true,false").foreach { args =>
+    "mor,8,false,false", "mor,8,false,true", "mor,8,true,false",*/
+    "mor,6,true,true"
+  ).foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val tableVersion = argList(1)
@@ -225,7 +226,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     }
 
     // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
-    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+    /*test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
       + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
       + s"setUpsertOperation=$setUpsertOperation)") {
       withSparkSqlSessionConfigWithCondition(
@@ -345,6 +346,6 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
             )): _*)
         })
       }
-    }
+    }*/
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestMergeModeCommitTimeOrdering.scala
@@ -28,13 +28,11 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.validateTableConf
 
 class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
-  // TODO(HUDI-8938): add "mor,true,true,6" after the fix
   Seq(
-    /*"cow,8,false,false", "cow,8,false,true", "cow,8,true,false",
+    "cow,8,false,false", "cow,8,false,true", "cow,8,true,false",
     "cow,6,true,false", "cow,6,true,true",
-    "mor,8,false,false", "mor,8,false,true", "mor,8,true,false",*/
-    "mor,6,true,true"
-  ).foreach { args =>
+    "mor,8,false,false", "mor,8,false,true", "mor,8,true,false",
+    "mor,6,true,true").foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val tableVersion = argList(1)
@@ -226,7 +224,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     }
 
     // TODO(HUDI-8468): add COW test after supporting COMMIT_TIME_ORDERING in MERGE INTO for COW
-    /*test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
+    test(s"Test merge operations with COMMIT_TIME_ORDERING for $tableType table "
       + s"(tableVersion=$tableVersion,setRecordMergeConfigs=$setRecordMergeConfigs,"
       + s"setUpsertOperation=$setUpsertOperation)") {
       withSparkSqlSessionConfigWithCondition(
@@ -346,6 +344,6 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
             )): _*)
         })
       }
-    }*/
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

We found an issue, where log file naming and creation logic with table version 6 could end up deleting already committed log files. Fixing the  same in this patch. 

### Impact

Robust log file naming and no data consistency issues with table version 6 writes. 

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
