### PR TITLE
[MINOR] Fix hudi-integ-test usage of readFromSource

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -87,8 +87,9 @@ public class HoodieDeltaStreamerWrapper extends HoodieDeltaStreamer {
         .setBasePath(service.getCfg().targetBasePath)
         .build();
     String instantTime = InProcessTimeGenerator.createNewInstantTime();
-    InputBatch inputBatch = service.readFromSource(instantTime, metaClient).getLeft();
-    return Pair.of(inputBatch.getSchemaProvider(), Pair.of(inputBatch.getCheckpointForNextBatch(), (JavaRDD<HoodieRecord>) inputBatch.getBatch().get()));
+    Pair<InputBatch, Boolean> inputBatchAndShouldUseRowWriter = service.readFromSource(instantTime, metaClient);
+    return Pair.of(inputBatchAndShouldUseRowWriter.getLeft().getSchemaProvider(),
+        Pair.of(inputBatchAndShouldUseRowWriter.getLeft().getCheckpointForNextBatch(), (JavaRDD<HoodieRecord>) inputBatchAndShouldUseRowWriter.getLeft().getBatch().get()));
   }
 
   public StreamSync getDeltaSync() {


### PR DESCRIPTION
### Change Logs

In https://github.com/apache/hudi/pull/11534, we changed the signature of readFromSource. Making it usage in HoodieDeltaStreamerWrapper compatible.

### Impact

Integ tests will build successfully

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
