### PR TITLE
[HUDI-7974] Adding support for empty cleans

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieArchivedLogFile;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -37,13 +38,16 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
+import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.table.timeline.MetadataConversionUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.v1.ActiveTimelineV1;
 import org.apache.hudi.common.table.timeline.versioning.v1.ArchivedTimelineV1;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantFileNameGeneratorV1;
+import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.CompactionUtils;
@@ -227,6 +231,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
     // unless HoodieArchivalConfig#ARCHIVE_BEYOND_SAVEPOINT is enabled.
     Option<HoodieInstant> firstSavepoint = table.getCompletedSavepointTimeline().firstInstant();
     Set<String> savepointTimestamps = table.getSavepointTimestamps();
+    Option<String> earliestCommitToNotArchiveOpt = getEarliestCommitToNotArchive(table.getActiveTimeline(), table.getMetaClient());
     if (!commitTimeline.empty() && commitTimeline.countInstants() > maxInstantsToKeep) {
       // For Merge-On-Read table, inline or async compaction is enabled
       // We need to make sure that there are enough delta commits in the active timeline
@@ -254,9 +259,16 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
               // skip savepoint commits and proceed further
               return !savepointTimestamps.contains(s.requestedTime());
             } else {
-              // if no savepoint present, then don't filter
-              // stop at first savepoint commit
-              return !(firstSavepoint.isPresent() && compareTimestamps(firstSavepoint.get().requestedTime(), LESSER_THAN_OR_EQUALS, s.requestedTime()));
+              Option<String> firstSavepointOpt = table.getCompletedSavepointTimeline().firstInstant().map(HoodieInstant::requestedTime);
+              Option<String> commitToNotArchiveOpt = earliestCommitToNotArchiveOpt;
+              if (firstSavepointOpt.isPresent() && earliestCommitToNotArchiveOpt.isPresent()
+                  && compareTimestamps(firstSavepointOpt.get(), LESSER_THAN, earliestCommitToNotArchiveOpt.get())) {
+                LOG.error("earliestCommitToNotArchive {} is greater than first savepoint {}, using first savepoint as the commitToNotArchive",
+                    earliestCommitToNotArchiveOpt.get(), firstSavepointOpt.get());
+                commitToNotArchiveOpt = firstSavepointOpt;
+              }
+              // stop at earliest commit to not archive
+              return !(commitToNotArchiveOpt.isPresent() && compareTimestamps(commitToNotArchiveOpt.get(), LESSER_THAN_OR_EQUALS, s.requestedTime()));
             }
           }).filter(s -> {
             // oldestCommitToRetain is the highest completed commit instant that is less than the oldest inflight instant.
@@ -278,6 +290,29 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
     } else {
       return Stream.empty();
     }
+  }
+
+  private Option<String> getEarliestCommitToNotArchive(HoodieActiveTimeline activeTimeline, HoodieTableMetaClient metaClient) throws IOException {
+    // if clean policy is based on file versions, earliest commit to not archive may not be set. So, we have to explicitly check the savepoint timeline
+    // and guard against the first one.
+    InstantGenerator factory = metaClient.getInstantGenerator();
+    String earliestInstantToNotArchive = table.getCompletedSavepointTimeline().firstInstant().map(HoodieInstant::requestedTime).orElse(null);
+    if (config.getCleanerPolicy() != HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS) {
+      Option<HoodieInstant> cleanInstantOpt =
+          activeTimeline.getCleanerTimeline().filterCompletedInstants().lastInstant();
+      if (cleanInstantOpt.isPresent()) {
+        HoodieInstant cleanInstant = cleanInstantOpt.get();
+        Map<String, String> extraMetadata = CleanerUtils.getCleanerPlan(metaClient, cleanInstant.isRequested()
+                ? cleanInstant
+                : factory.getCleanRequestedInstant(cleanInstant.requestedTime()))
+            .getExtraMetadata();
+        if (extraMetadata != null) {
+          String cleanerEarliestInstantToNotArchive = extraMetadata.getOrDefault(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE, null);
+          earliestInstantToNotArchive = InstantComparison.minTimestamp(earliestInstantToNotArchive, cleanerEarliestInstantToNotArchive);
+        }
+      }
+    }
+    return Option.ofNullable(earliestInstantToNotArchive);
   }
 
   private List<HoodieInstant> getInstantsToArchive() throws IOException {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -634,6 +634,17 @@ public class HoodieWriteConfig extends HoodieConfig {
       .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of times to retry a batch on conflict failure.");
 
+  public static final ConfigProperty<Long> MAX_DURATION_TO_CREATE_EMPTY_CLEAN_MS = ConfigProperty
+      .key("hoodie.write.empty.clean.create.duration.ms")
+      .defaultValue(-1L)
+      .markAdvanced()
+      .withDocumentation("In some cases empty clean commit needs to be created to ensure the clean planner "
+          + "does not look through entire dataset if there are no clean plans. This is possible for append-only "
+          + "dataset. Also, for these datasets we cannot ignore clean completely since in the future there could "
+          + "be upsert or replace operations. By creating empty clean commit, earliest_commit_to_retain value "
+          + "will be updated so that now clean planner can only check for partitions that are modified after the "
+          + "last empty clean's earliest_commit_toRetain value there by optimizing the clean planning");
+
   public static final ConfigProperty<String> WRITE_SCHEMA_OVERRIDE = ConfigProperty
       .key("hoodie.write.schema")
       .noDefaultValue()
@@ -2727,6 +2738,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(SKIP_DEFAULT_PARTITION_VALIDATION);
   }
 
+  public long maxDurationToCreateEmptyCleanMs() {
+    return getLong(MAX_DURATION_TO_CREATE_EMPTY_CLEAN_MS);
+  }
+
   /**
    * Are any table services configured to run inline for both scheduling and execution?
    *
@@ -3341,6 +3356,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withWriteConcurrencyMode(WriteConcurrencyMode concurrencyMode) {
       writeConfig.setValue(WRITE_CONCURRENCY_MODE, concurrencyMode.name());
+      return this;
+    }
+
+    public Builder withMaxDurationToCreateEmptyClean(long duration) {
+      writeConfig.setValue(MAX_DURATION_TO_CREATE_EMPTY_CLEAN_MS, String.valueOf(duration));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -54,6 +55,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.util.CleanerUtils.CLEAN_METADATA_VERSION_2;
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
 public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K, O, HoodieCleanMetadata> {
@@ -133,10 +135,10 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
    * @throws IllegalArgumentException if unknown cleaning policy is provided
    */
   List<HoodieCleanStat> clean(HoodieEngineContext context, HoodieCleanerPlan cleanerPlan) {
-    int cleanerParallelism = Math.min(
+    int cleanerParallelism = Math.max(1, Math.min(
         cleanerPlan.getFilePathsToBeDeletedPerPartition().values().stream().mapToInt(List::size).sum(),
-        config.getCleanerParallelism());
-    LOG.info("Using cleanerParallelism: " + cleanerParallelism);
+        config.getCleanerParallelism()));
+    LOG.info("Using cleanerParallelism: {}", cleanerParallelism);
 
     context.setJobStatus(this.getClass().getSimpleName(), "Perform cleaning of table: " + config.getTableName());
 
@@ -154,14 +156,14 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
 
     List<String> partitionsToBeDeleted = table.getMetaClient().getTableConfig().isTablePartitioned() && cleanerPlan.getPartitionsToBeDeleted() != null
         ? cleanerPlan.getPartitionsToBeDeleted()
-        : new ArrayList<>();
+        : Collections.emptyList();
     partitionsToBeDeleted.forEach(entry -> {
       try {
         if (!isNullOrEmpty(entry)) {
           deleteFileAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
         }
       } catch (IOException e) {
-        LOG.warn("Partition deletion failed " + entry);
+        LOG.warn("Partition deletion failed {}", entry);
       }
     });
 
@@ -217,17 +219,17 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
       }
 
       List<HoodieCleanStat> cleanStats = clean(context, cleanerPlan);
+      HoodieCleanMetadata metadata;
       if (cleanStats.isEmpty()) {
-        return HoodieCleanMetadata.newBuilder().build();
+        metadata = createEmptyCleanMetadata(cleanerPlan, inflightInstant, timer.endTimer());
+      } else {
+        table.getMetaClient().reloadActiveTimeline();
+        metadata = CleanerUtils.convertCleanMetadata(
+            inflightInstant.requestedTime(),
+            Option.of(timer.endTimer()),
+            cleanStats,
+            cleanerPlan.getExtraMetadata());
       }
-
-      table.getMetaClient().reloadActiveTimeline();
-      HoodieCleanMetadata metadata = CleanerUtils.convertCleanMetadata(
-          inflightInstant.requestedTime(),
-          Option.of(timer.endTimer()),
-          cleanStats,
-          cleanerPlan.getExtraMetadata()
-      );
       if (!skipLocking) {
         this.txnManager.beginTransaction(Option.of(inflightInstant), Option.empty());
       }
@@ -243,6 +245,20 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         this.txnManager.endTransaction(Option.ofNullable(inflightInstant));
       }
     }
