### PR TITLE
[HUDI-8989] Fixing Compaction scheduling for tbl v6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -19,9 +19,11 @@
 package org.apache.hudi.table.action.compact;
 
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
@@ -45,8 +47,13 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
+import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
+import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.util.CollectionUtils.nonEmpty;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
@@ -84,6 +91,28 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseTableServi
     ValidationUtils.checkArgument(this.table.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ,
         "Can only compact table of type " + HoodieTableType.MERGE_ON_READ + " and not "
             + this.table.getMetaClient().getTableType().name());
+    if (!table.getMetaClient().getTableConfig().getTableVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
+        && !config.getWriteConcurrencyMode().supportsMultiWriter()
+        && !config.getFailedWritesCleanPolicy().isLazy()) {
+      // TODO(yihua): this validation is removed for Java client used by kafka-connect.  Need to revisit this.
+      if (config.getEngineType() == EngineType.SPARK) {
+        // if there are inflight writes, their instantTime must not be less than that of compaction instant time
+        Option<HoodieInstant> earliestInflightOpt = table.getActiveTimeline().getCommitsTimeline().filterPendingExcludingCompactionAndLogCompaction().firstInstant();
+        if (earliestInflightOpt.isPresent() && !compareTimestamps(earliestInflightOpt.get().requestedTime(), GREATER_THAN, instantTime)) {
+          LOG.warn("Earliest write inflight instant time must be later than compaction time. Earliest :" + earliestInflightOpt.get()
+              + ", Compaction scheduled at " + instantTime + ". Hence skipping to schedule compaction");
+          return Option.empty();
+        }
+      }
+      // Committed and pending compaction instants should have strictly lower timestamps
+      List<HoodieInstant> conflictingInstants = table.getActiveTimeline()
+          .getWriteTimeline().filterCompletedAndCompactionInstants().getInstantsAsStream()
+          .filter(instant -> compareTimestamps(instant.requestedTime(), GREATER_THAN_OR_EQUALS, instantTime))
+          .collect(Collectors.toList());
+      ValidationUtils.checkArgument(conflictingInstants.isEmpty(),
+          "Following instants have timestamps >= compactionInstant (" + instantTime + ") Instants :"
+              + conflictingInstants);
+    }
 
     HoodieCompactionPlan plan = scheduleCompaction();
     Option<HoodieCompactionPlan> option = Option.empty();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -71,6 +71,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CompactionTestBase extends HoodieClientTestBase {
 
   protected HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit) {
+    return getConfigBuilder(autoCommit, basePath);
+  }
+
+  protected HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit, String basePath) {
     return HoodieWriteConfig.newBuilder().withPath(basePath)
         .withSchema(TRIP_EXAMPLE_SCHEMA)
         .withParallelism(2, 2)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -306,10 +308,18 @@ public class TestAsyncCompaction extends CompactionTestBase {
         metaClient.getActiveTimeline().filterPendingExcludingCompaction().firstInstant().get();
     assertEquals(inflightInstantTime, inflightInstant.requestedTime(), "inflight instant has expected instant time");
 
+/*<<<<<<< HEAD:hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
     assertDoesNotThrow(() -> {
       // Schedule compaction but do not run them
       scheduleCompaction(compactionInstantTime, client, cfg);
     }, "Earliest ingestion inflight instant time can be smaller than the compaction time");
+=======*/
+    // since there is a pending delta commit, compaction schedule should not generate any plan
+    client = getHoodieWriteClient(cfg);
+    client.scheduleCompactionAtInstant(compactionInstantTime, Option.empty());
+    metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(cfg.getBasePath()).build();
+    assertFalse(metaClient.getActiveTimeline().filterPendingCompactionTimeline().lastInstant().isPresent());
+//>>>>>>> 11fc9eb4a17 ([HUDI-7460] Relaxing compaction scheduling when there are pending delta commits (#549)):hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -286,7 +286,7 @@ public class TestAsyncCompaction extends CompactionTestBase {
   public void testScheduleCompactionAfterPendingIngestion() throws Exception {
     // Case: Failure case. Earliest ingestion inflight instant time must be later than compaction time
 
-    HoodieWriteConfig cfg = getConfig(false);
+    HoodieWriteConfig cfg = getConfigBuilder(false).withWriteTableVersion(6).build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
     SparkRDDReadClient readClient = getHoodieReadClient(cfg.getBasePath());
 
@@ -308,18 +308,17 @@ public class TestAsyncCompaction extends CompactionTestBase {
         metaClient.getActiveTimeline().filterPendingExcludingCompaction().firstInstant().get();
     assertEquals(inflightInstantTime, inflightInstant.requestedTime(), "inflight instant has expected instant time");
 
-/*<<<<<<< HEAD:hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+    /*<<<<<<< HEAD:hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
     assertDoesNotThrow(() -> {
       // Schedule compaction but do not run them
       scheduleCompaction(compactionInstantTime, client, cfg);
     }, "Earliest ingestion inflight instant time can be smaller than the compaction time");
-=======*/
+    =======*/
     // since there is a pending delta commit, compaction schedule should not generate any plan
     client = getHoodieWriteClient(cfg);
     client.scheduleCompactionAtInstant(compactionInstantTime, Option.empty());
-    metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(cfg.getBasePath()).build();
+    metaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf()).setBasePath(cfg.getBasePath()).build();
     assertFalse(metaClient.getActiveTimeline().filterPendingCompactionTimeline().lastInstant().isPresent());
-//>>>>>>> 11fc9eb4a17 ([HUDI-7460] Relaxing compaction scheduling when there are pending delta commits (#549)):hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -24,7 +24,10 @@ import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -39,12 +42,15 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -282,11 +288,16 @@ public class TestAsyncCompaction extends CompactionTestBase {
     }, "Latest pending compaction instant time can be earlier than this instant time");
   }
 
