### PR TITLE
[HUDI-8948] Use filtered query filters in Partition Stats Index pruning

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionStatsIndexSupport.scala
@@ -107,7 +107,7 @@ class PartitionStatsIndexSupport(spark: SparkSession,
                 //       column in a filter does not have the stats available, by making sure such a
                 //       filter does not prune any partition.
                 // to be fixed. HUDI-8836.
-                val indexFilter = queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols)).reduce(And)
+                val indexFilter = filteredQueryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexedCols = indexedCols)).reduce(And)
                 if (indexFilter.equals(TrueLiteral)) {
                   // if there are any non indexed cols or we can't translate source expr, we cannot prune partitions based on col stats lookup.
                   Some(allPartitions)


### PR DESCRIPTION
### Change Logs

The PR fixes the code to use filtered query filters in Partition Stats Index pruning. We are using original query filters while creating the index filter.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