+  }
+
+  private static HoodieCleanMetadata createEmptyCleanMetadata(HoodieCleanerPlan cleanerPlan, HoodieInstant inflightInstant, long timeTakenMillis) {
+    return HoodieCleanMetadata.newBuilder()
+        .setStartCleanTime(inflightInstant.requestedTime())
+        .setTimeTakenInMillis(timeTakenMillis)
+        .setTotalFilesDeleted(0)
+        .setLastCompletedCommitTimestamp(cleanerPlan.getLastCompletedCommitTimestamp())
+        .setEarliestCommitToRetain(cleanerPlan.getEarliestInstantToRetain().getTimestamp())
+        .setVersion(CLEAN_METADATA_VERSION_2)
+        .setPartitionMetadata(Collections.emptyMap())
+        .setExtraMetadata(cleanerPlan.getExtraMetadata())
+        .setBootstrapPartitionMetadata(Collections.emptyMap())
+        .build();
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -25,6 +25,7 @@ import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.CleanFileInfo;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV1MigrationHandler;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
@@ -92,6 +93,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   private transient HoodieEngineContext context;
   private final List<String> savepointedTimestamps;
   private Option<HoodieInstant> earliestCommitToRetain = Option.empty();
+  private Option<String> earliestCommitToNotArchive = Option.empty();
 
   public CleanPlanner(HoodieEngineContext context, HoodieTable<T, I, K, O> hoodieTable, HoodieWriteConfig config) {
     this.context = context;
@@ -569,6 +571,40 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
           hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone());
     }
     return earliestCommitToRetain;
+  }
+
+  /**
+   * Returns earliest commit to not archive to assist with guarding archival.
+   * @return
+   */
+  public Option<String> getEarliestCommitToNotArchive() {
+    // compute only if not set
+    if (!earliestCommitToNotArchive.isPresent() && config.getCleanerPolicy() != HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS) { // earliest commit to retain and earliest commit to not archive
+      // makes sense only when clean policy is num commits based or hours based.
+      Option<HoodieInstant> earliestToRetain = getEarliestCommitToRetain();
+      if (!savepointedTimestamps.isEmpty()) { // if savepoints are found.
+        // find the first savepoint timestamp
+        earliestCommitToNotArchive = Option.fromJavaOptional(savepointedTimestamps.stream().sorted().findFirst());
+
+        // earliest commit to not archive = min (earliest commit to retain, earliest commit to not archive)
+        if (earliestToRetain.isPresent()) {
+          earliestCommitToNotArchive = Option.of(InstantComparison.minTimestamp(earliestToRetain.get().requestedTime(), earliestCommitToNotArchive.get()));
+        }
+        LOG.info(String.format("Setting Earliest Commit to Not Archive to %s, earliestCommitToRetain: %s, total list of savepointed timestamps : %s", earliestCommitToNotArchive.get(),
+            earliestToRetain, Arrays.toString(savepointedTimestamps.toArray())));
+      } else {
+        // no savepoints found.
+        // lets set the value regardless. Would help us differentiate older versions of hudi where this will not be set vs latest version where this will be set to either earliest savepoint
+        // or the earliest commit to retain.
+        if (earliestToRetain.isPresent()) {
+          LOG.info(String.format("Setting Earliest Commit to Not Archive same as Earliest commit to retain to %s", earliestToRetain.get().requestedTime()));
+          earliestCommitToNotArchive = Option.of(earliestToRetain.get().requestedTime());
+        } else {
+          earliestCommitToNotArchive = Option.empty();
+        }
+      }
+    }
+    return earliestCommitToNotArchive;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -516,6 +516,13 @@ public class TestCleanPlanner {
         Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.empty(),
         activeInstantsPartitionsMap2, Collections.emptyList(), threePartitionsInActiveTimeline, true, Collections.emptyMap()));
 
+    // Empty cleaner plan case
+    arguments.add(Arguments.of(true, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
+        activeInstantsPartitionsMap2, Collections.emptyMap(), twoPartitionsInActiveTimeline, false));
+    arguments.add(Arguments.of(false, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
+        activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
     return arguments.stream();
   }
 
@@ -608,6 +615,11 @@ public class TestCleanPlanner {
           Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false)));
       Map<String, String> extraMetadata = new HashMap<>();
       extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointsToTrack.stream().collect(Collectors.joining(",")));
