### PR TITLE
[HUDI-8920] [RFC-84] Optimize SerDe of stream records for Flink write (excluding bulk insert and append mode)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
@@ -86,8 +86,12 @@ public class ConsistentBucketIdentifier extends BucketIdentifier {
     return getBucket(getHashKeys(hoodieKey.getRecordKey(), indexKeyFields));
   }
 
-  public ConsistentHashingNode getBucket(String hoodieKey, String indexKeyFields) {
-    return getBucket(getHashKeys(hoodieKey, indexKeyFields));
+  public ConsistentHashingNode getBucket(String recordKey, List<String> indexKeyFields) {
+    return getBucket(getHashKeys(recordKey, indexKeyFields));
+  }
+
+  public ConsistentHashingNode getBucket(String recordKey, String indexKeyFields) {
+    return getBucket(getHashKeys(recordKey, indexKeyFields));
   }
 
   protected ConsistentHashingNode getBucket(List<String> hashKeys) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRow.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRow.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.hudi.common.model.HoodieOperation;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.types.BooleanValue;
+
+import java.io.Serializable;
+
+/**
+ * Flink {@link RowData} with added Hudi metadata.
+ * For serialization/deserialization {@link HoodieFlinkInternalRowTypeInfo} and {@link HoodieFlinkInternalRowSerializer} are used
+ * to optimize serialization/deserialization costs.
+ */
+public class HoodieFlinkInternalRow implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  // the number of fields without nesting
+  protected static final int ARITY = 7;
+
+  private final StringData recordKey;
+
+  private final StringData partitionPath;
+
+  private StringData fileId;
+
+  private StringData instantTime;
+
+  /**
+   * {@link HoodieOperation}
+   */
+  private StringData operationType;
+
+  // there is no rowData for index record
+  private final BooleanValue isIndexRecord;
+
+  private final RowData rowData;
+
+  public HoodieFlinkInternalRow(String recordKey, String partitionPath, String operationType, RowData rowData) {
+    this(recordKey, partitionPath, "", "", operationType, false, rowData);
+  }
+
+  // constructor for index records without row data
+  public HoodieFlinkInternalRow(String recordKey, String partitionPath, String fileId, String instantTime) {
+    this(recordKey, partitionPath, fileId, instantTime, "", true, null);
+  }
+
+  public HoodieFlinkInternalRow(String recordKey,
+                                String partitionPath,
+                                String fileId,
+                                String instantTime,
+                                String operationType,
+                                boolean isIndexRecord,
+                                RowData rowData) {
+    this.recordKey = StringData.fromString(recordKey);
+    this.partitionPath = StringData.fromString(partitionPath);
+    this.fileId = StringData.fromString(fileId);
+    this.instantTime = StringData.fromString(instantTime);
+    this.operationType = StringData.fromString(operationType);
+    this.isIndexRecord = new BooleanValue(isIndexRecord);
+    this.rowData = rowData;
+  }
+
+  public String getRecordKey() {
+    return String.valueOf(recordKey);
+  }
+
+  public String getPartitionPath() {
+    return String.valueOf(partitionPath);
+  }
+
+  public void setFileId(String fileId) {
+    this.fileId = StringData.fromString(fileId);
+  }
+
+  public String getFileId() {
+    return String.valueOf(fileId);
+  }
+
+  public void setInstantTime(String instantTime) {
+    this.instantTime = StringData.fromString(instantTime);
+  }
+
+  public String getInstantTime() {
+    return String.valueOf(instantTime);
+  }
+
+  public void setOperationType(String operationType) {
+    this.operationType = StringData.fromString(operationType);
+  }
+
+  public String getOperationType() {
+    return String.valueOf(operationType);
+  }
+
+  public boolean isIndexRecord() {
+    return isIndexRecord.getValue();
+  }
+
+  public RowData getRowData() {
+    return rowData;
+  }
+
+  public HoodieFlinkInternalRow copy(RowDataSerializer rowDataSerializer) {
+    return new HoodieFlinkInternalRow(
+        this.recordKey.toString(),
+        this.partitionPath.toString(),
+        this.fileId.toString(),
+        this.instantTime.toString(),
+        this.operationType.toString(),
+        this.isIndexRecord.getValue(),
+        rowDataSerializer.copy(this.rowData));
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRowSerializer.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRowSerializer.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.StringDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Serializer for {@link HoodieFlinkInternalRow}
+ */
+public class HoodieFlinkInternalRowSerializer extends TypeSerializer<HoodieFlinkInternalRow> {
+
+  private static final long serialVersionUID = 1L;
+
+  protected RowType rowType;
+
+  protected RowDataSerializer rowDataSerializer;
+
+  protected StringDataSerializer stringDataSerializer;
+
+  public HoodieFlinkInternalRowSerializer(RowType rowType) {
+    this.rowType = rowType;
+    this.rowDataSerializer = new RowDataSerializer(rowType);
+    this.stringDataSerializer = StringDataSerializer.INSTANCE;
+  }
+
+  @Override
+  public boolean isImmutableType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<HoodieFlinkInternalRow> duplicate() {
+    return new HoodieFlinkInternalRowSerializer(rowType);
+  }
+
+  @Override
+  public HoodieFlinkInternalRow createInstance() {
+    throw new UnsupportedOperationException("HoodieFlinkInternalRow doesn't allow creation with some defaults.");
+  }
+
+  @Override
+  public HoodieFlinkInternalRow copy(HoodieFlinkInternalRow from) {
+    return from.copy(rowDataSerializer);
+  }
+
+  @Override
+  public HoodieFlinkInternalRow copy(HoodieFlinkInternalRow from, HoodieFlinkInternalRow reuse) {
+    throw new UnsupportedOperationException("HoodieFlinkInternalRow doesn't allow reusing.");
+  }
+
+  @Override
+  public int getLength() {
+    // -1 for variable length data types
+    return -1;
+  }
+
+  @Override
+  public void serialize(HoodieFlinkInternalRow record, DataOutputView target) throws IOException {
+    boolean isIndexRecord = record.isIndexRecord();
+    target.writeBoolean(isIndexRecord);
+    stringDataSerializer.serialize(StringData.fromString(record.getRecordKey()), target);
+    stringDataSerializer.serialize(StringData.fromString(record.getPartitionPath()), target);
+    stringDataSerializer.serialize(StringData.fromString(record.getFileId()), target);
+    stringDataSerializer.serialize(StringData.fromString(record.getInstantTime()), target);
+    stringDataSerializer.serialize(StringData.fromString(record.getOperationType()), target);
+    if (!isIndexRecord) {
+      rowDataSerializer.serialize(record.getRowData(), target);
+    }
+  }
+
+  @Override
+  public HoodieFlinkInternalRow deserialize(DataInputView source) throws IOException {
+    boolean isIndexRecord = source.readBoolean();
+    StringData recordKey = stringDataSerializer.deserialize(source);
+    StringData partition = stringDataSerializer.deserialize(source);
+    StringData fileId = stringDataSerializer.deserialize(source);
+    StringData instantTime = stringDataSerializer.deserialize(source);
+    StringData operationType = stringDataSerializer.deserialize(source);
+    HoodieFlinkInternalRow record;
+    if (!isIndexRecord) {
+      RowData rowData = rowDataSerializer.deserialize(source);
+      record = new HoodieFlinkInternalRow(
+          recordKey.toString(),
+          partition.toString(),
+          fileId.toString(),
+          instantTime.toString(),
+          operationType.toString(),
+          isIndexRecord,
+          rowData);
+    } else {
+      record = new HoodieFlinkInternalRow(
+          recordKey.toString(),
+          partition.toString(),
+          fileId.toString(),
+          instantTime.toString());
+    }
+    return record;
+  }
+
+  @Override
+  public HoodieFlinkInternalRow deserialize(HoodieFlinkInternalRow reuse, DataInputView source) throws IOException {
+    return deserialize(source);
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    boolean isIndexRecord = source.readBoolean();
+    target.writeBoolean(isIndexRecord);
+    stringDataSerializer.copy(source, target);
+    stringDataSerializer.copy(source, target);
+    stringDataSerializer.copy(source, target);
+    stringDataSerializer.copy(source, target);
+    stringDataSerializer.copy(source, target);
+    if (!isIndexRecord) {
+      rowDataSerializer.copy(source, target);
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (null == obj || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    HoodieFlinkInternalRowSerializer that = (HoodieFlinkInternalRowSerializer) obj;
+    return Objects.equals(rowDataSerializer, that.rowDataSerializer)
+        && Objects.equals(stringDataSerializer, that.stringDataSerializer);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Objects.hashCode(rowDataSerializer) + Objects.hashCode(stringDataSerializer);
+  }
+
+  @Override
+  public TypeSerializerSnapshot<HoodieFlinkInternalRow> snapshotConfiguration() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRowTypeInfo.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkInternalRowTypeInfo.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Objects;
+
+/**
+ * Type information class for {@link HoodieFlinkInternalRow}.
+ */
+public class HoodieFlinkInternalRowTypeInfo extends TypeInformation<HoodieFlinkInternalRow> {
+
+  private static final long serialVersionUID = 1L;
+
+  private final RowType rowType;
+
+  public HoodieFlinkInternalRowTypeInfo(RowType rowType) {
+    this.rowType = rowType;
+  }
+
+  @Override
+  public boolean isBasicType() {
+    return false;
+  }
+
+  @Override
+  public boolean isTupleType() {
+    return false;
+  }
+
+  @Override
+  public int getArity() {
+    return HoodieFlinkInternalRow.ARITY;
+  }
+
+  /**
+   * Used only in Flink `CompositeType`, not used in this type
+   */
+  @Override
+  public int getTotalFields() {
+    return HoodieFlinkInternalRow.ARITY;
+  }
+
+  @Override
+  public Class<HoodieFlinkInternalRow> getTypeClass() {
+    return HoodieFlinkInternalRow.class;
+  }
+
+  @Override
+  public boolean isKeyType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<HoodieFlinkInternalRow> createSerializer(ExecutionConfig config) {
+    return new HoodieFlinkInternalRowSerializer(this.rowType);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + "< RowType: " + rowType.toString() + " >";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof HoodieFlinkInternalRowTypeInfo) {
+      HoodieFlinkInternalRowTypeInfo recordTypeInfo = (HoodieFlinkInternalRowTypeInfo) obj;
+      return Objects.equals(rowType, recordTypeInfo.rowType);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rowType);
+  }
+
+  @Override
+  public boolean canEqual(Object obj) {
+    return obj instanceof HoodieFlinkInternalRowTypeInfo;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -19,8 +19,14 @@
 package org.apache.hudi.sink;
 
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.ObjectSizeCalculator;
@@ -30,13 +36,19 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metrics.FlinkStreamWriteMetrics;
 import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
+import org.apache.hudi.sink.utils.PayloadCreation;
 import org.apache.hudi.table.action.commit.FlinkWriteHelper;
+import org.apache.hudi.util.RowDataToAvroConverters;
 import org.apache.hudi.util.StreamerUtil;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +64,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 /**
  * Sink function to write the data to the underneath filesystem.
@@ -85,10 +98,9 @@ import java.util.function.BiFunction;
  *
  * <p>Note: The function task requires the input stream be shuffled by the file IDs.
  *
- * @param <I> Type of the input record
  * @see StreamWriteOperatorCoordinator
  */
-public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
+public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlinkInternalRow> {
 
   private static final long serialVersionUID = 1L;
 
@@ -102,6 +114,14 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   protected transient BiFunction<List<HoodieRecord>, String, List<WriteStatus>> writeFunction;
 
   private transient HoodieRecordMerger recordMerger;
+
+  protected final RowType rowType;
+
+  protected transient Schema avroSchema;
+
+  protected transient RowDataToAvroConverters.RowDataToAvroConverter converter;
+
+  protected transient PayloadCreation payloadCreation;
 
   /**
    * Total size tracer.
@@ -118,8 +138,9 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
    *
    * @param config The config options
    */
-  public StreamWriteFunction(Configuration config) {
+  public StreamWriteFunction(Configuration config, RowType rowType) {
     super(config);
+    this.rowType = rowType;
   }
 
   @Override
@@ -129,6 +150,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     initWriteFunction();
     initMergeClass();
     registerMetrics();
+    preparePayload();
   }
 
   @Override
@@ -140,8 +162,10 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   }
 
   @Override
-  public void processElement(I value, ProcessFunction<I, Object>.Context ctx, Collector<Object> out) throws Exception {
-    bufferRecord((HoodieRecord<?>) value);
+  public void processElement(HoodieFlinkInternalRow record,
+                             ProcessFunction<HoodieFlinkInternalRow, Object>.Context ctx,
+                             Collector<Object> out) throws Exception {
+    bufferRecord(record);
   }
 
   @Override
@@ -169,7 +193,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   public Map<String, List<HoodieRecord>> getDataBuffer() {
     Map<String, List<HoodieRecord>> ret = new HashMap<>();
     for (Map.Entry<String, DataBucket> entry : buckets.entrySet()) {
-      ret.put(entry.getKey(), entry.getValue().getRecords());
+      ret.put(entry.getKey(), convertToHoodieRecords(entry.getValue().getRecords()));
     }
     return ret;
   }
@@ -209,11 +233,21 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     LOG.info("init hoodie merge with class [{}]", recordMerger.getClass().getName());
   }
 
+  protected void preparePayload() {
+    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
+    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
+    try {
+      this.payloadCreation = PayloadCreation.instance(config);
+    } catch (Exception ex) {
+      throw new HoodieException("Failed payload creation in StreamWriteFunction", ex);
+    }
+  }
+
   /**
    * Data bucket.
    */
   protected static class DataBucket {
-    private final List<HoodieRecord> records;
+    private final List<HoodieFlinkInternalRow> records;
     private final BufferSizeDetector detector;
 
     private DataBucket(Double batchSize) {
@@ -221,7 +255,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
       this.detector = new BufferSizeDetector(batchSize);
     }
 
-    public List<HoodieRecord> getRecords() {
+    public List<HoodieFlinkInternalRow> getRecords() {
       return records;
     }
 
@@ -312,9 +346,8 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   /**
    * Returns the bucket ID with the given value {@code value}.
    */
-  private String getBucketID(HoodieRecord<?> record) {
-    final String fileId = record.getCurrentLocation().getFileId();
-    return StreamerUtil.generateBucketKey(record.getPartitionPath(), fileId);
+  private String getBucketID(String partitionPath, String fileId) {
+    return StreamerUtil.generateBucketKey(partitionPath, fileId);
   }
 
   /**
@@ -326,26 +359,26 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
    * <p>Flush the max size data bucket if the total buffer size exceeds the configured
    * threshold {@link FlinkOptions#WRITE_TASK_MAX_SIZE}.
    *
-   * @param value HoodieRecord
+   * @param record HoodieFlinkInternalRow
    */
-  protected void bufferRecord(HoodieRecord<?> value) {
+  protected void bufferRecord(HoodieFlinkInternalRow record) {
     writeMetrics.markRecordIn();
-    final String bucketID = getBucketID(value);
+    final String bucketID = getBucketID(record.getPartitionPath(), record.getFileId());
 
     DataBucket bucket = this.buckets.computeIfAbsent(bucketID,
         k -> new DataBucket(this.config.getDouble(FlinkOptions.WRITE_BATCH_SIZE)));
-    bucket.records.add(value);
+    bucket.records.add(record);
 
-    boolean flushBucket = bucket.detector.detect(value);
-    boolean flushBuffer = this.tracer.trace(bucket.detector.lastRecordSize);
+    boolean isFullBucket = bucket.detector.detect(record);
+    boolean isFullBuffer = this.tracer.trace(bucket.detector.lastRecordSize);
     // update buffer metrics after tracing buffer size
     writeMetrics.setWriteBufferedSize(this.tracer.bufferSize);
-    if (flushBucket) {
+    if (isFullBucket) {
       if (flushBucket(bucket)) {
         this.tracer.countDown(bucket.detector.totalSize);
         bucket.reset();
       }
-    } else if (flushBuffer) {
+    } else if (isFullBuffer) {
       // find the max size bucket and flush it out
       DataBucket bucketToFlush = this.buckets.values().stream()
           .max(Comparator.comparingLong(b -> b.detector.totalSize))
@@ -364,7 +397,6 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
         && this.buckets.values().stream().anyMatch(bucket -> !bucket.records.isEmpty());
   }
 
-  @SuppressWarnings("unchecked, rawtypes")
   private boolean flushBucket(DataBucket bucket) {
     String instant = instantToWrite(true);
 
@@ -389,7 +421,6 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     return true;
   }
 
-  @SuppressWarnings("unchecked, rawtypes")
   private void flushRemaining(boolean endInput) {
     writeMetrics.startDataFlush();
     this.currentInstant = instantToWrite(hasData());
@@ -439,12 +470,36 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     writeMetrics.registerMetrics();
   }
 
-  protected List<WriteStatus> writeRecords(String instant, List<HoodieRecord> records) {
+  protected List<WriteStatus> writeRecords(String instant, List<HoodieFlinkInternalRow> records) {
     writeMetrics.startFileFlush();
-    List<WriteStatus> statuses = writeFunction.apply(deduplicateRecordsIfNeeded(records), instant);
+    List<WriteStatus> statuses = writeFunction.apply(deduplicateRecordsIfNeeded(convertToHoodieRecords(records)), instant);
     writeMetrics.endFileFlush();
     writeMetrics.increaseNumOfFilesWritten();
     return statuses;
+  }
+
+  protected  List<HoodieRecord> convertToHoodieRecords(List<HoodieFlinkInternalRow> records) {
+    return records.stream()
+        .map(record -> {
+          RowData row = record.getRowData();
+          // [HUDI-8969] Analyze how to write `RowData` directly
+          GenericRecord gr = (GenericRecord) this.converter.convert(this.avroSchema, row);
+          HoodieRecordPayload payload;
+          try {
+            payload = payloadCreation.createPayload(gr);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+          HoodieRecord hoodieRecord =
+              new HoodieAvroRecord<>(
+                  new HoodieKey(record.getRecordKey(), record.getPartitionPath()),
+                  payload,
+                  HoodieOperation.fromName(record.getOperationType()));
+          hoodieRecord.unseal();
+          hoodieRecord.setCurrentLocation(new HoodieRecordLocation(record.getInstantTime(), record.getFileId()));
+          hoodieRecord.seal();
+          return hoodieRecord;
+        }).collect(Collectors.toList());
   }
 
   protected List<HoodieRecord> deduplicateRecordsIfNeeded(List<HoodieRecord> records) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
@@ -18,24 +18,24 @@
 
 package org.apache.hudi.sink;
 
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.sink.common.AbstractWriteOperator;
 import org.apache.hudi.sink.common.WriteOperatorFactory;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.table.types.logical.RowType;
 
 /**
  * Operator for {@link StreamSink}.
- *
- * @param <I> The input type
  */
-public class StreamWriteOperator<I> extends AbstractWriteOperator<I> {
+public class StreamWriteOperator extends AbstractWriteOperator<HoodieFlinkInternalRow> {
 
-  public StreamWriteOperator(Configuration conf) {
-    super(new StreamWriteFunction<>(conf));
+  public StreamWriteOperator(Configuration conf, RowType rowType) {
+    super(new StreamWriteFunction(conf, rowType));
   }
 
-  public static <I> WriteOperatorFactory<I> getFactory(Configuration conf) {
-    return WriteOperatorFactory.instance(conf, new StreamWriteOperator<>(conf));
+  public static WriteOperatorFactory<HoodieFlinkInternalRow> getFactory(Configuration conf, RowType rowType) {
+    return WriteOperatorFactory.instance(conf, new StreamWriteOperator(conf, rowType));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/batch/BatchBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/batch/BatchBootstrapOperator.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.sink.bootstrap.batch;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.sink.bootstrap.BootstrapOperator;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -39,8 +39,7 @@ import java.util.Set;
  *
  * <p>The input records should shuffle by the partition path to avoid repeated loading.
  */
-public class BatchBootstrapOperator<I, O extends HoodieRecord<?>>
-    extends BootstrapOperator<I, O> {
+public class BatchBootstrapOperator extends BootstrapOperator {
 
   private Set<String> partitionPathSet;
   private boolean haveSuccessfulCommits;
@@ -62,10 +61,8 @@ public class BatchBootstrapOperator<I, O extends HoodieRecord<?>>
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public void processElement(StreamRecord<I> element) throws Exception {
-    final HoodieRecord<?> record = (HoodieRecord<?>) element.getValue();
-    final String partitionPath = record.getKey().getPartitionPath();
+  public void processElement(StreamRecord<HoodieFlinkInternalRow> element) throws Exception {
+    final String partitionPath = element.getValue().getPartitionPath();
 
     if (haveSuccessfulCommits && !partitionPathSet.contains(partitionPath)) {
       loadRecords(partitionPath);
@@ -73,7 +70,7 @@ public class BatchBootstrapOperator<I, O extends HoodieRecord<?>>
     }
 
     // send the trigger record
-    output.collect((StreamRecord<O>) element);
+    output.collect(element);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperator.java
@@ -18,26 +18,26 @@
 
 package org.apache.hudi.sink.bucket;
 
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.sink.common.AbstractWriteOperator;
 import org.apache.hudi.sink.common.WriteOperatorFactory;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.types.logical.RowType;
 
 /**
  * Operator for {@link BucketStreamWriteFunction}.
- *
- * @param <I> The input type
  */
-public class BucketStreamWriteOperator<I> extends AbstractWriteOperator<I> {
+public class BucketStreamWriteOperator extends AbstractWriteOperator<HoodieFlinkInternalRow> {
 
-  public BucketStreamWriteOperator(Configuration conf) {
+  public BucketStreamWriteOperator(Configuration conf, RowType rowType) {
     super(OptionsResolver.isConsistentHashingBucketIndexType(conf)
-        ? new ConsistentBucketStreamWriteFunction<>(conf)
-        : new BucketStreamWriteFunction<>(conf));
+        ? new ConsistentBucketStreamWriteFunction(conf, rowType)
+        : new BucketStreamWriteFunction(conf, rowType));
   }
 
-  public static <I> WriteOperatorFactory<I> getFactory(Configuration conf) {
-    return WriteOperatorFactory.instance(conf, new BucketStreamWriteOperator<>(conf));
+  public static WriteOperatorFactory<HoodieFlinkInternalRow> getFactory(Configuration conf, RowType rowType) {
+    return WriteOperatorFactory.instance(conf, new BucketStreamWriteOperator(conf, rowType));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunction.java
@@ -18,100 +18,37 @@
 
 package org.apache.hudi.sink.transform;
 
-import org.apache.hudi.common.model.HoodieAvroRecord;
-import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.model.HoodieOperation;
-import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.keygen.KeyGenerator;
-import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
-import org.apache.hudi.sink.utils.PayloadCreation;
-import org.apache.hudi.util.RowDataToAvroConverters;
-import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.sink.bulk.RowDataKeyGen;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.io.IOException;
-
-import static org.apache.hudi.util.StreamerUtil.flinkConf2TypedProperties;
-
 /**
- * Function that transforms RowData to HoodieRecord.
+ * Function that converts Flink {@link RowData} into {@link HoodieFlinkInternalRow}.
  */
-public class RowDataToHoodieFunction<I extends RowData, O extends HoodieRecord>
+public class RowDataToHoodieFunction<I extends RowData, O extends HoodieFlinkInternalRow>
     extends RichMapFunction<I, O> {
-  /**
-   * Row type of the input.
-   */
-  private final RowType rowType;
-
-  /**
-   * Avro schema of the input.
-   */
-  private transient Schema avroSchema;
-
-  /**
-   * RowData to Avro record converter.
-   */
-  private transient RowDataToAvroConverters.RowDataToAvroConverter converter;
-
-  /**
-   * HoodieKey generator.
-   */
-  private transient KeyGenerator keyGenerator;
-
-  /**
-   * Utilities to create hoodie pay load instance.
-   */
-  private transient PayloadCreation payloadCreation;
-
-  /**
-   * Config options.
-   */
-  private final Configuration config;
+  RowDataKeyGen keyGen;
 
   public RowDataToHoodieFunction(RowType rowType, Configuration config) {
-    this.rowType = rowType;
-    this.config = config;
+    this.keyGen = RowDataKeyGen.instance(config, rowType);
   }
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
-    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
-    this.keyGenerator =
-        HoodieAvroKeyGeneratorFactory
-            .createKeyGenerator(flinkConf2TypedProperties(this.config));
-    this.payloadCreation = PayloadCreation.instance(config);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public O map(I i) throws Exception {
-    return (O) toHoodieRecord(i);
-  }
-
-  /**
-   * Converts the give record to a {@link HoodieRecord}.
-   *
-   * @param record The input record
-   * @return HoodieRecord based on the configuration
-   * @throws IOException if error occurs
-   */
-  @SuppressWarnings("rawtypes")
-  private HoodieRecord toHoodieRecord(I record) throws Exception {
-    GenericRecord gr = (GenericRecord) this.converter.convert(this.avroSchema, record);
-    final HoodieKey hoodieKey = keyGenerator.getKey(gr);
-
-    HoodieRecordPayload payload = payloadCreation.createPayload(gr);
-    HoodieOperation operation = HoodieOperation.fromValue(record.getRowKind().toByteValue());
-    return new HoodieAvroRecord<>(hoodieKey, payload, operation);
+  public O map(I row) throws Exception {
+    return (O) new HoodieFlinkInternalRow(
+        keyGen.getRecordKey(row),
+        keyGen.getPartitionPath(row),
+        HoodieOperation.fromValue(row.getRowKind().toByteValue()).getName(),
+        row);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctionWithRateLimit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctionWithRateLimit.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.sink.transform;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.util.RateLimiter;
 import org.apache.hudi.configuration.FlinkOptions;
 
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Function that transforms RowData to a HoodieRecord with RateLimit.
  */
-public class RowDataToHoodieFunctionWithRateLimit<I extends RowData, O extends HoodieRecord>
+public class RowDataToHoodieFunctionWithRateLimit<I extends RowData, O extends HoodieFlinkInternalRow>
     extends RowDataToHoodieFunction<I, O> {
   /**
    * Total rate limit per second for this job.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctions.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.sink.transform;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.configuration.FlinkOptions;
 
 import org.apache.flink.configuration.Configuration;
@@ -26,7 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 /**
- * Utilities for {@link RowDataToHoodieFunction}.
+ * Utilities for {@link RowDataToHoodieFunction} to handle rate limit if it was set.
  */
 public abstract class RowDataToHoodieFunctions {
   private RowDataToHoodieFunctions() {
@@ -35,8 +35,7 @@ public abstract class RowDataToHoodieFunctions {
   /**
    * Creates a {@link RowDataToHoodieFunction} instance based on the given configuration.
    */
-  @SuppressWarnings("rawtypes")
-  public static RowDataToHoodieFunction<RowData, HoodieRecord> create(RowType rowType, Configuration conf) {
+  public static RowDataToHoodieFunction<RowData, HoodieFlinkInternalRow> create(RowType rowType, Configuration conf) {
     if (conf.getLong(FlinkOptions.WRITE_RATE_LIMIT) > 0) {
       return new RowDataToHoodieFunctionWithRateLimit<>(rowType, conf);
     } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PayloadCreation.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PayloadCreation.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.sink.utils;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
-import org.apache.hudi.common.model.BaseAvroPayload;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
@@ -81,14 +80,6 @@ public class PayloadCreation implements Serializable {
       return (HoodieRecordPayload<?>) constructor.newInstance(record, orderingVal);
     } else {
       return (HoodieRecordPayload<?>) this.constructor.newInstance(Option.of(record));
-    }
-  }
-
-  public HoodieRecordPayload<?> createDeletePayload(BaseAvroPayload payload) throws Exception {
-    if (shouldCombine) {
-      return (HoodieRecordPayload<?>) constructor.newInstance(null, payload.getOrderingVal());
-    } else {
-      return (HoodieRecordPayload<?>) this.constructor.newInstance(Option.empty());
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
@@ -18,9 +18,9 @@
 
 package org.apache.hudi.streamer;
 
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsInference;
@@ -115,8 +115,8 @@ public class HoodieFlinkStreamer {
         Pipelines.dummySink(pipeline);
       }
     } else {
-      DataStream<HoodieRecord> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
-      pipeline = Pipelines.hoodieStreamWrite(conf, hoodieRecordDataStream);
+      DataStream<HoodieFlinkInternalRow> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
+      pipeline = Pipelines.hoodieStreamWrite(conf, rowType, hoodieRecordDataStream);
       if (OptionsResolver.needsAsyncCompaction(conf)) {
         Pipelines.compact(conf, pipeline);
       } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
@@ -21,7 +21,7 @@ package org.apache.hudi.table;
 import org.apache.hudi.adapter.DataStreamSinkProviderAdapter;
 import org.apache.hudi.adapter.SupportsRowLevelDeleteAdapter;
 import org.apache.hudi.adapter.SupportsRowLevelUpdateAdapter;
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsInference;
@@ -109,12 +109,10 @@ public class HoodieTableSink implements
         }
       }
 
+      // process dataStream and write corresponding files
       DataStream<Object> pipeline;
-      // bootstrap
-      final DataStream<HoodieRecord> hoodieRecordDataStream =
-          Pipelines.bootstrap(conf, rowType, dataStream, context.isBounded(), overwrite);
-      // write pipeline
-      pipeline = Pipelines.hoodieStreamWrite(conf, hoodieRecordDataStream);
+      final DataStream<HoodieFlinkInternalRow> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream, context.isBounded(), overwrite);
+      pipeline = Pipelines.hoodieStreamWrite(conf, rowType, hoodieRecordDataStream);
       // compaction
       if (OptionsResolver.needsAsyncCompaction(conf)) {
         // use synchronous compaction for bounded source.

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.sink;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -122,7 +122,7 @@ public class ITTestDataStreamWrite extends TestLogger {
     conf.setInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 1);
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
-    testWriteToHoodie(conf, "cow_write", 2, EXPECTED);
+    defaultWriteAndCheckExpected(conf, "cow_write", 2);
   }
 
   @Test
@@ -138,7 +138,7 @@ public class ITTestDataStreamWrite extends TestLogger {
       }
     });
 
-    testWriteToHoodie(transformer, "cow_write_with_transformer", EXPECTED_TRANSFORMER);
+    writeWithTransformerAndCheckExpected(transformer, "cow_write_with_transformer", EXPECTED_TRANSFORMER);
   }
 
   @Test
@@ -156,7 +156,7 @@ public class ITTestDataStreamWrite extends TestLogger {
 
     ChainedTransformer chainedTransformer = new ChainedTransformer(Arrays.asList(t1, t1));
 
-    testWriteToHoodie(chainedTransformer, "cow_write_with_chained_transformer", EXPECTED_CHAINED_TRANSFORMER);
+    writeWithTransformerAndCheckExpected(chainedTransformer, "cow_write_with_chained_transformer", EXPECTED_CHAINED_TRANSFORMER);
   }
 
   @ParameterizedTest
@@ -168,20 +168,12 @@ public class ITTestDataStreamWrite extends TestLogger {
     conf.setInteger(FlinkOptions.COMPACTION_DELTA_COMMITS, 1);
     conf.setString(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
 
-    testWriteToHoodie(conf, "mor_write_with_compact", 1, EXPECTED);
+    defaultWriteAndCheckExpected(conf, "mor_write_with_compact", 1);
   }
 
-  @Test
-  public void testWriteCopyOnWriteWithClustering() throws Exception {
-    testWriteCopyOnWriteWithClustering(false);
-  }
-
-  @Test
-  public void testWriteCopyOnWriteWithSortClustering() throws Exception {
-    testWriteCopyOnWriteWithClustering(true);
-  }
-
-  private void testWriteCopyOnWriteWithClustering(boolean sortClusteringEnabled) throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testWriteCopyOnWriteWithClustering(boolean sortClusteringEnabled) throws Exception {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.toURI().toString());
     conf.setBoolean(FlinkOptions.CLUSTERING_SCHEDULE_ENABLED, true);
     conf.setInteger(FlinkOptions.CLUSTERING_DELTA_COMMITS, 1);
@@ -190,35 +182,61 @@ public class ITTestDataStreamWrite extends TestLogger {
       conf.setString(FlinkOptions.CLUSTERING_SORT_COLUMNS, "uuid");
     }
 
-    testWriteToHoodieWithCluster(conf, "cow_write_with_cluster", 1, EXPECTED);
+    writeWithClusterAndCheckExpected(conf, "cow_write_with_cluster", 1, EXPECTED);
   }
 
-  private void testWriteToHoodie(
+  @ParameterizedTest
+  @ValueSource(strings = {"COPY_ON_WRITE", "MERGE_ON_READ"})
+  public void testStreamWriteWithIndexBootstrap(String tableType) throws Exception {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.toURI().toString());
+    conf.setString(FlinkOptions.TABLE_TYPE, tableType);
+
+    writeAndCheckExpected(
+        conf,
+        Option.empty(),
+        tableType + "_index_bootstrap",
+        2,
+        true,
+        EXPECTED);
+
+    // check that there is no exceptions during the same with enabled index bootstrap
+    conf.setString(FlinkOptions.INDEX_BOOTSTRAP_ENABLED.key(), "true");
+    writeAndCheckExpected(
+        conf,
+        Option.empty(),
+        tableType + "_index_bootstrap",
+        2,
+        true,
+        EXPECTED);
+  }
+
+  private void writeWithTransformerAndCheckExpected(
       Transformer transformer,
       String jobName,
       Map<String, List<String>> expected) throws Exception {
-    testWriteToHoodie(TestConfigurations.getDefaultConf(tempFile.toURI().toString()),
-        Option.of(transformer), jobName, 2, expected);
+    writeAndCheckExpected(
+        TestConfigurations.getDefaultConf(tempFile.toURI().toString()),
+        Option.of(transformer),
+        jobName,
+        2,
+        true,
+        expected);
   }
 
-  private void testWriteToHoodie(
+  private void defaultWriteAndCheckExpected(
       Configuration conf,
       String jobName,
-      int checkpoints,
-      Map<String, List<String>> expected) throws Exception {
-    testWriteToHoodie(conf, Option.empty(), jobName, checkpoints, expected);
+      int checkpoints) throws Exception {
+    writeAndCheckExpected(
+        conf,
+        Option.empty(),
+        jobName,
+        checkpoints,
+        true,
+        EXPECTED);
   }
 
-  private void testWriteToHoodie(
-      Configuration conf,
-      Option<Transformer> transformer,
-      String jobName,
-      int checkpoints,
-      Map<String, List<String>> expected) throws Exception {
-    testWriteToHoodie(conf, transformer, jobName, checkpoints, true, expected);
-  }
-
-  private void testWriteToHoodie(
+  private void writeAndCheckExpected(
       Configuration conf,
       Option<Transformer> transformer,
       String jobName,
@@ -273,8 +291,8 @@ public class ITTestDataStreamWrite extends TestLogger {
     }
 
     OptionsInference.setupSinkTasks(conf, execEnv.getParallelism());
-    DataStream<HoodieRecord> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
-    DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, hoodieRecordDataStream);
+    DataStream<HoodieFlinkInternalRow> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
+    DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, rowType, hoodieRecordDataStream);
     execEnv.addOperator(pipeline.getTransformation());
 
     if (isMor) {
@@ -285,7 +303,7 @@ public class ITTestDataStreamWrite extends TestLogger {
     TestData.checkWrittenDataCOW(tempFile, expected);
   }
 
-  private void testWriteToHoodieWithCluster(
+  private void writeWithClusterAndCheckExpected(
       Configuration conf,
       String jobName,
       int checkpoints,
@@ -538,7 +556,7 @@ public class ITTestDataStreamWrite extends TestLogger {
   public void testColumnDroppingIsNotAllowed() throws Exception {
     // Write cols: uuid, name, age, ts, partition
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.toURI().toString());
-    testWriteToHoodie(conf, "initial write", 1, EXPECTED);
+    defaultWriteAndCheckExpected(conf, "initial write", 1);
 
     // Write cols: uuid, name, ts, partition
     conf.setBoolean(AVRO_SCHEMA_VALIDATE_ENABLE.key(), false);
@@ -553,7 +571,7 @@ public class ITTestDataStreamWrite extends TestLogger {
 
     // assert job failure with schema compatibility exception
     try {
-      testWriteToHoodie(conf, Option.empty(), "failing job", 1, false, Collections.emptyMap());
+      writeAndCheckExpected(conf, Option.empty(), "failing job", 1, false, Collections.emptyMap());
     } catch (JobExecutionException e) {
       Throwable actualException = e;
       while (actualException != null) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -44,12 +44,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,13 +61,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(FlinkMiniCluster.class)
 public class ITTestBucketStreamWrite {
 
+  private static final Map<String, List<String>> EXPECTED_AS_LIST = new HashMap<>();
   private static final Map<String, String> EXPECTED = new HashMap<>();
 
   static {
-    EXPECTED.put("par1", "[id1,par1,id1,Danny,23,1000,par1, id2,par1,id2,Stephen,33,2000,par1]");
-    EXPECTED.put("par2", "[id3,par2,id3,Julian,53,3000,par2, id4,par2,id4,Fabian,31,4000,par2]");
-    EXPECTED.put("par3", "[id5,par3,id5,Sophia,18,5000,par3, id6,par3,id6,Emma,20,6000,par3]");
-    EXPECTED.put("par4", "[id7,par4,id7,Bob,44,7000,par4, id8,par4,id8,Han,56,8000,par4]");
+    EXPECTED_AS_LIST.put("par1", Arrays.asList("id1,par1,id1,Danny,23,1000,par1", "id2,par1,id2,Stephen,33,2000,par1"));
+    EXPECTED_AS_LIST.put("par2", Arrays.asList("id3,par2,id3,Julian,53,3000,par2", "id4,par2,id4,Fabian,31,4000,par2"));
+    EXPECTED_AS_LIST.put("par3", Arrays.asList("id5,par3,id5,Sophia,18,5000,par3", "id6,par3,id6,Emma,20,6000,par3"));
+    EXPECTED_AS_LIST.put("par4", Arrays.asList("id7,par4,id7,Bob,44,7000,par4", "id8,par4,id8,Han,56,8000,par4"));
+
+    for (Map.Entry<String, List<String>> entry : EXPECTED_AS_LIST.entrySet()) {
+      String value = entry.getValue().stream().map(Object::toString).collect(Collectors.joining(", "));
+      EXPECTED.put(entry.getKey(), "[" + value + "]");
+    }
   }
 
   @TempDir
@@ -78,10 +85,10 @@ public class ITTestBucketStreamWrite {
     // this test is to ensure that the correct fileId can be fetched when recovering from a rollover when a new
     // fileGroup is created for a bucketId
     String tablePath = tempFile.getAbsolutePath();
-    doWrite(tablePath, isCow);
-    doDeleteCommit(tablePath, isCow);
-    doWrite(tablePath, isCow);
-    doWrite(tablePath, isCow);
+    doWrite(tablePath, isCow, 1);
+    doDeleteCommit(tablePath);
+    doWrite(tablePath, isCow, 1);
+    doWrite(tablePath, isCow, 1);
 
     if (isCow) {
       TestData.checkWrittenData(tempFile, EXPECTED, 4);
@@ -91,7 +98,20 @@ public class ITTestBucketStreamWrite {
     }
   }
 
-  private static void doDeleteCommit(String tablePath, boolean isCow) throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testBucketWriteIntoMultipleBuckets(boolean isCow) throws Exception {
+    String tablePath = tempFile.getAbsolutePath();
+    doWrite(tablePath, isCow, 2);
+    if (isCow) {
+      TestData.checkWrittenDataCOW(tempFile, EXPECTED_AS_LIST);
+    } else {
+      HoodieStorage storage = HoodieTestUtils.getStorage(tempFile.getAbsolutePath());
+      TestData.checkWrittenDataMOR(storage, tempFile, EXPECTED, 4);
+    }
+  }
+
+  private static void doDeleteCommit(String tablePath) throws Exception {
     // create metaClient
     HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(tablePath);
 
@@ -127,17 +147,8 @@ public class ITTestBucketStreamWrite {
     });
   }
 
-  private static String getWriteToken(String relativeFilePath) {
-    Pattern writeTokenPattern = Pattern.compile("_((\\d+)-(\\d+)-(\\d+))_");
-    Matcher matcher = writeTokenPattern.matcher(relativeFilePath);
-    if (!matcher.find()) {
-      throw new RuntimeException("Invalid relative file path: " + relativeFilePath);
-    }
-    return matcher.group(1);
-  }
-
-  private static void doWrite(String path, boolean isCow) throws InterruptedException, ExecutionException {
-    // create hoodie table and perform writes
+  private static void doWrite(String path, boolean isCow, int bucketNum)
+      throws InterruptedException, ExecutionException {
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
     TableEnvironment tableEnv = TableEnvironmentImpl.create(settings);
     Map<String, String> options = new HashMap<>();
@@ -146,8 +157,9 @@ public class ITTestBucketStreamWrite {
     // use bucket index
     options.put(FlinkOptions.TABLE_TYPE.key(), isCow ? FlinkOptions.TABLE_TYPE_COPY_ON_WRITE : FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
     options.put(FlinkOptions.INDEX_TYPE.key(), IndexType.BUCKET.name());
-    options.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "1");
+    options.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), String.valueOf(bucketNum));
 
+    // create hoodie table and perform writes
     String hoodieTableDDL = TestConfigurations.getCreateHoodieTableDDL("t1", options);
     tableEnv.executeSql(hoodieTableDDL);
     tableEnv.executeSql(TestSQL.INSERT_T1).await();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestConsistentBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestConsistentBucketStreamWrite.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.sink.bucket;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -185,12 +185,12 @@ public class ITTestConsistentBucketStreamWrite extends TestLogger {
     }
 
     OptionsInference.setupSinkTasks(conf, execEnv.getParallelism());
-    DataStream<HoodieRecord> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
     // bulk_insert mode
     if (OptionsResolver.isBulkInsertOperation(conf)) {
       Pipelines.bulkInsert(conf, rowType, dataStream);
     } else {
-      DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, hoodieRecordDataStream);
+      DataStream<HoodieFlinkInternalRow> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, dataStream);
+      DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, rowType, hoodieRecordDataStream);
       execEnv.addOperator(pipeline.getTransformation());
     }
     JobClient client = execEnv.executeAsync(jobName);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.utils;
 
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
@@ -60,6 +61,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   protected final Configuration conf;
+  protected final RowType rowType;
 
   private final IOManager ioManager;
   protected final StreamingRuntimeContext runtimeContext;
@@ -69,14 +71,14 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   protected final MockStateInitializationContext stateInitializationContext;
 
   /**
-   * Function that converts row data to HoodieRecord.
+   * Function that converts row data to HoodieFlinkInternalRow.
    */
-  protected RowDataToHoodieFunction<RowData, HoodieRecord<?>> toHoodieFunction;
+  protected RowDataToHoodieFunction<RowData, HoodieFlinkInternalRow> toHoodieFunction;
 
   /**
    * Stream write function.
    */
-  protected StreamWriteFunction<HoodieRecord<?>> writeFunction;
+  protected StreamWriteFunction writeFunction;
 
   private CompactFunctionWrapper compactFunctionWrapper;
 
@@ -100,6 +102,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
     this.runtimeContext = new MockStreamingRuntimeContext(false, 1, 0, environment);
     this.gateway = new MockOperatorEventGateway();
     this.conf = conf;
+    this.rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
     // one function
     this.coordinatorContext = new MockOperatorCoordinatorContext(new OperatorID(), 1);
     this.coordinator = new StreamWriteOperatorCoordinator(conf, this.coordinatorContext);
@@ -117,7 +120,6 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   public void openFunction() throws Exception {
     this.coordinator.start();
     this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
-    RowType rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
     toHoodieFunction = new RowDataToHoodieFunction<>(rowType, conf);
     toHoodieFunction.setRuntimeContext(runtimeContext);
     toHoodieFunction.open(conf);
@@ -130,7 +132,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   }
 
   public void invoke(I record) throws Exception {
-    HoodieRecord<?> hoodieRecord = toHoodieFunction.map((RowData) record);
+    HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
     writeFunction.processElement(hoodieRecord, null, null);
   }
 
@@ -216,7 +218,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
     coordinator.handleEventFromOperator(0, getNextEvent());
   }
 
-  protected StreamWriteFunction<HoodieRecord<?>> createWriteFunction() {
-    return new BucketStreamWriteFunction<>(conf);
+  protected StreamWriteFunction createWriteFunction() {
+    return new BucketStreamWriteFunction(conf, rowType);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
@@ -18,11 +18,10 @@
 
 package org.apache.hudi.sink.utils;
 
-import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.sink.StreamWriteFunction;
 import org.apache.hudi.sink.bucket.ConsistentBucketAssignFunction;
 import org.apache.hudi.sink.bucket.ConsistentBucketStreamWriteFunction;
-import org.apache.hudi.utils.TestConfigurations;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -40,10 +39,6 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
 
   private ConsistentBucketAssignFunction assignFunction;
 
-  public ConsistentBucketStreamWriteFunctionWrapper(String tablePath) throws Exception {
-    this(tablePath, TestConfigurations.getDefaultConf(tablePath));
-  }
-
   public ConsistentBucketStreamWriteFunctionWrapper(String tablePath, Configuration conf) throws Exception {
     super(tablePath, conf);
   }
@@ -58,15 +53,15 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
 
   @Override
   public void invoke(I record) throws Exception {
-    HoodieRecord hoodieRecord = toHoodieFunction.map((RowData) record);
-    ScalaCollector<HoodieRecord> collector = ScalaCollector.getInstance();
+    HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
+    ScalaCollector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
     assignFunction.processElement(hoodieRecord, null, collector);
     writeFunction.processElement(collector.getVal(), null, null);
   }
 
   @Override
-  protected StreamWriteFunction<HoodieRecord<?>> createWriteFunction() {
-    return new ConsistentBucketStreamWriteFunction<>(conf);
+  protected StreamWriteFunction createWriteFunction() {
+    return new ConsistentBucketStreamWriteFunction(conf, rowType);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Changes in Flink stream write into Hudi table corresponding to [Design of RFC-84, Optimized SerDe of DataStream in Flink operators](https://github.com/apache/hudi/pull/12697).

Architecture of Flink write pipelines: https://miro.com/app/board/uXjVLsCpf48=/

Changes in this PR doesn't affect bulk insert and append mode.

Main points:
- `HoodieFlinkInternalRow` is introduced. It doesn't extend `HoodieRecord` because we need to create data structure with Flink row data and Hudi metadata, constructed from Flink internal data types.
- `HoodieFlinkInternalRow` is effective for Flink processing due to implemented `HoodieFlinkInternalRowTypeInfo` and `HoodieFlinkInternalRowSerializer` with custom `serialize` and `deserialize` methods.

#### Benchmark description

`Lineitem` table from TPC-H benchmark was used. 60 mln rows, from which 20 mln rows are unique.

Data is read from 8 Kafka topics, and is written into Hudi table:
```text
'table.type'='MERGE_ON_READ',
'write.operation'='upsert',
'write.tasks'='8'
```

For simple bucket:
```text
'index.type'='BUCKET',
'hoodie.bucket.index.hash.field'='l_orderkey,l_linenumber',
'hoodie.bucket.index.num.buckets'='8',
'hoodie.index.bucket.engine'='SIMPLE'
```

For consistent hashing:
```text
'index.type'='BUCKET',
'hoodie.bucket.index.hash.field'='l_orderkey,l_linenumber',
'hoodie.index.bucket.engine'='CONSISTENT_HASHING'
```

#### Perfomance estimation results

|                                         | Previous with Kryo | `HoodieFlinkInternalRow ` | Improvement |
| --------------------------- | ------------------ | --------------------- | -------------- |
| **Non bucket**               |                            |                                 |                       |
| Data passed, GB              | 43.9                    | 29.4                          | **33.0%**      |
| Total time, s                     | 620                     | 460                          | **25.8%**      |
| **Simple bucket index**  |                            |                                |                       |
| Data passed, GB              | 19.4                     | 13.7                        | **29.4%**     |
| Total time, s                     | 350                      | 320                         | **8.6%**      |
| **Consistent hashing**   |                            |                                |                       |
| Data passed, GB              | 24.6                     | 15.8                        | **35.8%**     |
| Total time, s                     | 1040                    | 800                         | **23.1%**      |


### Impact

Flink write performance improvement.

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
