### PR TITLE
[HUDI-8970] Change scheduleandexecute in RunCompactionProcedure to compact all pending plans too

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
@@ -80,8 +80,7 @@ object HoodieProcedureUtils {
   }
 
   /**
-   * scheduleAndExecute: schedule a new plan and then execute it, if no plan is generated during
-   * schedule, execute all pending plans
+   * scheduleAndExecute: schedule a new plan and then execute all pending plans regardless of plan scheduling outcome
    */
   case object ScheduleAndExecute extends Operation {
     override def value: String = "scheduleandexecute"

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -72,7 +72,7 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       confs = confs ++ HoodieCLIUtils.extractOptions(getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String])
     }
     var specificInstants = getArgValueOrDefault(args, PARAMETERS(5))
-    val limit = getArgValueOrDefault(args, PARAMETERS(6))
+    val limit = getArgValueOrDefault(args, PARAMETERS(6)).asInstanceOf[Option[Int]]
 
     // For old version compatibility
     if (op.equals("run")) {
@@ -92,7 +92,7 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       .toSeq.sortBy(f => f)
 
     var (filteredPendingCompactionInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
-      pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op), limit.asInstanceOf[Option[Int]])
+      pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op), limit)
 
     var client: SparkRDDWriteClient[_] = null
     try {
@@ -108,10 +108,16 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       if (operation.isSchedule) {
         val instantTime = client.scheduleCompaction(HOption.empty[java.util.Map[String, String]])
         instantTime.ifPresent(instant => {
-          filteredPendingCompactionInstants = Seq(instant)
+          // If schedule ONLY, return the instant scheduled else, return pending compaction instants too
+          filteredPendingCompactionInstants = if (operation.isExecute) filteredPendingCompactionInstants :+ instant else Seq(instant)
         })
       }
 
+      filteredPendingCompactionInstants = if (limit.isDefined) {
+        filteredPendingCompactionInstants.take(limit.get)
+      } else {
+        filteredPendingCompactionInstants
+      }
       logInfo(s"Compaction instants to run: ${filteredPendingCompactionInstants.mkString(",")}.")
 
       if (operation.isExecute) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
@@ -344,7 +344,7 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  test("Test Call run_clustering with limit parameter") {
+  test("Test Call run_compaction with limit parameter") {
     withSQLConf("hoodie.compact.inline" -> "false", "hoodie.compact.inline.max.delta.commits" -> "1") {
       withTempDir { tmp =>
         val tableName = generateTableName
@@ -368,7 +368,7 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
         val conf = new Configuration
         val metaClient = HoodieTestUtils.createMetaClient(new HadoopStorageConfiguration(conf), basePath)
 
-        assert(0 == metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.size())
+        assert(metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.size() == 0)
         assert(metaClient.getActiveTimeline.filterPendingClusteringTimeline().empty())
 
         spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
@@ -381,12 +381,58 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
 
         spark.sql(s"call run_compaction(table => '$tableName', op => 'schedule')")
         metaClient.reloadActiveTimeline();
-        assert(2 == metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size())
+        assert(metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size() == 2)
 
         spark.sql(s"call run_compaction(table => '$tableName', op => 'execute', limit => 1)");
 
         metaClient.reloadActiveTimeline();
-        assert(1 == metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size())
+        assert(metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size() == 1)
+      }
+    }
+  }
+
+  test("Test Call run_compaction with scheduleandexecute op") {
+    withSQLConf("hoodie.compact.inline" -> "false", "hoodie.compact.inline.max.delta.commits" -> "1") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'mor',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${basePath}'
+       """.stripMargin)
+
+        val conf = new Configuration
+        val metaClient = HoodieTestUtils.createMetaClient(new HadoopStorageConfiguration(conf), basePath)
+
+        assert(metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.size() == 0)
+        assert(metaClient.getActiveTimeline.filterPendingClusteringTimeline().empty())
+
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"update $tableName set name = 'a2' where id = 1")
+
+        spark.sql(s"call run_compaction(table => '$tableName', op => 'schedule')")
+
+        metaClient.reloadActiveTimeline();
+        assert(metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size() == 1)
+
+        spark.sql(s"insert into $tableName values(2, 'b1', 20, 3000)")
+        spark.sql(s"update $tableName set name = 'b3' where id = 2")
+        spark.sql(s"call run_compaction(table => '$tableName', op => 'scheduleandexecute')");
+
+        // scheduleandexecute should run compact on all pending compactions
+        metaClient.reloadActiveTimeline();
+        assert(metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size() == 0)
       }
     }
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16828

When `run_compaction` is invoked with op = `scheduleandexecute`, the procedure only executes the newly scheduled plan and silently skips any pre-existing pending compaction plans. If a previous `scheduleandexecute` run fails during the execute phase, rerunning the job schedules a new plan while the original plan stays stuck in the pending state. For users that trigger compaction from an external system on a fixed schedule, such stuck plans accumulate and require human intervention to drain.

### Summary and Changelog

`run_compaction` with op = `scheduleandexecute` now executes ALL pending compaction plans (oldest first), not just the plan it scheduled in the same invocation.

- `RunCompactionProcedure`: when a new plan is scheduled and the operation also executes, append the newly scheduled instant to the pending instants instead of replacing them. The `schedule` op alone still returns only the newly scheduled instant.
- `RunCompactionProcedure`: apply the `limit` argument after the newly scheduled instant is appended, so the number of executed plans is still capped by `limit`. Execution keeps FIFO ordering, i.e. oldest instants first.
- `HoodieProcedureUtils`: update the `ScheduleAndExecute` doc to reflect the new semantics.
- `TestCompactionProcedure`: add a test verifying `scheduleandexecute` drains all pending compactions; fix the copy-pasted title of the limit-parameter test (`run_clustering` to `run_compaction`).

### Impact

Behavior change for `run_compaction` with op = `scheduleandexecute` (and its legacy alias op = `run`): it now compacts all pending plans in one invocation rather than only the newly scheduled one. Users who want to bound the amount of work per invocation can still do so with the `limit` argument. No public API changes.

### Risk Level

low. Confined to the `run_compaction` Spark SQL procedure; executing multiple pending plans reuses the existing `execute` path and is covered by a new test.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