+      /* to be fixed
+      if (earliestCommitToNotArchive.isPresent()) {
+          extraMetadata.put(EARLIEST_COMMIT_TO_NOT_ARCHIVE, earliestCommitToNotArchive.get());
+        }
+       */
       HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(instantTime, 100L, 10, earliestCommitToRetain, lastCompletedTime, partitionMetadata,
           CLEAN_METADATA_VERSION_2, Collections.EMPTY_MAP, extraMetadata.isEmpty() ? null : extraMetadata);
       return Pair.of(cleanMetadata, TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -43,6 +44,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v2.BaseTimelineV2;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
@@ -60,9 +62,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -81,6 +85,7 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_PARSER;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.apache.hudi.common.util.CleanerUtils.CLEAN_METADATA_VERSION_2;
+import static org.apache.hudi.common.util.CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE;
 import static org.apache.hudi.common.util.CleanerUtils.SAVEPOINTED_TIMESTAMPS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -210,6 +215,216 @@ public class TestCleanPlanner {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
     assertEquals(expectedEarliestSavepointInLastClean, ClusteringUtils.getEarliestReplacedSavepointInClean(activeTimeline, config.getCleanerPolicy(), cleanerPlan));
+
+    Collections.sort(expectedPartitions);
+    Collections.sort(partitionsToClean);
+    assertEquals(expectedPartitions, partitionsToClean);
+  }
+
+  static Stream<Arguments> incrCleaningPartitionsNewTestCases() {
+    return keepLatestByHoursOrCommitsArgsIncrCleanPartitionsNew();
+  }
+
+  static Stream<Arguments> keepLatestByHoursOrCommitsArgsIncrCleanPartitionsNew() {
+    String earliestInstant = "20231204194919610";
+    String earliestInstantPlusTwoDays = "20231206194919610";
+    String lastCleanInstant = earliestInstantPlusTwoDays;
+    String earliestInstantMinusThreeDays = "20231201194919610";
+    String earliestInstantMinusFourDays = "20231130194919610";
+    String earliestInstantMinusFiveDays = "20231129194919610";
+    String earliestInstantMinusSixDays = "20231128194919610";
+    String earliestInstantInLastClean = earliestInstantMinusSixDays;
+    String lastCompletedInLastClean = earliestInstantMinusSixDays;
+    String earliestInstantMinusOneWeek = "20231127194919610";
+    String savepoint2 = earliestInstantMinusOneWeek;
+    String earliestInstantMinusOneMonth = "20231104194919610";
+    String savepoint3 = earliestInstantMinusOneMonth;
+
+    List<String> threePartitionsInActiveTimeline = Arrays.asList(PARTITION1, PARTITION2, PARTITION3);
+    Map<String, List<String>> activeInstantsPartitionsMap3 = new HashMap<>();
+    activeInstantsPartitionsMap3.put(earliestInstantMinusThreeDays, threePartitionsInActiveTimeline);
+    activeInstantsPartitionsMap3.put(earliestInstantMinusFourDays, threePartitionsInActiveTimeline);
+    activeInstantsPartitionsMap3.put(earliestInstantMinusFiveDays, threePartitionsInActiveTimeline);
+
+    List<String> twoPartitionsInActiveTimeline = Arrays.asList(PARTITION2, PARTITION3);
+    Map<String, List<String>> activeInstantsPartitionsMap2 = new HashMap<>();
+    activeInstantsPartitionsMap2.put(earliestInstantMinusThreeDays, twoPartitionsInActiveTimeline);
+    activeInstantsPartitionsMap2.put(earliestInstantMinusFourDays, twoPartitionsInActiveTimeline);
+    activeInstantsPartitionsMap2.put(earliestInstantMinusFiveDays, twoPartitionsInActiveTimeline);
+
+    List<Arguments> arguments = new ArrayList<>();
+
+    // Code snippet below generates different test cases which will assert the clean planner output
+    // for these cases. There is no sequential dependency between these cases and they can be considered
+    // independent.
+    // In the test cases below earliestInstant signifies the new value of earliest instant to retain as computed
+    // by CleanPlanner. The test case provides current state of the table and compare the expected values for
+    // earliestCommitToNotArchiveInLastClean and expectedPartitions against computed values for the same by clean planner
+
+    // no savepoints tracked in last clean and no additional savepoints. all partitions in uncleaned instants should be expected
+    // earliest commit to not archive is same as earliestInstant here because there are no savepoints in the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.of(earliestInstant),
+        activeInstantsPartitionsMap3, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
+
+    // a new savepoint is added after last clean. but rest of uncleaned touches all partitions, and so all partitions are expected
+    // earliest commit to not archive is same as savepoint2 since savepoint2 was added to the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1), Collections.emptyMap(), Option.of(savepoint2),
+        activeInstantsPartitionsMap3, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), threePartitionsInActiveTimeline, false));
+
+    // previous clean tracks a savepoint which exists in timeline still. only 2 partitions are touched by uncleaned instants. only 2 partitions are expected
+    // earliest commit to not archive is same as savepoint2 since savepoint2 is part of the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
+        activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
+
+    // savepoint tracked in previous clean was removed(touching partition1). latest uncleaned touched 2 other partitions. But when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(earliestInstant),
+        activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, false));
+
+    // previous savepoint still exists and touches partition1. uncleaned touches only partition2 and partition3. expected partition2 and partition3.
+    // earliest commit to not archive is same as savepoint2 since savepoint2 is part of the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(savepoint2),
+        activeInstantsPartitionsMap2, Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), twoPartitionsInActiveTimeline, false));
+
+    // a new savepoint was added compared to previous clean. all 2 partitions are expected since uncleaned commits touched just 2 partitions.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is the oldest savepoint timestamp in the timeline
+    Map<String, List<String>> latestSavepoints = new HashMap<>();
+    latestSavepoints.put(savepoint3, Collections.singletonList(PARTITION1));
+    latestSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION1)), Option.of(savepoint3),
+        activeInstantsPartitionsMap2, latestSavepoints, twoPartitionsInActiveTimeline, false));
+
+    // 2 savepoints were tracked in previous clean. one of them is removed in latest. When savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is part of the timeline
+    Map<String, List<String>> previousSavepoints = new HashMap<>();
+    previousSavepoints.put(savepoint2, Collections.singletonList(PARTITION1));
+    previousSavepoints.put(savepoint3, Collections.singletonList(PARTITION2));
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        previousSavepoints, Option.of(savepoint3), activeInstantsPartitionsMap2, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+
+    // 2 savepoints were tracked in previous clean. one of them is removed in latest. But a partition part of removed savepoint is already touched by uncleaned commits.
+    // Anyways, when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as savepoint3 since savepoint3 is part of the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        previousSavepoints, Option.of(savepoint3), activeInstantsPartitionsMap3, Collections.singletonMap(savepoint3, Collections.singletonList(PARTITION2)), threePartitionsInActiveTimeline, false));
+
+    // unpartitioned test case. savepoint removed.
+    List<String> unPartitionsInActiveTimeline = Arrays.asList(StringUtils.EMPTY_STRING);
+    Map<String, List<String>> activeInstantsUnPartitionsMap = new HashMap<>();
+    activeInstantsUnPartitionsMap.put(earliestInstantMinusThreeDays, unPartitionsInActiveTimeline);
+
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(false,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(StringUtils.EMPTY_STRING),
+        Collections.singletonMap(savepoint2, Collections.singletonList(StringUtils.EMPTY_STRING)), Option.of(earliestInstant),
+        activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
+
+    // savepoint tracked in previous clean was removed(touching partition1). active instants does not have the instant corresponding to the savepoint.
+    // latest uncleaned touched 2 other partitions. But when savepoint is removed, entire list of partitions are expected.
+    // earliest commit to not archive is same as earliestInstant since there is no savepoint in the timeline
+    activeInstantsPartitionsMap2.remove(earliestInstantMinusOneWeek);
+    arguments.addAll(buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(true,
+        earliestInstant, lastCompletedInLastClean, lastCleanInstant, earliestInstantInLastClean, Collections.singletonList(PARTITION1),
+        Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.of(earliestInstant),
+        activeInstantsPartitionsMap2, Collections.emptyMap(), threePartitionsInActiveTimeline, true));
+
+    // Empty cleaner plan case
+    arguments.add(Arguments.of(true, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
+        activeInstantsPartitionsMap2, Collections.emptyMap(), twoPartitionsInActiveTimeline, false));
+    arguments.add(Arguments.of(false, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
+        activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
+    return arguments.stream();
+  }
+
+  /**
+   * The function generates test arguments for two cases. One where cleaning policy
+   * is set to KEEP_LATEST_BY_HOURS and the other where cleaning policy is set to
+   * KEEP_LATEST_COMMITS. Rest of the arguments are same.
+   */
+  private static List<Arguments> buildArgumentsForCleanByHoursAndCommitsIncrCleanPartitionsCasesNew(boolean isPartitioned, String earliestInstant,
+                                                                                                 String latestCompletedInLastClean,
+                                                                                                 String lastKnownCleanInstantTime,
+                                                                                                 String earliestInstantInLastClean,
+                                                                                                 List<String> partitionsInLastClean,
+                                                                                                 Map<String, List<String>> savepointsTrackedInLastClean,
+                                                                                                 Option<String> expectedEarliestCommitToNotArchiveInLastClean,
+                                                                                                 Map<String, List<String>> activeInstantsToPartitionsMap,
+                                                                                                 Map<String, List<String>> savepoints,
+                                                                                                 List<String> expectedPartitions,
+                                                                                                 boolean areCommitsForSavepointsRemoved) {
+    return Arrays.asList(Arguments.of(isPartitioned, getCleanByHoursConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, expectedEarliestCommitToNotArchiveInLastClean,
+            activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved),
+        Arguments.of(isPartitioned, getCleanByCommitsConfig(), earliestInstant, latestCompletedInLastClean, lastKnownCleanInstantTime,
+            earliestInstantInLastClean, partitionsInLastClean, savepointsTrackedInLastClean, expectedEarliestCommitToNotArchiveInLastClean,
+            activeInstantsToPartitionsMap, savepoints, expectedPartitions, areCommitsForSavepointsRemoved));
+  }
+
+  /**
+   * The test asserts clean planner results for APIs org.apache.hudi.table.action.clean.CleanPlanner#getEarliestCommitToNotArchive()
+   * and org.apache.hudi.table.action.clean.CleanPlanner#getPartitionPathsToClean(org.apache.hudi.common.util.Option)
+   * given the other input arguments for clean metadata. The idea is the two API results should match the expected results.
+   */
+  @ParameterizedTest
+  @MethodSource("incrCleaningPartitionsNewTestCases")
+  void testPartitionsForIncrCleaningNew(boolean isPartitioned, HoodieWriteConfig config, String earliestInstant,
+                                     String lastCompletedTimeInLastClean, String lastCleanInstant, String earliestInstantsInLastClean, List<String> partitionsInLastClean,
+                                     Map<String, List<String>> savepointsTrackedInLastClean, Option<String> expectedEarliestCommitToNotArchiveInLastClean,
+                                     Map<String, List<String>> activeInstantsPartitions, Map<String, List<String>> savepoints, List<String> expectedPartitions,
+                                     boolean areCommitsForSavepointsRemoved) throws IOException, IllegalAccessException {
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
+    when(mockHoodieTable.getActiveTimeline()).thenReturn(activeTimeline);
+    // setup savepoint mocks
+    Set<String> savepointTimestamps = savepoints.keySet();
+    when(mockHoodieTable.getSavepointTimestamps()).thenReturn(savepointTimestamps);
+    if (!savepoints.isEmpty()) {
+      for (Map.Entry<String, List<String>> entry : savepoints.entrySet()) {
+        Pair<HoodieSavepointMetadata, Option<byte[]>> savepointMetadataOptionPair = getSavepointMetadata(entry.getValue());
+        HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.SAVEPOINT_ACTION, entry.getKey());
+        when(activeTimeline.getInstantDetails(instant)).thenReturn(savepointMetadataOptionPair.getRight());
+      }
+    }
+
+    // prepare last Clean Metadata
+    Pair<HoodieCleanMetadata, Option<byte[]>> cleanMetadata =
+        getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean,
+            savepointsTrackedInLastClean.keySet(), expectedEarliestCommitToNotArchiveInLastClean);
+    mockLastCleanCommitNew(mockHoodieTable, lastCleanInstant, earliestInstantsInLastClean, activeTimeline, cleanMetadata);
+    mockFewActiveInstantsNew(mockHoodieTable, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved);
+
+    // mock getAllPartitions
+    HoodieTableMetadata hoodieTableMetadata = mock(HoodieTableMetadata.class);
+    when(mockHoodieTable.getMetadataTable()).thenReturn(hoodieTableMetadata);
+    when(hoodieTableMetadata.getAllPartitionPaths()).thenReturn(isPartitioned ? Arrays.asList(PARTITION1, PARTITION2, PARTITION3) : Collections.singletonList(StringUtils.EMPTY_STRING));
+
+    // setup clean planner so that it uses the input earliestCommitToRetain for API
+    // org.apache.hudi.table.action.clean.CleanPlanner.getEarliestCommitToRetain
+    CleanPlanner<?, ?, ?, ?> cleanPlanner = new CleanPlanner<>(context, mockHoodieTable, config);
+    Field field = ReflectionUtils
+        .findFields(CleanPlanner.class, f -> f.getName().equals("earliestCommitToRetain"),
+            ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+        .get(0);
+    field.setAccessible(true);
+    HoodieInstant earliestCommitToRetain = new HoodieInstant(HoodieInstant.State.COMPLETED, "COMMIT", earliestInstant, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    field.set(cleanPlanner, Option.of(earliestCommitToRetain));
+
+    // Trigger clean and validate partitions to clean and earliest commit to not archive.
+    List<String> partitionsToClean = cleanPlanner.getPartitionPathsToClean(Option.of(earliestCommitToRetain));
+    assertEquals(expectedEarliestCommitToNotArchiveInLastClean, cleanPlanner.getEarliestCommitToNotArchive());
 
     Collections.sort(expectedPartitions);
     Collections.sort(partitionsToClean);
@@ -516,13 +731,15 @@ public class TestCleanPlanner {
         Collections.singletonMap(savepoint2, Collections.singletonList(PARTITION1)), Option.empty(),
         activeInstantsPartitionsMap2, Collections.emptyList(), threePartitionsInActiveTimeline, true, Collections.emptyMap()));
 
+
     // Empty cleaner plan case
+    activeInstantsUnPartitionsMap.put(earliestInstantMinusThreeDays, unPartitionsInActiveTimeline);
     arguments.add(Arguments.of(true, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
-        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
-        activeInstantsPartitionsMap2, Collections.emptyMap(), twoPartitionsInActiveTimeline, false));
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.empty(),
+        activeInstantsPartitionsMap2, Collections.emptyList(), twoPartitionsInActiveTimeline, false, Collections.emptyMap()));
     arguments.add(Arguments.of(false, getCleanByHoursConfig(), earliestInstant, lastCompletedInLastClean, lastCleanInstant,
-        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.of(earliestInstant),
-        activeInstantsUnPartitionsMap, Collections.emptyMap(), unPartitionsInActiveTimeline, false));
+        earliestInstantInLastClean, Collections.emptyList(), Collections.emptyMap(), Option.empty(),
+        activeInstantsUnPartitionsMap, Collections.emptyList(), unPartitionsInActiveTimeline, false, Collections.emptyMap()));
     return arguments.stream();
   }
 
