### PR TITLE
[HUDI-9000] Adding timestamp ordering validation for flink 0.x branch

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -900,8 +900,9 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   /**
    * Validates that the instantTime is latest in the write timeline.
    * @param instantTime instant time of interest.
+   * @param action
    */
-  public abstract void validateForLatestTimestamp(String instantTime);
+  public abstract void validateForLatestTimestamp(String instantTime, String action);
 
   protected void validateForLatestTimestampInternal(String instantTime) {
     if (this.config.shouldEnableTimestampOrderinValidation() && config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -179,7 +179,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
       final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
       // Save to both aux and timeline folder
       try {
-        table.validateForLatestTimestamp(cleanInstant.getTimestamp());
+        table.validateForLatestTimestamp(cleanInstant.getTimestamp(), HoodieTimeline.CLEAN_ACTION);
         table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
         LOG.info("Requesting Cleaning with instant time " + cleanInstant);
       } catch (IOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -98,7 +98,7 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseActionExecutor
             .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
             .setClusteringPlan(planOption.get())
             .build();
-        table.validateForLatestTimestamp(clusteringInstant.getTimestamp());
+        table.validateForLatestTimestamp(clusteringInstant.getTimestamp(), WriteOperationType.CLUSTER.name());
         table.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant,
             TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
       } catch (IOException ioe) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -114,7 +114,7 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseActionExec
     Option<HoodieCompactionPlan> option = Option.empty();
     if (plan != null && nonEmpty(plan.getOperations())) {
       extraMetadata.ifPresent(plan::setExtraMetadata);
-      table.validateForLatestTimestamp(instantTime);
+      table.validateForLatestTimestamp(instantTime, WriteOperationType.COMPACT.name());
       try {
         if (operationType.equals(WriteOperationType.COMPACT)) {
           HoodieInstant compactionInstant = new HoodieInstant(HoodieInstant.State.REQUESTED,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
@@ -113,7 +113,7 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
       HoodieRollbackPlan rollbackPlan = new HoodieRollbackPlan(new HoodieInstantInfo(instantToRollback.getTimestamp(),
           instantToRollback.getAction()), rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION);
       if (!skipTimelinePublish) {
-        table.validateForLatestTimestamp(rollbackInstant.getTimestamp());
+        table.validateForLatestTimestamp(rollbackInstant.getTimestamp(), HoodieTimeline.ROLLBACK_ACTION);
         if (table.getRollbackTimeline().filterInflightsAndRequested().containsInstant(rollbackInstant.getTimestamp())) {
           LOG.warn("Request Rollback found with instant time " + rollbackInstant + ", hence skipping scheduling rollback");
         } else {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -125,7 +125,7 @@ public class HoodieFlinkWriteClient<T> extends
 
   @Override
   protected void validateTimestamp(HoodieTableMetaClient metaClient, String instantTime) {
-    // no op
+    validateTimestampInternal(metaClient, instantTime);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
@@ -93,8 +94,10 @@ public class HoodieFlinkCopyOnWriteTable<T>
   }
 
   @Override
-  public void validateForLatestTimestamp(String instantTime) {
-    // no-op
+  public void validateForLatestTimestamp(String instantTime, String action) {
+    if (!action.equals(WriteOperationType.COMPACT.name())) { // compaction in flink is expected to have older timestamps compared to latest intant.
+      validateForLatestTimestampInternal(instantTime);
+    }
   }
 
   /**

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
@@ -93,7 +93,7 @@ public class HoodieJavaCopyOnWriteTable<T>
   }
 
   @Override
-  public void validateForLatestTimestamp(String instantTime) {
+  public void validateForLatestTimestamp(String instantTime, String action) {
     validateForLatestTimestampInternal(instantTime);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -105,7 +105,7 @@ public class HoodieSparkCopyOnWriteTable<T>
   }
 
   @Override
-  public void validateForLatestTimestamp(String instantTime) {
+  public void validateForLatestTimestamp(String instantTime, String action) {
     validateForLatestTimestampInternal(instantTime);
   }
 


### PR DESCRIPTION
### Change Logs

Adding timestamp ordering validation for flink 0.x branch. 
Same as https://github.com/apache/hudi/pull/11580, but for flink in 0.x branch.

### Impact

Adding timestamp ordering validation for flink 0.x branch. 
Same as https://github.com/apache/hudi/pull/11580, but for flink in 0.x branch.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
