### PR TITLE
[HUDI-8992] Initial changes to allow us to use streams instead of byte arrays

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
@@ -271,7 +271,7 @@ public class FileSystemViewCommand {
       instantsStream = instantsStream.filter(is -> predicate.test(maxInstant, is.requestedTime()));
     }
     TimelineFactory timelineFactory = metaClient.getTimelineLayout().getTimelineFactory();
-    HoodieTimeline filteredTimeline = timelineFactory.createDefaultTimeline(instantsStream, metaClient.getActiveTimeline()::getInstantDetails);
+    HoodieTimeline filteredTimeline = timelineFactory.createDefaultTimeline(instantsStream, metaClient.getActiveTimeline());
     return new HoodieTableFileSystemView(metaClient, filteredTimeline, pathInfoList);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
@@ -42,6 +42,7 @@ import org.apache.hudi.io.hadoop.HoodieAvroParquetReader;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
@@ -187,7 +188,7 @@ public class LSMTimelineWriter {
     int newVersion = currentVersion < 0 ? 1 : currentVersion + 1;
     // create manifest file
     final StoragePath manifestFilePath = LSMTimeline.getManifestFilePath(newVersion, archivePath);
-    metaClient.getStorage().createImmutableFileInPath(manifestFilePath, Option.of(content));
+    metaClient.getStorage().createImmutableFileInPath(manifestFilePath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(content)));
     // update version file
     updateVersionFile(newVersion);
   }
@@ -196,7 +197,7 @@ public class LSMTimelineWriter {
     byte[] content = getUTF8Bytes(String.valueOf(newVersion));
     final StoragePath versionFilePath = LSMTimeline.getVersionFilePath(archivePath);
     metaClient.getStorage().deleteFile(versionFilePath);
-    metaClient.getStorage().createImmutableFileInPath(versionFilePath, Option.of(content));
+    metaClient.getStorage().createImmutableFileInPath(versionFilePath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(content)));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -200,7 +201,7 @@ public class ConsistentBucketIndexUtils {
         // the file has been created by other tasks
         return true;
       }
-      storage.createImmutableFileInPath(fullPath, Option.of(metadata.toBytes()), true);
+      storage.createImmutableFileInPath(fullPath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(metadata.toBytes())), true);
       return true;
     } catch (IOException e1) {
       // ignore the exception and check the file existence

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieArchivedTimeline.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieArchivedTimeline.java
@@ -41,9 +41,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test cases for {@link HoodieArchivedTimeline}.
@@ -74,6 +76,11 @@ public class TestHoodieArchivedTimeline extends HoodieCommonTestHarness {
     assertThat(archivedTimeline.firstInstant().map(HoodieInstant::requestedTime).orElse(""), is("10000011"));
   }
 
+  @Test
+  void getInstantReaderReferencesSelf() {
+    HoodieArchivedTimeline timeline = TIMELINE_FACTORY.createArchivedTimeline(metaClient);
+    assertSame(timeline, timeline.getInstantReader());
+  }
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -192,7 +192,7 @@ public class TestCleanPlanner {
         getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean,
             savepointsTrackedInLastClean.keySet(), expectedEarliestSavepointInLastClean);
     HoodieCleanerPlan cleanerPlan = mockLastCleanCommit(mockHoodieTable, lastCleanInstant, earliestInstantsInLastClean, activeTimeline, cleanMetadataOptionPair, savepointsTrackedInLastClean.keySet());
-    mockFewActiveInstants(instantReader, mockHoodieTable, activeTimeline, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved, replaceCommits);
+    mockFewActiveInstants(mockHoodieTable, activeTimeline, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved, replaceCommits);
 
     // mock getAllPartitions
     HoodieStorage storage = mock(HoodieStorage.class);
@@ -655,10 +655,10 @@ public class TestCleanPlanner {
     return cleanerPlan;
   }
 
-  private static void mockFewActiveInstants(HoodieInstantReader instantReader, HoodieTable hoodieTable, HoodieActiveTimeline activeTimeline, Map<String, List<String>> activeInstantsToPartitions,
+  private static void mockFewActiveInstants(HoodieTable hoodieTable, HoodieActiveTimeline activeTimeline, Map<String, List<String>> activeInstantsToPartitions,
                                             Map<String, List<String>> savepointedCommitsToAdd, boolean areCommitsForSavepointsRemoved, List<String> replaceCommits)
       throws IOException {
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = new ArrayList<>();
     Map<String, List<String>> instantstoProcess = new HashMap<>();
     instantstoProcess.putAll(activeInstantsToPartitions);
@@ -688,12 +688,12 @@ public class TestCleanPlanner {
     when(hoodieTable.getActiveTimeline().getInstantsAsStream()).thenReturn(instants.stream());
     when(hoodieTable.getCompletedCommitsTimeline()).thenReturn(commitsTimeline);
 
-    BaseTimelineV2 savepointTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 savepointTimeline = new BaseTimelineV2();
     List<HoodieInstant> savepointInstants = savepointedCommitsToAdd.keySet().stream().map(sp -> INSTANT_GENERATOR.createNewInstant(COMPLETED, HoodieTimeline.SAVEPOINT_ACTION, sp))
         .collect(Collectors.toList());
     savepointTimeline.setInstants(savepointInstants);
 
-    BaseTimelineV2 completedReplaceTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 completedReplaceTimeline = new BaseTimelineV2();
     List<HoodieInstant> completedReplaceInstants = replaceCommits.stream().map(rc -> INSTANT_GENERATOR.createNewInstant(COMPLETED, HoodieTimeline.REPLACE_COMMIT_ACTION, rc))
         .collect(Collectors.toList());
     completedReplaceTimeline.setInstants(completedReplaceInstants);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -531,7 +531,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     setUp(IndexType.BLOOM, true, false);
 
     // When timeline is empty, all commits are invalid
-    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline().getInstantReader());
+    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline());
     assertTrue(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, "001"));
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, writeClient.createNewInstantTime()));
@@ -541,7 +541,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     final HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "010");
     String instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, writeClient.createNewInstantTime());
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant1.requestedTime()));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant2.requestedTime()));
@@ -557,7 +557,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     instantTimestamp = writeClient.createNewInstantTime();
     String instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant3 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestampSec);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestampSec));