@@ -615,11 +832,9 @@ public class TestCleanPlanner {
           Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false)));
       Map<String, String> extraMetadata = new HashMap<>();
       extraMetadata.put(SAVEPOINTED_TIMESTAMPS, savepointsToTrack.stream().collect(Collectors.joining(",")));
-      /* to be fixed
       if (earliestCommitToNotArchive.isPresent()) {
-          extraMetadata.put(EARLIEST_COMMIT_TO_NOT_ARCHIVE, earliestCommitToNotArchive.get());
-        }
-       */
+        extraMetadata.put(EARLIEST_COMMIT_TO_NOT_ARCHIVE, earliestCommitToNotArchive.get());
+      }
       HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(instantTime, 100L, 10, earliestCommitToRetain, lastCompletedTime, partitionMetadata,
           CLEAN_METADATA_VERSION_2, Collections.EMPTY_MAP, extraMetadata.isEmpty() ? null : extraMetadata);
       return Pair.of(cleanMetadata, TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
@@ -638,6 +853,27 @@ public class TestCleanPlanner {
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
+  }
+
+  private static void mockLastCleanCommitNew(HoodieTable hoodieTable, String timestamp, String earliestCommitToRetain, HoodieActiveTimeline activeTimeline,
+                                             Pair<HoodieCleanMetadata, Option<byte[]>> cleanMetadata)
+      throws IOException {
+    HoodieTimeline cleanTimeline = mock(HoodieTimeline.class);
+    when(activeTimeline.getCleanerTimeline()).thenReturn(cleanTimeline);
+    when(hoodieTable.getCleanTimeline()).thenReturn(cleanTimeline);
+    HoodieTimeline completedCleanTimeline = mock(HoodieTimeline.class);
+    when(cleanTimeline.filterCompletedInstants()).thenReturn(completedCleanTimeline);
+    HoodieInstant latestCleanInstant = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.CLEAN_ACTION, timestamp, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    when(completedCleanTimeline.lastInstant()).thenReturn(Option.of(latestCleanInstant));
+    when(activeTimeline.isEmpty(latestCleanInstant)).thenReturn(false);
+    when(activeTimeline.getInstantDetails(latestCleanInstant)).thenReturn(cleanMetadata.getValue());
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    when(activeTimeline.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.isBeforeTimelineStarts(earliestCommitToRetain)).thenReturn(false);
+
+    when(hoodieTable.isPartitioned()).thenReturn(true);
+    when(hoodieTable.isMetadataTable()).thenReturn(false);
   }
 
   private static HoodieCleanerPlan mockLastCleanCommit(HoodieTable hoodieTable, String timestamp, String earliestCommitToRetain, HoodieActiveTimeline activeTimeline,
@@ -665,6 +901,47 @@ public class TestCleanPlanner {
     when(hoodieTable.isPartitioned()).thenReturn(true);
     when(hoodieTable.isMetadataTable()).thenReturn(false);
     return cleanerPlan;
+  }
+
+  private static void mockFewActiveInstantsNew(HoodieTable hoodieTable, Map<String, List<String>> activeInstantsToPartitions,
+                                            Map<String, List<String>> savepointedCommitsToAdd, boolean areCommitsForSavepointsRemoved) {
+    HoodieTimeline commitsTimeline = new BaseTimelineV2();
+    when(hoodieTable.getMetaClient().getCommitMetadataSerDe()).thenReturn(COMMIT_METADATA_SER_DE);
+    List<HoodieInstant> instants = new ArrayList<>();
+    Map<String, List<String>> instantstoProcess = new HashMap<>();
+    instantstoProcess.putAll(activeInstantsToPartitions);
+    if (!areCommitsForSavepointsRemoved) {
+      instantstoProcess.putAll(savepointedCommitsToAdd);
+    }
+    instantstoProcess.forEach((k, v) -> {
+      boolean useReplaceInstant = instants.size() % 2 == 0;
+      HoodieInstant hoodieInstant = new HoodieInstant(HoodieInstant.State.COMPLETED, useReplaceInstant ? HoodieTimeline.REPLACE_COMMIT_ACTION : HoodieTimeline.COMMIT_ACTION, k,
+          InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+      instants.add(hoodieInstant);
+      try {
+        if (useReplaceInstant) {
+          HoodieReplaceCommitMetadata replaceCommitMetadata = new HoodieReplaceCommitMetadata();
+          replaceCommitMetadata.addReplaceFileId(v.get(0), UUID.randomUUID().toString());
+          v.stream().skip(1).forEach(partition -> replaceCommitMetadata.getPartitionToWriteStats().put(partition, Collections.emptyList()));
+          when(hoodieTable.getActiveTimeline().getInstantDetails(hoodieInstant)).thenReturn(
+              TimelineMetadataUtils.serializeCommitMetadata(COMMIT_METADATA_SER_DE, replaceCommitMetadata)
+          );
+        } else {
+          HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+          v.forEach(partition -> commitMetadata.getPartitionToWriteStats().put(partition, Collections.emptyList()));
+          when(hoodieTable.getActiveTimeline().getInstantDetails(hoodieInstant)).thenReturn(
+              TimelineMetadataUtils.serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata)
+          );
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Should not have failed", e);
+      }
+    });
+
+    commitsTimeline.setInstants(instants);
+    when(hoodieTable.getCompletedCommitsTimeline()).thenReturn(commitsTimeline);
+    when(hoodieTable.isPartitioned()).thenReturn(true);
+    when(hoodieTable.isMetadataTable()).thenReturn(false);
   }
 
   private static void mockFewActiveInstants(HoodieTable hoodieTable, HoodieActiveTimeline activeTimeline, Map<String, List<String>> activeInstantsToPartitions,

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -415,6 +415,54 @@ public class TestCleaner extends HoodieCleanerTestBase {
     }
   }
 
+  @Test
+  void testEmptyClean() throws IOException {
+    // validate that an empty cleaner plan does not throw any errors at execution time
+    HoodieWriteConfig writeConfig = getConfigBuilder().withPath(basePath)
+        .withFileSystemViewConfig(new FileSystemViewStorageConfig.Builder()
+            .withEnableBackupForRemoteFileSystemView(false)
+            .build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withAutoClean(false)
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS)
+            .retainCommits(1)
+            .build())
+        .withEmbeddedTimelineServerEnabled(false).build();
+    // datagen for non-partitioned table
+    initTestDataGenerator(new String[] {NO_PARTITION_PATH});
+    // init non-partitioned table
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(hadoopConf, basePath, HoodieTableType.COPY_ON_WRITE, HoodieFileFormat.PARQUET,
+        true, "org.apache.hudi.keygen.NonpartitionedKeyGenerator", true);
+
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient(context, writeConfig)) {
+      String instantTime = HoodieActiveTimeline.createNewInstantTime();
+      List<HoodieRecord> records = dataGen.generateInserts(instantTime, 1);
+      client.startCommitWithTime(instantTime);
+      client.insert(jsc.parallelize(records, 1), instantTime).collect();
+
+      instantTime = HoodieActiveTimeline.createNewInstantTime();
+      HoodieTable table = HoodieSparkTable.create(writeConfig, context);
+
+      HoodieActiveTimeline timeline = metaClient.reloadActiveTimeline();
+      HoodieInstant hoodieInstant = timeline.firstInstant().get();
+      HoodieCleanerPlan cleanerPlan = HoodieCleanerPlan.newBuilder()
+          .setPolicy(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS.name())
+          .setVersion(CleanPlanner.LATEST_CLEAN_PLAN_VERSION)
+          .setEarliestInstantToRetain(new HoodieActionInstant(hoodieInstant.getTimestamp(), hoodieInstant.getAction(), hoodieInstant.getState().name()))
+          .setLastCompletedCommitTimestamp(timeline.lastInstant().get().getTimestamp())
+          .setFilePathsToBeDeletedPerPartition(Collections.emptyMap())
+          .build();
+      final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, instantTime);
+      table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+
+      table.getMetaClient().reloadActiveTimeline();
+      // clean
+      HoodieCleanMetadata cleanMetadata = table.clean(context, instantTime);
+      // check the cleaned files are empty
+      assertTrue(cleanMetadata.getPartitionMetadata().isEmpty());
+    }
+  }
+
   /**
    * Tests no more than 1 clean is scheduled if hoodie.clean.multiple.enabled config is set to false.
    */

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -59,9 +59,9 @@ import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataMigra
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanMigrator;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV1MigrationHandler;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
-import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CleanerUtils;
@@ -107,6 +107,7 @@ import scala.Tuple3;
 
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.NO_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
@@ -383,7 +384,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
             .build())
         .withEmbeddedTimelineServerEnabled(false).build();
     // datagen for non-partitioned table
