### PR TITLE
[HUDI-7986] Fix Duplicate handling behavior when Precombine value is not set 

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -1485,6 +1485,55 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     assertEquals(inputRows, readRows)
   }
 
+  @Test
+  def testEmptyPrecombine() : Unit  = {
+      val readType = HoodieRecordType.AVRO
+      val writeType = HoodieRecordType.AVRO
+      val (_, readOpts) = getWriterReaderOpts(readType)
+      var (writeOpts, _) = getWriterReaderOpts(writeType)
+      writeOpts = writeOpts ++ Map(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key()
+        -> classOf[OverwriteWithLatestAvroPayload].getName.toString) ++
+        Map(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key() -> "") ++
+        Map(DataSourceWriteOptions.TABLE_TYPE.key() -> "MERGE_ON_READ")
+
+      val records1 = recordsToStrings(dataGen.generateInserts("001", 100)).asScala.toSeq
+      val inputDF1 = spark.read.json(spark.sparkContext.parallelize(records1, 2))
+      inputDF1.write.format("org.apache.hudi")
+        .options(writeOpts)
+        .option("hoodie.compact.inline", "false") // else fails due to compaction & deltacommit instant times being same
+        .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+        .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+        .mode(SaveMode.Overwrite)
+        .save(basePath)
+      assertTrue(HoodieDataSourceHelpers.hasNewCommits(storage, basePath, "000"))
+      val hudiSnapshotDF1 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+        .load(basePath)
+      assertEquals(100, hudiSnapshotDF1.count()) // still 100, since we only updated
+
+      // Second Operation:
+      // SNAPSHOT view should read the log files only with the latest commit time.
+      val records2 = recordsToStrings(dataGen.generateUniqueUpdates("002", 100)).asScala.toSeq
+      val inputDF2: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(records2, 2))
+      inputDF2.write.format("org.apache.hudi")
+        .options(writeOpts)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      val hudiSnapshotDF2 = spark.read.format("org.apache.hudi")
+        .options(readOpts)
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+        .load(basePath)
+      assertEquals(100, hudiSnapshotDF2.count()) // still 100, since we only updated
+      val commit1Time = hudiSnapshotDF1.select("_hoodie_commit_time").head().get(0).toString
+      val commit2Time = hudiSnapshotDF2.select("_hoodie_commit_time").head().get(0).toString
+      assertEquals(hudiSnapshotDF2.select("_hoodie_commit_time").distinct().count(), 1)
+      assertTrue(commit2Time > commit1Time)
+      assertEquals(100, hudiSnapshotDF2.join(hudiSnapshotDF1, Seq("_hoodie_record_key"), "left").count())
+      val hudiWithoutMeta = hudiSnapshotDF2.drop(HoodieRecord.HOODIE_META_COLUMNS.asScala.toSeq: _*)
+      assertEquals(inputDF2.except(hudiWithoutMeta).count(), 0)
+  }
+
   def getWriterReaderOpts(recordType: HoodieRecordType = HoodieRecordType.AVRO,
                           opt: Map[String, String] = commonOpts,
                           enableFileIndex: Boolean = DataSourceReadOptions.ENABLE_HOODIE_FILE_INDEX.defaultValue()):


### PR DESCRIPTION
### Change Logs

We expect precombine as mandatory config to be set for mutable streams. For immutable streams, precombine could be avoided based on the writer. With HoodieStreamer, for immutable streams, we could set precombine as empty string and get a pipeline running. This just works bcoz, the precombine is never used anywhere (compaction, snapshot read, dedup etc). But if user enables "filterDupes" feature with HoodieStreamer, it breaks.

So, in this patch we are relaxing the constraint. Users can still avoid setting precombine and enable "filterDupes" feature with HoodieStreamer. Not only for immutable streams, for mutable streams it should be feasible to use "OverwriteWithLatestAvroPayload" and get an end to end stream working w/o a need to set an explicit ordering field.

So, this patch takes a stab at enabling this.

### Impact

Fix a corner case.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
