### PR TITLE
[HUDI-8972] Fixing heart beats for failed writes in HoodieStreamer

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1443,8 +1443,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   /**
    * Called after each write, to release any resources used.
    */
-  protected void releaseResources(String instantTime) {
-    // do nothing here
+  public void releaseResources(String instantTime) {
+    // stop heartbeat for instant
+    heartbeatClient.stop(instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -340,7 +340,8 @@ public class SparkRDDWriteClient<T> extends
   }
 
   @Override
-  protected void releaseResources(String instantTime) {
+  public void releaseResources(String instantTime) {
+    super.releaseResources(instantTime);
     SparkReleaseResources.releaseCachedData(context, config, basePath, instantTime);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -269,20 +269,23 @@ public class HoodieCommonTestHarness {
     return metaClient.getActiveTimeline();
   }
 
-  protected Boolean hasPendingCommits() {
+  protected Boolean hasPendingCommitsOrRollbacks() {
     HoodieActiveTimeline timeline = getActiveTimeline();
-    HoodieTimeline completedTimeline = timeline.filterCompletedInstants();
-    Set<String> completedInstants = completedTimeline
-        .getInstants()
-        .stream()
-        .map(HoodieInstant::requestedTime).collect(Collectors.toSet());
-    List<String> pendingInstants = timeline
-        .getInstants()
-        .stream()
-        .map(HoodieInstant::requestedTime)
-        .filter(t -> !completedInstants.contains(t))
-        .collect(Collectors.toList());
-    return !pendingInstants.isEmpty();
+    if (timeline.getRollbackTimeline().empty()) {
+      HoodieTimeline completedTimeline = timeline.filterCompletedInstants();
+      Set<String> completedInstants = completedTimeline
+          .getInstants()
+          .stream()
+          .map(HoodieInstant::requestedTime).collect(Collectors.toSet());
+      List<String> pendingInstants = timeline
+          .getInstants()
+          .stream()
+          .map(HoodieInstant::requestedTime)
+          .filter(t -> !completedInstants.contains(t))
+          .collect(Collectors.toList());
+      return !pendingInstants.isEmpty();
+    }
+    return true;
   }
 
   protected HoodieEngineContext getEngineContext() {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -271,7 +271,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
 
     if (useUpsert) {
       pollForTimeline(basePath, storageConf, 2)
-      assertTrue(hasPendingCommits)
+      assertTrue(hasPendingCommitsOrRollbacks())
     } else {
       pollForTimeline(basePath, storageConf, 3)
       assertTrue(checkIfCommitsAreConcurrent())
@@ -677,6 +677,7 @@ object TestPartitionStatsIndex {
       Arguments.of(HoodieTableType.MERGE_ON_READ, java.lang.Boolean.TRUE),
       Arguments.of(HoodieTableType.MERGE_ON_READ, java.lang.Boolean.FALSE),
       Arguments.of(HoodieTableType.COPY_ON_WRITE, java.lang.Boolean.TRUE),
-      Arguments.of(HoodieTableType.COPY_ON_WRITE, java.lang.Boolean.FALSE)).asJava.stream()
+      Arguments.of(HoodieTableType.COPY_ON_WRITE, java.lang.Boolean.FALSE)
+    ).asJava.stream()
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -177,7 +177,8 @@ public class HoodieStreamer implements Serializable {
         cfg.runBootstrap ? null : new StreamSyncService(cfg, sparkEngineContext, fs, conf, Option.ofNullable(this.properties), sourceProfileSupplier));
   }
 
-  private static TypedProperties combineProperties(Config cfg, Option<TypedProperties> propsOverride, Configuration hadoopConf) {
+  @VisibleForTesting
+  public static TypedProperties combineProperties(Config cfg, Option<TypedProperties> propsOverride, Configuration hadoopConf) {
     HoodieConfig hoodieConfig = new HoodieConfig();
     // Resolving the properties in a consistent way:
     //   1. Properties override always takes precedence

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -23,6 +23,7 @@ import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.DefaultSparkRecordMerger;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -92,6 +93,7 @@ import org.apache.hudi.utilities.HoodieClusteringJob;
 import org.apache.hudi.utilities.HoodieIndexer;
 import org.apache.hudi.utilities.HoodieMetadataTableValidator;
 import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.config.HoodieSchemaProviderConfig;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
 import org.apache.hudi.utilities.config.SourceTestConfig;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
@@ -1024,6 +1026,75 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       assertFalse(meta.getStorage().exists(new StoragePath(replacedFilePath)));
     }
     UtilitiesTestBase.Helpers.deleteFileFromDfs(fs, tableBasePath);
+  }
+
+  /**
+   * Tests that we release resources even on failures scenarios.
+   * @param testFailureCase
+   * @throws Exception
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testReleaseResources(boolean testFailureCase) throws Exception {
+    String tableBasePath = basePath + "/inlineClusteringPending";
+    int totalRecords = 1000;
+    HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT);
+    cfg.continuousMode = false;
+    cfg.tableType = HoodieTableType.COPY_ON_WRITE.name();
+    cfg.configs.add(String.format("%s=%s", "hoodie.datasource.write.row.writer.enable", "false"));
+    HoodieDeltaStreamer ds = new HoodieDeltaStreamer(cfg, jsc);
+    ds.sync();
+    ds.shutdownGracefully();
+    // assert ingest successful
+    TestHelpers.assertAtLeastNCommits(1, tableBasePath);
+
+    // schedule a clustering job to build a clustering plan and leave it in pending state.
+    HoodieClusteringJob clusteringJob = initialHoodieClusteringJob(tableBasePath, null, false, "schedule");
+    clusteringJob.cluster(0);
+    HoodieTableMetaClient tableMetaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf()).setBasePath(tableBasePath).build();
+    assertEquals(1, tableMetaClient.getActiveTimeline().filterPendingReplaceTimeline().getInstants().size());
+
+    // do another ingestion with inline clustering enabled
+    cfg.configs.addAll(getTableServicesConfigs(totalRecords, "false", "true", "2", "", ""));
+    // based on if we want to test happy path or failure scenario, set the right value for retryLastPendingInlineClusteringJob.
+    cfg.retryLastPendingInlineClusteringJob = !testFailureCase;
+    TypedProperties properties = HoodieStreamer.combineProperties(cfg, Option.empty(), jsc.hadoopConfiguration());
+    SchemaProvider schemaProvider = UtilHelpers.wrapSchemaProviderWithPostProcessor(UtilHelpers.createSchemaProvider(cfg.schemaProviderClassName, properties, jsc),
+        properties, jsc, cfg.transformerClassNames);
+
+    try (TestReleaseResourcesStreamSync streamSync = new TestReleaseResourcesStreamSync(cfg, sparkSession, schemaProvider, properties,
+        jsc, fs, jsc.hadoopConfiguration(), client -> true)) {
+      assertTrue(streamSync.releaseResourcesCalledSet.isEmpty());
+      try {
+        streamSync.syncOnce();
+        if (testFailureCase) {
+          fail("Should not reach here when there is conflict w/ pending clustering and when retryLastPendingInlineClusteringJob is set to false");
+        }
+      } catch (HoodieException e) {
+        if (!testFailureCase) {
+          fail("Should not reach here when retryLastPendingInlineClusteringJob is set to true");
+        }
+      }
+
+      tableMetaClient = HoodieTableMetaClient.reload(tableMetaClient);
+      Option<HoodieInstant> failedInstant = tableMetaClient.getActiveTimeline().getCommitTimeline().lastInstant();
+      assertTrue(failedInstant.isPresent());
+      assertTrue(testFailureCase ? !failedInstant.get().isCompleted() : failedInstant.get().isCompleted());
+
+      if (testFailureCase) {
+        // validate that release resource is invoked
+        assertEquals(1, streamSync.releaseResourcesCalledSet.size());
+        assertTrue(streamSync.releaseResourcesCalledSet.contains(failedInstant.get().requestedTime()));
+      } else {
+        assertTrue(streamSync.releaseResourcesCalledSet.isEmpty());
+      }
+
+      // validate heartbeat is closed or expired.
+      HoodieHeartbeatClient heartbeatClient = new HoodieHeartbeatClient(tableMetaClient.getStorage(), this.basePath,
+          (long) HoodieWriteConfig.CLIENT_HEARTBEAT_INTERVAL_IN_MS.defaultValue(), HoodieWriteConfig.CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES.defaultValue());
+      assertTrue(heartbeatClient.isHeartbeatExpired(failedInstant.get().requestedTime()));
+      heartbeatClient.close();
+    }
   }
 
   private List<String> getAllMultiWriterConfigs() {
@@ -3186,6 +3257,23 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
                            JavaSparkContext jssc, FileSystem fs, Configuration conf,
                            Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
       super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
+    }
+  }
+
+  class TestReleaseResourcesStreamSync extends DeltaSync {
+
+    private final Set<String> releaseResourcesCalledSet = new HashSet<>();
+
+    public TestReleaseResourcesStreamSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
+                                          JavaSparkContext jssc, FileSystem fs, Configuration conf,
+                                          Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+      super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
+    }
+
+    @Override
+    protected void releaseResources(String instantTime) {
+      super.releaseResources(instantTime);
+      releaseResourcesCalledSet.add(instantTime);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -93,7 +93,6 @@ import org.apache.hudi.utilities.HoodieClusteringJob;
 import org.apache.hudi.utilities.HoodieIndexer;
 import org.apache.hudi.utilities.HoodieMetadataTableValidator;
 import org.apache.hudi.utilities.UtilHelpers;
-import org.apache.hudi.utilities.config.HoodieSchemaProviderConfig;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
 import org.apache.hudi.utilities.config.SourceTestConfig;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
@@ -1036,7 +1035,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testReleaseResources(boolean testFailureCase) throws Exception {
-    String tableBasePath = basePath + "/inlineClusteringPending";
+    String tableBasePath = basePath + "/inlineClusteringPending_" + testFailureCase;
     int totalRecords = 1000;
     HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT);
     cfg.continuousMode = false;
@@ -1052,7 +1051,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     HoodieClusteringJob clusteringJob = initialHoodieClusteringJob(tableBasePath, null, false, "schedule");
     clusteringJob.cluster(0);
     HoodieTableMetaClient tableMetaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf()).setBasePath(tableBasePath).build();
-    assertEquals(1, tableMetaClient.getActiveTimeline().filterPendingReplaceTimeline().getInstants().size());
+    assertEquals(1, tableMetaClient.getActiveTimeline().filterPendingClusteringTimeline().getInstants().size());
 
     // do another ingestion with inline clustering enabled
     cfg.configs.addAll(getTableServicesConfigs(totalRecords, "false", "true", "2", "", ""));


### PR DESCRIPTION
### Change Logs

Every commit is expected to release resources irrespective of whether it succeeds or fail. But in HoodieStreamer, in some unhappy paths, we missed to do that. And so, the heart beat could potentially be getting updated for a failed ingestion commit which in turn will never get a chance to rollback by async workers (STS). We are fixing the resource closure ( and hence the heart beat emitting) for failed writes in HoodieStreamer in this patch. 

Tests have been written to validate both happy and unhappy paths. 

### Impact

Robust closure of resources and heart beat stoppage for failed commits in HoodieStreamer. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