-    initTestDataGenerator(new String[] {HoodieTestDataGenerator.NO_PARTITION_PATH});
+    initTestDataGenerator(new String[] {NO_PARTITION_PATH});
     // init non-partitioned table
     HoodieTestUtils.init(storageConf, basePath, HoodieTableType.COPY_ON_WRITE, HoodieFileFormat.PARQUET,
         true, "org.apache.hudi.keygen.NonpartitionedKeyGenerator", true);
@@ -401,17 +402,17 @@ public class TestCleaner extends HoodieCleanerTestBase {
       HoodieTable table = HoodieSparkTable.create(writeConfig, context);
       Option<HoodieCleanerPlan> cleanPlan = table.scheduleCleaning(context, instantTime, Option.empty());
       assertEquals(cleanPlan.get().getPartitionsToBeDeleted().size(), 0);
-      assertEquals(cleanPlan.get().getFilePathsToBeDeletedPerPartition().get(HoodieTestDataGenerator.NO_PARTITION_PATH).size(), 1);
+      assertEquals(cleanPlan.get().getFilePathsToBeDeletedPerPartition().get(NO_PARTITION_PATH).size(), 1);
       table.getMetaClient().reloadActiveTimeline();
-      String filePathToClean = cleanPlan.get().getFilePathsToBeDeletedPerPartition().get(HoodieTestDataGenerator.NO_PARTITION_PATH).get(0).getFilePath();
+      String filePathToClean = cleanPlan.get().getFilePathsToBeDeletedPerPartition().get(NO_PARTITION_PATH).get(0).getFilePath();
       // clean
       HoodieCleanMetadata cleanMetadata = table.clean(context, instantTime);
       // check the cleaned file
-      assertEquals(cleanMetadata.getPartitionMetadata().get(HoodieTestDataGenerator.NO_PARTITION_PATH).getSuccessDeleteFiles().size(), 1);
-      assertTrue(filePathToClean.contains(cleanMetadata.getPartitionMetadata().get(HoodieTestDataGenerator.NO_PARTITION_PATH).getSuccessDeleteFiles().get(0)));
+      assertEquals(cleanMetadata.getPartitionMetadata().get(NO_PARTITION_PATH).getSuccessDeleteFiles().size(), 1);
+      assertTrue(filePathToClean.contains(cleanMetadata.getPartitionMetadata().get(NO_PARTITION_PATH).getSuccessDeleteFiles().get(0)));
       // ensure table is not fully cleaned and has a file group
       assertTrue(FSUtils.isTableExists(basePath, storage));
-      assertTrue(table.getFileSystemView().getAllFileGroups(HoodieTestDataGenerator.NO_PARTITION_PATH).findAny().isPresent());
+      assertTrue(table.getFileSystemView().getAllFileGroups(NO_PARTITION_PATH).findAny().isPresent());
     }
   }
 