@@ -565,7 +565,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     // With a sec format instant time lesser than first entry in the active timeline, checkifContainsOrBefore() should return true
     instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline());
     instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
@@ -588,14 +588,14 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String newTimestamp = writeClient.createNewInstantTime();
     String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(checkInstantTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestampSec));
 
     final HoodieInstant instant6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.DELTA_COMMIT_ACTION, newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(newTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestamp));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -531,7 +531,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     setUp(IndexType.BLOOM, true, false);
 
     // When timeline is empty, all commits are invalid
-    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline()::getInstantDetails);
+    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline().getInstantReader());
     assertTrue(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, "001"));
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, writeClient.createNewInstantTime()));
@@ -541,7 +541,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     final HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "010");
     String instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, writeClient.createNewInstantTime());
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant1.requestedTime()));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant2.requestedTime()));
@@ -557,7 +557,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     instantTimestamp = writeClient.createNewInstantTime();
     String instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant3 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestampSec);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestampSec));
@@ -565,7 +565,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     // With a sec format instant time lesser than first entry in the active timeline, checkifContainsOrBefore() should return true
     instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline().getInstantReader());
     instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
@@ -588,14 +588,14 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String newTimestamp = writeClient.createNewInstantTime();
     String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(checkInstantTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestampSec));
 
     final HoodieInstant instant6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.DELTA_COMMIT_ACTION, newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(newTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestamp));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -68,7 +68,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
     HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
-    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
+    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -104,7 +104,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -68,7 +68,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
     HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
