### PR TITLE
[HUDI-8967] Add a config to fail job if duplicate data files detected during reconcileAgainstMarkers

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -234,6 +234,11 @@ public class HoodieWriteConfig extends HoodieConfig {
       .withDocumentation("Enables a more efficient mechanism for rollbacks based on the marker files generated "
           + "during the writes. Turned on by default.");
 
+  public static final ConfigProperty<String> FAIL_JOB_ON_DUPLICATE_DATA_FILE_DETECTION = ConfigProperty
+      .key("hoodie.fail.job.on.duplicate.data.file.detection")
+      .defaultValue("false")
+      .withDocumentation("If config is enabled, entire job is failed on invalid file detection");
+
   public static final ConfigProperty<String> TIMELINE_LAYOUT_VERSION_NUM = ConfigProperty
       .key("hoodie.timeline.layout.version")
       .defaultValue(Integer.toString(TimelineLayoutVersion.CURR_VERSION))
@@ -1432,6 +1437,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean shouldRollbackUsingMarkers() {
     return getBoolean(ROLLBACK_USING_MARKERS_ENABLE);
+  }
+
+  public boolean shouldFailOnDuplicateDataFileDetection() {
+    return getBoolean(FAIL_JOB_ON_DUPLICATE_DATA_FILE_DETECTION);
   }
 
   public int getWriteBufferLimitBytes() {

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieDuplicateDataFileDetectedException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieDuplicateDataFileDetectedException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+/**
+ * <p>
+ * Exception thrown for duplicate data files detection failures .
+ * </p>
+ */
+public class HoodieDuplicateDataFileDetectedException extends HoodieException {
+
+  public HoodieDuplicateDataFileDetectedException(String msg) {
+    super(msg);
+  }
+
+}


### PR DESCRIPTION
### Change Logs

The PR adds a config which fails the entire job if an invaild file is detected. The config is disabled by default.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
