### PR TITLE
[HUDI-8992] Migrate HoodieCommitMetadata and HoodieReplaceCommitMetadata reading

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.cli.utils.CommitUtil.getTimeDaysAgo;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
+import static org.apache.hudi.common.table.timeline.TimelineUtils.getCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineUtils.getTimeline;
 
 /**
@@ -72,9 +73,8 @@ public class CommitsCommand {
 
     for (final HoodieInstant commit : commits) {
       if (timeline.getInstantDetails(commit).isPresent()) {
-        final HoodieCommitMetadata commitMetadata = HoodieCLI.getTableMetaClient().getCommitMetadataSerDe().deserialize(
+        final HoodieCommitMetadata commitMetadata = getCommitMetadata(HoodieCLI.getTableMetaClient().getActiveTimeline(),
             commit,
-            timeline.getInstantDetails(commit).get(),
             HoodieCommitMetadata.class);
         rows.add(new Comparable[] {commit.requestedTime(),
             commitMetadata.fetchTotalBytesWritten(),
@@ -421,7 +421,7 @@ public class CommitsCommand {
 
   private Option<HoodieCommitMetadata> getHoodieCommitMetadata(HoodieTimeline timeline, Option<HoodieInstant> hoodieInstant) throws IOException {
     if (hoodieInstant.isPresent()) {
-      return Option.of(TimelineUtils.getCommitMetadata(hoodieInstant.get(), timeline));
+      return Option.of(getCommitMetadata(hoodieInstant.get(), timeline));
     }
     return Option.empty();
   }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -25,11 +25,10 @@ import org.apache.hudi.cli.TableHeader;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantComparator;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.NumericUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -73,7 +72,7 @@ public class CommitsCommand {
 
     for (final HoodieInstant commit : commits) {
       if (timeline.getInstantDetails(commit).isPresent()) {
-        final HoodieCommitMetadata commitMetadata = getCommitMetadata(HoodieCLI.getTableMetaClient().getActiveTimeline(),
+        final HoodieCommitMetadata commitMetadata = HoodieCLI.getTableMetaClient().getActiveTimeline().deserializeInstantContent(
             commit,
             HoodieCommitMetadata.class);
         rows.add(new Comparable[] {commit.requestedTime(),
@@ -112,9 +111,8 @@ public class CommitsCommand {
 
     for (final HoodieInstant commit : commits) {
       if (timeline.getInstantDetails(commit).isPresent()) {
-        final HoodieCommitMetadata commitMetadata = HoodieCLI.getTableMetaClient().getCommitMetadataSerDe().deserialize(
+        final HoodieCommitMetadata commitMetadata = HoodieCLI.getTableMetaClient().getActiveTimeline().deserializeInstantContent(
             commit,
-            timeline.getInstantDetails(commit).get(),
             HoodieCommitMetadata.class);
 
         for (Map.Entry<String, List<HoodieWriteStat>> partitionWriteStat :

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
@@ -120,7 +120,7 @@ public class DiffCommand {
     for (final HoodieInstant commit : commits) {
       Option<byte[]> instantDetails = timeline.getInstantDetails(commit);
       if (instantDetails.isPresent()) {
-        HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe().deserialize(commit, instantDetails.get(), HoodieCommitMetadata.class);
+        HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(commit, HoodieCommitMetadata.class);
         for (Map.Entry<String, List<HoodieWriteStat>> partitionWriteStat :
             commitMetadata.getPartitionToWriteStats().entrySet()) {
           for (HoodieWriteStat hoodieWriteStat : partitionWriteStat.getValue()) {

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
@@ -271,7 +271,7 @@ public class FileSystemViewCommand {
       instantsStream = instantsStream.filter(is -> predicate.test(maxInstant, is.requestedTime()));
     }
     TimelineFactory timelineFactory = metaClient.getTimelineLayout().getTimelineFactory();
-    HoodieTimeline filteredTimeline = timelineFactory.createDefaultTimeline(instantsStream, metaClient.getActiveTimeline()::getInstantDetails);
+    HoodieTimeline filteredTimeline = timelineFactory.createDefaultTimeline(instantsStream, metaClient.getActiveTimeline());
     return new HoodieTableFileSystemView(metaClient, filteredTimeline, pathInfoList);
   }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/StatsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/StatsCommand.java
@@ -77,8 +77,7 @@ public class StatsCommand {
     TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
     for (HoodieInstant instantTime : timeline.getInstants()) {
       String waf = "0";
-      HoodieCommitMetadata commit = layout.getCommitMetadataSerDe().deserialize(instantTime, activeTimeline.getInstantDetails(instantTime).get(),
-          HoodieCommitMetadata.class);
+      HoodieCommitMetadata commit = timeline.deserializeInstantContent(instantTime, HoodieCommitMetadata.class);
       if (commit.fetchTotalUpdateRecordsWritten() > 0) {
         waf = df.format((float) commit.fetchTotalRecordsWritten() / commit.fetchTotalUpdateRecordsWritten());
       }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/CommitUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/CommitUtil.java
@@ -39,10 +39,7 @@ public class CommitUtil {
     HoodieTimeline timeline = metaClient.reloadActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants();
     for (String commit : commitsToCatchup) {
       HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, commit);
-      HoodieCommitMetadata c = metaClient.getCommitMetadataSerDe().deserialize(
-          instant,
-          timeline.getInstantDetails(instant).get(),
-          HoodieCommitMetadata.class);
+      HoodieCommitMetadata c = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
       totalNew += c.fetchTotalRecordsWritten() - c.fetchTotalUpdateRecordsWritten();
     }
     return totalNew;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1424,8 +1424,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
                   || s.getAction().equals(HoodieActiveTimeline.REPLACE_COMMIT_ACTION))
               .lastInstant();
       if (lastInstant.isPresent()) {
-        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(lastInstant.get(),
-            activeTimeline.getInstantDetails(lastInstant.get()).get(), HoodieCommitMetadata.class);
+        HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(lastInstant.get(), HoodieCommitMetadata.class);
         String extraSchema = commitMetadata.getExtraMetadata().get(SCHEMA_KEY);
         if (!StringUtils.isNullOrEmpty(extraSchema)) {
           config.setSchema(commitMetadata.getExtraMetadata().get(SCHEMA_KEY));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieColumnStatsIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieColumnStatsIndexUtils.java
@@ -61,9 +61,8 @@ public class HoodieColumnStatsIndexUtils {
               .setBasePath(HoodieTableMetadata.getMetadataTableBasePath(dataTable.getMetaClient().getBasePath()))
               .build();
           HoodieInstant latestInstant = mdtMetaClient.getActiveTimeline().getWriteTimeline().filterCompletedInstants().lastInstant().get();
-          final HoodieCommitMetadata mdtCommitMetadata = mdtMetaClient.getTimelineLayout().getCommitMetadataSerDe().deserialize(
+          final HoodieCommitMetadata mdtCommitMetadata = mdtMetaClient.getActiveTimeline().deserializeInstantContent(
               latestInstant,
-              mdtMetaClient.getActiveTimeline().getInstantDetails(latestInstant).get(),
               HoodieCommitMetadata.class);
           if (mdtCommitMetadata.getPartitionToWriteStats().containsKey(MetadataPartitionType.COLUMN_STATS.getPartitionPath())) {
             // update data table's table config for list of columns indexed.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
@@ -42,6 +42,7 @@ import org.apache.hudi.io.hadoop.HoodieAvroParquetReader;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
@@ -187,7 +188,7 @@ public class LSMTimelineWriter {
     int newVersion = currentVersion < 0 ? 1 : currentVersion + 1;
     // create manifest file
     final StoragePath manifestFilePath = LSMTimeline.getManifestFilePath(newVersion, archivePath);
-    metaClient.getStorage().createImmutableFileInPath(manifestFilePath, Option.of(content));
+    metaClient.getStorage().createImmutableFileInPath(manifestFilePath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(content)));
     // update version file
     updateVersionFile(newVersion);
   }
@@ -196,7 +197,7 @@ public class LSMTimelineWriter {
     byte[] content = getUTF8Bytes(String.valueOf(newVersion));
     final StoragePath versionFilePath = LSMTimeline.getVersionFilePath(archivePath);
     metaClient.getStorage().deleteFile(versionFilePath);
-    metaClient.getStorage().createImmutableFileInPath(versionFilePath, Option.of(content));
+    metaClient.getStorage().createImmutableFileInPath(versionFilePath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(content)));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
-import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -55,8 +54,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Tools used for migrating to new LSM tree style archived timeline.
@@ -103,8 +100,8 @@ public class LegacyArchivedMetaEntryReader {
           // should be json bytes.
           try {
             HoodieInstant instant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, action, instantTime, stateTransitionTime);
-            org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata = new CommitMetadataSerDeV1().deserialize(instant, getUTF8Bytes(actionData.toString()),
-                org.apache.hudi.common.model.HoodieCommitMetadata.class);
+            org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(
+                instant, org.apache.hudi.common.model.HoodieCommitMetadata.class);
             // convert to avro bytes.
             return metaClient.getCommitMetadataSerDe().serialize(commitMetadata).get();
           } catch (IOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -200,7 +201,7 @@ public class ConsistentBucketIndexUtils {
         // the file has been created by other tasks
         return true;
       }
-      storage.createImmutableFileInPath(fullPath, Option.of(metadata.toBytes()), true);
+      storage.createImmutableFileInPath(fullPath, Option.of(HoodieInstantWriter.convertByteArrayToWriter(metadata.toBytes())), true);
       return true;
     } catch (IOException e1) {
       // ignore the exception and check the file existence

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -256,8 +256,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
         return Stream.concat(replaceCommitMetadata.getPartitionToReplaceFileIds().keySet().stream(), replaceCommitMetadata.getPartitionToWriteStats().keySet().stream());
       } else {
         HoodieCommitMetadata commitMetadata = hoodieTable.getMetaClient()
-            .getCommitMetadataSerDe().deserialize(instant, hoodieTable.getActiveTimeline().getInstantDetails(instant).get(),
-                HoodieCommitMetadata.class);
+            .getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
         return commitMetadata.getPartitionToWriteStats().keySet().stream();
       }
     } catch (IOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
@@ -52,8 +52,7 @@ public class RecordBasedIndexingCatchupTask extends AbstractIndexingCatchupTask 
 
   @Override
   public void updateIndexForWriteAction(HoodieInstant instant) throws IOException {
-    HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant,
-        metaClient.getActiveTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
     metadataWriter.update(commitMetadata, instant.requestedTime());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
@@ -52,8 +52,7 @@ public class WriteStatBasedIndexingCatchupTask extends AbstractIndexingCatchupTa
 
   @Override
   public void updateIndexForWriteAction(HoodieInstant instant) throws IOException {
-    HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant,
-        metaClient.getActiveTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
     metadataWriter.update(commitMetadata, instant.requestedTime());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/repair/RepairUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/repair/RepairUtils.java
@@ -93,8 +93,7 @@ public final class RepairUtils {
       case DELTA_COMMIT_ACTION:
         TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
         final HoodieCommitMetadata commitMetadata =
-            layout.getCommitMetadataSerDe().deserialize(instant,
-                timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+            timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
         return Option.of(commitMetadata.getPartitionToWriteStats().values().stream().flatMap(List::stream)
             .map(HoodieWriteStat::getPath).collect(Collectors.toSet()));
       case REPLACE_COMMIT_ACTION:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToSevenDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToSevenDowngradeHandler.java
@@ -41,7 +41,6 @@ import org.apache.hudi.common.table.timeline.versioning.v1.ActiveTimelineV1;
 import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.ArchivedTimelineLoaderV2;
-import org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -119,12 +118,11 @@ public class EightToSevenDowngradeHandler implements DowngradeHandler {
 
     if (!instants.isEmpty()) {
       InstantFileNameGenerator instantFileNameGenerator = metaClient.getInstantFileNameGenerator();
-      CommitMetadataSerDeV2 commitMetadataSerDeV2 = new CommitMetadataSerDeV2();
       CommitMetadataSerDeV1 commitMetadataSerDeV1 = new CommitMetadataSerDeV1();
       ActiveTimelineV1 activeTimelineV1 = new ActiveTimelineV1(metaClient);
       context.map(instants, instant -> {
         String originalFileName = instantFileNameGenerator.getFileName(instant);
-        return downgradeActiveTimelineInstant(instant, originalFileName, metaClient, commitMetadataSerDeV2, commitMetadataSerDeV1, activeTimelineV1);
+        return downgradeActiveTimelineInstant(instant, originalFileName, metaClient, commitMetadataSerDeV1, activeTimelineV1);
       }, instants.size());
     }
     try {
@@ -272,7 +270,7 @@ public class EightToSevenDowngradeHandler implements DowngradeHandler {
     }
   }
 
-  static boolean downgradeActiveTimelineInstant(HoodieInstant instant, String originalFileName, HoodieTableMetaClient metaClient, CommitMetadataSerDeV2 commitMetadataSerDeV2,
+  static boolean downgradeActiveTimelineInstant(HoodieInstant instant, String originalFileName, HoodieTableMetaClient metaClient,
                                                 CommitMetadataSerDeV1 commitMetadataSerDeV1, ActiveTimelineV1 activeTimelineV1) {
     String replacedFileName = originalFileName;
     boolean isCompleted = instant.isCompleted();
@@ -287,7 +285,7 @@ public class EightToSevenDowngradeHandler implements DowngradeHandler {
       replacedFileName = replacedFileName.replace(instant.getAction(), EIGHT_TO_SIX_TIMELINE_ACTION_MAP.get(instant.getAction()));
     }
     try {
-      return rewriteTimelineV2InstantFileToV1Format(instant, metaClient, originalFileName, replacedFileName, commitMetadataSerDeV2, commitMetadataSerDeV1, activeTimelineV1);
+      return rewriteTimelineV2InstantFileToV1Format(instant, metaClient, originalFileName, replacedFileName, commitMetadataSerDeV1, activeTimelineV1);
     } catch (IOException e) {
       LOG.error("Can not to complete the downgrade from version eight to version seven. The reason for failure is {}", e.getMessage());
       throw new HoodieException(e);
@@ -295,7 +293,7 @@ public class EightToSevenDowngradeHandler implements DowngradeHandler {
   }
 
   static boolean rewriteTimelineV2InstantFileToV1Format(HoodieInstant instant, HoodieTableMetaClient metaClient, String originalFileName, String replacedFileName,
-                                                        CommitMetadataSerDeV2 commitMetadataSerDeV2, CommitMetadataSerDeV1 commitMetadataSerDeV1, ActiveTimelineV1 activeTimelineV1)
+                                                        CommitMetadataSerDeV1 commitMetadataSerDeV1, ActiveTimelineV1 activeTimelineV1)
       throws IOException {
     StoragePath fromPath = new StoragePath(TIMELINE_LAYOUT_V2.getTimelinePathProvider().getTimelinePath(metaClient.getTableConfig(), metaClient.getBasePath()), originalFileName);
     long modificationTime = instant.isCompleted() ? convertCompletionTimeToEpoch(instant) : -1;
@@ -305,9 +303,9 @@ public class EightToSevenDowngradeHandler implements DowngradeHandler {
         || ((instant.getAction().equals(REPLACE_COMMIT_ACTION) || instant.getAction().equals(CLUSTERING_ACTION)) && instant.isCompleted())) {
       Option<byte[]> data;
       if (instant.getAction().equals(REPLACE_COMMIT_ACTION) || instant.getAction().equals(CLUSTERING_ACTION)) {
-        data = commitMetadataSerDeV1.serialize(HoodieReplaceCommitMetadata.fromBytes(metaClient.getActiveTimeline().getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class));
+        data = commitMetadataSerDeV1.serialize(activeTimelineV1.deserializeInstantContent(instant, HoodieReplaceCommitMetadata.class));
       } else {
-        data = commitMetadataSerDeV1.serialize(commitMetadataSerDeV2.deserialize(instant, metaClient.getActiveTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class));
+        data = commitMetadataSerDeV1.serialize(metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class));
       }
       String toPathStr = toPath.toUri().toString();
       activeTimelineV1.createFileInMetaPath(toPathStr, data, true);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -289,7 +289,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     boolean success = true;
     if (instant.getAction().equals(COMMIT_ACTION) || instant.getAction().equals(DELTA_COMMIT_ACTION) || (instant.getAction().equals(REPLACE_COMMIT_ACTION) && instant.isCompleted())) {
       Class<? extends HoodieCommitMetadata> clazz = instant.getAction().equals(REPLACE_COMMIT_ACTION) ? HoodieReplaceCommitMetadata.class : HoodieCommitMetadata.class;
-      HoodieCommitMetadata commitMetadata = commitMetadataSerDeV1.deserialize(instant, metaClient.getActiveTimeline().getInstantDetails(instant).get(), clazz);
+      HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, clazz);
       Option<byte[]> data = commitMetadataSerDeV2.serialize(commitMetadata);
       String toPathStr = toPath.toUri().toString();
       activeTimelineV2.createFileInMetaPath(toPathStr, data, true);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieArchivedTimeline.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieArchivedTimeline.java
@@ -41,9 +41,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test cases for {@link HoodieArchivedTimeline}.
@@ -74,6 +76,11 @@ public class TestHoodieArchivedTimeline extends HoodieCommonTestHarness {
     assertThat(archivedTimeline.firstInstant().map(HoodieInstant::requestedTime).orElse(""), is("10000011"));
   }
 
+  @Test
+  void getInstantReaderReferencesSelf() {
+    HoodieArchivedTimeline timeline = TIMELINE_FACTORY.createArchivedTimeline(metaClient);
+    assertSame(timeline, timeline.getInstantReader());
+  }
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -192,7 +192,7 @@ public class TestCleanPlanner {
         getCleanCommitMetadata(partitionsInLastClean, lastCleanInstant, earliestInstantsInLastClean, lastCompletedTimeInLastClean,
             savepointsTrackedInLastClean.keySet(), expectedEarliestSavepointInLastClean);
     HoodieCleanerPlan cleanerPlan = mockLastCleanCommit(mockHoodieTable, lastCleanInstant, earliestInstantsInLastClean, activeTimeline, cleanMetadataOptionPair, savepointsTrackedInLastClean.keySet());
-    mockFewActiveInstants(instantReader, mockHoodieTable, activeTimeline, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved, replaceCommits);
+    mockFewActiveInstants(mockHoodieTable, activeTimeline, activeInstantsPartitions, savepointsTrackedInLastClean, areCommitsForSavepointsRemoved, replaceCommits);
 
     // mock getAllPartitions
     HoodieStorage storage = mock(HoodieStorage.class);
@@ -655,10 +655,10 @@ public class TestCleanPlanner {
     return cleanerPlan;
   }
 
-  private static void mockFewActiveInstants(HoodieInstantReader instantReader, HoodieTable hoodieTable, HoodieActiveTimeline activeTimeline, Map<String, List<String>> activeInstantsToPartitions,
+  private static void mockFewActiveInstants(HoodieTable hoodieTable, HoodieActiveTimeline activeTimeline, Map<String, List<String>> activeInstantsToPartitions,
                                             Map<String, List<String>> savepointedCommitsToAdd, boolean areCommitsForSavepointsRemoved, List<String> replaceCommits)
       throws IOException {
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = new ArrayList<>();
     Map<String, List<String>> instantstoProcess = new HashMap<>();
     instantstoProcess.putAll(activeInstantsToPartitions);
@@ -688,12 +688,12 @@ public class TestCleanPlanner {
     when(hoodieTable.getActiveTimeline().getInstantsAsStream()).thenReturn(instants.stream());
     when(hoodieTable.getCompletedCommitsTimeline()).thenReturn(commitsTimeline);
 
-    BaseTimelineV2 savepointTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 savepointTimeline = new BaseTimelineV2();
     List<HoodieInstant> savepointInstants = savepointedCommitsToAdd.keySet().stream().map(sp -> INSTANT_GENERATOR.createNewInstant(COMPLETED, HoodieTimeline.SAVEPOINT_ACTION, sp))
         .collect(Collectors.toList());
     savepointTimeline.setInstants(savepointInstants);
 
-    BaseTimelineV2 completedReplaceTimeline = new BaseTimelineV2(instantReader);
+    BaseTimelineV2 completedReplaceTimeline = new BaseTimelineV2();
     List<HoodieInstant> completedReplaceInstants = replaceCommits.stream().map(rc -> INSTANT_GENERATOR.createNewInstant(COMPLETED, HoodieTimeline.REPLACE_COMMIT_ACTION, rc))
         .collect(Collectors.toList());
     completedReplaceTimeline.setInstants(completedReplaceInstants);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
@@ -219,9 +219,9 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
     assertEquals(newCommitTime, archived.getInstantTime());
     assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, archived.getAction());
     assertDoesNotThrow(() -> HoodieReplaceCommitMetadata.fromBytes(archived.getMetadata().array(), HoodieReplaceCommitMetadata.class));
-    assertDoesNotThrow(() -> metaClient.getCommitMetadataSerDe().deserialize(
-        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime),
-        archived.getPlan().array(), HoodieCommitMetadata.class), "Insert overwrite without clustering should have a plan");
+    assertDoesNotThrow(() -> metaClient.getActiveTimeline().deserializeInstantContent(
+        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime), HoodieCommitMetadata.class),
+        "Insert overwrite without clustering should have a plan");
 
     String newCommitTime2 = HoodieTestTable.makeNewCommitTime();
     createReplace(newCommitTime2, WriteOperationType.INSERT_OVERWRITE_TABLE, false);
@@ -230,9 +230,8 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
     assertEquals(newCommitTime2, archived2.getInstantTime());
     assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, archived2.getAction());
     assertDoesNotThrow(() -> HoodieReplaceCommitMetadata.fromBytes(archived2.getMetadata().array(), HoodieReplaceCommitMetadata.class));
-    assertDoesNotThrow(() -> metaClient.getCommitMetadataSerDe().deserialize(
-        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime2),
-        archived2.getPlan().array(), HoodieCommitMetadata.class),
+    assertDoesNotThrow(() -> metaClient.getActiveTimeline().deserializeInstantContent(
+        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime2), HoodieCommitMetadata.class),
         "Insert overwrite table without clustering should have a plan");
   }
 
@@ -264,9 +263,8 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
     HoodieLSMTimelineInstant archived = MetadataConversionUtils.createLSMTimelineInstant(getActiveInstant(newCommitTime), metaClient);
     assertEquals(newCommitTime, archived.getInstantTime());
     assertEquals(HoodieTimeline.COMMIT_ACTION, archived.getAction());
-    assertDoesNotThrow(() -> metaClient.getCommitMetadataSerDe().deserialize(
-        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime),
-        archived.getMetadata().array(), HoodieCommitMetadata.class));
+    assertDoesNotThrow(() -> metaClient.getActiveTimeline().deserializeInstantContent(
+        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime), HoodieCommitMetadata.class));
   }
 
   @Test
@@ -297,9 +295,8 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
     HoodieLSMTimelineInstant archived = MetadataConversionUtils.createLSMTimelineInstant(getActiveInstant(newCommitTime), metaClient);
     assertEquals(newCommitTime, archived.getInstantTime());
     assertEquals(HoodieTimeline.COMMIT_ACTION, archived.getAction());
-    assertDoesNotThrow(() -> metaClient.getCommitMetadataSerDe().deserialize(
-        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime),
-        archived.getMetadata().array(), HoodieCommitMetadata.class));
+    assertDoesNotThrow(() -> metaClient.getActiveTimeline().deserializeInstantContent(
+        INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, newCommitTime), HoodieCommitMetadata.class));
     assertDoesNotThrow(() -> CompactionUtils.getCompactionPlan(metaClient, Option.of(archived.getPlan().array())));
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/FlinkSizeBasedClusteringPlanStrategyRecently.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/FlinkSizeBasedClusteringPlanStrategyRecently.java
@@ -120,8 +120,7 @@ public class FlinkSizeBasedClusteringPlanStrategyRecently<T> extends FlinkSizeBa
     HoodieTimeline cowCommitTimeline = hoodieTable.getActiveTimeline().getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION)).filterCompletedInstants();
     cowCommitTimeline.getInstants().forEach(instant -> {
       try {
-        HoodieCommitMetadata metadata = hoodieTable.getMetaClient().getCommitMetadataSerDe().deserialize(instant,
-            cowCommitTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+        HoodieCommitMetadata metadata = hoodieTable.getMetaClient().getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
         partitions.addAll(metadata.getWritePartitionPaths());
       } catch (IOException e) {
         // ignore Exception here

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
@@ -322,8 +322,7 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
         while (instants.hasNext()) {
           HoodieInstant instant = instants.next();
           TimelineLayout layout = TimelineLayout.fromVersion(commitTimeline.getTimelineLayoutVersion());
-          HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe()
-              .deserialize(instant, commitTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+          HoodieCommitMetadata commitMetadata = commitTimeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
           long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
           long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
           if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -1440,8 +1440,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // populate commit -> partition -> file info to assist in validation and prefix search
       metaClient.getActiveTimeline().getInstants().forEach(entry -> {
         try {
-          HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe()
-              .deserialize(entry, metaClient.getActiveTimeline().getInstantDetails(entry).get(), HoodieCommitMetadata.class);
+          HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(entry, HoodieCommitMetadata.class);
           String commitTime = entry.requestedTime();
           if (!commitToPartitionsToFiles.containsKey(commitTime)) {
             commitToPartitionsToFiles.put(commitTime, new HashMap<>());

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
@@ -949,7 +949,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
     TimelineLayout layout = TimelineLayout.fromVersion(commitTimeline.getTimelineLayoutVersion());
     for (HoodieInstant commit : commitsToReturn) {
       HoodieCommitMetadata metadata =
-          layout.getCommitMetadataSerDe().deserialize(commit, commitTimeline.getInstantDetails(commit).get(), HoodieCommitMetadata.class);
+          commitTimeline.deserializeInstantContent(commit, HoodieCommitMetadata.class);
       fileIdToFullPath.putAll(metadata.getFileIdAndFullPaths(new StoragePath(basePath)));
     }
     return fileIdToFullPath;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/AverageRecordSizeUtils.java
@@ -56,8 +56,7 @@ public class AverageRecordSizeUtils {
       while (instants.hasNext()) {
         HoodieInstant instant = instants.next();
         try {
-          HoodieCommitMetadata commitMetadata = commitMetadataSerDe
-              .deserialize(instant, commitTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+          HoodieCommitMetadata commitMetadata = commitTimeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
           if (instant.getAction().equals(COMMIT_ACTION) || instant.getAction().equals(REPLACE_COMMIT_ACTION)) {
             long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
             long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
@@ -111,9 +111,8 @@ public class TestSavepoint extends HoodieClientTestBase {
               .getPartitionMetadata();
 
       HoodieTimeline commitsTimeline = table.getActiveTimeline().getCommitsTimeline();
-      Map<String, List<HoodieWriteStat>> partitionToWriteStats = metaClient.getCommitMetadataSerDe().deserialize(
+      Map<String, List<HoodieWriteStat>> partitionToWriteStats = metaClient.getActiveTimeline().deserializeInstantContent(
               commitsTimeline.lastInstant().get(),
-              commitsTimeline.getInstantDetails(commitsTimeline.lastInstant().get()).get(),
               HoodieCommitMetadata.class)
           .getPartitionToWriteStats();
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
@@ -370,8 +370,7 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
         .filter(s -> {
           try {
             return s.getAction().equals(HoodieTimeline.COMMIT_ACTION)
-                && metaClient.getCommitMetadataSerDe().deserialize(s,
-                    timeline.getInstantDetails(s).get(), HoodieCommitMetadata.class)
+                && metaClient.getActiveTimeline().deserializeInstantContent(s, HoodieCommitMetadata.class)
                 .getOperationType().equals(COMPACT);
           } catch (IOException e) {
             throw new RuntimeException(e);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -531,7 +531,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     setUp(IndexType.BLOOM, true, false);
 
     // When timeline is empty, all commits are invalid
-    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline().getInstantReader());
+    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline());
     assertTrue(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, "001"));
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, writeClient.createNewInstantTime()));
@@ -541,7 +541,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     final HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "010");
     String instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, writeClient.createNewInstantTime());
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant1.requestedTime()));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant2.requestedTime()));
@@ -557,7 +557,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     instantTimestamp = writeClient.createNewInstantTime();
     String instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant3 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestampSec);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestampSec));
@@ -565,7 +565,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     // With a sec format instant time lesser than first entry in the active timeline, checkifContainsOrBefore() should return true
     instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline());
     instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
@@ -588,14 +588,14 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String newTimestamp = writeClient.createNewInstantTime();
     String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(checkInstantTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestampSec));
 
     final HoodieInstant instant6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.DELTA_COMMIT_ACTION, newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline().getInstantReader());
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(newTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestamp));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -531,7 +531,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     setUp(IndexType.BLOOM, true, false);
 
     // When timeline is empty, all commits are invalid
-    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline()::getInstantDetails);
+    HoodieTimeline timeline = TIMELINE_FACTORY.createDefaultTimeline(Collections.EMPTY_LIST.stream(), metaClient.getActiveTimeline().getInstantReader());
     assertTrue(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, "001"));
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, writeClient.createNewInstantTime()));
@@ -541,7 +541,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     final HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "010");
     String instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, writeClient.createNewInstantTime());
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant2), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant1.requestedTime()));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instant2.requestedTime()));
@@ -557,7 +557,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     instantTimestamp = writeClient.createNewInstantTime();
     String instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant3 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestampSec);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant1, instant3), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestampSec));
@@ -565,7 +565,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     // With a sec format instant time lesser than first entry in the active timeline, checkifContainsOrBefore() should return true
     instantTimestamp = writeClient.createNewInstantTime();
     final HoodieInstant instant4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, instantTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant4), metaClient.getActiveTimeline().getInstantReader());
     instantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     assertFalse(timeline.empty());
     assertTrue(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
@@ -588,14 +588,14 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String newTimestamp = writeClient.createNewInstantTime();
     String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(checkInstantTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestampSec));
 
     final HoodieInstant instant6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.DELTA_COMMIT_ACTION, newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT);
-    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline()::getInstantDetails);
+    timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline().getInstantReader());
     assertFalse(timeline.empty());
     assertFalse(timeline.containsInstant(newTimestamp));
     assertFalse(timeline.containsInstant(checkInstantTimestamp));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByCommits.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByCommits.java
@@ -216,7 +216,7 @@ public class TestCleanerInsertAndCleanByCommits extends SparkClientFunctionalTes
         try {
           HoodieInstant instant1 = timeline.filter(inst -> inst.requestedTime().equals(newInstant))
               .firstInstant().get();
-          return layout.getCommitMetadataSerDe().deserialize(instant1, timeline.getInstantDetails(instant1).get(), HoodieCommitMetadata.class)
+          return timeline.deserializeInstantContent(instant1, HoodieCommitMetadata.class)
               .getWriteStats();
         } catch (IOException e) {
           return Collections.EMPTY_LIST;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -193,7 +193,7 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
           HashMap<String, TreeSet<String>> fileIdToVersions = new HashMap<>();
           for (HoodieInstant entry : timeline.getInstants()) {
             HoodieCommitMetadata commitMetadata =
-                metaClient.getCommitMetadataSerDe().deserialize(entry, timeline.getInstantDetails(entry).get(), HoodieCommitMetadata.class);
+                metaClient.getActiveTimeline().deserializeInstantContent(entry, HoodieCommitMetadata.class);
 
             for (HoodieWriteStat wstat : commitMetadata.getWriteStats(partitionPath)) {
               if (!fileIdToVersions.containsKey(wstat.getFileId())) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -68,7 +68,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
     HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
-    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
+    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -104,7 +104,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -68,7 +68,7 @@ public class TestAverageRecordSizeUtils {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
     HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
-    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
+    HoodieTimeline commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -99,12 +99,11 @@ public class TestAverageRecordSizeUtils {
 
   @Test
   public void testErrorHandling() throws IOException {
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
     int recordSize = 10000;
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline());
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestAverageRecordSizeUtils.java
@@ -22,10 +22,12 @@ package org.apache.hudi.table.action.commit;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v2.BaseTimelineV2;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 
@@ -62,10 +64,11 @@ public class TestAverageRecordSizeUtils {
 
   @ParameterizedTest
   @MethodSource("testCases")
-  public void testAverageRecordSize(List<Pair<HoodieInstant, List<HWriteStat>>> instantSizePairs, long expectedSize) {
+  public void testAverageRecordSize(List<Pair<HoodieInstant, List<HWriteStat>>> instantSizePairs, long expectedSize) throws IOException {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .build();
-    HoodieTimeline commitsTimeline = new BaseTimelineV2();
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
+    HoodieTimeline commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
     List<HoodieInstant> instants = new ArrayList<>();
     instantSizePairs.forEach(entry -> {
       HoodieInstant hoodieInstant = entry.getKey();
@@ -95,12 +98,13 @@ public class TestAverageRecordSizeUtils {
   }
 
   @Test
-  public void testErrorHandling() {
+  public void testErrorHandling() throws IOException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init("/tmp");
     int recordSize = 10000;
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(recordSize)))
         .build(false);
-    BaseTimelineV2 commitsTimeline = new BaseTimelineV2();
+    BaseTimelineV2 commitsTimeline = new BaseTimelineV2(metaClient.getActiveTimeline().getInstantReader());
     List<HoodieInstant> instants = Collections.singletonList(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "1"));
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -142,7 +142,7 @@ public class HoodieClientTestUtils {
     TimelineLayout layout = TimelineLayout.fromVersion(commitTimeline.getTimelineLayoutVersion());
     for (HoodieInstant commit : commitsToReturn) {
       HoodieCommitMetadata metadata =
-          layout.getCommitMetadataSerDe().deserialize(commit, commitTimeline.getInstantDetails(commit).get(), HoodieCommitMetadata.class);
+          commitTimeline.deserializeInstantContent(commit, HoodieCommitMetadata.class);
       fileIdToFullPath.putAll(metadata.getFileIdAndFullPaths(new StoragePath(basePath)));
     }
     return fileIdToFullPath;
@@ -329,7 +329,7 @@ public class HoodieClientTestUtils {
     try {
       HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
       byte[] data = timeline.getInstantDetails(instant).get();
-      return Option.of(metaClient.getCommitMetadataSerDe().deserialize(instant, data, HoodieCommitMetadata.class));
+      return Option.of(metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class));
     } catch (Exception e) {
       throw new HoodieException("Failed to read schema from commit metadata", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -112,8 +113,8 @@ public class HoodiePartitionMetadata {
               // Backwards compatible properties file format
               try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                 props.store(os, "partition metadata");
-                Option content = Option.of(os.toByteArray());
-                storage.createImmutableFileInPath(metaPath, content);
+                Option<byte []> content = Option.of(os.toByteArray());
+                storage.createImmutableFileInPath(metaPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
               }
             }
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -265,9 +265,8 @@ public class TableSchemaResolver {
         // Make sure the commit metadata has a valid schema inside. Same caching the result for expensive operation.
         .filter(s -> {
           try {
-            return !StringUtils.isNullOrEmpty(metaClient.getCommitMetadataSerDe().deserialize(
+            return !StringUtils.isNullOrEmpty(metaClient.getActiveTimeline().deserializeInstantContent(
                       s,
-                      reversedTimeline.getInstantDetails(s).get(),
                       HoodieCommitMetadata.class)
                 .getMetadata(HoodieCommitMetadata.SCHEMA_KEY));
           } catch (IOException e) {
@@ -365,8 +364,8 @@ public class TableSchemaResolver {
         "Could not read schema from last compaction, no compaction commits found on path " + metaClient));
 
     // Read from the compacted file wrote
-    HoodieCommitMetadata compactionMetadata = metaClient.getCommitMetadataSerDe().deserialize(
-        lastCompactionCommit, activeTimeline.getInstantDetails(lastCompactionCommit).get(),HoodieCommitMetadata.class);
+    HoodieCommitMetadata compactionMetadata = metaClient.getActiveTimeline().deserializeInstantContent(
+        lastCompactionCommit, HoodieCommitMetadata.class);
     String filePath = compactionMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().findAny()
         .orElseThrow(() -> new IllegalArgumentException("Could not find any data file written for compaction "
             + lastCompactionCommit + ", could not get schema for table " + metaClient.getBasePath()));
@@ -410,8 +409,7 @@ public class TableSchemaResolver {
     HoodieTimeline timeline = completedInstants
         .filter(instant -> { // consider only instants that can update/change schema.
           try {
-            HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(
-                instant, completedInstants.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+            HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
             return WriteOperationType.canUpdateSchema(commitMetadata.getOperationType());
           } catch (IOException e) {
             throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", instant), e);
@@ -521,10 +519,8 @@ public class TableSchemaResolver {
   private HoodieCommitMetadata getCachedCommitMetadata(HoodieInstant instant) {
     return commitMetadataCache.get()
         .computeIfAbsent(instant, (missingInstant) -> {
-          HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-          byte[] data = timeline.getInstantDetails(missingInstant).get();
           try {
-            return metaClient.getCommitMetadataSerDe().deserialize(missingInstant, data, HoodieCommitMetadata.class);
+            return metaClient.getActiveTimeline().deserializeInstantContent(missingInstant, HoodieCommitMetadata.class);
           } catch (IOException e) {
             throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", missingInstant), e);
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -624,6 +624,6 @@ public class TableSchemaResolver {
         .sorted(reversedComparator);
     return timelineLayout.getTimelineFactory().createDefaultTimeline(
         reversedTimelineWithTableSchema,
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -624,6 +624,6 @@ public class TableSchemaResolver {
         .sorted(reversedComparator);
     return timelineLayout.getTimelineFactory().createDefaultTimeline(
         reversedTimelineWithTableSchema,
-        metaClient.getActiveTimeline()::getInstantDetails);
+        metaClient.getActiveTimeline().getInstantReader());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -22,13 +22,16 @@ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -565,19 +568,23 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   }
 
   @Override
-  public <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
-    try (InputStream inputStream = getInstantContentStream(instant)) {
-      DatumReader<T> reader = new SpecificDatumReader<>(clazz);
-      DataFileStream<T> fileReader = new DataFileStream<>(inputStream, reader);
-      ValidationUtils.checkArgument(fileReader.hasNext(), "Could not deserialize metadata of type " + clazz);
-      return fileReader.next();
-    }
-  }
-
-  @Override
-  public <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
-    try (InputStream inputStream = getInstantContentStream(instant)) {
-      return JsonUtils.getObjectMapper().readValue(inputStream, clazz);
+  public <T> T deserializeInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
+    if (SpecificRecord.class.isAssignableFrom(clazz)) {
+      try (InputStream inputStream = getInstantContentStream(instant)) {
+        DatumReader<T> reader = new SpecificDatumReader<>(clazz);
+        DataFileStream<T> fileReader = new DataFileStream<>(inputStream, reader);
+        ValidationUtils.checkArgument(fileReader.hasNext(), "Could not deserialize metadata of type " + clazz);
+        return fileReader.next();
+      }
+    } else {
+      try (InputStream inputStream = getInstantContentStream(instant)) {
+        return JsonUtils.getObjectMapper().readValue(inputStream, clazz);
+      } catch (MismatchedInputException ex) {
+        if (ex.getMessage().startsWith("No content to map")) {
+          return ReflectionUtils.loadClass(clazz.getName());
+        }
+        throw ex;
+      }
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -20,14 +20,20 @@ package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.specific.SpecificDatumReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -36,7 +42,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +55,7 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * HoodieDefaultTimeline is a default implementation of the HoodieTimeline. It provides methods to inspect a
- * List[HoodieInstant]. Function to get the details of the instant is passed in as a lambda.
+ * List[HoodieInstant]. Function to get the instantReader of the instant is passed in as a lambda.
  *
  * @see HoodieTimeline
  */