-  @Test
-  public void testScheduleCompactionAfterPendingIngestion() throws Exception {
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  public void testScheduleCompactionAfterPendingIngestion(int tableVersion) throws Exception {
     // Case: Failure case. Earliest ingestion inflight instant time must be later than compaction time
+    String localBasePath = basePath + "_" + tableVersion;
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(tableVersion));
+    metaClient = HoodieTestUtils.init(storageConf, localBasePath, HoodieTableType.MERGE_ON_READ, props);
 
-    HoodieWriteConfig cfg = getConfigBuilder(false).withWriteTableVersion(6).build();
+    HoodieWriteConfig cfg = getConfigBuilder(false, localBasePath).withWriteTableVersion(tableVersion).build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
     SparkRDDReadClient readClient = getHoodieReadClient(cfg.getBasePath());
 
@@ -308,17 +319,19 @@ public class TestAsyncCompaction extends CompactionTestBase {
         metaClient.getActiveTimeline().filterPendingExcludingCompaction().firstInstant().get();
     assertEquals(inflightInstantTime, inflightInstant.requestedTime(), "inflight instant has expected instant time");
 
-    /*<<<<<<< HEAD:hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
-    assertDoesNotThrow(() -> {
-      // Schedule compaction but do not run them
-      scheduleCompaction(compactionInstantTime, client, cfg);
-    }, "Earliest ingestion inflight instant time can be smaller than the compaction time");
-    =======*/
-    // since there is a pending delta commit, compaction schedule should not generate any plan
-    client = getHoodieWriteClient(cfg);
-    client.scheduleCompactionAtInstant(compactionInstantTime, Option.empty());
-    metaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf()).setBasePath(cfg.getBasePath()).build();
-    assertFalse(metaClient.getActiveTimeline().filterPendingCompactionTimeline().lastInstant().isPresent());
+    if (tableVersion >= HoodieTableVersion.EIGHT.versionCode()) {
+      SparkRDDWriteClient finalClient = client;
+      assertDoesNotThrow(() -> {
+        // Schedule compaction but do not run them
+        scheduleCompaction(compactionInstantTime, finalClient, cfg);
+      }, "Earliest ingestion inflight instant time can be smaller than the compaction time");
+    } else {
+      // since there is a pending delta commit, compaction schedule should not generate any plan
+      client = getHoodieWriteClient(cfg);
+      client.scheduleCompactionAtInstant(compactionInstantTime, Option.empty());
+      metaClient = HoodieTableMetaClient.builder().setConf(context.getStorageConf()).setBasePath(cfg.getBasePath()).build();
+      assertFalse(metaClient.getActiveTimeline().filterPendingCompactionTimeline().lastInstant().isPresent());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

- Fixing Compaction scheduling for tbl v6. w/ Table version 6, when there are pending delta commits, we can't schedule compaction. So, this fixes the backwards compatible writer for compaction scheduling. 

### Impact

- Fixing Compaction scheduling for tbl v6. w/ Table version 6, when there are pending delta commits, we can't schedule compaction. So, this fixes the backwards compatible writer for compaction scheduling. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