-    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
+    HoodieTimeline commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -99,12 +99,11 @@ public class TestAverageRecordSizeUtils {
 
   @Test
   public void testErrorHandling() throws IOException {
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
     int recordSize = 10000;
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -22,10 +22,12 @@ package org.apache.hudi.table.action.commit;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v2.BaseTimelineV2;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 
@@ -62,10 +64,11 @@ public class TestAverageRecordSizeUtils {
 
   @ParameterizedTest
   @MethodSource("testCases")
-  public void testAverageRecordSize(List<Pair<HoodieInstant, List<HWriteStat>>> instantSizePairs, long expectedSize) {
+  public void testAverageRecordSize(List<Pair<HoodieInstant, List<HWriteStat>>> instantSizePairs, long expectedSize) throws IOException {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
-    HoodieTimeline commitsTimeline = new BaseTimelineV2();
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
+    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -95,12 +98,13 @@ public class TestAverageRecordSizeUtils {
   }
 
   @Test
-  public void testErrorHandling() {
+  public void testErrorHandling() throws IOException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
     int recordSize = 10000;
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -112,8 +113,8 @@ public class HoodiePartitionMetadata {
               // Backwards compatible properties file format
               try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                 props.store(os, "partition metadata");
-                Option content = Option.of(os.toByteArray());
-                storage.createImmutableFileInPath(metaPath, content);
+                Option<byte []> content = Option.of(os.toByteArray());
+                storage.createImmutableFileInPath(metaPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
               }
             }
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -624,6 +624,6 @@ public class TableSchemaResolver {
         .sorted(reversedComparator);
     return timelineLayout.getTimelineFactory().createDefaultTimeline(
         reversedTimelineWithTableSchema,
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -624,6 +624,6 @@ public class TableSchemaResolver {
         .sorted(reversedComparator);
     return timelineLayout.getTimelineFactory().createDefaultTimeline(
         reversedTimelineWithTableSchema,
-        metaClient.getActiveTimeline()::getInstantDetails);
+        metaClient.getActiveTimeline().getInstantReader());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -20,14 +20,20 @@ package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.specific.SpecificDatumReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -36,7 +42,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +55,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * HoodieDefaultTimeline is a default implementation of the HoodieTimeline. It provides methods to inspect a
- * List[HoodieInstant]. Function to get the details of the instant is passed in as a lambda.
+ * List[HoodieInstant]. Function to get the instantReader of the instant is passed in as a lambda.
  *
  * @see HoodieTimeline
  */
@@ -62,7 +67,7 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   private static final String HASHING_ALGORITHM = "SHA-256";
 
-  protected transient Function<HoodieInstant, Option<byte[]>> details;
+  protected transient HoodieInstantReader instantReader;
   private List<HoodieInstant> instants;
   // for efficient #contains queries.
   private transient volatile Set<String> instantTimeSet;
@@ -78,15 +83,16 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   protected InstantComparator instantComparator;
   protected InstantGenerator instantGenerator;
 
-  public BaseHoodieTimeline(TimelineLayout layout) {
+  public BaseHoodieTimeline(TimelineLayout layout, HoodieInstantReader instantReader) {
     this.factory = layout.getTimelineFactory();
     this.instantComparator = layout.getInstantComparator();
     this.instantGenerator = layout.getInstantGenerator();
+    this.instantReader = instantReader;
   }
 
-  public BaseHoodieTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details,
+  public BaseHoodieTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader,
                             TimelineFactory factory, InstantComparator instantComparator, InstantGenerator instantGenerator) {
-    this.details = details;
+    this.instantReader = instantReader;
     this.factory = factory;
     this.instantComparator = instantComparator;
     this.instantGenerator = instantGenerator;
@@ -117,62 +123,62 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline filterInflights() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), instantReader);
   }
 
   @Override
   public HoodieTimeline filterInflightsAndRequested() {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(i -> i.getState().equals(State.REQUESTED) || i.getState().equals(State.INFLIGHT)),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), details);
+        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompactionAndLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
         && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
-        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), details);
+        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedInstants() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedAndCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), details);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedOrMajorOrMinorCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), details);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedInstantsOrRewriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
@@ -188,13 +194,13 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline getCompletedReplaceTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
@@ -209,25 +215,25 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filterPendingRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterRequestedRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), details);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingLogCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), instantReader);
   }
 
   /**
@@ -238,26 +244,26 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
             || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), details);
+        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInClosedRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), details);
+        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInRangeByCompletionTime(String startTs, String endTs) {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getCompletionTime() != null && InstantComparison.isInClosedRange(s.getCompletionTime(), startTs, endTs)),
-        details);
+        instantReader);
   }
 
   @Override
@@ -266,40 +272,40 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
         // either pending or completionTime greater than instantTime
         .filter(s -> (s.getCompletionTime() == null && compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime))
             || (s.getCompletionTime() != null && compareTimestamps(s.getCompletionTime(), GREATER_THAN, instantTime) && !s.requestedTime().equals(instantTime))),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)).limit(numCommits),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), details);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime))
-        .limit(numCommits), details);
+        .limit(numCommits), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), details);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsBefore(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN, instantTime)),
-        details);
+        instantReader);
   }
 
   @Override
@@ -313,22 +319,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   public HoodieTimeline findInstantsBeforeOrEquals(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN_OR_EQUALS, instantTime)),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), instantReader);
   }
 
   @Override
@@ -356,26 +362,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getDeltaCommitTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getTimelineOfActions(Set<String> actions) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline getCleanerTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getRollbackTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION), instantReader);
   }
 
   @Override
@@ -385,14 +387,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getSavePointTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getRestoreTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION), instantReader);
   }
 
   protected Stream<HoodieInstant> filterInstantsByAction(String action) {
@@ -556,7 +556,29 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
-    return details.apply(instant);
+    return instantReader.getInstantDetails(instant);
+  }
+
+  @Override
+  public InputStream getInstantContentStream(HoodieInstant instant) {
+    return instantReader.getContentStream(instant);
+  }
+
+  @Override
+  public <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
+    try (InputStream inputStream = getInstantContentStream(instant)) {
+      DatumReader<T> reader = new SpecificDatumReader<>(clazz);
+      DataFileStream<T> fileReader = new DataFileStream<>(inputStream, reader);
+      ValidationUtils.checkArgument(fileReader.hasNext(), "Could not deserialize metadata of type " + clazz);
+      return fileReader.next();
+    }
+  }
+
+  @Override
+  public <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
+    try (InputStream inputStream = getInstantContentStream(instant)) {
+      return JsonUtils.getObjectMapper().readValue(inputStream, clazz);
+    }
   }
 
   @Override
@@ -609,14 +631,7 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline mergeTimeline(HoodieTimeline timeline) {
     Stream<HoodieInstant> instantStream = Stream.concat(getInstantsAsStream(), timeline.getInstantsAsStream()).sorted();
-    Function<HoodieInstant, Option<byte[]>> details = instant -> {
-      if (getInstantsAsStream().anyMatch(i -> i.equals(instant))) {
-        return this.getInstantDetails(instant);
-      } else {
-        return timeline.getInstantDetails(instant);
-      }
-    };
-    return factory.createDefaultTimeline(instantStream, details);
+    return factory.createDefaultTimeline(instantStream, new MergedReader(this, timeline));
   }
 
   /**
@@ -632,6 +647,10 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
       throw new HoodieException(nse);
     }
     return StringUtils.toHexString(md.digest());
+  }
+
+  public HoodieInstantReader getInstantReader() {
+    return instantReader;
   }
 
   /**
@@ -655,5 +674,24 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
       Collections.sort(merged);
     }
     return merged;
+  }
+
+  private static class MergedReader implements HoodieInstantReader, Serializable {
+    private final HoodieTimeline timeline1;
+    private final HoodieTimeline timeline2;
+
+    public MergedReader(HoodieTimeline timeline1, HoodieTimeline timeline2) {
+      this.timeline1 = timeline1;
+      this.timeline2 = timeline2;
+    }
+
+    @Override
+    public InputStream getContentStream(HoodieInstant instant) {
+      if (timeline1.getInstantsAsStream().anyMatch(i -> i.equals(instant))) {
+        return timeline1.getInstantContentStream(instant);
+      } else {
+        return timeline2.getInstantContentStream(instant);
+      }
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -84,10 +84,10 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   protected InstantGenerator instantGenerator;
 
   public BaseHoodieTimeline(TimelineLayout layout, HoodieInstantReader instantReader) {
+    this.instantReader = instantReader;
     this.factory = layout.getTimelineFactory();
     this.instantComparator = layout.getInstantComparator();
     this.instantGenerator = layout.getInstantGenerator();
-    this.instantReader = instantReader;
   }
 
   public BaseHoodieTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader,
@@ -123,62 +123,62 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline filterInflights() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterInflightsAndRequested() {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(i -> i.getState().equals(State.REQUESTED) || i.getState().equals(State.INFLIGHT)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
+        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompactionAndLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
         && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
-        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
+        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedInstants() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedAndCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), instantReader);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedOrMajorOrMinorCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), instantReader);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedInstantsOrRewriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
@@ -194,13 +194,13 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline getCompletedReplaceTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
@@ -215,25 +215,25 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filterPendingRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterRequestedRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingLogCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   /**
@@ -244,26 +244,26 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
             || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), instantReader);
+        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInClosedRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), instantReader);
+        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInRangeByCompletionTime(String startTs, String endTs) {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getCompletionTime() != null && InstantComparison.isInClosedRange(s.getCompletionTime(), startTs, endTs)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
@@ -272,40 +272,40 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
         // either pending or completionTime greater than instantTime
         .filter(s -> (s.getCompletionTime() == null && compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime))
             || (s.getCompletionTime() != null && compareTimestamps(s.getCompletionTime(), GREATER_THAN, instantTime) && !s.requestedTime().equals(instantTime))),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)).limit(numCommits),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), instantReader);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime))
-        .limit(numCommits), instantReader);
+        .limit(numCommits),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), instantReader);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsBefore(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN, instantTime)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
@@ -319,22 +319,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   public HoodieTimeline findInstantsBeforeOrEquals(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN_OR_EQUALS, instantTime)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()),  getInstantReader());
   }
 
   @Override
@@ -362,22 +362,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getDeltaCommitTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getTimelineOfActions(Set<String> actions) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getCleanerTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getRollbackTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION),  getInstantReader());
   }
 
   @Override
@@ -387,12 +387,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getSavePointTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getRestoreTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION),  getInstantReader());
   }
 
   protected Stream<HoodieInstant> filterInstantsByAction(String action) {
@@ -556,12 +556,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
-    return instantReader.getInstantDetails(instant);
+    return  getInstantReader().getInstantDetails(instant);
   }
 
   @Override
   public InputStream getInstantContentStream(HoodieInstant instant) {
-    return instantReader.getContentStream(instant);
+    return getInstantReader().getContentStream(instant);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -442,4 +442,9 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @return
    */
   Set<String> getValidExtensions();