@@ -62,7 +67,7 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   private static final String HASHING_ALGORITHM = "SHA-256";
 
-  protected transient Function<HoodieInstant, Option<byte[]>> details;
+  protected transient HoodieInstantReader instantReader;
   private List<HoodieInstant> instants;
   // for efficient #contains queries.
   private transient volatile Set<String> instantTimeSet;
@@ -78,15 +83,16 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   protected InstantComparator instantComparator;
   protected InstantGenerator instantGenerator;
 
-  public BaseHoodieTimeline(TimelineLayout layout) {
+  public BaseHoodieTimeline(TimelineLayout layout, HoodieInstantReader instantReader) {
     this.factory = layout.getTimelineFactory();
     this.instantComparator = layout.getInstantComparator();
     this.instantGenerator = layout.getInstantGenerator();
+    this.instantReader = instantReader;
   }
 
-  public BaseHoodieTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details,
+  public BaseHoodieTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader,
                             TimelineFactory factory, InstantComparator instantComparator, InstantGenerator instantGenerator) {
-    this.details = details;
+    this.instantReader = instantReader;
     this.factory = factory;
     this.instantComparator = instantComparator;
     this.instantGenerator = instantGenerator;
@@ -117,62 +123,62 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline filterInflights() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), instantReader);
   }
 
   @Override
   public HoodieTimeline filterInflightsAndRequested() {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(i -> i.getState().equals(State.REQUESTED) || i.getState().equals(State.INFLIGHT)),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), details);