@@ -431,16 +432,16 @@ public class TestCleaner extends HoodieCleanerTestBase {
     // datagen for non-partitioned table
     initTestDataGenerator(new String[] {NO_PARTITION_PATH});
     // init non-partitioned table
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(hadoopConf, basePath, HoodieTableType.COPY_ON_WRITE, HoodieFileFormat.PARQUET,
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(context.getStorageConf(), basePath, HoodieTableType.COPY_ON_WRITE, HoodieFileFormat.PARQUET,
         true, "org.apache.hudi.keygen.NonpartitionedKeyGenerator", true);
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context, writeConfig)) {
-      String instantTime = HoodieActiveTimeline.createNewInstantTime();
+      String instantTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(instantTime, 1);
       client.startCommitWithTime(instantTime);
       client.insert(jsc.parallelize(records, 1), instantTime).collect();
 
-      instantTime = HoodieActiveTimeline.createNewInstantTime();
+      instantTime = client.createNewInstantTime();
       HoodieTable table = HoodieSparkTable.create(writeConfig, context);
 
       HoodieActiveTimeline timeline = metaClient.reloadActiveTimeline();
@@ -448,11 +449,12 @@ public class TestCleaner extends HoodieCleanerTestBase {
       HoodieCleanerPlan cleanerPlan = HoodieCleanerPlan.newBuilder()
           .setPolicy(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS.name())
           .setVersion(CleanPlanner.LATEST_CLEAN_PLAN_VERSION)
-          .setEarliestInstantToRetain(new HoodieActionInstant(hoodieInstant.getTimestamp(), hoodieInstant.getAction(), hoodieInstant.getState().name()))
-          .setLastCompletedCommitTimestamp(timeline.lastInstant().get().getTimestamp())
+          .setEarliestInstantToRetain(new HoodieActionInstant(hoodieInstant.requestedTime(), hoodieInstant.getAction(), hoodieInstant.getState().name()))
+          .setLastCompletedCommitTimestamp(timeline.lastInstant().get().requestedTime())
           .setFilePathsToBeDeletedPerPartition(Collections.emptyMap())
           .build();
-      final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, instantTime);
+      final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, instantTime,
+          InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
       table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
 
       table.getMetaClient().reloadActiveTimeline();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -30,18 +30,20 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.table.action.clean.CleanPlanner;
 import org.apache.hudi.testutils.HoodieCleanerTestBase;
 
 import org.junit.jupiter.api.Test;
@@ -747,7 +749,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
     boolean enableIncrementalClean = true;
     boolean enableBootstrapSourceClean = false;
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).enable(false).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withIncrementalCleaningMode(enableIncrementalClean)
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER)
@@ -765,7 +767,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       Instant instant = Instant.now();
       ZonedDateTime commitDateTime = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
       int minutesForFirstCommit = 180;
-      String firstCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFirstCommit).toInstant()));
+      String firstCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFirstCommit).toInstant()));
 
       commitToTestTable(testTable, firstCommitTs, p0, file1P0C0);
       testTable = tearDownTestTableAndReinit(testTable, config);
