### PR TITLE
[HUDI-8945] Rename merger classes to be consistent with merge modes

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/CommitTimeBasedSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/CommitTimeBasedSparkRecordMerger.java
@@ -29,9 +29,9 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 
 /**
- * Spark merger that always chooses the newer record
+ * Spark merger that always chooses the newer record based on the commit time
  */
-public class OverwriteWithLatestSparkRecordMerger extends HoodieSparkRecordMerger {
+public class CommitTimeBasedSparkRecordMerger extends HoodieSparkRecordMerger {
 
   @Override
   public String getMergingStrategy() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/EventTimeBasedSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/EventTimeBasedSparkRecordMerger.java
@@ -34,9 +34,9 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 
 /**
- * Record merger for spark that implements the default merger strategy
+ * Record merger for spark that implements the event-time based merging strategy
  */
-public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
+public class EventTimeBasedSparkRecordMerger extends HoodieSparkRecordMerger {
 
   @Override
   public String getMergingStrategy() {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -60,9 +60,9 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
     // get rid of event time and commit time ordering. Just return Option.empty
     switch (mergeMode) {
       case EVENT_TIME_ORDERING:
-        return Option.of(new DefaultSparkRecordMerger());
+        return Option.of(new EventTimeBasedSparkRecordMerger());
       case COMMIT_TIME_ORDERING:
-        return Option.of(new OverwriteWithLatestSparkRecordMerger());
+        return Option.of(new CommitTimeBasedSparkRecordMerger());
       case CUSTOM:
       default:
         if (mergeStrategyId.equals(HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/CommitTimeBasedMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/CommitTimeBasedMerger.java
@@ -28,9 +28,9 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 
 /**
- * Avro Merger that always chooses the newer record
+ * Avro Merger that always chooses the newer record based on the commit time
  */
-public class OverwriteWithLatestMerger implements HoodieRecordMerger {
+public class CommitTimeBasedMerger implements HoodieRecordMerger {
 
   @Override
   public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCommitTimeBasedMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCommitTimeBasedMerger.java
@@ -20,9 +20,9 @@
 package org.apache.hudi.common.table.read;
 
 import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.model.CommitTimeBasedMerger;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
-import org.apache.hudi.common.model.OverwriteWithLatestMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
@@ -54,7 +54,7 @@ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.Operati
 import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.ROW_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestOverwriteWithLatestMerger extends HoodieFileGroupReaderTestHarness {
+public class TestCommitTimeBasedMerger extends HoodieFileGroupReaderTestHarness {
 
   @Override
   protected Properties getMetaProps() {
@@ -65,7 +65,7 @@ public class TestOverwriteWithLatestMerger extends HoodieFileGroupReaderTestHarn
 
   @BeforeAll
   public static void setUp() throws IOException {
-    HoodieRecordMerger merger = new OverwriteWithLatestMerger();
+    HoodieRecordMerger merger = new CommitTimeBasedMerger();
     readerContext = new HoodieTestReaderContext(
         Option.of(merger),
         Option.of(OverwriteWithLatestAvroPayload.class.getName()));
@@ -113,7 +113,7 @@ public class TestOverwriteWithLatestMerger extends HoodieFileGroupReaderTestHarn
 
   @BeforeEach
   public void initialize() throws Exception {
-    setTableName(TestOverwriteWithLatestMerger.class.getName());
+    setTableName(TestCommitTimeBasedMerger.class.getName());
     initPath(tableName);
     initMetaClient();
     initTestDataGenerator(new String[]{PARTITION_PATH});

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/CommitTimeBasedHiveRecordMerger.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/CommitTimeBasedHiveRecordMerger.java
@@ -29,9 +29,9 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 
 /**
- * Hive merger that always chooses the newer record
+ * Hive merger that always chooses the newer record based on the commit time
  */
-public class OverwriteWithLatestHiveRecordMerger extends HoodieHiveRecordMerger {
+public class CommitTimeBasedHiveRecordMerger extends HoodieHiveRecordMerger {
   @Override
   public String getMergingStrategy() {
     return COMMIT_TIME_BASED_MERGE_STRATEGY_UUID;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/EventTimeBasedHiveRecordMerger.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/EventTimeBasedHiveRecordMerger.java
@@ -31,9 +31,9 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 
 /**
- * Record merger for hive that implements the default merger strategy
+ * Record merger for hive that implements the event-time based merging strategy
  */
-public class DefaultHiveRecordMerger extends HoodieHiveRecordMerger {
+public class EventTimeBasedHiveRecordMerger extends HoodieHiveRecordMerger {
   @Override
   public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
     ValidationUtils.checkArgument(older.getRecordType() == HoodieRecord.HoodieRecordType.HIVE);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -181,9 +181,9 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
     // get rid of event time and commit time ordering. Just return Option.empty
     switch (mergeMode) {
       case EVENT_TIME_ORDERING:
-        return Option.of(new DefaultHiveRecordMerger());
+        return Option.of(new EventTimeBasedHiveRecordMerger());
       case COMMIT_TIME_ORDERING:
-        return Option.of(new OverwriteWithLatestHiveRecordMerger());
+        return Option.of(new CommitTimeBasedHiveRecordMerger());
       case CUSTOM:
       default:
         if (mergeStrategyId.equals(HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID)) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/HoodieSparkValidateDuplicateKeyRecordMerger.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/HoodieSparkValidateDuplicateKeyRecordMerger.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hudi.command
 
-import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkRecordMerger}
+import org.apache.hudi.{EventTimeBasedSparkRecordMerger, HoodieSparkRecordMerger}
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.model.{HoodieRecord, HoodieRecordMerger, OperationModeAwareness}
 import org.apache.hudi.common.util.{collection, HoodieRecordUtils, Option => HOption}
@@ -39,7 +39,7 @@ class HoodieSparkValidateDuplicateKeyRecordMerger extends HoodieSparkRecordMerge
   }
 
   override def asPreCombiningMode(): HoodieRecordMerger = {
-    HoodieRecordUtils.loadRecordMerger(classOf[DefaultSparkRecordMerger].getName)
+    HoodieRecordUtils.loadRecordMerger(classOf[EventTimeBasedSparkRecordMerger].getName)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
@@ -23,17 +23,17 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
-import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, StructField, StructType}
+
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, StructField, StructType}
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class TestDecimalTypeDataWorkflow extends SparkClientFunctionalTestHarness{
   val sparkOpts: Map[String, String] = Map(
     HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet",
-    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName)
+    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName)
   val fgReaderOpts: Map[String, String] = Map(
     HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key -> "true",
     HoodieReaderConfig.MERGE_USE_RECORD_POSITIONS.key -> "true")

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -75,7 +75,7 @@ class TestDefaultSparkRecordMerger {
   void testMergerWithAvroRecord() {
     try (HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(0L)) {
       List<HoodieRecord> records = dataGenerator.generateInserts("001", 2);
-      DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+      EventTimeBasedSparkRecordMerger merger = new EventTimeBasedSparkRecordMerger();
       TypedProperties props = new TypedProperties();
       Schema recordSchema = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
       assertThrows(
@@ -98,7 +98,7 @@ class TestDefaultSparkRecordMerger {
     HoodieRecord<InternalRow> newRecord =
         new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), SPARK_SCHEMA);
 
-    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    EventTimeBasedSparkRecordMerger merger = new EventTimeBasedSparkRecordMerger();
     TypedProperties props = new TypedProperties();
     props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
@@ -125,7 +125,7 @@ class TestDefaultSparkRecordMerger {
     HoodieRecord<InternalRow> newRecord =
         new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), SPARK_SCHEMA);
 
-    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    EventTimeBasedSparkRecordMerger merger = new EventTimeBasedSparkRecordMerger();
     TypedProperties props = new TypedProperties();
     props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
@@ -149,7 +149,7 @@ class TestDefaultSparkRecordMerger {
         new HoodieSparkRecord(InternalRow.apply(oldValue.toSeq()), SPARK_SCHEMA);
     HoodieRecord<InternalRow> newRecord = new HoodieEmptyRecord<>(key, SPARK);
 
-    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    EventTimeBasedSparkRecordMerger merger = new EventTimeBasedSparkRecordMerger();
     TypedProperties props = new TypedProperties();
     props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
@@ -170,7 +170,7 @@ class TestDefaultSparkRecordMerger {
     HoodieRecord<InternalRow> newRecord =
         new HoodieSparkRecord(InternalRow.apply(newValue.toSeq()), SPARK_SCHEMA);
 
-    DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+    EventTimeBasedSparkRecordMerger merger = new EventTimeBasedSparkRecordMerger();
     TypedProperties props = new TypedProperties();
     props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
@@ -95,7 +95,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
   public void testDefaultMerger() throws Exception {
     HoodieWriteConfig writeConfig = buildDefaultWriteConfig(SCHEMA);
     HoodieRecordMerger merger = writeConfig.getRecordMerger();
-    assertTrue(merger instanceof DefaultMerger);
+    assertTrue(merger instanceof EventTimeBasedMerger);
     assertTrue(writeConfig.getBooleanOrDefault(FILE_GROUP_READER_ENABLED.key(), false));
     insertAndUpdate(writeConfig, 114);
   }
@@ -335,7 +335,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
 
     @Override
     public HoodieRecordMerger getRecordMerger() {
-      return new DefaultMerger();
+      return new EventTimeBasedMerger();
     }
   }
 
@@ -361,21 +361,21 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
     }
   }
 
-  public static class DefaultMerger extends DefaultSparkRecordMerger {
+  public static class EventTimeBasedMerger extends EventTimeBasedSparkRecordMerger {
     @Override
     public boolean shouldFlush(HoodieRecord record, Schema schema, TypedProperties props) {
       return true;
     }
   }
 
-  public static class NoFlushMerger extends DefaultSparkRecordMerger {
+  public static class NoFlushMerger extends EventTimeBasedSparkRecordMerger {
     @Override
     public boolean shouldFlush(HoodieRecord record, Schema schema, TypedProperties props) {
       return false;
     }
   }
 
-  public static class CustomMerger extends DefaultSparkRecordMerger {
+  public static class CustomMerger extends EventTimeBasedSparkRecordMerger {
     @Override
     public boolean shouldFlush(HoodieRecord record, Schema schema, TypedProperties props) throws IOException {
       return !((HoodieSparkRecord) record).getData().getString(0).equals("001");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
@@ -19,7 +19,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, DefaultSparkRecordMerger}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, EventTimeBasedSparkRecordMerger}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.HoodieTableConfig
@@ -39,7 +39,7 @@ object CommonOptionUtils {
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
   )
-  val sparkOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName)
+  val sparkOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName)
 
   def getWriterReaderOpts(recordType: HoodieRecordType,
                           opt: Map[String, String] = commonOpts,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieDataSourceHelpers}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, EventTimeBasedSparkRecordMerger, HoodieDataSourceHelpers}
 import org.apache.hudi.bootstrap.SparkParquetBootstrapDataProvider
 import org.apache.hudi.client.bootstrap.selector.{FullRecordBootstrapModeSelector, MetadataOnlyBootstrapModeSelector}
 import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
@@ -29,6 +29,7 @@ import org.apache.hudi.functional.TestDataSourceForBootstrap.{dropMetaCols, sort
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.keygen.{NonpartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieClientTestUtils}
+
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SaveMode, SparkSession}
@@ -41,6 +42,7 @@ import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
 
 import java.time.Instant
 import java.util.Collections
+
 import scala.collection.JavaConverters._
 
 class TestDataSourceForBootstrap {
@@ -61,7 +63,7 @@ class TestDataSourceForBootstrap {
   )
 
   val sparkRecordTypeOpts = Map(
-    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
     HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
@@ -19,20 +19,21 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.{DataSourceWriteOptions, EventTimeBasedSparkRecordMerger, SparkDatasetMixin}
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.engine.{HoodieEngineContext, HoodieLocalEngineContext}
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieTableType}
-import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig, SyncableFileSystemView}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig, SyncableFileSystemView}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator.{DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
-import org.apache.hudi.{DataSourceWriteOptions, DefaultSparkRecordMerger, SparkDatasetMixin}
+
 import org.apache.spark.sql.{Dataset, Row, SaveMode, SparkSession}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -54,7 +55,7 @@ class TestHoodieMultipleBaseFileFormat extends HoodieSparkClientTestBase with Sp
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
   )
   val sparkOpts = Map(
-    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
     HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceReadOptions, DataSourceUtils, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieDataSourceHelpers, SparkDatasetMixin}
+import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceReadOptions, DataSourceUtils, DataSourceWriteOptions, EventTimeBasedSparkRecordMerger, HoodieDataSourceHelpers, SparkDatasetMixin}
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.client.SparkRDDWriteClient
@@ -68,7 +68,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
   )
   val sparkOpts = Map(
-    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
     HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
   )
 
@@ -1072,7 +1072,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       "hoodie.datasource.write.row.writer.enable" -> "false"
     )
     if (recordType.equals(HoodieRecordType.SPARK)) {
-      writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+      writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
         HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet") ++ writeOpts
     }
     val records1 = recordsToStrings(dataGen.generateInserts("001", 10)).asScala.toSeq
@@ -1114,7 +1114,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       "hoodie.datasource.write.row.writer.enable" -> "false"
     )
     if (recordType.equals(HoodieRecordType.SPARK)) {
-      writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+      writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
         HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet") ++ writeOpts
     }
     val records1 = recordsToStrings(dataGen.generateInserts("001", 10)).asScala.toSeq

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{DataSourceWriteOptions, DefaultSparkRecordMerger, ScalaAssertionSupport}
+import org.apache.hudi.{DataSourceWriteOptions, EventTimeBasedSparkRecordMerger, ScalaAssertionSupport}
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.HoodieTableConfig
@@ -58,7 +58,7 @@ class TestSparkDataSourceDAGExecution extends HoodieSparkClientTestBase with Sca
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
     HoodieMetadataConfig.ENABLE.key -> "false"
   )
-  val sparkOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName)
+  val sparkOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName)
 
   val verificationCol: String = "driver"
   val updatedVerificationVal: String = "driver_update"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/ReadAndWriteWithoutAvroBenchmark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/ReadAndWriteWithoutAvroBenchmark.scala
@@ -18,10 +18,10 @@
 
 package org.apache.spark.sql.execution.benchmark
 
-import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.HoodieAvroRecordMerger
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.EventTimeBasedSparkRecordMerger
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
@@ -118,7 +118,7 @@ object ReadAndWriteWithoutAvroBenchmark extends HoodieBenchmarkBase {
   private def overwriteBenchmark(): Unit = {
     val df = createComplexDataFrame(1000000)
     val benchmark = new HoodieBenchmark("pref insert overwrite", 1000000, 3)
-    Seq(classOf[HoodieAvroRecordMerger].getName, classOf[DefaultSparkRecordMerger].getName).zip(Seq(avroTable, sparkTable)).foreach {
+    Seq(classOf[HoodieAvroRecordMerger].getName, classOf[EventTimeBasedSparkRecordMerger].getName).zip(Seq(avroTable, sparkTable)).foreach {
       case (merger, tableName) => benchmark.addCase(merger) { _ =>
         withTempDir { f =>
           prepareHoodieTable(tableName, new Path(f.getCanonicalPath, tableName).toUri.toString, "mor", merger, df)
@@ -145,7 +145,7 @@ object ReadAndWriteWithoutAvroBenchmark extends HoodieBenchmarkBase {
    */
   private def upsertThenReadBenchmark(): Unit = {
     val avroMergerImpl = classOf[HoodieAvroRecordMerger].getName
-    val sparkMergerImpl = classOf[DefaultSparkRecordMerger].getName
+    val sparkMergerImpl = classOf[EventTimeBasedSparkRecordMerger].getName
     val df = createComplexDataFrame(10000)
     withTempDir { avroPath =>
       withTempDir { sparkPath =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hudi.common
 
-import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkUtils}
+import org.apache.hudi.{EventTimeBasedSparkRecordMerger, HoodieSparkUtils}
 import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
 import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecord}
@@ -352,7 +352,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     // TODO HUDI-5264 Test parquet log with avro record in spark sql test
     recordTypes.foreach { recordType =>
       val (merger, format) = recordType match {
-        case HoodieRecordType.SPARK => (classOf[DefaultSparkRecordMerger].getName, "parquet")
+        case HoodieRecordType.SPARK => (classOf[EventTimeBasedSparkRecordMerger].getName, "parquet")
         case _ => (classOf[HoodieAvroRecordMerger].getName, "avro")
       }
       val config = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hudi.ddl
 
-import org.apache.hudi.{DataSourceWriteOptions, DefaultSparkRecordMerger, QuickstartUtils}
+import org.apache.hudi.{DataSourceWriteOptions, EventTimeBasedSparkRecordMerger, QuickstartUtils}
 import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
@@ -802,7 +802,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
   }
 
   val sparkOpts = Map(
-    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
+    HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[EventTimeBasedSparkRecordMerger].getName,
     HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
   )
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -21,7 +21,7 @@ package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
-import org.apache.hudi.DefaultSparkRecordMerger;
+import org.apache.hudi.EventTimeBasedSparkRecordMerger;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
@@ -193,7 +193,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   private void addRecordMerger(HoodieRecordType type, List<String> hoodieConfig) {
     if (type == HoodieRecordType.SPARK) {
       Map<String, String> opts = new HashMap<>();
-      opts.put(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key(), DefaultSparkRecordMerger.class.getName());
+      opts.put(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key(), EventTimeBasedSparkRecordMerger.class.getName());
       opts.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
       opts.put(HoodieWriteConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name());
       opts.put(HoodieWriteConfig.RECORD_MERGE_STRATEGY_ID.key(), HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID);


### PR DESCRIPTION
### Change Logs

As above.

### Impact

Renaming only, to embrace consistency.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