+        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompactionAndLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
         && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
-        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), details);
+        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedInstants() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedAndCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), details);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedOrMajorOrMinorCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), details);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedInstantsOrRewriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
@@ -188,13 +194,13 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline getCompletedReplaceTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
@@ -209,25 +215,25 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filterPendingRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterRequestedRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), details);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingLogCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), details);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), instantReader);
   }
 
   /**
@@ -238,26 +244,26 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
             || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), details);
+        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInClosedRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), details);
+        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsInRangeByCompletionTime(String startTs, String endTs) {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getCompletionTime() != null && InstantComparison.isInClosedRange(s.getCompletionTime(), startTs, endTs)),
-        details);
+        instantReader);
   }
 
   @Override
@@ -266,40 +272,40 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
         // either pending or completionTime greater than instantTime
         .filter(s -> (s.getCompletionTime() == null && compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime))
             || (s.getCompletionTime() != null && compareTimestamps(s.getCompletionTime(), GREATER_THAN, instantTime) && !s.requestedTime().equals(instantTime))),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)).limit(numCommits),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), details);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime))
-        .limit(numCommits), details);
+        .limit(numCommits), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), details);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), instantReader);
   }
 
   @Override
   public HoodieTimeline findInstantsBefore(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN, instantTime)),
-        details);
+        instantReader);
   }
 
   @Override
@@ -313,22 +319,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   public HoodieTimeline findInstantsBeforeOrEquals(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN_OR_EQUALS, instantTime)),
-        details);
+        instantReader);
   }
 
   @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterCompletedIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), instantReader);
   }
 
   @Override
@@ -356,26 +362,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getDeltaCommitTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getTimelineOfActions(Set<String> actions) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline getCleanerTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getRollbackTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION), instantReader);
   }
 
   @Override
@@ -385,14 +387,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getSavePointTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION), instantReader);
   }
 
   @Override
   public HoodieTimeline getRestoreTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION),
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails);
+    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION), instantReader);
   }
 
   protected Stream<HoodieInstant> filterInstantsByAction(String action) {
@@ -556,7 +556,29 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
-    return details.apply(instant);
+    return instantReader.getInstantDetails(instant);
+  }
+
+  @Override
+  public InputStream getInstantContentStream(HoodieInstant instant) {
+    return instantReader.getContentStream(instant);
+  }
+
+  @Override
+  public <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
+    try (InputStream inputStream = getInstantContentStream(instant)) {
+      DatumReader<T> reader = new SpecificDatumReader<>(clazz);
+      DataFileStream<T> fileReader = new DataFileStream<>(inputStream, reader);
+      ValidationUtils.checkArgument(fileReader.hasNext(), "Could not deserialize metadata of type " + clazz);
+      return fileReader.next();
+    }
+  }
+
+  @Override
+  public <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException {
+    try (InputStream inputStream = getInstantContentStream(instant)) {
+      return JsonUtils.getObjectMapper().readValue(inputStream, clazz);
+    }
   }
 
   @Override
@@ -609,14 +631,7 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline mergeTimeline(HoodieTimeline timeline) {
     Stream<HoodieInstant> instantStream = Stream.concat(getInstantsAsStream(), timeline.getInstantsAsStream()).sorted();
-    Function<HoodieInstant, Option<byte[]>> details = instant -> {
-      if (getInstantsAsStream().anyMatch(i -> i.equals(instant))) {
-        return this.getInstantDetails(instant);
-      } else {
-        return timeline.getInstantDetails(instant);
-      }
-    };
-    return factory.createDefaultTimeline(instantStream, details);
+    return factory.createDefaultTimeline(instantStream, new MergedReader(this, timeline));
   }
 
   /**
@@ -632,6 +647,10 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
       throw new HoodieException(nse);
     }
     return StringUtils.toHexString(md.digest());
+  }
+
+  public HoodieInstantReader getInstantReader() {
+    return instantReader;
   }
 
   /**
@@ -655,5 +674,24 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
       Collections.sort(merged);
     }
     return merged;
+  }
+
+  private static class MergedReader implements HoodieInstantReader, Serializable {
+    private final HoodieTimeline timeline1;
+    private final HoodieTimeline timeline2;
+
+    public MergedReader(HoodieTimeline timeline1, HoodieTimeline timeline2) {
+      this.timeline1 = timeline1;
+      this.timeline2 = timeline2;
+    }
+
+    @Override
+    public InputStream getContentStream(HoodieInstant instant) {
+      if (timeline1.getInstantsAsStream().anyMatch(i -> i.equals(instant))) {
+        return timeline1.getInstantContentStream(instant);
+      } else {
+        return timeline2.getInstantContentStream(instant);
+      }
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -84,10 +84,10 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   protected InstantGenerator instantGenerator;
 
   public BaseHoodieTimeline(TimelineLayout layout, HoodieInstantReader instantReader) {
+    this.instantReader = instantReader;
     this.factory = layout.getTimelineFactory();
     this.instantComparator = layout.getInstantComparator();
     this.instantGenerator = layout.getInstantGenerator();
-    this.instantReader = instantReader;
   }
 
   public BaseHoodieTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader,
@@ -123,62 +123,62 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline filterInflights() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isInflight),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterInflightsAndRequested() {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(i -> i.getState().equals(State.REQUESTED) || i.getState().equals(State.INFLIGHT)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+        && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
-        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
+        && (!instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingExcludingCompactionAndLogCompaction() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(instant -> (!instant.isCompleted())
         && (!instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
-        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))), instantReader);
+        || !instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION))),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedInstants() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(HoodieInstant::isCompleted),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedAndCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), instantReader);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedOrMajorOrMinorCompactionInstants() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted()
-        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)), instantReader);
+        || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedInstantsOrRewriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.isCompleted() || validActions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
@@ -194,13 +194,13 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline getCompletedReplaceTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(REPLACE_COMMIT_ACTION)).filter(HoodieInstant::isCompleted),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
@@ -215,25 +215,25 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filterPendingRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterRequestedRollbackTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingLogCompactionTimeline() {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()), instantReader);
+        getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   /**
@@ -244,26 +244,26 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)
             || s.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION)
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)), instantReader);
+        getInstantsAsStream().filter(s -> InstantComparison.isInRange(s.requestedTime(), startTs, endTs)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInClosedRange(String startTs, String endTs) {
     return factory.createDefaultTimeline(
-        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)), instantReader);
+        instants.stream().filter(instant -> InstantComparison.isInClosedRange(instant.requestedTime(), startTs, endTs)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsInRangeByCompletionTime(String startTs, String endTs) {
     return factory.createDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getCompletionTime() != null && InstantComparison.isInClosedRange(s.getCompletionTime(), startTs, endTs)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
@@ -272,40 +272,40 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
         // either pending or completionTime greater than instantTime
         .filter(s -> (s.getCompletionTime() == null && compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime))
             || (s.getCompletionTime() != null && compareTimestamps(s.getCompletionTime(), GREATER_THAN, instantTime) && !s.requestedTime().equals(instantTime))),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)).limit(numCommits),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfter(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)), instantReader);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN, instantTime)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime))
-        .limit(numCommits), instantReader);
+        .limit(numCommits),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsAfterOrEquals(String commitTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
-        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)), instantReader);
+        .filter(s -> compareTimestamps(s.requestedTime(), GREATER_THAN_OR_EQUALS, commitTime)),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline findInstantsBefore(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN, instantTime)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
@@ -319,22 +319,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
   public HoodieTimeline findInstantsBeforeOrEquals(String instantTime) {
     return factory.createDefaultTimeline(getInstantsAsStream()
         .filter(s -> compareTimestamps(s.requestedTime(), LESSER_THAN_OR_EQUALS, instantTime)),
-        instantReader);
+         getInstantReader());
   }
 
   @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(filter),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && !s.isCompleted()),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterCompletedIndexTimeline() {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> s.getAction().equals(INDEXING_ACTION) && s.isCompleted()),  getInstantReader());
   }
 
   @Override
@@ -362,22 +362,22 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getDeltaCommitTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(DELTA_COMMIT_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getTimelineOfActions(Set<String> actions) {
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> actions.contains(s.getAction())),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getCleanerTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(CLEAN_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getRollbackTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(ROLLBACK_ACTION),  getInstantReader());
   }
 
   @Override
@@ -387,12 +387,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public HoodieTimeline getSavePointTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION),  getInstantReader());
   }
 
   @Override
   public HoodieTimeline getRestoreTimeline() {
-    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION), instantReader);
+    return factory.createDefaultTimeline(filterInstantsByAction(RESTORE_ACTION),  getInstantReader());
   }
 
   protected Stream<HoodieInstant> filterInstantsByAction(String action) {
@@ -556,12 +556,12 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
 
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
-    return instantReader.getInstantDetails(instant);
+    return  getInstantReader().getInstantDetails(instant);
   }
 
   @Override
   public InputStream getInstantContentStream(HoodieInstant instant) {
-    return instantReader.getContentStream(instant);
+    return getInstantReader().getContentStream(instant);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -442,4 +442,9 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @return
    */
   Set<String> getValidExtensions();
+
+  /**
+   * Get the instant reader interface.
+   * */
+  public HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -442,9 +442,4 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @return
    */
   Set<String> getValidExtensions();