@@ -773,7 +775,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       // make next commit, with 1 insert & 1 update per partition
       String file2P0C1 = UUID.randomUUID().toString();
       int minutesForSecondCommit = 150;
-      String secondCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForSecondCommit).toInstant()));
+      String secondCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(commitDateTime.minusMinutes(minutesForSecondCommit).toInstant()));
       testTable = tearDownTestTableAndReinit(testTable, config);
 
       commitToTestTable(testTable, secondCommitTs, p0, file2P0C1);
@@ -782,7 +784,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
 
       // make next commit, with 1 insert per partition
       int minutesForThirdCommit = 90;
-      String thirdCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForThirdCommit).toInstant()));
+      String thirdCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(commitDateTime.minusMinutes(minutesForThirdCommit).toInstant()));
       String file3P0C2 = UUID.randomUUID().toString();
 
       testTable = tearDownTestTableAndReinit(testTable, config);
@@ -792,14 +794,14 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       // first empty clean can be generated since earliest instant to retain will be the first commit (always keep last two instants at a minimum)
-      String firstCleanInstant = HoodieActiveTimeline.createNewInstantTime();
+      String firstCleanInstant = metaClient.createNewInstantTime();
       List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config, firstCleanInstant);
       assertEquals(0, hoodieCleanStatsThree.size(), "Must not scan any partitions and clean any files");
       assertEquals(1, metaClient.reloadActiveTimeline().getCleanerTimeline().filterCompletedInstants().countInstants());
 
       String file4P0C1 = UUID.randomUUID().toString();
       int minutesForFourthCommit = 10;
-      String fourthCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFourthCommit).toInstant()));
+      String fourthCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFourthCommit).toInstant()));
       testTable = tearDownTestTableAndReinit(testTable, config);
 
       commitToTestTable(testTable, fourthCommitTs, p0, file4P0C1);
@@ -808,9 +810,9 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
       // add a savepoint
       getHoodieWriteClient(config).savepoint(fourthCommitTs, "user", "comment");
 
-      Date firstCleanDate = HoodieActiveTimeline.parseDateFromInstantTime(firstCleanInstant);
+      Date firstCleanDate = HoodieInstantTimeGenerator.parseDateFromInstantTime(firstCleanInstant);
       int minutesBetweenCleans = secondCommitAfterThreshold ? 70 : 30;
