### PR TITLE
[HUDI-8950] Explicitly set base path in sync config

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
@@ -119,6 +120,7 @@ public class SyncUtilHelpers {
                                                        Option<HoodieTableMetaClient> metaClient) {
     TypedProperties properties = new TypedProperties();
     properties.putAll(props);
+    properties.put(BASE_PATH.key(), targetBasePath);
     properties.put(META_SYNC_BASE_PATH.key(), targetBasePath);
     properties.put(META_SYNC_BASE_FILE_FORMAT.key(), baseFileFormat);
     if (properties.containsKey(META_SYNC_TABLE_NAME.key())) {


### PR DESCRIPTION
### Change Logs

This change included on Hudi 1.0 require hoodie.base.path to exist in the props #11498 

But when running Hudi jobs with dataframe api, users are not required to configure `hoodie.base.path` explicitly, causing metrics feature not usable due to the exception below:

```
Caused by: org.apache.hudi.exception.HoodieException: Unable to instantiate class org.apache.hudi.hive.HiveSyncTool
    at org.apache.hudi.common.util.ReflectionUtils.loadClass(ReflectionUtils.java:75) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.instantiateMetaSyncTool(SyncUtilHelpers.java:140) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.runHoodieMetaSync(SyncUtilHelpers.java:103) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    ... 106 more
Caused by: java.lang.reflect.InvocationTargetException
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
    at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[?:?]
    at java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[?:?]
    at org.apache.hudi.common.util.ReflectionUtils.loadClass(ReflectionUtils.java:73) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.instantiateMetaSyncTool(SyncUtilHelpers.java:140) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.runHoodieMetaSync(SyncUtilHelpers.java:103) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    ... 106 more
Caused by: java.lang.NullPointerException: Cannot invoke "String.endsWith(String)" because "basePath" is null
    at org.apache.hudi.metrics.Metrics.getBasePath(Metrics.java:195) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.metrics.Metrics.getInstance(Metrics.java:82) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.metrics.HoodieMetaSyncMetrics.<init>(HoodieMetaSyncMetrics.java:62) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.HoodieSyncTool.<init>(HoodieSyncTool.java:50) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.hive.HiveSyncTool.<init>(HiveSyncTool.java:112) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
    at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500) ~[?:?]
    at java.lang.reflect.Constructor.newInstance(Constructor.java:481) ~[?:?]
    at org.apache.hudi.common.util.ReflectionUtils.loadClass(ReflectionUtils.java:73) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.instantiateMetaSyncTool(SyncUtilHelpers.java:140) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    at org.apache.hudi.sync.common.util.SyncUtilHelpers.runHoodieMetaSync(SyncUtilHelpers.java:103) ~[hudi-spark3-bundle_2.12-1.0.0.jar:1.0.0]
    ... 106 more 
Attachments
```

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