-
-  /**
-   * Get the instant reader interface.
-   * */
-  public HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Interface for classes that are capable of reading the contents of a HoodieInstant.
+ */
+public interface HoodieInstantReader {
+  /**
+   * Reads the provided instant's content into a stream for parsing.
+   * @param instant the instant to read
+   * @return an InputStream with the content
+   */
+  InputStream getContentStream(HoodieInstant instant);
+
+  /**
+   * Reads the provided instant's content into a byte array for parsing.
+   * @param instant the instant to read
+   * @return an InputStream with the details
+   */
+  @Deprecated
+  default Option<byte[]> getInstantDetails(HoodieInstant instant) {
+    try (InputStream inputStream = getContentStream(instant)) {
+      return Option.of(FileIOUtils.readAsByteArray(inputStream));
+    } catch (IOException ex) {
+      throw new HoodieIOException("Could not read commit details from stream", ex);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantReader.java
@@ -34,7 +34,9 @@ public interface HoodieInstantReader {
    * @param instant the instant to read
    * @return an InputStream with the content
    */
-  InputStream getContentStream(HoodieInstant instant);
+  default InputStream getContentStream(HoodieInstant instant) {
+    throw new RuntimeException("Not implemented");
+  }
 
   /**
    * Reads the provided instant's content into a byte array for parsing.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -457,9 +457,7 @@ public interface HoodieTimeline extends HoodieInstantReader, Serializable {
    */
   InputStream getInstantContentStream(HoodieInstant instant);
 
-  <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
-
-  <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
+  <T> T deserializeInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
 
   boolean isEmpty(HoodieInstant instant);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
@@ -452,6 +454,17 @@ public interface HoodieTimeline extends Serializable {
    * Read the completed instant details.
    */
   Option<byte[]> getInstantDetails(HoodieInstant instant);
+
+  /**
+   * Read the instant content to an input stream.
+   * @param instant the instant to fetch
+   * @return stream with content for instant
+   */
+  InputStream getInstantContentStream(HoodieInstant instant);
+
+  <T> T deserializeAvroInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
+
+  <T> T deserializeJsonInstantContent(HoodieInstant instant, Class<T> clazz) throws IOException;
 
   boolean isEmpty(HoodieInstant instant);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
  * @see HoodieInstant
  * @since 0.3.0
  */
-public interface HoodieTimeline extends Serializable {
+public interface HoodieTimeline extends HoodieInstantReader, Serializable {
 
   String COMMIT_ACTION = "commit";
   String DELTA_COMMIT_ACTION = "deltacommit";
@@ -451,11 +451,6 @@ public interface HoodieTimeline extends Serializable {
   boolean isPendingClusteringInstant(String instantTime);
 
   /**
-   * Read the completed instant details.
-   */
-  Option<byte[]> getInstantDetails(HoodieInstant instant);
-
-  /**
    * Read the instant content to an input stream.
    * @param instant the instant to fetch
    * @return stream with content for instant
@@ -546,4 +541,9 @@ public interface HoodieTimeline extends Serializable {
    * @return
    */
   TimelineLayoutVersion getTimelineLayoutVersion();
+
+  /**
+   * Get instant reader
+   * */
+  HoodieInstantReader getInstantReader();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.v2.ArchivedTimelineV2;
@@ -56,100 +57,103 @@ import java.nio.ByteBuffer;
  */
 public class MetadataConversionUtils {
 
-  public static HoodieArchivedMetaEntry createMetaWrapper(HoodieInstant hoodieInstant, HoodieTableMetaClient metaClient) throws IOException {
-    Option<byte[]> instantDetails = metaClient.getActiveTimeline().getInstantDetails(hoodieInstant);
-    if (hoodieInstant.isCompleted() && instantDetails.get().length == 0) {
+  public static HoodieArchivedMetaEntry createMetaWrapper(HoodieInstant hoodieInstant, HoodieTableMetaClient metaClient) {
+    try {
+      HoodieArchivedMetaEntry archivedMetaWrapper = new HoodieArchivedMetaEntry();
+      archivedMetaWrapper.setCommitTime(hoodieInstant.requestedTime());
+      archivedMetaWrapper.setActionState(hoodieInstant.getState().name());
+      archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getCompletionTime());
+      switch (hoodieInstant.getAction()) {
+        case HoodieTimeline.CLEAN_ACTION: {
+          if (hoodieInstant.isCompleted()) {
+            archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get()));
+          } else {
+            archivedMetaWrapper.setHoodieCleanerPlan(CleanerUtils.getCleanerPlan(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get()));
+          }
+          archivedMetaWrapper.setActionType(ActionType.clean.name());
+          break;
+        }
+        case HoodieTimeline.COMMIT_ACTION: {
+          getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class)
+              .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(commitMetadata)));
+          archivedMetaWrapper.setActionType(ActionType.commit.name());
+          break;
+        }
+        case HoodieTimeline.DELTA_COMMIT_ACTION: {
+          getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class)
+              .ifPresent(deltaCommitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(deltaCommitMetadata)));
+          archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
+          break;
+        }
+        case HoodieTimeline.REPLACE_COMMIT_ACTION:
+        case HoodieTimeline.CLUSTERING_ACTION: {
+          if (hoodieInstant.isCompleted()) {
+            getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieReplaceCommitMetadata.class)
+                .ifPresent(replaceCommitMetadata -> archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertReplaceCommitMetadata(replaceCommitMetadata)));
+          } else if (hoodieInstant.isInflight()) {
+            // inflight replacecommit files have the same metadata body as HoodieCommitMetadata
+            // so we could re-use it without further creating an inflight extension.
+            // Or inflight replacecommit files are empty under clustering circumstance
+            Option<HoodieCommitMetadata> inflightCommitMetadata = getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class);
+            if (inflightCommitMetadata.isPresent()) {
+              archivedMetaWrapper.setHoodieInflightReplaceMetadata(convertCommitMetadata(inflightCommitMetadata.get()));
+            }
+          } else {
+            // we may have cases with empty HoodieRequestedReplaceMetadata e.g. insert_overwrite_table or insert_overwrite
+            // without clustering. However, we should revisit the requested commit file standardization
+            Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata = getRequestedReplaceMetadata(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant));
+            if (requestedReplaceMetadata.isPresent()) {
+              archivedMetaWrapper.setHoodieRequestedReplaceMetadata(requestedReplaceMetadata.get());
+            }
+          }
+          archivedMetaWrapper.setActionType(
+              hoodieInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) ? ActionType.replacecommit.name() : ActionType.clustering.name());
+          break;
+        }
+        case HoodieTimeline.ROLLBACK_ACTION: {
+          if (hoodieInstant.isCompleted()) {
+            archivedMetaWrapper.setHoodieRollbackMetadata(
+                TimelineMetadataUtils.deserializeAvroMetadata(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieRollbackMetadata.class));
+          }
+          archivedMetaWrapper.setActionType(ActionType.rollback.name());
+          break;
+        }
+        case HoodieTimeline.SAVEPOINT_ACTION: {
+          archivedMetaWrapper.setHoodieSavePointMetadata(
+              TimelineMetadataUtils.deserializeAvroMetadata(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieSavepointMetadata.class));
+          archivedMetaWrapper.setActionType(ActionType.savepoint.name());
+          break;
+        }
+        case HoodieTimeline.COMPACTION_ACTION: {
+          if (hoodieInstant.isRequested()) {
+            HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant));
+            archivedMetaWrapper.setHoodieCompactionPlan(plan);
+          }
+          archivedMetaWrapper.setActionType(ActionType.compaction.name());
+          break;
+        }
+        case HoodieTimeline.LOG_COMPACTION_ACTION: {
+          if (hoodieInstant.isRequested()) {
+            HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant));
+            archivedMetaWrapper.setHoodieCompactionPlan(plan);
+          }
+          archivedMetaWrapper.setActionType(ActionType.logcompaction.name());
+          break;
+        }
+        default: {
+          throw new UnsupportedOperationException("Action not fully supported yet");
+        }
+      }
+      return archivedMetaWrapper;
+    } catch (IOException | HoodieIOException ex) {
       // in local FS and HDFS, there could be empty completed instants due to crash.
       // let's add an entry to the archival, even if not for the plan.
       return createMetaWrapperForEmptyInstant(hoodieInstant);
     }
-    HoodieArchivedMetaEntry archivedMetaWrapper = new HoodieArchivedMetaEntry();
-    archivedMetaWrapper.setCommitTime(hoodieInstant.requestedTime());
-    archivedMetaWrapper.setActionState(hoodieInstant.getState().name());
-    archivedMetaWrapper.setStateTransitionTime(hoodieInstant.getCompletionTime());
-    switch (hoodieInstant.getAction()) {
-      case HoodieTimeline.CLEAN_ACTION: {
-        if (hoodieInstant.isCompleted()) {
-          archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, instantDetails.get()));
-        } else {
-          archivedMetaWrapper.setHoodieCleanerPlan(CleanerUtils.getCleanerPlan(metaClient, instantDetails.get()));
-        }
-        archivedMetaWrapper.setActionType(ActionType.clean.name());
-        break;
-      }
-      case HoodieTimeline.COMMIT_ACTION: {
-        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, instantDetails.get(), HoodieCommitMetadata.class);
-        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(commitMetadata));
-        archivedMetaWrapper.setActionType(ActionType.commit.name());
-        break;
-      }
-      case HoodieTimeline.DELTA_COMMIT_ACTION: {
-        HoodieCommitMetadata deltaCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, instantDetails.get(), HoodieCommitMetadata.class);
-        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(deltaCommitMetadata));
-        archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
-        break;
-      }
-      case HoodieTimeline.REPLACE_COMMIT_ACTION:
-      case HoodieTimeline.CLUSTERING_ACTION: {
-        if (hoodieInstant.isCompleted()) {
-          HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(instantDetails.get(), HoodieReplaceCommitMetadata.class);
-          archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertReplaceCommitMetadata(replaceCommitMetadata));
-        } else if (hoodieInstant.isInflight()) {
-          // inflight replacecommit files have the same metadata body as HoodieCommitMetadata
-          // so we could re-use it without further creating an inflight extension.
-          // Or inflight replacecommit files are empty under clustering circumstance
-          Option<HoodieCommitMetadata> inflightCommitMetadata = getInflightCommitMetadata(metaClient, hoodieInstant, instantDetails);
-          if (inflightCommitMetadata.isPresent()) {
-            archivedMetaWrapper.setHoodieInflightReplaceMetadata(convertCommitMetadata(inflightCommitMetadata.get()));
-          }
-        } else {
-          // we may have cases with empty HoodieRequestedReplaceMetadata e.g. insert_overwrite_table or insert_overwrite
-          // without clustering. However, we should revisit the requested commit file standardization
-          Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata = getRequestedReplaceMetadata(instantDetails);
-          if (requestedReplaceMetadata.isPresent()) {
-            archivedMetaWrapper.setHoodieRequestedReplaceMetadata(requestedReplaceMetadata.get());
-          }
-        }
-        archivedMetaWrapper.setActionType(
-            hoodieInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) ? ActionType.replacecommit.name() : ActionType.clustering.name());
-        break;
-      }
-      case HoodieTimeline.ROLLBACK_ACTION: {
-        if (hoodieInstant.isCompleted()) {
-          archivedMetaWrapper.setHoodieRollbackMetadata(TimelineMetadataUtils.deserializeAvroMetadata(instantDetails.get(), HoodieRollbackMetadata.class));
-        }
-        archivedMetaWrapper.setActionType(ActionType.rollback.name());
-        break;
-      }
-      case HoodieTimeline.SAVEPOINT_ACTION: {
-        archivedMetaWrapper.setHoodieSavePointMetadata(TimelineMetadataUtils.deserializeAvroMetadata(instantDetails.get(), HoodieSavepointMetadata.class));
-        archivedMetaWrapper.setActionType(ActionType.savepoint.name());
-        break;
-      }
-      case HoodieTimeline.COMPACTION_ACTION: {
-        if (hoodieInstant.isRequested()) {
-          HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, instantDetails);
-          archivedMetaWrapper.setHoodieCompactionPlan(plan);
-        }
-        archivedMetaWrapper.setActionType(ActionType.compaction.name());
-        break;
-      }
-      case HoodieTimeline.LOG_COMPACTION_ACTION: {
-        if (hoodieInstant.isRequested()) {
-          HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, instantDetails);
-          archivedMetaWrapper.setHoodieCompactionPlan(plan);
-        }
-        archivedMetaWrapper.setActionType(ActionType.logcompaction.name());
-        break;
-      }
-      default: {
-        throw new UnsupportedOperationException("Action not fully supported yet");
-      }
-    }
-    return archivedMetaWrapper;
   }
 
   /**
+   * TODO(reviewers) - new code applied similar refactoring, please pay close attention.
    * Creates the legacy archived metadata entry from the new LSM-timeline read.
    *
    * <p>For legacy archive log, 3 entries are persisted for one instant, here only one summary entry is converted into.
@@ -173,7 +177,7 @@ public class MetadataConversionUtils {
     archivedMetaWrapper.setActionState(HoodieInstant.State.COMPLETED.name());
     archivedMetaWrapper.setStateTransitionTime(completionTime);
     String actionType = lsmTimelineRecord.get(ArchivedTimelineV2.ACTION_ARCHIVED_META_FIELD).toString();
-    HoodieInstant instant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, actionType, instantTime, completionTime);
+    HoodieInstant hoodieInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, actionType, instantTime, completionTime);
     switch (actionType) {
       case HoodieTimeline.CLEAN_ACTION: {
         archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, instantDetails.get()));
@@ -182,8 +186,8 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.COMMIT_ACTION: {
-        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant, instantDetails.get(), HoodieCommitMetadata.class);
-        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(commitMetadata));
+        getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class)
+              .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(commitMetadata)));
         archivedMetaWrapper.setActionType(ActionType.commit.name());
 
         if (planBytes.isPresent()) {
@@ -194,8 +198,8 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.DELTA_COMMIT_ACTION: {
-        HoodieCommitMetadata deltaCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant, instantDetails.get(), HoodieCommitMetadata.class);
-        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(deltaCommitMetadata));
+        getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class)
+              .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadata(commitMetadata)));
         archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
 
         if (planBytes.isPresent()) {
@@ -207,38 +211,41 @@ public class MetadataConversionUtils {
       }
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
       case HoodieTimeline.CLUSTERING_ACTION: {
-        HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(instantDetails.get(), HoodieReplaceCommitMetadata.class);
-        archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertReplaceCommitMetadata(replaceCommitMetadata));
+        getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieReplaceCommitMetadata.class)
+                        .ifPresent(replaceCommitMetadata -> archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertReplaceCommitMetadata(replaceCommitMetadata)));
 
         // inflight replacecommit files have the same metadata body as HoodieCommitMetadata
         // so we could re-use it without further creating an inflight extension.
         // Or inflight replacecommit files are empty under clustering circumstance
-        Option<HoodieCommitMetadata> inflightCommitMetadata = getInflightCommitMetadata(metaClient, instant, instantDetails);
+        Option<HoodieCommitMetadata> inflightCommitMetadata = getCommitMetadata(metaClient.getActiveTimeline(), hoodieInstant, HoodieCommitMetadata.class);
         if (inflightCommitMetadata.isPresent()) {
           archivedMetaWrapper.setHoodieInflightReplaceMetadata(convertCommitMetadata(inflightCommitMetadata.get()));
         }
-        archivedMetaWrapper.setActionType(ActionType.replacecommit.name());
+        archivedMetaWrapper.setActionType(
+            hoodieInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) ? ActionType.replacecommit.name() : ActionType.clustering.name());
         break;
       }
       case HoodieTimeline.ROLLBACK_ACTION: {
-        archivedMetaWrapper.setHoodieRollbackMetadata(TimelineMetadataUtils.deserializeAvroMetadata(instantDetails.get(), HoodieRollbackMetadata.class));
+        archivedMetaWrapper.setHoodieRollbackMetadata(
+                TimelineMetadataUtils.deserializeAvroMetadata(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieRollbackMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.rollback.name());
         break;
       }
       case HoodieTimeline.SAVEPOINT_ACTION: {
-        archivedMetaWrapper.setHoodieSavePointMetadata(TimelineMetadataUtils.deserializeAvroMetadata(instantDetails.get(), HoodieSavepointMetadata.class));
+        archivedMetaWrapper.setHoodieSavePointMetadata(
+            TimelineMetadataUtils.deserializeAvroMetadata(metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieSavepointMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.savepoint.name());
         break;
       }
       case HoodieTimeline.COMPACTION_ACTION: {
         // should be handled by commit_action branch though, this logic is redundant.
-        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, planBytes);
+        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant));
         archivedMetaWrapper.setHoodieCompactionPlan(plan);
         archivedMetaWrapper.setActionType(ActionType.compaction.name());
         break;
       }
       case HoodieTimeline.LOG_COMPACTION_ACTION: {
-        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, planBytes);
+        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, metaClient.getActiveTimeline().getInstantDetails(hoodieInstant));
         archivedMetaWrapper.setHoodieCompactionPlan(plan);
         archivedMetaWrapper.setActionType(ActionType.logcompaction.name());
         break;
@@ -332,13 +339,13 @@ public class MetadataConversionUtils {
     return archivedMetaWrapper;
   }
 
-  private static Option<HoodieCommitMetadata> getInflightCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant,
-                                                                        Option<byte[]> inflightContent) throws IOException {
-    if (!inflightContent.isPresent() || inflightContent.get().length == 0) {
-      // inflight files can be empty in some certain cases, e.g. when users opt in clustering
+  private static <T extends HoodieCommitMetadata> Option<T> getCommitMetadata(HoodieActiveTimeline timeline, HoodieInstant instant, Class<T> clazz) throws IOException {
+    T commitMetadata = timeline.deserializeInstantContent(instant, clazz);
+    // an empty file will return the default instance with an UNKNOWN operation type and in that case we return an empty option
+    if (commitMetadata.getOperationType() == WriteOperationType.UNKNOWN) {
       return Option.empty();
     }
-    return Option.of(metaClient.getCommitMetadataSerDe().deserialize(instant, inflightContent.get(), HoodieCommitMetadata.class));
+    return Option.of(commitMetadata);
   }
 
   private static Option<HoodieRequestedReplaceMetadata> getRequestedReplaceMetadata(Option<byte[]> requestedContent) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
@@ -19,16 +19,13 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.util.Option;
 
 import java.io.Serializable;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public abstract class TimelineFactory implements Serializable {
 
-  public abstract HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants,
-                                                       Function<HoodieInstant, Option<byte[]>> details);
+  public abstract HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader);
 
   public abstract HoodieActiveTimeline createActiveTimeline();
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -596,7 +596,7 @@ public class TimelineUtils {
                                               HoodieTableMetaClient metaClient) {
     return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(
         Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 
   public static boolean isDeletePartition(WriteOperationType operation) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -169,8 +169,7 @@ public class TimelineUtils {
         case COMMIT_ACTION:
         case DELTA_COMMIT_ACTION:
           try {
-            CommitMetadataSerDe metadataSerDe = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion()).getCommitMetadataSerDe();
-            HoodieCommitMetadata commitMetadata = metadataSerDe.deserialize(s, timeline.getInstantDetails(s).get(), HoodieCommitMetadata.class);
+            HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(s, HoodieCommitMetadata.class);
             return commitMetadata.getPartitionToWriteStats().keySet().stream();
           } catch (IOException e) {
             throw new HoodieIOException("Failed to get partitions written at " + s, e);
@@ -256,8 +255,7 @@ public class TimelineUtils {
   private static Option<String> getMetadataValue(HoodieTableMetaClient metaClient, String extraMetadataKey, HoodieInstant instant) {
     try {
       LOG.info("reading checkpoint info for:" + instant + " key: " + extraMetadataKey);
-      HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant,
-          metaClient.getCommitsTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+      HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
 
       return Option.ofNullable(commitMetadata.getExtraMetadata().get(extraMetadataKey));
     } catch (IOException e) {
@@ -338,8 +336,7 @@ public class TimelineUtils {
     if (instant.getAction().equals(REPLACE_COMMIT_ACTION) || instant.getAction().equals(CLUSTERING_ACTION)) {
       return HoodieReplaceCommitMetadata.fromBytes(data, HoodieReplaceCommitMetadata.class);
     } else {
-      CommitMetadataSerDe metadataSerDe = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion()).getCommitMetadataSerDe();
-      return metadataSerDe.deserialize(instant, data, HoodieCommitMetadata.class);
+      return timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -594,8 +594,9 @@ public class TimelineUtils {
    */
   public static HoodieTimeline concatTimeline(HoodieTimeline timeline1, HoodieTimeline timeline2,
                                               HoodieTableMetaClient metaClient) {
-    return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
-        instant -> metaClient.getActiveTimeline().getInstantDetails(instant));
+    return metaClient.getTimelineLayout().getTimelineFactory().createDefaultTimeline(
+        Stream.concat(timeline1.getInstantsAsStream(), timeline2.getInstantsAsStream()).sorted(),
+        metaClient.getActiveTimeline().getInstantReader());
   }
 
   public static boolean isDeletePartition(WriteOperationType operation) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