-      String secondCleanInstant = HoodieActiveTimeline.formatDate(Date.from(firstCleanDate.toInstant().plus(minutesBetweenCleans, ChronoUnit.MINUTES)));
+      String secondCleanInstant = HoodieInstantTimeGenerator.formatDate(Date.from(firstCleanDate.toInstant().plus(minutesBetweenCleans, ChronoUnit.MINUTES)));
       List<HoodieCleanStat> hoodieCleanStatsFour = runCleaner(config, secondCleanInstant);
       HoodieTimeline finalCompletedCleanInstants = metaClient.reloadActiveTimeline().getCleanerTimeline().filterCompletedInstants();
       if (secondCommitAfterThreshold) {
@@ -820,16 +822,16 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
         // Ensure that extra metadata is properly set for empty clean commits
         HoodieCleanMetadata secondCleanMetadata = CleanerUtils.getCleanerMetadata(HoodieTableMetaClient.reload(metaClient), finalCompletedCleanInstants.lastInstant().get());
         // new clean should have the savepoint created
-        assertEquals(fourthCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanPlanner.SAVEPOINTED_TIMESTAMPS));
-        assertEquals(thirdCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
+        assertEquals(fourthCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanerUtils.SAVEPOINTED_TIMESTAMPS));
+        assertEquals(thirdCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
       } else {
         // no cleaner commit should be added because the time since last clean threshold has not been met
         assertEquals(1, finalCompletedCleanInstants.countInstants());
         // Ensure that extra metadata is properly set for empty clean commits
         HoodieCleanMetadata firstCleanMetadata = CleanerUtils.getCleanerMetadata(HoodieTableMetaClient.reload(metaClient), finalCompletedCleanInstants.lastInstant().get());
-        assertEquals(thirdCommitTs, firstCleanMetadata.getExtraMetadata().get(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
-        // first clean commit happened before the savepoint so this field is expected to not be present in the map
-        assertFalse(firstCleanMetadata.getExtraMetadata().containsKey(CleanPlanner.SAVEPOINTED_TIMESTAMPS));
+        assertEquals(thirdCommitTs, firstCleanMetadata.getExtraMetadata().get(CleanerUtils.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
+        // first clean commit happened before the savepoint so this field is expected to not be present in the map or empty string.
+        assertTrue(StringUtils.isNullOrEmpty(firstCleanMetadata.getExtraMetadata().get(CleanerUtils.SAVEPOINTED_TIMESTAMPS)));
       }
     } finally {
       testTable.close();
@@ -841,7 +843,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
     testTable.withBaseFilesInPartition(partition, fileId);
     HoodieCommitMetadata commitMeta = generateCommitMetadata(commitTimeTs, Collections.singletonMap(partition, Collections.singletonList(fileId)));
     metaClient.getActiveTimeline().saveAsComplete(
-        new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTimeTs),
+        new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTimeTs, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
         Option.of(commitMeta.toJsonString().getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.functional;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieFileStatus;
 import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -34,23 +35,28 @@ import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.action.clean.CleanPlanner;
 import org.apache.hudi.testutils.HoodieCleanerTestBase;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -58,6 +64,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
@@ -732,5 +739,109 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
     } finally {
       testTable.close();
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testEmptyCleansAddedAfterThreshold(boolean secondCommitAfterThreshold) throws Exception {
+    boolean enableIncrementalClean = true;
+    boolean enableBootstrapSourceClean = false;
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).enable(false).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withIncrementalCleaningMode(enableIncrementalClean)
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER)
+            .withCleanBootstrapBaseFileEnabled(enableBootstrapSourceClean)
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS).cleanerNumHoursRetained(2)
+            .build())
+        .withMaxDurationToCreateEmptyClean(TimeUnit.MINUTES.toMillis(60))
+        .build();
+
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    try  {
+      String p0 = "2020/01/01";
+
+      String file1P0C0 = UUID.randomUUID().toString();
+      Instant instant = Instant.now();
+      ZonedDateTime commitDateTime = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+      int minutesForFirstCommit = 180;
+      String firstCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFirstCommit).toInstant()));
+
+      commitToTestTable(testTable, firstCommitTs, p0, file1P0C0);
+      testTable = tearDownTestTableAndReinit(testTable, config);
+
+      // make next commit, with 1 insert & 1 update per partition
+      String file2P0C1 = UUID.randomUUID().toString();
+      int minutesForSecondCommit = 150;
+      String secondCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForSecondCommit).toInstant()));
+      testTable = tearDownTestTableAndReinit(testTable, config);
+
+      commitToTestTable(testTable, secondCommitTs, p0, file2P0C1);
+      testTable = tearDownTestTableAndReinit(testTable, config);
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+
+      // make next commit, with 1 insert per partition
+      int minutesForThirdCommit = 90;
+      String thirdCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForThirdCommit).toInstant()));
+      String file3P0C2 = UUID.randomUUID().toString();
+
+      testTable = tearDownTestTableAndReinit(testTable, config);
+
+      commitToTestTable(testTable, thirdCommitTs, p0, file3P0C2);
+      testTable = tearDownTestTableAndReinit(testTable, config);
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+
+      // first empty clean can be generated since earliest instant to retain will be the first commit (always keep last two instants at a minimum)
+      String firstCleanInstant = HoodieActiveTimeline.createNewInstantTime();
+      List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config, firstCleanInstant);
+      assertEquals(0, hoodieCleanStatsThree.size(), "Must not scan any partitions and clean any files");
+      assertEquals(1, metaClient.reloadActiveTimeline().getCleanerTimeline().filterCompletedInstants().countInstants());
+
+      String file4P0C1 = UUID.randomUUID().toString();
+      int minutesForFourthCommit = 10;
+      String fourthCommitTs = HoodieActiveTimeline.formatDate(Date.from(commitDateTime.minusMinutes(minutesForFourthCommit).toInstant()));
+      testTable = tearDownTestTableAndReinit(testTable, config);
+
+      commitToTestTable(testTable, fourthCommitTs, p0, file4P0C1);
+      testTable = tearDownTestTableAndReinit(testTable, config);
+
+      // add a savepoint
+      getHoodieWriteClient(config).savepoint(fourthCommitTs, "user", "comment");
+
+      Date firstCleanDate = HoodieActiveTimeline.parseDateFromInstantTime(firstCleanInstant);
+      int minutesBetweenCleans = secondCommitAfterThreshold ? 70 : 30;
+      String secondCleanInstant = HoodieActiveTimeline.formatDate(Date.from(firstCleanDate.toInstant().plus(minutesBetweenCleans, ChronoUnit.MINUTES)));
+      List<HoodieCleanStat> hoodieCleanStatsFour = runCleaner(config, secondCleanInstant);
+      HoodieTimeline finalCompletedCleanInstants = metaClient.reloadActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+      if (secondCommitAfterThreshold) {
+        // second empty clean is added
+        assertEquals(0, hoodieCleanStatsFour.size(), "Must not scan any partitions and clean any files");
+        assertEquals(2, finalCompletedCleanInstants.countInstants());
+        // Ensure that extra metadata is properly set for empty clean commits
+        HoodieCleanMetadata secondCleanMetadata = CleanerUtils.getCleanerMetadata(HoodieTableMetaClient.reload(metaClient), finalCompletedCleanInstants.lastInstant().get());
+        // new clean should have the savepoint created
+        assertEquals(fourthCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanPlanner.SAVEPOINTED_TIMESTAMPS));
+        assertEquals(thirdCommitTs, secondCleanMetadata.getExtraMetadata().get(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
+      } else {
+        // no cleaner commit should be added because the time since last clean threshold has not been met
+        assertEquals(1, finalCompletedCleanInstants.countInstants());
+        // Ensure that extra metadata is properly set for empty clean commits
+        HoodieCleanMetadata firstCleanMetadata = CleanerUtils.getCleanerMetadata(HoodieTableMetaClient.reload(metaClient), finalCompletedCleanInstants.lastInstant().get());
+        assertEquals(thirdCommitTs, firstCleanMetadata.getExtraMetadata().get(CleanPlanner.EARLIEST_COMMIT_TO_NOT_ARCHIVE));
+        // first clean commit happened before the savepoint so this field is expected to not be present in the map
+        assertFalse(firstCleanMetadata.getExtraMetadata().containsKey(CleanPlanner.SAVEPOINTED_TIMESTAMPS));
+      }
+    } finally {
+      testTable.close();
+    }
+  }
+
+  private void commitToTestTable(HoodieTestTable testTable, String commitTimeTs, String partition, String fileId) throws Exception {
+    testTable.addInflightCommit(commitTimeTs);
+    testTable.withBaseFilesInPartition(partition, fileId);
+    HoodieCommitMetadata commitMeta = generateCommitMetadata(commitTimeTs, Collections.singletonMap(partition, Collections.singletonList(fileId)));
+    metaClient.getActiveTimeline().saveAsComplete(
+        new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTimeTs),
+        Option.of(commitMeta.toJsonString().getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
@@ -101,16 +101,25 @@ public class HoodieCleanerTestBase extends HoodieClientTestBase {
     return runCleaner(config, simulateRetryFailure, simulateMetadataFailure, 1, false);
   }
 
+  protected List<HoodieCleanStat> runCleaner(
+      HoodieWriteConfig config, boolean simulateRetryFailure, boolean simulateMetadataFailure,
+      Integer firstCommitSequence, boolean needInstantInHudiFormat) throws IOException {
+    String cleanInstantTs = needInstantInHudiFormat ? makeNewCommitTime(firstCommitSequence, "%014d") : makeNewCommitTime(firstCommitSequence, "%09d");
+    return runCleaner(config, simulateRetryFailure, simulateMetadataFailure, cleanInstantTs);
+  }
+
+  protected List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, String cleanInstantTs) throws IOException {
+    return runCleaner(config, false, false, cleanInstantTs);
+  }
+
   /**
    * Helper to run cleaner and collect Clean Stats.
    *
    * @param config HoodieWriteConfig
    */
-  protected List<HoodieCleanStat> runCleaner(
-      HoodieWriteConfig config, boolean simulateRetryFailure, boolean simulateMetadataFailure,
-      Integer firstCommitSequence, boolean needInstantInHudiFormat) throws IOException {
+  protected List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, boolean simulateRetryFailure,
+                                             boolean simulateMetadataFailure, String cleanInstantTs) throws IOException {
     SparkRDDWriteClient<?> writeClient = getHoodieWriteClient(config);
-    String cleanInstantTs = needInstantInHudiFormat ? makeNewCommitTime(firstCommitSequence, "%014d") : makeNewCommitTime(firstCommitSequence, "%09d");
     HoodieCleanMetadata cleanMetadata1 = writeClient.clean(cleanInstantTs);
 
     if (null == cleanMetadata1) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -60,6 +60,7 @@ public class CleanerUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(CleanerUtils.class);
   public static final String SAVEPOINTED_TIMESTAMPS = "savepointed_timestamps";
+  public static final String EARLIEST_COMMIT_TO_NOT_ARCHIVE = "earliest_commit_to_not_archive";
   public static final Integer CLEAN_METADATA_VERSION_1 = CleanMetadataV1MigrationHandler.VERSION;
   public static final Integer CLEAN_METADATA_VERSION_2 = CleanMetadataV2MigrationHandler.VERSION;
   public static final Integer LATEST_CLEAN_METADATA_VERSION = CLEAN_METADATA_VERSION_2;


### PR DESCRIPTION
### Change Logs

- Add configuration for periodically creating empty clean commits when there are no files to clean.
- Added a new metadata entry to Clean plan keyed as "EarliestCommitToNotArchive". This will be leveraged by archival to ensure it will not proceed beyond the configured value for EarliestCommitToNotArchive. On rare scenarios, when cleaner and archival are executed separately, where cleaner is disabled and archival is executed, chances that archival could result in duplicates by archiving instants which are not yet cleaned by the cleaner. So, fixing that by adding this additional metadata. 

### Impact

Fixes an issue in append only tables where the archival does not kick in since the archival is now dependent on information in the cleaner metadata. w/o empty cleans, active timeline for append only tables kept on growing forever. 

### Risk level (write none, low medium or high below)

low 

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
