### PR TITLE
[HUDI-8569] Fix Insert overwrite / update MOR with global index does not work

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -341,7 +341,7 @@ public class HoodieIndexUtils {
           .prependMetaFields(writeSchema, writeSchemaWithMetaFields, new MetadataValues().setRecordKey(incoming.getRecordKey()).setPartitionPath(incoming.getPartitionPath()), config.getProps());
       // after prepend the meta fields, convert the record back to the original payload
       HoodieRecord incomingWithMetaFields = incomingPrepended
-          .wrapIntoHoodieRecordPayloadWithParams(writeSchema, config.getProps(), Option.empty(), config.allowOperationMetadataField(), Option.empty(), false, Option.empty());
+          .wrapIntoHoodieRecordPayloadWithParams(writeSchemaWithMetaFields, config.getProps(), Option.empty(), config.allowOperationMetadataField(), Option.empty(), false, Option.empty());
       Option<Pair<HoodieRecord, Schema>> mergeResult = recordMerger
           .merge(existing, existingSchema, incomingWithMetaFields, writeSchemaWithMetaFields, config.getProps());
       if (mergeResult.isPresent()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestGlobalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestGlobalIndex.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+
+class TestGlobalIndex extends HoodieSparkSqlTestBase {
+
+  test("Test Type Casting with Global Index for Primary Key and Partition Key insert overwrite") {
+    withRecordType()(withTempDir { tmp =>
+      withSQLConf("hoodie.index.type" -> "GLOBAL_SIMPLE",
+        "hoodie.simple.index.update.partition.path" -> "true") {
+        val tableName = generateTableName
+
+        // Create table with both primary key and partition key
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |c1 int,
+             |c2 int,
+             |c3 string,
+             |ts long
+             |) using hudi
+             |partitioned by (c2)
+             |location '${tmp.getCanonicalPath}/$tableName'
+             |tblproperties (
+             |type = 'mor',
+             |primaryKey = 'c1',
+             |preCombineField = 'ts'
+             |)
+          """.stripMargin)
+
+        // Initial insert with double values
+        spark.sql(
+          s"""
+             |insert into $tableName
+             |select cast(1.0 as double) as c1,
+             |cast(1.0 as double) as c2,
+             |'a' as c3,
+             |1000 as ts
+          """.stripMargin)
+
+        // Verify initial insert
+        checkAnswer(s"select c1, c2, c3 from $tableName")(
+          Seq(1, 1, "a")
+        )
+
+        // Update partition value
+        spark.sql(
+          s"""
+             |insert into $tableName
+             |select cast(1.1 as double) as c1,
+             |cast(2.2 as double) as c2,
+             |'a' as c3,
+             |1001 as ts
+          """.stripMargin)
+
+        // Verify partition key update
+        checkAnswer(
+          s"select c1, c2, c3 from $tableName")(
+          Seq(1, 2, "a")
+        )
+
+        // Test Case 3: Insert overwrite with double values
+        spark.sql(
+          s"""
+             |insert overwrite table $tableName
+             |partition (c2)
+             |select cast(2.3 as double) as c1,
+             |cast(3.3 as double) as c2,
+             |'a' as c3,
+             |1003 as ts
+          """.stripMargin)
+
+        // Additional verification: check complete table state with sorting
+        checkAnswer(s"select c1, c2, c3 from $tableName order by c1, c2")(Seq(2, 3, "a"))
+      }
+    })
+  }
+}


### PR DESCRIPTION
### Change Logs

We prepend the meta fields, but used schema without meta fields for converting records to payload

### Impact

Fix problem with update/insert overwrite mor table with global index

### Risk level (write none, low medium or high below)

NA

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