@@ -20,11 +20,11 @@ package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantGenerator;
+import org.apache.hudi.common.table.timeline.TimelineFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.hudi.common.table.timeline.InstantGenerator;
-import org.apache.hudi.common.table.timeline.TimelineFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,6 +49,6 @@ public class TimelineDTO {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     // TODO: For Now, we will assume, only active-timeline will be transferred.
     return factory.createDefaultTimeline(dto.instants.stream().map(d -> InstantDTO.toInstant(d, instantGenerator)),
-        metaClient.getActiveTimeline()::getInstantDetails);
+        metaClient.getActiveTimeline().getInstantReader());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
@@ -49,6 +49,6 @@ public class TimelineDTO {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     // TODO: For Now, we will assume, only active-timeline will be transferred.
     return factory.createDefaultTimeline(dto.instants.stream().map(d -> InstantDTO.toInstant(d, instantGenerator)),
-        metaClient.getActiveTimeline().getInstantReader());
+        metaClient.getActiveTimeline());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -52,7 +52,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTimeline, HoodieInstantReader {
+public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTimeline {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -73,7 +73,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
 
   protected ActiveTimelineV1(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                              boolean applyLayoutFilters) {
-    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -85,7 +84,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -104,8 +102,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV1() {
-    super(null);
-    this.instantReader = this;
   }
 
   /**
@@ -260,7 +256,7 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
 
   @Override
   public HoodieInstantReader getInstantReader() {
-    return instantReader;
+    return this;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -288,7 +288,7 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
         .map(instant -> {
           try {
             HoodieCommitMetadata commitMetadata =
-                metaClient.getCommitMetadataSerDe().deserialize(instant, getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+                metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
             return Pair.of(instant, commitMetadata);
           } catch (IOException e) {
             throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", instant), e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
@@ -65,12 +65,10 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants(false));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
   }
 
   /**
@@ -78,13 +76,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient, String startTs) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new StartTsFilter(startTs), true,
         record -> HoodieInstant.State.COMPLETED.toString().equals(record.get(ACTION_STATE).toString())));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
   }
 
   /**
@@ -93,8 +89,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV1() {
-    super(null);
-    this.instantReader = this;
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return this;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineV1.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.StoragePath;
@@ -34,8 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.Serializable;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchivedTimeline {
+public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchivedTimeline, HoodieInstantReader {
   private static final String HOODIE_COMMIT_ARCHIVE_LOG_FILE_PREFIX = "commits";
   private static final String ACTION_TYPE_KEY = "actionType";
   private static final String ACTION_STATE = "actionState";
@@ -63,11 +65,12 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient) {
+    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants(false));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
   }
 
   /**
@@ -75,12 +78,13 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV1(HoodieTableMetaClient metaClient, String startTs) {
+    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new StartTsFilter(startTs), true,
         record -> HoodieInstant.State.COMPLETED.toString().equals(record.get(ACTION_STATE).toString())));
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
   }
 
   /**
@@ -89,6 +93,8 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV1() {
+    super(null);
+    this.instantReader = this;
   }
 
   /**
@@ -103,6 +109,11 @@ public class ArchivedTimelineV1 extends BaseTimelineV1 implements HoodieArchived
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
     return Option.ofNullable(readCommits.get(instant.requestedTime()));
+  }
+
+  @Override
+  public InputStream getContentStream(HoodieInstant instant) {
+    return new ByteArrayInputStream(getInstantDetails(instant).orElseGet(() -> new byte[0]));
   }
 
   public static StoragePath getArchiveLogPath(StoragePath archiveFolder) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
@@ -18,29 +18,29 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v1;
 
-import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.BaseHoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseTimelineV1 extends BaseHoodieTimeline {
 
-  public BaseTimelineV1(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    this(instants, details, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
+  public BaseTimelineV1(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    this(instants, instantReader, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
   }
 
-  private BaseTimelineV1(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details, TimelineLayout layout) {
-    super(instants, details, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
+  private BaseTimelineV1(Stream<HoodieInstant> instants, HoodieInstantReader instantReader, TimelineLayout layout) {
+    super(instants, instantReader, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
   }
 
   /**
@@ -49,35 +49,35 @@ public class BaseTimelineV1 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV1() {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1));
+  public BaseTimelineV1(HoodieInstantReader instantReader) {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted())
-        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), details);
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceClusteringAndCompactionTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/BaseTimelineV1.java
@@ -49,35 +49,35 @@ public class BaseTimelineV1 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV1(HoodieInstantReader instantReader) {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), instantReader);
+  public BaseTimelineV1() {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_1), null);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION) && !s.isCompleted())
-        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), instantReader);
+        .filter(i -> ClusteringUtils.isClusteringInstant(this, i, instantGenerator)), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceClusteringAndCompactionTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), getInstantReader());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
@@ -21,15 +21,14 @@ package org.apache.hudi.common.table.timeline.versioning.v1;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.util.Option;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class TimelineV1Factory extends TimelineFactory {
@@ -41,8 +40,8 @@ public class TimelineV1Factory extends TimelineFactory {
   }
 
   @Override
-  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    return new BaseTimelineV1(instants, details);
+  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    return new BaseTimelineV1(instants, instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
@@ -37,6 +38,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -45,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -53,10 +54,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline  {
+public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline, HoodieInstantReader {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -78,6 +78,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   private ActiveTimelineV2(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                            boolean applyLayoutFilters) {
+    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -89,7 +90,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.details = (Function<HoodieInstant, Option<byte[]>> & Serializable) this::getInstantDetails;
+    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -108,6 +109,8 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV2() {
+    super(null);
+    this.instantReader = this;
   }
 
   /**
@@ -262,6 +265,17 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {
     StoragePath detailPath = getInstantFileNamePath(getInstantFileName(instant));
     return readDataFromPath(detailPath);
+  }
+
+  @Override
+  public InputStream getContentStream(HoodieInstant instant) {
+    StoragePath filePath = getInstantFileNamePath(instantFileNameGenerator.getFileName(instant));
+    return readDataStreamFromPath(filePath);
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return instantReader;
   }
 
   @Override
@@ -557,7 +571,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
         if (allowRedundantTransitions) {
           FileIOUtils.createFileInPath(storage, getInstantFileNamePath(toInstantFileName), data);
         } else {
-          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), data);
+          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), data.map(HoodieInstantWriter::convertByteArrayToWriter));
         }
         LOG.info("Create new file for toInstant ?" + getInstantFileNamePath(toInstantFileName));
       }
@@ -728,7 +742,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     if (allowOverwrite || metaClient.getTimelineLayoutVersion().isNullVersion()) {
       FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, content);
     } else {
-      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content);
+      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
     }
   }
 
@@ -742,7 +756,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         FileIOUtils.createFileInPath(metaClient.getStorage(), fullPath, content);
       } else {
-        metaClient.getStorage().createImmutableFileInPath(fullPath, content);
+        metaClient.getStorage().createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
       }
       LOG.info("Created new file for toInstant ?" + fullPath);
     });
@@ -753,6 +767,14 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       return Option.of(FileIOUtils.readAsByteArray(is));
     } catch (IOException e) {
       throw new HoodieIOException("Could not read commit details from " + detailPath, e);
+    }
+  }
+
+  protected InputStream readDataStreamFromPath(StoragePath filePath) {
+    try {
+      return metaClient.getStorage().open(filePath);
+    } catch (IOException e) {
+      throw new HoodieIOException("Could not read commit details from " + filePath, e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -303,7 +303,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
         .map(instant -> {
           try {
             HoodieCommitMetadata commitMetadata =
-                metaClient.getCommitMetadataSerDe().deserialize(instant, getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+                metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
             return Pair.of(instant, commitMetadata);
           } catch (IOException e) {
             throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", instant), e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -56,7 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline, HoodieInstantReader {
+public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline {
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,
@@ -78,7 +78,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   private ActiveTimelineV2(HoodieTableMetaClient metaClient, Set<String> includedExtensions,
                            boolean applyLayoutFilters) {
-    super(null);
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
@@ -90,7 +89,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
-    this.instantReader = this;
     LOG.info("Loaded instants upto : " + lastInstant());
   }
 
@@ -109,8 +107,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
    */
   @Deprecated
   public ActiveTimelineV2() {
-    super(null);
-    this.instantReader = this;
   }
 
   /**
@@ -275,7 +271,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   @Override
   public HoodieInstantReader getInstantReader() {
-    return instantReader;
+    return this;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
@@ -74,7 +74,6 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * TBD: Should we enforce maximum time range?
    */
   public ArchivedTimelineV2(HoodieTableMetaClient metaClient) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(this.loadInstants());
     this.cursorInstant = firstInstant().map(HoodieInstant::requestedTime).orElse(null);
@@ -88,7 +87,6 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * Note that there is no lazy loading, so this may not work if really early startTs is specified.
    */
   public ArchivedTimelineV2(HoodieTableMetaClient metaClient, String startTs) {
-    super(null);
     this.metaClient = metaClient;
     setInstants(loadInstants(new HoodieArchivedTimeline.StartTsFilter(startTs), HoodieArchivedTimeline.LoadMode.METADATA));
     this.cursorInstant = startTs;
@@ -103,8 +101,12 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
    * @deprecated
    */
   public ArchivedTimelineV2() {
-    super(null);
     this.instantReader = this;
+  }
+
+  @Override
+  public HoodieInstantReader getInstantReader() {
+    return this;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
@@ -18,29 +18,29 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v2;
 
-import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.BaseHoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseTimelineV2 extends BaseHoodieTimeline {
 
-  public BaseTimelineV2(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    this(instants, details, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
+  public BaseTimelineV2(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    this(instants, instantReader, TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
   }
 
-  public BaseTimelineV2(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details, TimelineLayout layout) {
-    super(instants, details, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
+  public BaseTimelineV2(Stream<HoodieInstant> instants, HoodieInstantReader instantReader, TimelineLayout layout) {
+    super(instants, instantReader, layout.getTimelineFactory(), layout.getInstantComparator(), layout.getInstantGenerator());
   }
 
   /**
@@ -49,14 +49,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV2() {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2));
+  public BaseTimelineV2(HoodieInstantReader instantReader) {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), instantReader);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), details);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
   }
 
   @Override
@@ -67,14 +67,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), details);
+        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), instantReader);
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), details);
+            && !s.isCompleted()), instantReader);
   }
 
   @Override
@@ -82,7 +82,7 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)
             || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), details);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/BaseTimelineV2.java
@@ -49,14 +49,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
    * @deprecated
    */
   @Deprecated
-  public BaseTimelineV2(HoodieInstantReader instantReader) {
-    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), instantReader);
+  public BaseTimelineV2() {
+    super(TimelineLayout.fromVersion(TimelineLayoutVersion.LAYOUT_VERSION_2), null);
   }
 
   @Override
   public HoodieTimeline getWriteTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION);
-    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), instantReader);
+    return factory.createDefaultTimeline(getInstantsAsStream().filter(s -> validActions.contains(s.getAction())), getInstantReader());
   }
 
   @Override
@@ -67,14 +67,14 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
   @Override
   public HoodieTimeline filterPendingClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
-        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), instantReader);
+        s -> s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) && !s.isCompleted()), getInstantReader());
   }
 
   @Override
   public HoodieTimeline filterPendingReplaceOrClusteringTimeline() {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION) || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