+
+  /**
+   * Get the instant reader interface.
+   * */
+  public HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -442,9 +442,4 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @return
    */
   Set<String> getValidExtensions();
-
-  /**
-   * Get the instant reader interface.
-   * */
-  public HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Interface for classes that are capable of reading the contents of a HoodieInstant.
+ */
+public interface HoodieInstantReader {
+  /**
+   * Reads the provided instant's content into a stream for parsing.
+   * @param instant the instant to read
+   * @return an InputStream with the content
+   */
+  InputStream getContentStream(HoodieInstant instant);
+
+  /**
+   * Reads the provided instant's content into a byte array for parsing.
+   * @param instant the instant to read
+   * @return an InputStream with the details
+   */
+  @Deprecated
+  default Option<byte[]> getInstantDetails(HoodieInstant instant) {
+    try (InputStream inputStream = getContentStream(instant)) {
+      return Option.of(FileIOUtils.readAsByteArray(inputStream));
+    } catch (IOException ex) {
+      throw new HoodieIOException("Could not read commit details from stream", ex);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
@@ -34,7 +34,9 @@ public interface HoodieInstantReader {
    * @param instant the instant to read
    * @return an InputStream with the content
    */
-  InputStream getContentStream(HoodieInstant instant);
+  default InputStream getContentStream(HoodieInstant instant) {
+    throw new RuntimeException("Not implemented");
+  }
 
   /**
    * Reads the provided instant's content into a byte array for parsing.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
@@ -452,6 +454,17 @@ public interface HoodieTimeline extends Serializable {
    * Read the completed instant details.
    */
   Option<byte[]> getInstantDetails(HoodieInstant instant);
+
+  /**
+   * Read the instant content to an input stream.
+   * @param instant the instant to fetch
+   * @return stream with content for instant
+   */
+  InputStream getInstantContentStream(HoodieInstant instant);
+
+  <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
+
+  <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
 
   boolean isEmpty(HoodieInstant instant);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
  * @see HoodieInstant
  * @since 0.3.0
  */
-public interface HoodieTimeline extends Serializable {
+public interface HoodieTimeline extends HoodieInstantReader, Serializable {
 
   String COMMIT_ACTION = "commit";
   String DELTA_COMMIT_ACTION = "deltacommit";
@@ -451,11 +451,6 @@ public interface HoodieTimeline extends Serializable {
   boolean isPendingClusteringInstant(String instantTime);
 
   /**
-   * Read the completed instant details.
-   */
-  Option<byte[]> getInstantDetails(HoodieInstant instant);
-
-  /**
    * Read the instant content to an input stream.
    * @param instant the instant to fetch
    * @return stream with content for instant
@@ -546,4 +541,9 @@ public interface HoodieTimeline extends Serializable {
    * @return
    */
   TimelineLayoutVersion getTimelineLayoutVersion();
+
+  /**
+   * Get instant reader
+   * */
+  HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
@@ -19,16 +19,13 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.util.Option;
 
 import java.io.Serializable;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public abstract class TimelineFactory implements Serializable {
 
-  public abstract HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants,
-                                                       Function<HoodieInstant, Option<byte[]>> details);
+  public abstract HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader);
 
   public abstract HoodieActiveTimeline createActiveTimeline();
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -596,7 +596,7 @@ public class TimelineUtils {
                                               HoodieTableMetaClient metaClient) {
     return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(
         Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 
   public static boolean isDeletePartition(WriteOperationType operation) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -594,8 +594,9 @@ public class TimelineUtils {
    */
   public static HoodieTimeline concatTimeline(HoodieTimeline timeline1, HoodieTimeline timeline2,
                                               HoodieTableMetaClient metaClient) {
-    return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
-        instant -> metaClient.getActiveTimeline().getInstantDetails(instant));
+    return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(
+        Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
+        metaClient.getActiveTimeline().getInstantReader());
   }
 
   public static boolean isDeletePartition(WriteOperationType operation) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
@@ -20,11 +20,11 @@ package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantGenerator;
+import org.apache.hudi.common.table.timeline.TimelineFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.hudi.common.table.timeline.InstantGenerator;
-import org.apache.hudi.common.table.timeline.TimelineFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,6 +49,6 @@ public class TimelineDTO {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     // TODO: For Now, we will assume, only active-timeline will be transferred.
     return factory.createDefaultTimeline(dto.instants.stream().map(d -> InstantDTO.toInstant(d, instantGenerator)),
-        metaClient.getActiveTimeline()::getInstantDetails);
+        metaClient.getActiveTimeline().getInstantReader());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
@@ -49,6 +49,6 @@ public class TimelineDTO {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     // TODO: For Now, we will assume, only active-timeline will be transferred.
     return factory.createDefaultTimeline(dto.instants.stream().map(d -> InstantDTO.toInstant(d, instantGenerator)),
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -52,7 +52,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTimeline, HoodieInstantReader {
+public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTimeline {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -73,7 +73,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
 
   protected ActiveTimelineV1(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                              boolean applyLayoutFilters) {
-    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -85,7 +84,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -104,8 +102,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV1() {
-    super(null);
-    this.instantReader = this;
   }
 
   /**
@@ -260,7 +256,7 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
 
   @Override
   public HoodieInstantReader getInstantReader() {
-    return instantReader;
+    return this;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
@@ -65,12 +65,10 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants(false));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
   }
 
   /**
@@ -78,13 +76,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient, String startTs) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new StartTsFilter(startTs), true,
         record -> HoodieInstant.State.COMPLETED.toString().equals(record.get(ACTION_STATE).toString())));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
   }
 
   /**
@@ -93,8 +89,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV1() {
-    super(null);
-    this.instantReader = this;
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return this;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.StoragePath;
@@ -34,8 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.Serializable;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchivedTimeline {
+public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchivedTimeline, HoodieInstantReader {
   private static final String HOODIE_COMMIT_ARCHIVE_LOG_FILE_PREFIX = "commits";
   private static final String ACTION_TYPE_KEY = "actionType";
   private static final String ACTION_STATE = "actionState";
@@ -63,11 +65,12 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient) {
+    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants(false));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
   }
 
   /**
@@ -75,12 +78,13 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient, String startTs) {
+    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new StartTsFilter(startTs), true,
         record -> HoodieInstant.State.COMPLETED.toString().equals(record.get(ACTION_STATE).toString())));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
   }
 
   /**
@@ -89,6 +93,8 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV1() {
+    super(null);
+    this.instantReader = this;
   }
 
   /**
@@ -103,6 +109,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
     return Option.ofNullable(readCommits.get(instant.requestedTime()));
+  }
+
+  @Override
+  public InputStream getContentStream(HoodieInstant instant) {
+    return new ByteArrayInputStream(getInstantDetails(instant).orElseGet(() -> new byte[0]));
   }
 
   public static StoragePath getArchiveLogPath(StoragePath archiveFolder) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
@@ -18,29 +18,29 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v1;
 
-import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.BaseHoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseTimelineV1 extends BaseHoodieTimeline {
 
-  public BaseTimelineV1(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    this(instants, details, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
+  public BaseTimelineV1(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    this(instants, instantReader, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
   }
 
-  private BaseTimelineV1(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details, TimelineLayout layout) {
-    super(instants, details, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
+  private BaseTimelineV1(Stream<HoodieInstant> instants, HoodieInstantReader instantReader, TimelineLayout layout) {
+    super(instants, instantReader, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
   }
 
   /**
@@ -49,35 +49,35 @@ public class BaseTimelineV1 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV1() {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
+  public BaseTimelineV1(HoodieInstantReader instantReader) {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted())
-        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), details);
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceClusteringAndCompactionTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
@@ -49,35 +49,35 @@ public class BaseTimelineV1 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV1(HoodieInstantReader instantReader) {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), instantReader);
+  public BaseTimelineV1() {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), null);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted())
-        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), instantReader);
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceClusteringAndCompactionTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), getInstantReader());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
@@ -21,15 +21,14 @@ package org.apache.hudi.common.table.timeline.versioning.v1;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.util.Option;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class TimelineV1Factory extends TimelineFactory {
@@ -41,8 +40,8 @@ public class TimelineV1Factory extends TimelineFactory {
   }
 
   @Override
-  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    return new BaseTimelineV1(instants, details);
+  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    return new BaseTimelineV1(instants, instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
@@ -37,6 +38,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -45,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -53,10 +54,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline  {
+public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline, HoodieInstantReader {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -78,6 +78,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   private ActiveTimelineV2(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                            boolean applyLayoutFilters) {
+    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -89,7 +90,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -108,6 +109,8 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV2() {
+    super(null);
+    this.instantReader = this;
   }
 
   /**
@@ -262,6 +265,17 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
     StoragePath detailPath = getInstantFileNamePath(getInstantFileName(instant));
     return readDataFromPath(detailPath);
+  }
+
+  @Override
+  public InputStream getContentStream(HoodieInstant instant) {
+    StoragePath filePath = getInstantFileNamePath(instantFileNameGenerator.getFileName(instant));
+    return readDataStreamFromPath(filePath);
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return instantReader;
   }
 
   @Override
@@ -557,7 +571,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
         if (allowRedundantTransitions) {
           FileIOUtils.createFileInPath(storage, getInstantFileNamePath(toInstantFileName), data);
         } else {
-          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), data);
+          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), data.map(HoodieInstantWriter::convertByteArrayToWriter));
         }
         LOG.info("Create new file for toInstant ?" + getInstantFileNamePath(toInstantFileName));
       }
@@ -728,7 +742,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     if (allowOverwrite || metaClient.getTimelineLayoutVersion().isNullVersion()) {
       FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, content);
     } else {
-      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content);
+      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
     }
   }
 
@@ -742,7 +756,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         FileIOUtils.createFileInPath(metaClient.getStorage(), fullPath, content);
       } else {
-        metaClient.getStorage().createImmutableFileInPath(fullPath, content);
+        metaClient.getStorage().createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
       }
       LOG.info("Created new file for toInstant ?" + fullPath);
     });
@@ -753,6 +767,14 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       return Option.of(FileIOUtils.readAsByteArray(is));
     } catch (IOException e) {
       throw new HoodieIOException("Could not read commit details from " + detailPath, e);
+    }
+  }
+
+  protected InputStream readDataStreamFromPath(StoragePath filePath) {
+    try {
+      return metaClient.getStorage().open(filePath);
+    } catch (IOException e) {
+      throw new HoodieIOException("Could not read commit details from " + filePath, e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -56,7 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline, HoodieInstantReader {
+public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -78,7 +78,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   private ActiveTimelineV2(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                            boolean applyLayoutFilters) {
-    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -90,7 +89,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -109,8 +107,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV2() {
-    super(null);
-    this.instantReader = this;
   }
 
   /**
@@ -275,7 +271,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   @Override
   public HoodieInstantReader getInstantReader() {
-    return instantReader;
+    return this;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
@@ -74,7 +74,6 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV2(HoodieTableMetaClient metaClient) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants());
     this.cursorInstant = firstInstant().map(HoodieInstant::requestedTime).orElse(null);
@@ -88,7 +87,6 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV2(HoodieTableMetaClient metaClient, String startTs) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new HoodieArchivedTimeline.StartTsFilter(startTs), HoodieArchivedTimeline.LoadMode.METADATA));
     this.cursorInstant = startTs;
@@ -103,8 +101,12 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV2() {
-    super(null);
     this.instantReader = this;
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return this;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
@@ -18,29 +18,29 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v2;
 
-import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.BaseHoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseTimelineV2 extends BaseHoodieTimeline {
 
-  public BaseTimelineV2(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    this(instants, details, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
+  public BaseTimelineV2(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    this(instants, instantReader, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
   }
 
-  public BaseTimelineV2(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details, TimelineLayout layout) {
-    super(instants, details, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
+  public BaseTimelineV2(Stream<HoodieInstant> instants, HoodieInstantReader instantReader, TimelineLayout layout) {
+    super(instants, instantReader, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
   }
 
   /**
@@ -49,14 +49,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV2() {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
+  public BaseTimelineV2(HoodieInstantReader instantReader) {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
@@ -67,14 +67,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
@@ -82,7 +82,7 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)
             || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
@@ -49,14 +49,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV2(HoodieInstantReader instantReader) {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), instantReader);
+  public BaseTimelineV2() {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), null);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), getInstantReader());
   }
 
   @Override
@@ -67,14 +67,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()), getInstantReader());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)
             || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), getInstantReader());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
@@ -21,15 +21,14 @@ package org.apache.hudi.common.table.timeline.versioning.v2;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.util.Option;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class TimelineV2Factory extends TimelineFactory {
@@ -41,8 +40,8 @@ public class TimelineV2Factory extends TimelineFactory {
   }
 
   @Override
-  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    return new BaseTimelineV2(instants, details);
+  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    return new BaseTimelineV2(instants, instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1395,7 +1395,7 @@ public class HoodieTableMetadataUtil {
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
           metaClient.createNewInstantTime(false));
-      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
+      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline().getInstantReader());
     }
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
     return HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, timeline);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1395,7 +1395,7 @@ public class HoodieTableMetadataUtil {
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
           metaClient.createNewInstantTime(false));
-      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline().getInstantReader());
+      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline());
     }
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
     return HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, timeline);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.shouldUseExternalHdfs;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.useExternalHdfs;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestHoodieWrapperFileSystem {
@@ -78,8 +77,8 @@ class TestHoodieWrapperFileSystem {
 
     // create same commit twice
     HoodieStorage storage = new HoodieHadoopStorage(fs);
-    storage.createImmutableFileInPath(testFile, Option.of(getUTF8Bytes(testContent)));
-    storage.createImmutableFileInPath(testFile, Option.of(getUTF8Bytes(testContent)));
+    storage.createImmutableFileInPath(testFile, Option.of(outputStream -> outputStream.write(testContent.getBytes())));
+    storage.createImmutableFileInPath(testFile, Option.of(outputStream -> outputStream.write(testContent.getBytes())));
     List<StoragePathInfo> pathInfoList = storage.listDirectEntries(new StoragePath(basePath));
 
     assertEquals(1, pathInfoList.size(),

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -391,15 +391,13 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         .thenReturn(mockArchivedTimeline);
     HoodieTimeline mergedTimeline = new BaseTimelineV2(
         archivedInstants.stream()
-            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0),
-        i -> Option.empty())
+            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0), null)
         .mergeTimeline(activeTimeline);
     when(mockArchivedTimeline.mergeTimeline(eq(activeTimeline)))
         .thenReturn(mergedTimeline);
     HoodieTimeline mergedWriteTimeline = new BaseTimelineV2(
         archivedInstants.stream()
-            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0),
-        i -> Option.empty())
+            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0), null)
         .mergeTimeline(activeTimeline.getWriteTimeline());
     when(mockArchivedTimeline.mergeTimeline(argThat(timeline -> timeline.filter(
         instant -> instant.getAction().equals(ROLLBACK_ACTION)).countInstants() == 0)))

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -18,7 +18,10 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.fs.NoOpConsistencyGuard;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -26,6 +29,7 @@ import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -37,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,9 +64,9 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_TH
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.testutils.Assertions.assertStreamEquals;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_PARSER;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.hamcrest.CoreMatchers.is;
@@ -70,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -346,6 +352,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     checkTimeline.accept(timeline.getDeltaCommitTimeline(), Collections.singleton(HoodieTimeline.DELTA_COMMIT_ACTION));
     checkTimeline.accept(timeline.getCleanerTimeline(), Collections.singleton(HoodieTimeline.CLEAN_ACTION));
     checkTimeline.accept(timeline.getRollbackTimeline(), Collections.singleton(HoodieTimeline.ROLLBACK_ACTION));
+    checkTimeline.accept(timeline.getRollbackAndRestoreTimeline(), CollectionUtils.createSet(HoodieTimeline.RESTORE_ACTION, HoodieTimeline.ROLLBACK_ACTION));
     checkTimeline.accept(timeline.getRestoreTimeline(), Collections.singleton(HoodieTimeline.RESTORE_ACTION));
     checkTimeline.accept(timeline.getSavePointTimeline(), Collections.singleton(HoodieTimeline.SAVEPOINT_ACTION));
     checkTimeline.accept(timeline.getAllCommitsTimeline(), CollectionUtils.createSet(
@@ -421,10 +428,16 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     assertTrue(timeline.containsInstant(compaction));
     assertFalse(timeline.containsInstant(inflight));
     inflight = timeline.transitionCompactionRequestedToInflight(compaction);
-    compaction = timeline.transitionCompactionInflightToComplete(true, inflight, Option.empty());
+    timeline.reload();
+    assertFalse(timeline.filterPendingExcludingCompaction().containsInstant(compaction));
+    assertTrue(timeline.filterPendingCompactionTimeline().containsInstant(compaction));
+    assertTrue(timeline.filterPendingMajorOrMinorCompactionTimeline().containsInstant(compaction));
+    compaction = timeline.transitionCompactionInflightToComplete(false, inflight, Option.empty());
     timeline = timeline.reload();
     assertTrue(timeline.containsInstant(compaction));
     assertFalse(timeline.containsInstant(inflight));
+    assertFalse(timeline.filterPendingCompactionTimeline().containsInstant(compaction));
+    assertFalse(timeline.filterPendingMajorOrMinorCompactionTimeline().containsInstant(compaction));
 
     // transitionCleanXXXtoYYY
     HoodieInstant clean = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "4");
@@ -530,6 +543,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     // filterCompletedAndCompactionInstants
     // This cannot be done using checkFilter as it involves both states and actions
     final HoodieTimeline t1 = timeline.filterCompletedAndCompactionInstants();
+    assertTrue(t1.countInstants() > 0);
     final Set<State> states = CollectionUtils.createSet(State.COMPLETED);
     final Set<String> actions = Collections.singleton(HoodieTimeline.COMPACTION_ACTION);
     sup.get().filter(i -> states.contains(i.getState()) || actions.contains(i.getAction()))
@@ -539,10 +553,116 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
 
     // filterPendingCompactionTimeline
     final HoodieTimeline t2 = timeline.filterPendingCompactionTimeline();
+    assertTrue(t2.countInstants() > 0);
     sup.get().filter(i -> i.getAction().equals(HoodieTimeline.COMPACTION_ACTION))
         .forEach(i -> assertTrue(t2.containsInstant(i)));
     sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.COMPACTION_ACTION))
         .forEach(i -> assertFalse(t2.containsInstant(i)));
+
+    // filterPendingIndexTimeline
+    final HoodieTimeline t3 = timeline.filterPendingIndexTimeline();
+    assertEquals(2, t3.countInstants());
+    sup.get().filter(i -> i.getAction().equals(HoodieTimeline.INDEXING_ACTION) && !i.isCompleted())
+        .forEach(i -> assertTrue(t3.containsInstant(i)));
+    sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.INDEXING_ACTION) || i.getState() == State.COMPLETED)
+        .forEach(i -> assertFalse(t3.containsInstant(i)));
+
+    // filterCompletedIndexTimeline
+    final HoodieTimeline t4 = timeline.filterCompletedIndexTimeline();
+    assertEquals(1, t4.countInstants());
+    sup.get().filter(i -> i.getAction().equals(HoodieTimeline.INDEXING_ACTION) && i.isCompleted())
+        .forEach(i -> assertTrue(t4.containsInstant(i)));
+    sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.INDEXING_ACTION) || !i.isCompleted())
+        .forEach(i -> assertFalse(t4.containsInstant(i)));
+
+    // filterCompletedInstantsOrRewriteTimeline
+    final HoodieTimeline t5 = timeline.filterCompletedInstantsOrRewriteTimeline();
+    assertTrue(t5.countInstants() > 0);
+    sup.get().filter(i -> CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION).contains(i.getAction())
+        || i.isCompleted()).forEach(i -> assertTrue(t5.containsInstant(i)));
+    sup.get().filter(i -> !(CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION).contains(i.getAction())
+        || i.isCompleted())).forEach(i -> assertFalse(t5.containsInstant(i)));
+
+    // filterPendingMajorOrMinorCompactionTimeline
+    final HoodieTimeline t6 = timeline.filterPendingMajorOrMinorCompactionTimeline();
+    assertTrue(t6.countInstants() > 0);
+    sup.get().filter(i -> CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION).contains(i.getAction())
+        && !i.isCompleted()).forEach(i -> assertTrue(t6.containsInstant(i)));
+    sup.get().filter(i -> !(CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION).contains(i.getAction())
+        && !i.isCompleted())).forEach(i -> assertFalse(t6.containsInstant(i)));
+
+    // filterPendingExcludingCompaction
+    final HoodieTimeline t7 = timeline.filterPendingExcludingCompaction();
+    assertTrue(t7.countInstants() > 0);
+    sup.get().filter(i -> !HoodieTimeline.COMPACTION_ACTION.equals(i.getAction()) && !i.isCompleted())
+        .forEach(i -> assertTrue(t7.containsInstant(i)));
+    sup.get().filter(i -> !(!HoodieTimeline.COMPACTION_ACTION.equals(i.getAction()) && !i.isCompleted()))
+        .forEach(i -> assertFalse(t7.containsInstant(i)));
+  }
+
+  @Test
+  public void testRollbackActionsTimeline() {
+    int instantTime = 1;
+    List<HoodieInstant> allInstants = new ArrayList<>();
+    allInstants.add(metaClient.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, String.format("%03d", instantTime++)));
+    HoodieInstant rollbackInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, String.format("%03d", instantTime++));
+    allInstants.add(rollbackInstant);
+
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.setInstants(allInstants);
+    assertEquals(1, timeline.filterRequestedRollbackTimeline().countInstants());
+    assertEquals(1, timeline.filterPendingRollbackTimeline().countInstants());
+
+    rollbackInstant = metaClient.createNewInstant(State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstant.requestedTime());
+    allInstants.set(1, rollbackInstant);
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.setInstants(allInstants);
+    assertEquals(0, timeline.filterRequestedRollbackTimeline().countInstants());
+    assertEquals(1, timeline.filterPendingRollbackTimeline().countInstants());
+  }
+
+  @Test
+  void testParsingCommitDetails() throws IOException {
+    HoodieInstant commitInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
+    HoodieInstant cleanInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "2");
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat hoodieWriteStat = new HoodieWriteStat();
+    hoodieWriteStat.setFileId("file_id1");
+    hoodieWriteStat.setPath("path1");
+    hoodieWriteStat.setPrevCommit("1");
+    commitMetadata.addWriteStat("partition1", hoodieWriteStat);
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.createNewInstant(commitInstant);
+    timeline.transitionRequestedToInflight(commitInstant, Option.empty());
+    HoodieInstant completeCommitInstant = metaClient.createNewInstant(State.INFLIGHT, commitInstant.getAction(), commitInstant.requestedTime());
+    timeline.saveAsComplete(completeCommitInstant,
+        Option.of(commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8)));
+    HoodieActiveTimeline timelineAfterFirstInstant = timeline.reload();
+
+    HoodieInstant completedCommitInstant = timelineAfterFirstInstant.lastInstant().get();
+    assertEquals(commitMetadata, timelineAfterFirstInstant.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+
+    HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan();
+    cleanerPlan.setLastCompletedCommitTimestamp("1");
+    cleanerPlan.setPolicy("policy");
+    cleanerPlan.setVersion(1);
+    cleanerPlan.setPartitionsToBeDeleted(Collections.singletonList("partition1"));
+    timeline.saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+
+    assertEquals(cleanerPlan, timeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
+
+    HoodieTimeline mergedTimeline = timelineAfterFirstInstant.mergeTimeline(timeline.reload());
+    assertEquals(commitMetadata, mergedTimeline.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+    assertEquals(cleanerPlan, mergedTimeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
+    assertEquals(commitMetadata, metaClient.getCommitMetadataSerDe().deserialize(completedCommitInstant, mergedTimeline.getInstantDetails(completedCommitInstant).get(), HoodieCommitMetadata.class));
+  }
+
+  @Test
+  void missingInstantCausesError() {
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    HoodieInstant commitInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
+    assertThrows(HoodieIOException.class, () -> timeline.getInstantDetails(commitInstant));
   }
 
   @Test

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -166,7 +167,7 @@ public class FileIOUtils {
 
   public static void createFileInPath(HoodieStorage storage,
                                       StoragePath fullPath,
-                                      Option<byte[]> content, boolean ignoreIOE) {
+                                      Option<HoodieInstantWriter> contentWriter, boolean ignoreIOE) {
     try {
       // If the path does not exist, create it first
       if (!storage.exists(fullPath)) {
@@ -177,9 +178,9 @@ public class FileIOUtils {
         }
       }
 
-      if (content.isPresent()) {
+      if (contentWriter.isPresent()) {
         try (OutputStream out = storage.create(fullPath, true)) {
-          out.write(content.get());
+          contentWriter.get().writeToStream(out);
         }
       }
     } catch (IOException e) {
@@ -191,7 +192,7 @@ public class FileIOUtils {
   }
 
   public static void createFileInPath(HoodieStorage storage, StoragePath fullPath, Option<byte[]> content) {
-    createFileInPath(storage, fullPath, content, false);
+    createFileInPath(storage, fullPath, content.map(bytes -> (outputStream) -> outputStream.write(bytes)), false);
   }
 
   public static boolean copy(HoodieStorage srcStorage, StoragePath src,

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.storage;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Interface for classes that can write instant data to the timeline.
+ */
+public interface HoodieInstantWriter {
+  /**
+   * Writes the instants data to the provided output stream.
+   * @param outputStream stream where the data should be written
+   * @throws IOException thrown if there are issues serializing the data
+   */
+  void writeToStream(OutputStream outputStream) throws IOException;
+}

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
@@ -31,4 +31,8 @@ public interface HoodieInstantWriter {
    * @throws IOException thrown if there are issues serializing the data
    */
   void writeToStream(OutputStream outputStream) throws IOException;
+
+  static HoodieInstantWriter convertByteArrayToWriter(byte[] bytes) {
+    return outputStream -> outputStream.write(bytes);
+  }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -22,6 +22,7 @@ package org.apache.hudi.io.storage;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.util.IOUtils;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -140,7 +141,7 @@ public abstract class TestHoodieStorageBase {
 
     StoragePath path3 = new StoragePath(getTempDir(), "testCreateAppendAndRead/3.file");
     assertFalse(storage.exists(path3));
-    storage.createImmutableFileInPath(path3, Option.of(data));
+    storage.createImmutableFileInPath(path3, Option.of(HoodieInstantWriter.convertByteArrayToWriter(data)));
     validatePathInfo(storage, path3, data, false);
 
     StoragePath path4 = new StoragePath(getTempDir(), "testCreateAppendAndRead/4");

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowColumnStatsOverlapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowColumnStatsOverlapProcedure.scala
@@ -266,15 +266,9 @@ class ShowColumnStatsOverlapProcedure extends BaseProcedure with ProcedureBuilde
     val maxInstant = metaClient.createNewInstantTime()
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): HOption[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(),
+      metaClient.getActiveTimeline.getInstantReader)
 
     new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses)
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -114,15 +114,8 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
       instants = instants.filter(instant => predicate.test(maxInstant, instant.requestedTime))
     }
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): util.Option[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new JArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new JArrayList[HoodieInstant](instants.toList.asJava).stream(), metaClient.getActiveTimeline.getInstantReader)
     new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -140,15 +140,8 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     val maxInstant = metaClient.createNewInstantTime()
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): HOption[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), metaClient.getActiveTimeline.getInstantReader)
 
     HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, filteredTimeline)
   }


### PR DESCRIPTION
### Change Logs

- Add new interface which we can implement for each metadata type to write directly to the output stream
- Adds new method for reading details as a stream
### Impact

Handle larger commit metadata and improve performance 

### Risk level (write none, low medium or high below)

Low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