-            && !s.isCompleted()), instantReader);
+            && !s.isCompleted()), getInstantReader());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class BaseTimelineV2 extends BaseHoodieTimeline {
     return factory.createDefaultTimeline(getInstantsAsStream().filter(
         s -> !s.isCompleted() && (s.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)
             || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)
-            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), instantReader);
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION))), getInstantReader());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
@@ -21,15 +21,14 @@ package org.apache.hudi.common.table.timeline.versioning.v2;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantReader;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
-import org.apache.hudi.common.util.Option;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class TimelineV2Factory extends TimelineFactory {
@@ -41,8 +40,8 @@ public class TimelineV2Factory extends TimelineFactory {
   }
 
   @Override
-  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, Function<HoodieInstant, Option<byte[]>> details) {
-    return new BaseTimelineV2(instants, details);
+  public HoodieTimeline createDefaultTimeline(Stream<HoodieInstant> instants, HoodieInstantReader instantReader) {
+    return new BaseTimelineV2(instants, instantReader);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
@@ -257,7 +257,7 @@ public abstract class IncrementalTimelineSyncFileSystemView extends AbstractTabl
   private void addCommitInstant(HoodieTimeline timeline, HoodieInstant instant) throws IOException {
     LOG.info("Syncing committed instant (" + instant + ")");
     HoodieCommitMetadata commitMetadata =
-        metaClient.getCommitMetadataSerDe().deserialize(instant, timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+        metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
     updatePartitionWriteFileGroups(commitMetadata.getPartitionToWriteStats(), timeline, instant);
     LOG.info("Done Syncing committed instant (" + instant + ")");
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -128,9 +128,7 @@ public class CommitUtils {
   public static Option<HoodieCommitMetadata> buildMetadataFromInstant(HoodieTimeline timeline, HoodieInstant instant) {
     try {
       TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
-      HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe().deserialize(instant,
-          timeline.getInstantDetails(instant).get(),
-          HoodieCommitMetadata.class);
+      HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
 
       return Option.of(commitMetadata);
     } catch (IOException e) {
@@ -185,8 +183,7 @@ public class CommitUtils {
     return (Option<String>) timeline.getWriteTimeline().filterCompletedInstants().getReverseOrderedInstants()
         .map(instant -> {
           try {
-            HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe()
-                .deserialize(instant, timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+            HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
             // process commits only with checkpoint entries
             String checkpointValue = commitMetadata.getMetadata(checkpointKey);
             if (StringUtils.nonEmpty(checkpointValue)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
@@ -36,11 +36,11 @@ import org.apache.hudi.internal.schema.utils.InternalSchemaUtils;
 import org.apache.hudi.internal.schema.utils.SerDeHelper;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.avro.Schema;
-import org.apache.hudi.storage.StoragePathInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +124,7 @@ public class InternalSchemaCache {
         return Option.empty();
       }
       byte[] data = timeline.getInstantDetails(instants.get(0)).get();
-      HoodieCommitMetadata metadata = metaClient.getCommitMetadataSerDe().deserialize(instants.get(0), data, HoodieCommitMetadata.class);
+      HoodieCommitMetadata metadata = metaClient.getActiveTimeline().deserializeInstantContent(instants.get(0), HoodieCommitMetadata.class);
       String latestInternalSchemaStr = metadata.getMetadata(SerDeHelper.LATEST_SCHEMA);
       return SerDeHelper.fromJson(latestInternalSchemaStr);
     } catch (Exception e) {
@@ -148,7 +148,7 @@ public class InternalSchemaCache {
       byte[] data = timelineBeforeCurrentCompaction.getInstantDetails(lastInstantBeforeCurrentCompaction.get()).get();
       HoodieCommitMetadata metadata;
       try {
-        metadata = metaClient.getCommitMetadataSerDe().deserialize(lastInstantBeforeCurrentCompaction.get(), data, HoodieCommitMetadata.class);
+        metadata = metaClient.getActiveTimeline().deserializeInstantContent(lastInstantBeforeCurrentCompaction.get(), HoodieCommitMetadata.class);
       } catch (Exception e) {
         throw new HoodieException(String.format("cannot read metadata from commit: %s", lastInstantBeforeCurrentCompaction.get()), e);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
@@ -278,8 +278,7 @@ public class MarkerUtils {
     currentInstants.removeAll(completedCommitInstants);
     Set<String> missingFileIDs = currentInstants.stream().flatMap(instant -> {
       try {
-        TimelineLayout layout = TimelineLayout.fromVersion(activeTimeline.getTimelineLayoutVersion());
-        return layout.getCommitMetadataSerDe().deserialize(instant, activeTimeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class)
+        return activeTimeline.deserializeInstantContent(instant, HoodieCommitMetadata.class)
             .getFileIdAndRelativePaths().keySet().stream();
       } catch (Exception e) {
         return Stream.empty();

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1394,7 +1394,7 @@ public class HoodieTableMetadataUtil {
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
           metaClient.createNewInstantTime(false));
-      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
+      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline().getInstantReader());
     }
     return new HoodieTableFileSystemView(metaClient, timeline);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1394,7 +1394,7 @@ public class HoodieTableMetadataUtil {
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
           metaClient.createNewInstantTime(false));
-      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline().getInstantReader());
+      timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline());
     }
     return new HoodieTableFileSystemView(metaClient, timeline);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -160,8 +160,7 @@ public class TestHoodieCommitMetadata {
     // Case: Reading 1.x written commit metadata
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "1");
     org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata1 =
-        COMMIT_METADATA_SER_DE.deserialize(instant,
-            serializedCommitMetadata, org.apache.hudi.common.model.HoodieCommitMetadata.class);
+        COMMIT_METADATA_SER_DE.deserialize(instant, serializedCommitMetadata, org.apache.hudi.common.model.HoodieCommitMetadata.class);
     assertEquals(2, commitMetadata1.partitionToWriteStats.size());
     assertEquals(2, commitMetadata1.partitionToWriteStats.get("partition1").size());
     assertEquals(2, commitMetadata1.partitionToWriteStats.get("partition1").size());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
@@ -175,7 +175,7 @@ public class WriteProfiles {
     try {
       byte[] data = timeline.getInstantDetails(instant).get();
       TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
-      return Option.of(layout.getCommitMetadataSerDe().deserialize(instant, data, HoodieCommitMetadata.class));
+      return Option.of(timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class));
     } catch (FileNotFoundException fe) {
       // make this fail safe.
       LOG.warn("Instant {} was deleted by the cleaner, ignore", instant.requestedTime());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -104,9 +104,7 @@ public class ITTestBucketStreamWrite {
     String commitInstant = instant.requestedTime();
     String filename = INSTANT_FILE_NAME_GENERATOR.getFileName(activeCompletedTimeline.getInstants().get(0));
 
-    HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe()
-        .deserialize(instant, metaClient.getActiveTimeline().getInstantDetails(instant).get(),
-            HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
 
     // delete successful commit to simulate an unsuccessful write
     HoodieStorage storage = metaClient.getStorage();

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.shouldUseExternalHdfs;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.useExternalHdfs;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestHoodieWrapperFileSystem {
@@ -78,8 +77,8 @@ class TestHoodieWrapperFileSystem {
 
     // create same commit twice
     HoodieStorage storage = new HoodieHadoopStorage(fs);
-    storage.createImmutableFileInPath(testFile, Option.of(getUTF8Bytes(testContent)));
-    storage.createImmutableFileInPath(testFile, Option.of(getUTF8Bytes(testContent)));
+    storage.createImmutableFileInPath(testFile, Option.of(outputStream -> outputStream.write(testContent.getBytes())));
+    storage.createImmutableFileInPath(testFile, Option.of(outputStream -> outputStream.write(testContent.getBytes())));
     List<StoragePathInfo> pathInfoList = storage.listDirectEntries(new StoragePath(basePath));
 
     assertEquals(1, pathInfoList.size(),

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -391,15 +391,13 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         .thenReturn(mockArchivedTimeline);
     HoodieTimeline mergedTimeline = new BaseTimelineV2(
         archivedInstants.stream()
-            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0),
-        i -> Option.empty())
+            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0), null)
         .mergeTimeline(activeTimeline);
     when(mockArchivedTimeline.mergeTimeline(eq(activeTimeline)))
         .thenReturn(mergedTimeline);
     HoodieTimeline mergedWriteTimeline = new BaseTimelineV2(
         archivedInstants.stream()
-            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0),
-        i -> Option.empty())
+            .filter(instant -> instant.requestedTime().compareTo(startTs) >= 0), null)
         .mergeTimeline(activeTimeline.getWriteTimeline());
     when(mockArchivedTimeline.mergeTimeline(argThat(timeline -> timeline.filter(
         instant -> instant.getAction().equals(ROLLBACK_ACTION)).countInstants() == 0)))

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -649,7 +649,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     HoodieActiveTimeline timelineAfterFirstInstant = timeline.reload();
 
     HoodieInstant completedCommitInstant = timelineAfterFirstInstant.lastInstant().get();
-    assertEquals(commitMetadata, timelineAfterFirstInstant.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+    assertEquals(commitMetadata, timelineAfterFirstInstant.deserializeInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
 
     HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan();
     cleanerPlan.setLastCompletedCommitTimestamp("1");
@@ -658,12 +658,12 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     cleanerPlan.setPartitionsToBeDeleted(Collections.singletonList("partition1"));
     timeline.saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
 
-    assertEquals(cleanerPlan, timeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
+    assertEquals(cleanerPlan, timeline.deserializeInstantContent(cleanInstant, HoodieCleanerPlan.class));
 
     HoodieTimeline mergedTimeline = timelineAfterFirstInstant.mergeTimeline(timeline.reload());
-    assertEquals(commitMetadata, mergedTimeline.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
-    assertEquals(cleanerPlan, mergedTimeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
-    assertEquals(commitMetadata, metaClient.getCommitMetadataSerDe().deserialize(completedCommitInstant, mergedTimeline.getInstantDetails(completedCommitInstant).get(), HoodieCommitMetadata.class));
+    assertEquals(commitMetadata, mergedTimeline.deserializeInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+    assertEquals(cleanerPlan, mergedTimeline.deserializeInstantContent(cleanInstant, HoodieCleanerPlan.class));
+    assertEquals(commitMetadata, metaClient.getActiveTimeline().deserializeInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -75,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -619,6 +620,13 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     timeline.setInstants(allInstants);
     assertEquals(0, timeline.filterRequestedRollbackTimeline().countInstants());
     assertEquals(1, timeline.filterPendingRollbackTimeline().countInstants());
+
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    rollbackInstant = metaClient.createNewInstant(State.COMPLETED, HoodieTimeline.ROLLBACK_ACTION, rollbackInstant.requestedTime());
+    allInstants.set(1, rollbackInstant);
+    timeline.setInstants(allInstants);
+    assertEquals(0, timeline.filterPendingRollbackTimeline().countInstants());
+    assertEquals(0, timeline.filterRequestedRollbackTimeline().countInstants());
   }
 
   @Test
@@ -663,6 +671,12 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
     HoodieInstant commitInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
     assertThrows(HoodieIOException.class, () -> timeline.getInstantDetails(commitInstant));
+  }
+
+  @Test
+  void getInstantReaderReferencesSelf() {
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    assertSame(timeline, timeline.getInstantReader());
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -18,7 +18,10 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.fs.NoOpConsistencyGuard;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -26,6 +29,7 @@ import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -37,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,9 +64,9 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_TH
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.testutils.Assertions.assertStreamEquals;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_PARSER;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.hamcrest.CoreMatchers.is;
@@ -70,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -346,6 +352,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     checkTimeline.accept(timeline.getDeltaCommitTimeline(), Collections.singleton(HoodieTimeline.DELTA_COMMIT_ACTION));
     checkTimeline.accept(timeline.getCleanerTimeline(), Collections.singleton(HoodieTimeline.CLEAN_ACTION));
     checkTimeline.accept(timeline.getRollbackTimeline(), Collections.singleton(HoodieTimeline.ROLLBACK_ACTION));
+    checkTimeline.accept(timeline.getRollbackAndRestoreTimeline(), CollectionUtils.createSet(HoodieTimeline.RESTORE_ACTION, HoodieTimeline.ROLLBACK_ACTION));
     checkTimeline.accept(timeline.getRestoreTimeline(), Collections.singleton(HoodieTimeline.RESTORE_ACTION));
     checkTimeline.accept(timeline.getSavePointTimeline(), Collections.singleton(HoodieTimeline.SAVEPOINT_ACTION));
     checkTimeline.accept(timeline.getAllCommitsTimeline(), CollectionUtils.createSet(
@@ -421,10 +428,16 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     assertTrue(timeline.containsInstant(compaction));
     assertFalse(timeline.containsInstant(inflight));
     inflight = timeline.transitionCompactionRequestedToInflight(compaction);
-    compaction = timeline.transitionCompactionInflightToComplete(true, inflight, Option.empty());
+    timeline.reload();
+    assertFalse(timeline.filterPendingExcludingCompaction().containsInstant(compaction));
+    assertTrue(timeline.filterPendingCompactionTimeline().containsInstant(compaction));
+    assertTrue(timeline.filterPendingMajorOrMinorCompactionTimeline().containsInstant(compaction));
+    compaction = timeline.transitionCompactionInflightToComplete(false, inflight, Option.empty());
     timeline = timeline.reload();
     assertTrue(timeline.containsInstant(compaction));
     assertFalse(timeline.containsInstant(inflight));
+    assertFalse(timeline.filterPendingCompactionTimeline().containsInstant(compaction));
+    assertFalse(timeline.filterPendingMajorOrMinorCompactionTimeline().containsInstant(compaction));
 
     // transitionCleanXXXtoYYY
     HoodieInstant clean = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "4");
@@ -530,6 +543,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     // filterCompletedAndCompactionInstants
     // This cannot be done using checkFilter as it involves both states and actions
     final HoodieTimeline t1 = timeline.filterCompletedAndCompactionInstants();
+    assertTrue(t1.countInstants() > 0);
     final Set<State> states = CollectionUtils.createSet(State.COMPLETED);
     final Set<String> actions = Collections.singleton(HoodieTimeline.COMPACTION_ACTION);
     sup.get().filter(i -> states.contains(i.getState()) || actions.contains(i.getAction()))
@@ -539,10 +553,116 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
 
     // filterPendingCompactionTimeline
     final HoodieTimeline t2 = timeline.filterPendingCompactionTimeline();
+    assertTrue(t2.countInstants() > 0);
     sup.get().filter(i -> i.getAction().equals(HoodieTimeline.COMPACTION_ACTION))
         .forEach(i -> assertTrue(t2.containsInstant(i)));
     sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.COMPACTION_ACTION))
         .forEach(i -> assertFalse(t2.containsInstant(i)));
+
+    // filterPendingIndexTimeline
+    final HoodieTimeline t3 = timeline.filterPendingIndexTimeline();
+    assertEquals(2, t3.countInstants());
+    sup.get().filter(i -> i.getAction().equals(HoodieTimeline.INDEXING_ACTION) && !i.isCompleted())
+        .forEach(i -> assertTrue(t3.containsInstant(i)));
+    sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.INDEXING_ACTION) || i.getState() == State.COMPLETED)
+        .forEach(i -> assertFalse(t3.containsInstant(i)));
+
+    // filterCompletedIndexTimeline
+    final HoodieTimeline t4 = timeline.filterCompletedIndexTimeline();
+    assertEquals(1, t4.countInstants());
+    sup.get().filter(i -> i.getAction().equals(HoodieTimeline.INDEXING_ACTION) && i.isCompleted())
+        .forEach(i -> assertTrue(t4.containsInstant(i)));
+    sup.get().filter(i -> !i.getAction().equals(HoodieTimeline.INDEXING_ACTION) || !i.isCompleted())
+        .forEach(i -> assertFalse(t4.containsInstant(i)));
+
+    // filterCompletedInstantsOrRewriteTimeline
+    final HoodieTimeline t5 = timeline.filterCompletedInstantsOrRewriteTimeline();
+    assertTrue(t5.countInstants() > 0);
+    sup.get().filter(i -> CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION).contains(i.getAction())
+        || i.isCompleted()).forEach(i -> assertTrue(t5.containsInstant(i)));
+    sup.get().filter(i -> !(CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION).contains(i.getAction())
+        || i.isCompleted())).forEach(i -> assertFalse(t5.containsInstant(i)));
+
+    // filterPendingMajorOrMinorCompactionTimeline
+    final HoodieTimeline t6 = timeline.filterPendingMajorOrMinorCompactionTimeline();
+    assertTrue(t6.countInstants() > 0);
+    sup.get().filter(i -> CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION).contains(i.getAction())
+        && !i.isCompleted()).forEach(i -> assertTrue(t6.containsInstant(i)));
+    sup.get().filter(i -> !(CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION).contains(i.getAction())
+        && !i.isCompleted())).forEach(i -> assertFalse(t6.containsInstant(i)));
+
+    // filterPendingExcludingCompaction
+    final HoodieTimeline t7 = timeline.filterPendingExcludingCompaction();
+    assertTrue(t7.countInstants() > 0);
+    sup.get().filter(i -> !HoodieTimeline.COMPACTION_ACTION.equals(i.getAction()) && !i.isCompleted())
+        .forEach(i -> assertTrue(t7.containsInstant(i)));
+    sup.get().filter(i -> !(!HoodieTimeline.COMPACTION_ACTION.equals(i.getAction()) && !i.isCompleted()))
+        .forEach(i -> assertFalse(t7.containsInstant(i)));
+  }
+
+  @Test
+  public void testRollbackActionsTimeline() {
+    int instantTime = 1;
+    List<HoodieInstant> allInstants = new ArrayList<>();
+    allInstants.add(metaClient.createNewInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, String.format("%03d", instantTime++)));
+    HoodieInstant rollbackInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, String.format("%03d", instantTime++));
+    allInstants.add(rollbackInstant);
+
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.setInstants(allInstants);
+    assertEquals(1, timeline.filterRequestedRollbackTimeline().countInstants());
+    assertEquals(1, timeline.filterPendingRollbackTimeline().countInstants());
+
+    rollbackInstant = metaClient.createNewInstant(State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstant.requestedTime());
+    allInstants.set(1, rollbackInstant);
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.setInstants(allInstants);
+    assertEquals(0, timeline.filterRequestedRollbackTimeline().countInstants());
+    assertEquals(1, timeline.filterPendingRollbackTimeline().countInstants());
+  }
+
+  @Test
+  void testParsingCommitDetails() throws IOException {
+    HoodieInstant commitInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
+    HoodieInstant cleanInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "2");
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat hoodieWriteStat = new HoodieWriteStat();
+    hoodieWriteStat.setFileId("file_id1");
+    hoodieWriteStat.setPath("path1");
+    hoodieWriteStat.setPrevCommit("1");
+    commitMetadata.addWriteStat("partition1", hoodieWriteStat);
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    timeline.createNewInstant(commitInstant);
+    timeline.transitionRequestedToInflight(commitInstant, Option.empty());
+    HoodieInstant completeCommitInstant = metaClient.createNewInstant(State.INFLIGHT, commitInstant.getAction(), commitInstant.requestedTime());
+    timeline.saveAsComplete(completeCommitInstant,
+        Option.of(commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8)));
+    HoodieActiveTimeline timelineAfterFirstInstant = timeline.reload();
+
+    HoodieInstant completedCommitInstant = timelineAfterFirstInstant.lastInstant().get();
+    assertEquals(commitMetadata, timelineAfterFirstInstant.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+
+    HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan();
+    cleanerPlan.setLastCompletedCommitTimestamp("1");
+    cleanerPlan.setPolicy("policy");
+    cleanerPlan.setVersion(1);
+    cleanerPlan.setPartitionsToBeDeleted(Collections.singletonList("partition1"));
+    timeline.saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+
+    assertEquals(cleanerPlan, timeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
+
+    HoodieTimeline mergedTimeline = timelineAfterFirstInstant.mergeTimeline(timeline.reload());
+    assertEquals(commitMetadata, mergedTimeline.deserializeJsonInstantContent(completedCommitInstant, HoodieCommitMetadata.class));
+    assertEquals(cleanerPlan, mergedTimeline.deserializeAvroInstantContent(cleanInstant, HoodieCleanerPlan.class));
+    assertEquals(commitMetadata, metaClient.getCommitMetadataSerDe().deserialize(completedCommitInstant, mergedTimeline.getInstantDetails(completedCommitInstant).get(), HoodieCommitMetadata.class));
+  }
+
+  @Test
+  void missingInstantCausesError() {
+    timeline = TIMELINE_FACTORY.createActiveTimeline(metaClient);
+    HoodieInstant commitInstant = metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "1");
+    assertThrows(HoodieIOException.class, () -> timeline.getInstantDetails(commitInstant));
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -1276,9 +1276,8 @@ public class HoodieTestTable implements AutoCloseable {
         return Option.of(replaceCommitMetadata);
       case HoodieTimeline.DELTA_COMMIT_ACTION:
       case HoodieTimeline.COMMIT_ACTION:
-        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(
-            hoodieInstant,
-            metaClient.getActiveTimeline().getInstantDetails(hoodieInstant).get(), HoodieCommitMetadata.class);
+        HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(
+            hoodieInstant, HoodieCommitMetadata.class);
         return Option.of(commitMetadata);
       default:
         throw new IllegalArgumentException("Unknown instant action" + hoodieInstant.getAction());

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -251,8 +251,7 @@ public class HoodieInputFormatUtils {
                                                      List<Path> inputPaths) throws IOException {
     Set<String> partitionsToList = new HashSet<>();
     for (HoodieInstant commit : commitsToCheck) {
-      HoodieCommitMetadata commitMetadata = tableMetaClient.getCommitMetadataSerDe().deserialize(commit,
-          timeline.getInstantDetails(commit).get(), HoodieCommitMetadata.class);
+      HoodieCommitMetadata commitMetadata = tableMetaClient.getActiveTimeline().deserializeInstantContent(commit, HoodieCommitMetadata.class);
       partitionsToList.addAll(commitMetadata.getPartitionToWriteStats().keySet());
     }
     if (partitionsToList.isEmpty()) {

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteJob.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteJob.java
@@ -154,9 +154,8 @@ public class HoodieTestSuiteJob {
       HoodieTimeline timeline = new ActiveTimelineV2(metaClient).getCommitsTimeline();
       // Pickup the schema version from nth commit from last (most recent insert/upsert will be rolled back).
       HoodieInstant prevInstant = timeline.nthFromLastInstant(nthCommit).get();
-      HoodieCommitMetadata commit = metaClient.getCommitMetadataSerDe().deserialize(
+      HoodieCommitMetadata commit = metaClient.getActiveTimeline().deserializeInstantContent(
           prevInstant,
-          timeline.getInstantDetails(prevInstant).get(),
           HoodieCommitMetadata.class);
       Map<String, String> extraMetadata = commit.getExtraMetadata();
       String avroSchemaStr = extraMetadata.get(HoodieCommitMetadata.SCHEMA_KEY);

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/dag/nodes/ScheduleCompactNode.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/dag/nodes/ScheduleCompactNode.java
@@ -48,7 +48,7 @@ public class ScheduleCompactNode extends DagNode<Option<String>> {
         .build();
     Option<HoodieInstant> lastInstant = metaClient.getActiveTimeline().getCommitsTimeline().lastInstant();
     if (lastInstant.isPresent()) {
-      HoodieCommitMetadata metadata = metaClient.getCommitMetadataSerDe().deserialize(
+      HoodieCommitMetadata metadata = metaClient.getActiveTimeline().deserializeInstantContent(
           lastInstant.get(), metaClient.getActiveTimeline().getInstantDetails(lastInstant.get()).get(), HoodieCommitMetadata.class);
       Option<String> scheduledInstant = executionContext.getHoodieTestSuiteWriter().scheduleCompaction(Option.of(metadata
           .getExtraMetadata()));

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -166,7 +167,7 @@ public class FileIOUtils {
 
   public static void createFileInPath(HoodieStorage storage,
                                       StoragePath fullPath,
-                                      Option<byte[]> content, boolean ignoreIOE) {
+                                      Option<HoodieInstantWriter> contentWriter, boolean ignoreIOE) {
     try {
       // If the path does not exist, create it first
       if (!storage.exists(fullPath)) {
@@ -177,9 +178,9 @@ public class FileIOUtils {
         }
       }
 
-      if (content.isPresent()) {
+      if (contentWriter.isPresent()) {
         try (OutputStream out = storage.create(fullPath, true)) {
-          out.write(content.get());
+          contentWriter.get().writeToStream(out);
         }
       }
     } catch (IOException e) {
@@ -191,7 +192,7 @@ public class FileIOUtils {
   }
 
   public static void createFileInPath(HoodieStorage storage, StoragePath fullPath, Option<byte[]> content) {
-    createFileInPath(storage, fullPath, content, false);
+    createFileInPath(storage, fullPath, content.map(bytes -> (outputStream) -> outputStream.write(bytes)), false);
   }
 
   public static boolean copy(HoodieStorage srcStorage, StoragePath src,

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.storage;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Interface for classes that can write instant data to the timeline.
+ */
+public interface HoodieInstantWriter {
+  /**
+   * Writes the instants data to the provided output stream.
+   * @param outputStream stream where the data should be written
+   * @throws IOException thrown if there are issues serializing the data
+   */
+  void writeToStream(OutputStream outputStream) throws IOException;
+}

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieInstantWriter.java
@@ -31,4 +31,8 @@ public interface HoodieInstantWriter {
    * @throws IOException thrown if there are issues serializing the data
    */
   void writeToStream(OutputStream outputStream) throws IOException;
+
+  static HoodieInstantWriter convertByteArrayToWriter(byte[] bytes) {
+    return outputStream -> outputStream.write(bytes);
+  }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -22,6 +22,7 @@ package org.apache.hudi.io.storage;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.util.IOUtils;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -140,7 +141,7 @@ public abstract class TestHoodieStorageBase {
 
     StoragePath path3 = new StoragePath(getTempDir(), "testCreateAppendAndRead/3.file");
     assertFalse(storage.exists(path3));
-    storage.createImmutableFileInPath(path3, Option.of(data));
+    storage.createImmutableFileInPath(path3, Option.of(HoodieInstantWriter.convertByteArrayToWriter(data)));
     validatePathInfo(storage, path3, data, false);
 
     StoragePath path4 = new StoragePath(getTempDir(), "testCreateAppendAndRead/4");

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/utils/KafkaConnectUtils.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/utils/KafkaConnectUtils.java
@@ -208,7 +208,7 @@ public class KafkaConnectUtils {
     if (latestInstant.isPresent()) {
       try {
         byte[] data = timeline.getInstantDetails(latestInstant.get()).get();
-        return Option.of(metaClient.getCommitMetadataSerDe().deserialize(latestInstant.get(), data, HoodieCommitMetadata.class));
+        return Option.of(metaClient.getActiveTimeline().deserializeInstantContent(latestInstant.get(), HoodieCommitMetadata.class));
       } catch (Exception e) {
         throw new HoodieException("Failed to read schema from commit metadata", e);
       }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV1.scala
@@ -169,8 +169,8 @@ class IncrementalRelationV1(val sqlContext: SQLContext,
       }.toMap
 
       for (commit <- commitsToReturn) {
-        val metadata: HoodieCommitMetadata = metaClient.getCommitMetadataSerDe.deserialize(
-          commit, commitTimeline.getInstantDetails(commit).get(), classOf[HoodieCommitMetadata])
+        val metadata: HoodieCommitMetadata = metaClient.getActiveTimeline.deserializeInstantContent(
+          commit, classOf[HoodieCommitMetadata])
 
         if (HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS == commit.requestedTime) {
           metaBootstrapFileIdToFullPath ++= metadata.getFileIdAndFullPaths(basePath).asScala.filterNot { case (k, v) =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV2.scala
@@ -153,8 +153,8 @@ class IncrementalRelationV2(val sqlContext: SQLContext,
       }.toMap
 
       for (commit <- commitsToReturn) {
-        val metadata: HoodieCommitMetadata = metaClient.getCommitMetadataSerDe.deserialize(commit,
-          commitTimeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
+        val metadata: HoodieCommitMetadata = metaClient.getActiveTimeline.deserializeInstantContent(commit,
+          classOf[HoodieCommitMetadata])
 
         if (HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS == commit.requestedTime) {
           metaBootstrapFileIdToFullPath ++= metadata.getFileIdAndFullPaths(basePath).asScala.filterNot { case (k, v) =>

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
@@ -116,7 +116,7 @@ class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BasePr
     val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
-      val commitMetadata = layout.getCommitMetadataSerDe.deserialize(commit, timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
+      val commitMetadata = timeline.deserializeInstantContent(commit, classOf[HoodieCommitMetadata])
       for (partitionWriteStat <- commitMetadata.getPartitionToWriteStats.entrySet.asScala) {
         for (hoodieWriteStat <- partitionWriteStat.getValue.asScala) {
           rows.add(Row(
@@ -150,7 +150,7 @@ class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BasePr
     val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
-      val commitMetadata = layout.getCommitMetadataSerDe.deserialize(commit, timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
+      val commitMetadata = timeline.deserializeInstantContent(commit, classOf[HoodieCommitMetadata])
       rows.add(Row(commit.requestedTime, commit.getCompletionTime, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
         commitMetadata.fetchTotalFilesUpdated, commitMetadata.fetchTotalPartitionsWritten,
         commitMetadata.fetchTotalRecordsWritten, commitMetadata.fetchTotalUpdateRecordsWritten,

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowColumnStatsOverlapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowColumnStatsOverlapProcedure.scala
@@ -266,15 +266,9 @@ class ShowColumnStatsOverlapProcedure extends BaseProcedure with ProcedureBuilde
     val maxInstant = metaClient.createNewInstantTime()
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): HOption[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(),
+      metaClient.getActiveTimeline.getInstantReader)
 
     new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses)
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
@@ -124,8 +124,7 @@ class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBui
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {
-        Option(layout.getCommitMetadataSerDe.deserialize(hoodieInstant.get, timeline.getInstantDetails(hoodieInstant.get).get,
-          classOf[HoodieCommitMetadata]))
+        Option(timeline.deserializeInstantContent(hoodieInstant.get, classOf[HoodieCommitMetadata]))
       }
     } else {
       Option.empty

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
@@ -108,8 +108,7 @@ class ShowCommitFilesProcedure() extends BaseProcedure with ProcedureBuilder {
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {
-        Option(layout.getCommitMetadataSerDe.deserialize(hoodieInstant.get, timeline.getInstantDetails(hoodieInstant.get).get,
-          classOf[HoodieCommitMetadata]))
+        Option(timeline.deserializeInstantContent(hoodieInstant.get, classOf[HoodieCommitMetadata]))
       }
     } else {
       Option.empty

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
@@ -123,8 +123,7 @@ class ShowCommitPartitionsProcedure() extends BaseProcedure with ProcedureBuilde
           classOf[HoodieReplaceCommitMetadata]))
       } else {
         val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
-        Option(layout.getCommitMetadataSerDe.deserialize(hoodieInstant.get, timeline.getInstantDetails(hoodieInstant.get).get,
-          classOf[HoodieCommitMetadata]))
+        Option(timeline.deserializeInstantContent(hoodieInstant.get, classOf[HoodieCommitMetadata]))
       }
     } else {
       Option.empty

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
@@ -99,9 +99,7 @@ class ShowCommitWriteStatsProcedure() extends BaseProcedure with ProcedureBuilde
         Option(HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant.get).get,
           classOf[HoodieReplaceCommitMetadata]))
       } else {
-        val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
-        Option(layout.getCommitMetadataSerDe.deserialize(hoodieInstant.get, timeline.getInstantDetails(hoodieInstant.get).get,
-          classOf[HoodieCommitMetadata]))
+        Option(timeline.deserializeInstantContent(hoodieInstant.get, classOf[HoodieCommitMetadata]))
       }
     } else {
       Option.empty

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
@@ -101,7 +101,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
     val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
-      val commitMetadata = layout.getCommitMetadataSerDe.deserialize(commit, timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
+      val commitMetadata = timeline.deserializeInstantContent(commit, classOf[HoodieCommitMetadata])
       for (partitionWriteStat <- commitMetadata.getPartitionToWriteStats.entrySet.asScala) {
         for (hoodieWriteStat <- partitionWriteStat.getValue.asScala) {
           rows.add(Row(
@@ -135,7 +135,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
     val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
     for (i <- 0 until newCommits.size) {
       val commit = newCommits.get(i)
-      val commitMetadata = layout.getCommitMetadataSerDe.deserialize(commit, timeline.getInstantDetails(commit).get, classOf[HoodieCommitMetadata])
+      val commitMetadata = timeline.deserializeInstantContent(commit, classOf[HoodieCommitMetadata])
       rows.add(Row(commit.requestedTime, commit.getCompletionTime, commit.getAction, commitMetadata.fetchTotalBytesWritten, commitMetadata.fetchTotalFilesInsert,
         commitMetadata.fetchTotalFilesUpdated, commitMetadata.fetchTotalPartitionsWritten,
         commitMetadata.fetchTotalRecordsWritten, commitMetadata.fetchTotalUpdateRecordsWritten,

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -114,15 +114,8 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
       instants = instants.filter(instant => predicate.test(maxInstant, instant.requestedTime))
     }
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): util.Option[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new JArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new JArrayList[HoodieInstant](instants.toList.asJava).stream(), metaClient.getActiveTimeline.getInstantReader)
     new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -139,15 +139,8 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     val maxInstant = metaClient.createNewInstantTime()
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
-    val details = new Function[HoodieInstant, org.apache.hudi.common.util.Option[Array[Byte]]]
-      with java.io.Serializable {
-      override def apply(instant: HoodieInstant): HOption[Array[Byte]] = {
-        metaClient.getActiveTimeline.getInstantDetails(instant)
-      }
-    }
-
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), details)
+      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), metaClient.getActiveTimeline.getInstantReader)
 
     new HoodieTableFileSystemView(metaClient, filteredTimeline, new java.util.ArrayList[StoragePathInfo])
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsWriteAmplificationProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsWriteAmplificationProcedure.scala
@@ -56,7 +56,7 @@ class StatsWriteAmplificationProcedure extends BaseProcedure with ProcedureBuild
     timeline.getInstants.iterator.asScala.foreach(
       instantTime => {
         var waf = "0"
-        val commit = layout.getCommitMetadataSerDe.deserialize(instantTime, activeTimeline.getInstantDetails(instantTime).get(), classOf[HoodieCommitMetadata])
+        val commit = timeline.deserializeInstantContent(instantTime, classOf[HoodieCommitMetadata])
         if (commit.fetchTotalUpdateRecordsWritten() > 0) {
           waf = df.format(commit.fetchTotalRecordsWritten().toFloat / commit.fetchTotalUpdateRecordsWritten())
         }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateHoodieSyncProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateHoodieSyncProcedure.scala
@@ -194,8 +194,7 @@ class ValidateHoodieSyncProcedure extends BaseProcedure with ProcedureBuilder wi
     for (commit <- commitsToCatchup) {
       val instantGenerator = target.getTimelineLayout.getInstantGenerator
       val instant: HoodieInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, commit)
-      val c: HoodieCommitMetadata = target.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant, timeline.getInstantDetails(instant).get,
-        classOf[HoodieCommitMetadata])
+      val c: HoodieCommitMetadata = target.getActiveTimeline.deserializeInstantContent(instant, classOf[HoodieCommitMetadata])
       totalNew += c.fetchTotalRecordsWritten - c.fetchTotalUpdateRecordsWritten
     }
     totalNew

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -1941,8 +1941,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // populate commit -> partition -> file info to assist in validation and prefix search
       metaClient.getActiveTimeline().getInstants().forEach(entry -> {
         try {
-          HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe()
-              .deserialize(entry, metaClient.getActiveTimeline().getInstantDetails(entry).get(), HoodieCommitMetadata.class);
+          HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(entry, HoodieCommitMetadata.class);
           String commitTime = entry.requestedTime();
           if (!commitToPartitionsToFiles.containsKey(commitTime)) {
             commitToPartitionsToFiles.put(commitTime, new HashMap<>());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -72,7 +72,6 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.view.FileSystemViewStorageConfig.REMOTE_PORT_NUM;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -74,8 +74,7 @@ public class TestWriteClient extends HoodieSparkClientTestBase {
       // Schema Validations.
       HoodieTableMetaClient metaClient = createMetaClient(jsc, basePath);
       HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
-      HoodieCommitMetadata metadata = metaClient.getCommitMetadataSerDe().deserialize(timeline.lastInstant().get(),
-          timeline.getInstantDetails(timeline.lastInstant().get()).get(), HoodieCommitMetadata.class);
+      HoodieCommitMetadata metadata = timeline.deserializeInstantContent(timeline.lastInstant().get(), HoodieCommitMetadata.class);
       assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
       TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
       assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -577,8 +577,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instantOne = table.getActiveTimeline().getDeltaCommitTimeline().lastInstant().get();
-      HoodieCommitMetadata metadata = metaClient.getCommitMetadataSerDe().deserialize(instantOne,
-          table.getActiveTimeline().getInstantDetails(instantOne).get(), HoodieCommitMetadata.class);
+      HoodieCommitMetadata metadata = metaClient.getActiveTimeline().deserializeInstantContent(instantOne, HoodieCommitMetadata.class);
       int inserts = 0;
       for (Map.Entry<String, List<HoodieWriteStat>> pstat : metadata.getPartitionToWriteStats().entrySet()) {
         for (HoodieWriteStat stat : pstat.getValue()) {
@@ -610,8 +609,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instant3 = table.getActiveTimeline().getDeltaCommitTimeline().lastInstant().get();
-      metadata = metaClient.getCommitMetadataSerDe().deserialize(instant3,
-          table.getActiveTimeline().getInstantDetails(instant3).get(), HoodieCommitMetadata.class);
+      metadata = metaClient.getActiveTimeline().deserializeInstantContent(instant3, HoodieCommitMetadata.class);
       inserts = 0;
       upserts = 0;
       for (Map.Entry<String, List<HoodieWriteStat>> pstat : metadata.getPartitionToWriteStats().entrySet()) {
@@ -650,8 +648,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       HoodieTable table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instantOne = table.getActiveTimeline().getDeltaCommitTimeline().lastInstant().get();
-      HoodieCommitMetadata metadata = metaClient.getCommitMetadataSerDe().deserialize(instantOne,
-          table.getActiveTimeline().getInstantDetails(instantOne).get(),
+      HoodieCommitMetadata metadata = metaClient.getActiveTimeline().deserializeInstantContent(instantOne,
           HoodieCommitMetadata.class);
       int inserts = 0;
       for (Map.Entry<String, List<HoodieWriteStat>> pstat : metadata.getPartitionToWriteStats().entrySet()) {
@@ -675,8 +672,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instantTwo = table.getActiveTimeline().getDeltaCommitTimeline().lastInstant().get();
-      metadata = metaClient.getCommitMetadataSerDe().deserialize(instantTwo,
-          table.getActiveTimeline().getInstantDetails(instantTwo).get(),
+      metadata = metaClient.getActiveTimeline().deserializeInstantContent(instantTwo,
           HoodieCommitMetadata.class);
       inserts = 0;
       int upserts = 0;
@@ -702,8 +698,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instantThree = table.getActiveTimeline().getCommitsTimeline().lastInstant().get();
-      HoodieCommitMetadata metadata1 = metaClient.getCommitMetadataSerDe().deserialize(instantThree,
-          table.getActiveTimeline().getInstantDetails(instantThree).get(),
+      HoodieCommitMetadata metadata1 = metaClient.getActiveTimeline().deserializeInstantContent(instantThree,
           HoodieCommitMetadata.class);
 
       // Ensure that the metadata stats from the extra metadata of delta commits is copied over to the compaction commit
@@ -726,9 +721,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       // Read from commit file
       table = HoodieSparkTable.create(cfg, context());
       HoodieInstant instant = table.getActiveTimeline().getDeltaCommitTimeline().lastInstant().get();
-      metadata = metaClient.getCommitMetadataSerDe().deserialize(instant,
-          table.getActiveTimeline().getInstantDetails(instant).get(),
-          HoodieCommitMetadata.class);
+      metadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
       inserts = 0;
       upserts = 0;
       for (Map.Entry<String, List<HoodieWriteStat>> pstat : metadata.getPartitionToWriteStats().entrySet()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
@@ -372,11 +372,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
 
     // check hoodieCommitMeta
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "001");
-    HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant,
-        table.getMetaClient().getCommitTimeline()
-            .getInstantDetails(instant)
-            .get(),
-        HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
     List<HoodieWriteStat> firstPartitionWriteStat = commitMetadata.getPartitionToWriteStats().get(DEFAULT_FIRST_PARTITION_PATH);
     assertEquals(2, firstPartitionWriteStat.size());
     // we have an empty writeStat for all partition
@@ -400,11 +396,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
     client.commit(newCommitTime, statuses);
     table = this.getHoodieTable(metaClient, cfg);
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, newCommitTime);
-    commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(instant1,
-        table.getMetaClient().getCommitTimeline()
-            .getInstantDetails(instant1)
-            .get(),
-        HoodieCommitMetadata.class);
+    commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant1, HoodieCommitMetadata.class);
     assertTrue(commitMetadata.getPartitionToWriteStats().containsKey(DEFAULT_FIRST_PARTITION_PATH));
     assertTrue(commitMetadata.getPartitionToWriteStats().containsKey(DEFAULT_SECOND_PARTITION_PATH));
     List<HoodieWriteStat> hoodieWriteStatOptionList = commitMetadata.getPartitionToWriteStats().get(DEFAULT_FIRST_PARTITION_PATH);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
@@ -333,9 +333,8 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
                                         shouldContainRecordPosition: Boolean,
                                         shouldBaseFileInstantTimeMatch: Boolean = true): List[HoodieLogFile] = {
     val instant = metaClient.getActiveTimeline.getDeltaCommitTimeline.lastInstant().get()
-    val commitMetadata = metaClient.getCommitMetadataSerDe.deserialize(
-      instant, metaClient.getActiveTimeline.getInstantDetails(instant).get,
-      classOf[HoodieCommitMetadata])
+    val commitMetadata = metaClient.getActiveTimeline.deserializeInstantContent(
+      instant, classOf[HoodieCommitMetadata])
     val logFileList: List[HoodieLogFile] = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath)
       .asScala.values
       .filter(e => FSUtils.isLogFile(new StoragePath(e)))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -464,7 +464,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
       val compactionTimeline = metadataTableFSView.getVisibleCommitsAndCompactionTimeline.filterCompletedAndCompactionInstants()
       val lastCompactionInstant = compactionTimeline
         .filter(JavaConversions.getPredicate((instant: HoodieInstant) =>
-          metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant, compactionTimeline.getInstantDetails(instant).get, classOf[HoodieCommitMetadata])
+          metaClient.getActiveTimeline.deserializeInstantContent(instant, classOf[HoodieCommitMetadata])
             .getOperationType == WriteOperationType.COMPACT))
         .lastInstant()
       val compactionBaseFile = metadataTableFSView.getAllBaseFiles(MetadataPartitionType.PARTITION_STATS.getPartitionPath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -528,7 +528,7 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase {
     val compactionTimeline = metadataTableFSView.getVisibleCommitsAndCompactionTimeline.filterCompletedAndCompactionInstants()
     val lastCompactionInstant = compactionTimeline
       .filter(JavaConversions.getPredicate((instant: HoodieInstant) =>
-        metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant, compactionTimeline.getInstantDetails(instant).get, classOf[HoodieCommitMetadata])
+        metaClient.getActiveTimeline.deserializeInstantContent(instant, classOf[HoodieCommitMetadata])
           .getOperationType == WriteOperationType.COMPACT))
       .lastInstant()
     val compactionBaseFile = metadataTableFSView.getAllBaseFiles(MetadataPartitionType.RECORD_INDEX.getPartitionPath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
@@ -681,7 +681,7 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
       val compactionTimeline = metadataTableFSView.getVisibleCommitsAndCompactionTimeline.filterCompletedAndCompactionInstants()
       val lastCompactionInstant = compactionTimeline
         .filter(JavaConversions.getPredicate((instant: HoodieInstant) =>
-          metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant, compactionTimeline.getInstantDetails(instant).get, classOf[HoodieCommitMetadata])
+          metaClient.getActiveTimeline.deserializeInstantContent(instant, classOf[HoodieCommitMetadata])
             .getOperationType == WriteOperationType.COMPACT))
         .lastInstant()
       val compactionBaseFile = metadataTableFSView.getAllBaseFiles("secondary_index_idx_not_record_key_col")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
@@ -94,8 +94,7 @@ abstract class HoodieCDCTestBase extends HoodieSparkClientTestBase {
    * whether this instant will create a cdc log file.
    */
   protected def hasCDCLogFile(instant: HoodieInstant): Boolean = {
-    val commitMetadata = metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant,
-      metaClient.reloadActiveTimeline().getInstantDetails(instant).get(),
+    val commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant,
       classOf[HoodieCommitMetadata]
     )
     val hoodieWriteStats = commitMetadata.getWriteStats.asScala
@@ -110,8 +109,7 @@ abstract class HoodieCDCTestBase extends HoodieSparkClientTestBase {
    * extract a list of cdc log file.
    */
   protected def getCDCLogFile(instant: HoodieInstant): List[String] = {
-    val commitMetadata = metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(instant,
-      metaClient.reloadActiveTimeline().getInstantDetails(instant).get(),
+    val commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant,
       classOf[HoodieCommitMetadata]
     )
     commitMetadata.getWriteStats.asScala.flatMap(_.getCdcStats.asScala.keys).toList

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
@@ -44,7 +44,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
     // And available public methods does not allow to specify exact instant to get schema from, only latest after some filtering
     // which may lead to false positives in test scenarios.
     val lastInstant = metaClient.getActiveTimeline.getCompletedReplaceTimeline.lastInstant().get()
-    val commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(lastInstant, metaClient.getActiveTimeline.getInstantDetails(lastInstant).get(), classOf[HoodieCommitMetadata])
+    val commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(lastInstant, classOf[HoodieCommitMetadata])
     val schemaStr = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY)
     val schema = new Schema.Parser().parse(schemaStr)
     val fields = schema.getFields.asScala.map(_.name())
@@ -500,8 +500,8 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
         // check schema
         val metaClient = createMetaClient(spark, s"${tmp.getCanonicalPath}/$tableName")
         val lastInstant = metaClient.getActiveTimeline.getCommitsTimeline.lastInstant()
-        val commitMetadata = metaClient.getTimelineLayout.getCommitMetadataSerDe.deserialize(lastInstant.get(), metaClient.getActiveTimeline.getInstantDetails(
-          lastInstant.get()).get(), classOf[HoodieCommitMetadata])
+        val commitMetadata = metaClient.getActiveTimeline.deserializeInstantContent(
+          lastInstant.get(), classOf[HoodieCommitMetadata])
         val schemaStr = commitMetadata.getExtraMetadata.get(HoodieCommitMetadata.SCHEMA_KEY)
         Assertions.assertFalse(StringUtils.isNullOrEmpty(schemaStr))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
@@ -832,8 +832,7 @@ class TestClusteringProcedure extends HoodieSparkProcedureTestBase {
     var totalRecordsCount = 0L
     val layout = TimelineLayout.fromVersion(commitTimeline.getTimelineLayoutVersion)
     commitTimeline.getReverseOrderedInstants.toArray.foreach(instant => {
-      val commitMetadata = layout.getCommitMetadataSerDe.deserialize(instant.asInstanceOf[HoodieInstant],
-        commitTimeline.getInstantDetails(instant.asInstanceOf[HoodieInstant]).get, classOf[HoodieCommitMetadata])
+      val commitMetadata = commitTimeline.deserializeInstantContent(instant.asInstanceOf[HoodieInstant], classOf[HoodieCommitMetadata])
       totalByteSize = totalByteSize + commitMetadata.fetchTotalBytesWritten()
       totalRecordsCount = totalRecordsCount + commitMetadata.fetchTotalRecordsWritten()
     })

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1578,10 +1578,7 @@ public class HoodieMetadataTableValidator implements Serializable {
             if (!committedFilesMap.containsKey(instantTime)) {
               HoodieInstant instant =  completedInstantsTimeline.filter(i -> i.requestedTime().equals(instantTime))
                   .firstInstant().get();
-              HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(
-                  instant, completedInstantsTimeline.getInstantDetails(instant).get(),
-                  HoodieCommitMetadata.class
-              );
+              HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(instant, HoodieCommitMetadata.class);
               committedFilesMap.put(
                   instantTime,
                   commitMetadata.getWriteStats().stream()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/checkpointing/InitialCheckpointFromAnotherHoodieTimelineProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/checkpointing/InitialCheckpointFromAnotherHoodieTimelineProvider.java
@@ -56,9 +56,8 @@ public class InitialCheckpointFromAnotherHoodieTimelineProvider extends InitialC
     return anotherDsHoodieMetaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
         .map(instant -> {
           try {
-            HoodieCommitMetadata commitMetadata = anotherDsHoodieMetaClient.getCommitMetadataSerDe()
-                .deserialize(instant, anotherDsHoodieMetaClient.getActiveTimeline().getInstantDetails(instant).get(),
-                    HoodieCommitMetadata.class);
+            HoodieCommitMetadata commitMetadata = anotherDsHoodieMetaClient.getActiveTimeline().deserializeInstantContent(
+                instant, HoodieCommitMetadata.class);
             return commitMetadata.getMetadata(CHECKPOINT_KEY);
           } catch (IOException e) {
             return null;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -151,8 +151,8 @@ public class SparkSampleWritesUtils {
     Option<HoodieInstant> lastInstantOpt = metaClient.getCommitTimeline().filterCompletedInstants().lastInstant();
     checkState(lastInstantOpt.isPresent(), "The only completed instant should be present in sample_writes table.");
     HoodieInstant instant = lastInstantOpt.get();
-    HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe()
-        .deserialize(instant, metaClient.getCommitTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().deserializeInstantContent(
+        instant, HoodieCommitMetadata.class);
     long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
     long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
     return (long) Math.ceil((1.0 * totalBytesWritten) / totalRecordsWritten);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -204,9 +204,7 @@ public class StreamerCheckpointUtils {
       throws IOException {
     return (Option<Pair<String, HoodieCommitMetadata>>) timeline.getReverseOrderedInstants().map(instant -> {
       try {
-        TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
-        HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe()
-            .deserialize(instant, timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+        HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(instant, HoodieCommitMetadata.class);
         if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(HoodieStreamer.CHECKPOINT_KEY))
             || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(HoodieStreamer.CHECKPOINT_RESET_KEY))
             || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V2))

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.table.checkpoint.CheckpointUtils;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -694,7 +694,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
       HoodieInstant lastInstant = timeline.lastInstant().get();
       HoodieCommitMetadata commitMetadata =
-          meta.getCommitMetadataSerDe().deserialize(lastInstant, timeline.getInstantDetails(lastInstant).get(), HoodieCommitMetadata.class);
+          meta.getActiveTimeline().deserializeInstantContent(lastInstant, HoodieCommitMetadata.class);
       assertEquals(totalCommits, timeline.countInstants());
       if (meta.getTableConfig().getTableVersion() == HoodieTableVersion.EIGHT) {
         assertEquals(expected, commitMetadata.getMetadata(StreamerCheckpointV2.STREAMER_CHECKPOINT_KEY_V2));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.checkpoint.CheckpointUtils;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
@@ -147,9 +146,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     cfgBackfillJob.continuousMode = false;
     HoodieTableMetaClient meta = createMetaClient(new HadoopStorageConfiguration(hadoopConf), tableBasePath);
     HoodieTimeline timeline = meta.reloadActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-    TimelineLayout layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion());
-    HoodieCommitMetadata commitMetadata = layout.getCommitMetadataSerDe()
-        .deserialize(timeline.firstInstant().get(), timeline.getInstantDetails(timeline.firstInstant().get()).get(), HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = timeline.deserializeInstantContent(timeline.firstInstant().get(), HoodieCommitMetadata.class);
     cfgBackfillJob.checkpoint = commitMetadata.getMetadata(CHECKPOINT_KEY);
     cfgBackfillJob.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
     cfgBackfillJob.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
@@ -216,8 +213,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     cfgBackfillJob2.continuousMode = false;
     HoodieTableMetaClient meta = createMetaClient(new HadoopStorageConfiguration(hadoopConf), tableBasePath);
     HoodieTimeline timeline = meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-    HoodieCommitMetadata commitMetadata = meta.getCommitMetadataSerDe().deserialize(
-        timeline.firstInstant().get(), timeline.getInstantDetails(timeline.firstInstant().get()).get(), HoodieCommitMetadata.class);
+    HoodieCommitMetadata commitMetadata = meta.getActiveTimeline().deserializeInstantContent(timeline.firstInstant().get(), HoodieCommitMetadata.class);
     cfgBackfillJob2.checkpoint = commitMetadata.getMetadata(CHECKPOINT_KEY);
     cfgBackfillJob2.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
     cfgBackfillJob2.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
@@ -327,8 +323,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
       throws IOException {
     HoodieTimeline timeline =
         meta.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants();
-    return meta.getCommitMetadataSerDe().deserialize(
-        timeline.firstInstant().get(), timeline.getInstantDetails(timeline.lastInstant().get()).get(), HoodieCommitMetadata.class);
+    return meta.getActiveTimeline().deserializeInstantContent(timeline.firstInstant().get(), HoodieCommitMetadata.class);
   }
 
   private static TypedProperties prepareMultiWriterProps(HoodieStorage storage, String basePath,


### PR DESCRIPTION
## Please start review from commit with title "util changes done". Up stream commits are from PR https://github.com/apache/hudi/pull/12814

### Change Logs


- Migrate all readers of the two commit types to use input streams
- Update portions of the code that rely on empty input streams to use other signals for proper parsing

### Impact

- Allows for reading of large commit metadata

### Risk level (write none, low medium or high below)

low

### Documentation Update
NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
