### PR TITLE
[HUDI-8992] Fix serde issues in commit metadata

### DIFF
--- a/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
@@ -162,11 +162,56 @@
                            }
                         ],
                         "default": null
+                     },
+                     {
+                        "name":"prevBaseFile",
+                        "type":["null","string"],
+                        "default": null
+                     },
+                     {
+                        "name":"minEventTime",
+                        "type":["null","long"],
+                        "default": null
+                     },
+                     {
+                        "name":"maxEventTime", 
+                        "type":["null","long"],
+                        "default": null
+                     },
+                     {
+                        "name":"runtimeStats",
+                        "type":["null", {
+                           "type": "record",
+                           "name": "HoodieRuntimeStats",
+                           "fields": [
+                              {
+                                 "name": "totalScanTime",
+                                 "type": ["null", "long"],
+                                 "default": null
+                              },
+                              {
+                                 "name": "totalCreateTime",
+                                 "type": ["null", "long"],
+                                 "default": null
+                              },
+                              {
+                                 "name": "totalUpsertTime",
+                                 "type": ["null", "long"],
+                                 "default": null
+                              }
+                           ]
+                        }],
+                        "default": null
                      }
                   ]
                }
             }
          }],
+         "default": null
+      },
+      {
+         "name":"compacted",
+         "type":["null", "boolean"],
          "default": null
       },
       {

--- a/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
@@ -202,6 +202,31 @@
                            ]
                         }],
                         "default": null
+                     },
+                     {
+                        "name":"totalLogFilesCompacted",
+                        "type":["null","long"],
+                        "default" : null
+                     },
+                     {
+                        "name":"totalLogReadTimeMs",
+                        "type":["null","long"],
+                        "default" : null
+                     },
+                     {
+                        "name":"totalLogSizeCompacted",
+                        "type":["null","long"],
+                        "default" : null
+                     },
+                     {
+                        "name":"tempPath",
+                        "type":["null","string"],
+                        "default" : null
+                     },
+                     {
+                        "name":"numUpdates",
+                        "type":["null","long"],
+                        "default" : null
                      }
                   ]
                }

--- a/hudi-common/src/main/avro/HoodieReplaceCommitMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieReplaceCommitMetadata.avsc
@@ -32,6 +32,11 @@
          "default": null
       },
       {
+         "name":"compacted",
+         "type":["null", "boolean"],
+         "default": null
+      },
+      {
          "name":"extraMetadata",
          "type":["null", {
             "type":"map",

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -45,6 +45,13 @@ import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deseri
 
 /**
  * All the metadata that gets stored along with a commit.
+ * ******** IMPORTANT ********
+ * For any newly added/removed data fields, make sure we have the same definition in
+ * src/main/avro/HoodieCommitMetadata.avsc file!!!!!
+ *
+ * For any newly added subclass, make sure we add corresponding handler in
+ * org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2#deserialize method.
+ * ***************************
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HoodieCommitMetadata implements Serializable {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
@@ -37,6 +37,13 @@ import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
 /**
  * All the metadata that gets stored along with a commit.
+ * ******** IMPORTANT ********
+ * For any newly added/removed data fields, make sure we have the same definition in
+ * src/main/avro/HoodieReplaceCommitMetadata.avsc file!!!!!
+ *
+ * For any newly added subclass, make sure we add corresponding handler in
+ * org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2#deserialize method.
+ * ***************************
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HoodieReplaceCommitMetadata extends HoodieCommitMetadata {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -371,7 +371,7 @@ public class MetadataConversionUtils {
   /**
    * Convert commit metadata from avro to pojo.
    */
-  public static HoodieCommitMetadata convertCommitMetadataAvroToPojo(org.apache.hudi.avro.model.HoodieCommitMetadata hoodieCommitMetadata) {
+  public static HoodieCommitMetadata convertCommitMetadataToPojo(org.apache.hudi.avro.model.HoodieCommitMetadata hoodieCommitMetadata) {
     // While it is valid to have a null key in the hash map in java, avro map could not accommodate this, so we need to remove null key explicitly before the conversion.
     hoodieCommitMetadata.getPartitionToWriteStats().remove(null);
     return JsonUtils.getObjectMapper().convertValue(hoodieCommitMetadata, HoodieCommitMetadata.class);
@@ -385,7 +385,7 @@ public class MetadataConversionUtils {
   }
 
   /**
-   * Convert replacecommit metadata from pojo to avro.
+   * Convert replacecommit metadata from avro to pojo.
    */
   public static HoodieReplaceCommitMetadata convertReplaceCommitMetadataToPojo(org.apache.hudi.avro.model.HoodieReplaceCommitMetadata replaceCommitMetadata) {
     // While it is valid to have a null key in the hash map in java, avro map could not accommodate this, so we need to remove null key explicitly before the conversion.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -370,12 +370,29 @@ public class MetadataConversionUtils {
   }
 
   /**
+   * Convert commit metadata from json to avro.
+   */
+  public static HoodieCommitMetadata convertCommitMetadataAvroToPojo(org.apache.hudi.avro.model.HoodieCommitMetadata hoodieCommitMetadata) {
+    hoodieCommitMetadata.getPartitionToWriteStats().remove(null);
+    return JsonUtils.getObjectMapper().convertValue(hoodieCommitMetadata, HoodieCommitMetadata.class);
+  }
+
+  /**
    * Convert replacecommit metadata from json to avro.
    */
   private static org.apache.hudi.avro.model.HoodieReplaceCommitMetadata convertReplaceCommitMetadata(HoodieReplaceCommitMetadata replaceCommitMetadata) {
     replaceCommitMetadata.getPartitionToWriteStats().remove(null);
     replaceCommitMetadata.getPartitionToReplaceFileIds().remove(null);
     return JsonUtils.getObjectMapper().convertValue(replaceCommitMetadata, org.apache.hudi.avro.model.HoodieReplaceCommitMetadata.class);
+  }
+
+  /**
+   * Convert replacecommit metadata from json to avro.
+   */
+  public static HoodieReplaceCommitMetadata convertReplaceCommitMetadataAvroToPojo(org.apache.hudi.avro.model.HoodieReplaceCommitMetadata replaceCommitMetadata) {
+    replaceCommitMetadata.getPartitionToWriteStats().remove(null);
+    replaceCommitMetadata.getPartitionToReplaceFileIds().remove(null);
+    return JsonUtils.getObjectMapper().convertValue(replaceCommitMetadata, HoodieReplaceCommitMetadata.class);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -364,7 +364,6 @@ public class MetadataConversionUtils {
     if (hoodieCommitMetadata instanceof HoodieReplaceCommitMetadata) {
       return (T) convertReplaceCommitMetadata((HoodieReplaceCommitMetadata) hoodieCommitMetadata);
     }
-    hoodieCommitMetadata.getPartitionToWriteStats().remove(null);
     org.apache.hudi.avro.model.HoodieCommitMetadata avroMetaData = JsonUtils.getObjectMapper().convertValue(hoodieCommitMetadata, org.apache.hudi.avro.model.HoodieCommitMetadata.class);
     return (T) avroMetaData;
   }
@@ -381,8 +380,6 @@ public class MetadataConversionUtils {
    * Convert replacecommit metadata from json to avro.
    */
   private static org.apache.hudi.avro.model.HoodieReplaceCommitMetadata convertReplaceCommitMetadata(HoodieReplaceCommitMetadata replaceCommitMetadata) {
-    replaceCommitMetadata.getPartitionToWriteStats().remove(null);
-    replaceCommitMetadata.getPartitionToReplaceFileIds().remove(null);
     return JsonUtils.getObjectMapper().convertValue(replaceCommitMetadata, org.apache.hudi.avro.model.HoodieReplaceCommitMetadata.class);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
@@ -204,7 +204,7 @@ public class TimelineMetadataUtils {
     return deserializeAvroMetadata(bytes, HoodieReplaceCommitMetadata.class);
   }
 
-  public static <T extends SpecificRecordBase> T deserializeAvroMetadata(byte[] bytes, Class<T> clazz)
+  public static <T> T deserializeAvroMetadata(byte[] bytes, Class<T> clazz)
       throws IOException {
     DatumReader<T> reader = new SpecificDatumReader<>(clazz);
     FileReader<T> fileReader = DataFileReader.openReader(new SeekableByteArrayInput(bytes), reader);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
@@ -204,7 +204,7 @@ public class TimelineMetadataUtils {
     return deserializeAvroMetadata(bytes, HoodieReplaceCommitMetadata.class);
   }
 
-  public static <T> T deserializeAvroMetadata(byte[] bytes, Class<T> clazz)
+  public static <T extends SpecificRecordBase> T deserializeAvroMetadata(byte[] bytes, Class<T> clazz)
       throws IOException {
     DatumReader<T> reader = new SpecificDatumReader<>(clazz);
     FileReader<T> fileReader = DataFileReader.openReader(new SeekableByteArrayInput(bytes), reader);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
@@ -35,7 +35,7 @@ import org.apache.avro.specific.SpecificRecordBase;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataAvroToPojo;
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToPojo;
 import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertReplaceCommitMetadataToPojo;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeReplaceCommitMetadata;
@@ -60,7 +60,7 @@ public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
       if (org.apache.hudi.common.model.HoodieReplaceCommitMetadata.class.isAssignableFrom(clazz)) {
         return (T) convertReplaceCommitMetadataToPojo(deserializeReplaceCommitMetadata(bytes));
       }
-      return (T) convertCommitMetadataAvroToPojo(deserializeCommitMetadata(bytes));
+      return (T) convertCommitMetadataToPojo(deserializeCommitMetadata(bytes));
     } catch (Exception e) {
       throw new IOException("unable to read commit metadata for instant " + instant + " bytes length: " + bytes.length, e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.MetadataConversionUtils;
+import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
 
@@ -34,9 +35,10 @@ import org.apache.avro.specific.SpecificRecordBase;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToJsonBytes;
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataAvroToPojo;
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertReplaceCommitMetadataAvroToPojo;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeCommitMetadata;
-import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeReplaceCommitMetadata;
 
 public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
 
@@ -47,16 +49,18 @@ public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
         return clazz.newInstance();
       }
       if (instant.isLegacy()) {
+        // For legacy instant, delegate to legacy SerDe.
         try {
-          return fromJsonString(fromUTF8Bytes(bytes), clazz);
+          return new CommitMetadataSerDeV1().deserialize(instant, bytes, clazz);
         } catch (Exception e) {
           throw new IOException("unable to read legacy commit metadata for instant " + instant, e);
         }
       }
-      return fromJsonString(
-          fromUTF8Bytes(
-              convertCommitMetadataToJsonBytes(deserializeCommitMetadata(bytes), org.apache.hudi.avro.model.HoodieCommitMetadata.class)),
-          clazz);
+      // For any new commit metadata class being added, we need the corresponding logic added here
+      if (org.apache.hudi.common.model.HoodieReplaceCommitMetadata.class.isAssignableFrom(clazz)) {
+        return (T) convertReplaceCommitMetadataAvroToPojo(deserializeReplaceCommitMetadata(bytes));
+      }
+      return (T) convertCommitMetadataAvroToPojo(deserializeCommitMetadata(bytes));
     } catch (Exception e) {
       throw new IOException("unable to read commit metadata for instant " + instant + " bytes length: " + bytes.length, e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
@@ -36,7 +36,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataAvroToPojo;
-import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertReplaceCommitMetadataAvroToPojo;
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertReplaceCommitMetadataToPojo;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeReplaceCommitMetadata;
 
@@ -58,7 +58,7 @@ public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
       }
       // For any new commit metadata class being added, we need the corresponding logic added here
       if (org.apache.hudi.common.model.HoodieReplaceCommitMetadata.class.isAssignableFrom(clazz)) {
-        return (T) convertReplaceCommitMetadataAvroToPojo(deserializeReplaceCommitMetadata(bytes));
+        return (T) convertReplaceCommitMetadataToPojo(deserializeReplaceCommitMetadata(bytes));
       }
       return (T) convertCommitMetadataAvroToPojo(deserializeCommitMetadata(bytes));
     } catch (Exception e) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
@@ -1,0 +1,205 @@
+package org.apache.hudi.common.table.timeline.versioning;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseTestCommitMetadataSerDe {
+    protected static final String TEST_PARTITION_PATH = "2023/01/01";
+    protected static final String TEST_FILE_ID = "test-file-id";
+    protected static final String TEST_PREV_COMMIT = "000001";
+    protected static final String TEST_BASE_FILE = "test-base-file";
+
+    protected String testPath;
+    protected abstract CommitMetadataSerDe getSerDe();
+    protected abstract HoodieInstant createTestInstant(String action, String id);
+
+    @BeforeEach
+    public void setUp() {
+        testPath = "file:///path/1/";
+    }
+
+    protected void testEmptyMetadataSerDe() throws Exception {
+        // Create empty commit metadata
+        HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+
+        // Create SerDe instance
+        CommitMetadataSerDe serDe = getSerDe();
+
+        // Create test instant
+        HoodieInstant instant = createTestInstant("commit", "001");
+
+        // Serialize
+        Option<byte[]> serialized = serDe.serialize(emptyMetadata);
+        assertTrue(serialized.isPresent());
+
+        // Deserialize
+        HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+
+        // Verify
+        assertNotNull(deserialized);
+        assertEquals(0, deserialized.getPartitionToWriteStats().size());
+        assertEquals(false, deserialized.getCompacted());
+        assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
+        assertTrue(deserialized.getExtraMetadata().isEmpty());
+    }
+
+    protected void testPopulatedMetadataSerDe() throws Exception {
+        // Create populated commit metadata
+        HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+        HoodieWriteStat writeStat = createTestWriteStat();
+        metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+
+        // Set other metadata fields
+        metadata.setOperationType(WriteOperationType.INSERT);
+        metadata.setCompacted(true);
+        metadata.addMetadata("test-key", "test-value");
+
+        // Create SerDe instance and test instant
+        CommitMetadataSerDe serDe = getSerDe();
+        HoodieInstant instant = createTestInstant("commit", "001");
+
+        // Serialize and deserialize
+        Option<byte[]> serialized = serDe.serialize(metadata);
+        assertTrue(serialized.isPresent());
+        HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+
+        // Verify
+        verifyCommitMetadata(deserialized);
+        verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
+    }
+
+    protected void testReplaceCommitMetadataSerDe() throws Exception {
+        // Create populated replace commit metadata
+        HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+        HoodieWriteStat writeStat = createTestWriteStat();
+        metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+
+        // Add replace file IDs
+        metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
+        metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
+        metadata.addReplaceFileId("other-partition", "replaced-file-3");
+
+        // Set other metadata fields
+        metadata.setOperationType(WriteOperationType.CLUSTER);
+        metadata.setCompacted(true);
+        metadata.addMetadata("test-key-1", "test-value-1");
+        metadata.addMetadata("test-key-2", "test-value-2");
+
+        // Create SerDe instance and test instant
+        CommitMetadataSerDe serDe = getSerDe();
+        HoodieInstant instant = createTestInstant("replacecommit", "001");
+
+        // Serialize and deserialize
+        Option<byte[]> serialized = serDe.serialize(metadata);
+        assertTrue(serialized.isPresent());
+        HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
+
+        // Verify
+        verifyReplaceCommitMetadata(deserialized);
+        verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
+        verifyReplaceFileIds(deserialized.getPartitionToReplaceFileIds());
+    }
+
+    private HoodieWriteStat createTestWriteStat() {
+        HoodieWriteStat writeStat = new HoodieWriteStat();
+        // Set basic fields
+        writeStat.setFileId(TEST_FILE_ID);
+        writeStat.setPath(testPath);
+        writeStat.setPrevCommit(TEST_PREV_COMMIT);
+        writeStat.setNumWrites(100);
+        writeStat.setNumUpdateWrites(50);
+        writeStat.setTotalWriteBytes(1024);
+        writeStat.setTotalWriteErrors(0);
+        writeStat.setPartitionPath(TEST_PARTITION_PATH);
+        writeStat.setFileSizeInBytes(2048);
+        writeStat.setPrevBaseFile(TEST_BASE_FILE);
+        writeStat.setMinEventTime(1000L);
+        writeStat.setMaxEventTime(2000L);
+
+        // Set CDC stats
+        Map<String, Long> cdcStats = new HashMap<>();
+        cdcStats.put("cdc-file-1.log", 512L);
+        writeStat.setCdcStats(cdcStats);
+
+        // Set runtime stats
+        HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
+        runtimeStats.setTotalScanTime(100);
+        runtimeStats.setTotalCreateTime(200);
+        runtimeStats.setTotalUpsertTime(300);
+        writeStat.setRuntimeStats(runtimeStats);
+
+        // Set new fields
+        writeStat.setTotalLogFilesCompacted(5L);
+        writeStat.setTotalLogReadTimeMs(150L);
+        writeStat.setTotalLogSizeCompacted(1024L);
+        writeStat.setTempPath("temp/path/file1");
+
+        return writeStat;
+    }
+
+    private void verifyCommitMetadata(HoodieCommitMetadata metadata) {
+        assertNotNull(metadata);
+        assertEquals(1, metadata.getPartitionToWriteStats().size());
+        assertEquals(true, metadata.getCompacted());
+        assertEquals(WriteOperationType.INSERT, metadata.getOperationType());
+        assertEquals("test-value", metadata.getExtraMetadata().get("test-key"));
+    }
+
+    private void verifyReplaceCommitMetadata(HoodieReplaceCommitMetadata metadata) {
+        assertNotNull(metadata);
+        assertEquals(true, metadata.getCompacted());
+        assertEquals(WriteOperationType.CLUSTER, metadata.getOperationType());
+        assertEquals("test-value-1", metadata.getExtraMetadata().get("test-key-1"));
+        assertEquals("test-value-2", metadata.getExtraMetadata().get("test-key-2"));
+    }
+
+    private void verifyWriteStat(HoodieWriteStat stat) {
+        assertEquals(TEST_FILE_ID, stat.getFileId());
+        assertEquals(testPath, stat.getPath());
+        assertEquals(TEST_PREV_COMMIT, stat.getPrevCommit());
+        assertEquals(100, stat.getNumWrites());
+        assertEquals(50, stat.getNumUpdateWrites());
+        assertEquals(1024, stat.getTotalWriteBytes());
+        assertEquals(0, stat.getTotalWriteErrors());
+        assertEquals(TEST_PARTITION_PATH, stat.getPartitionPath());
+        assertEquals(2048, stat.getFileSizeInBytes());
+        assertEquals(TEST_BASE_FILE, stat.getPrevBaseFile());
+        assertEquals(1000L, stat.getMinEventTime());
+        assertEquals(2000L, stat.getMaxEventTime());
+        assertEquals(512L, stat.getCdcStats().get("cdc-file-1.log"));
+        assertNotNull(stat.getRuntimeStats());
+        assertEquals(100, stat.getRuntimeStats().getTotalScanTime());
+        assertEquals(200, stat.getRuntimeStats().getTotalCreateTime());
+        assertEquals(300, stat.getRuntimeStats().getTotalUpsertTime());
+        assertEquals(5L, stat.getTotalLogFilesCompacted());
+        assertEquals(150L, stat.getTotalLogReadTimeMs());
+        assertEquals(1024L, stat.getTotalLogSizeCompacted());
+        assertEquals("temp/path/file1", stat.getTempPath());
+        assertEquals(0L, stat.getNumUpdates());
+    }
+
+    private void verifyReplaceFileIds(Map<String, List<String>> replaceFileIds) {
+        assertEquals(2, replaceFileIds.size());
+        assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), 
+            replaceFileIds.get(TEST_PARTITION_PATH));
+        assertEquals(Collections.singletonList("replaced-file-3"), 
+            replaceFileIds.get("other-partition"));
+    }
+} 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.common.table.timeline.versioning;
 
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -21,185 +39,187 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class BaseTestCommitMetadataSerDe {
-    protected static final String TEST_PARTITION_PATH = "2023/01/01";
-    protected static final String TEST_FILE_ID = "test-file-id";
-    protected static final String TEST_PREV_COMMIT = "000001";
-    protected static final String TEST_BASE_FILE = "test-base-file";
+  protected static final String TEST_PARTITION_PATH = "2023/01/01";
+  protected static final String TEST_FILE_ID = "test-file-id";
+  protected static final String TEST_PREV_COMMIT = "000001";
+  protected static final String TEST_BASE_FILE = "test-base-file";
 
-    protected String testPath;
-    protected abstract CommitMetadataSerDe getSerDe();
-    protected abstract HoodieInstant createTestInstant(String action, String id);
+  protected String testPath;
 
-    @BeforeEach
-    public void setUp() {
-        testPath = "file:///path/1/";
-    }
+  protected abstract CommitMetadataSerDe getSerDe();
 
-    protected void testEmptyMetadataSerDe() throws Exception {
-        // Create empty commit metadata
-        HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+  protected abstract HoodieInstant createTestInstant(String action, String id);
 
-        // Create SerDe instance
-        CommitMetadataSerDe serDe = getSerDe();
+  @BeforeEach
+  public void setUp() {
+    testPath = "file:///path/1/";
+  }
 
-        // Create test instant
-        HoodieInstant instant = createTestInstant("commit", "001");
+  protected void testEmptyMetadataSerDe() throws Exception {
+    // Create empty commit metadata
+    HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
 
-        // Serialize
-        Option<byte[]> serialized = serDe.serialize(emptyMetadata);
-        assertTrue(serialized.isPresent());
+    // Create SerDe instance
+    CommitMetadataSerDe serDe = getSerDe();
 
-        // Deserialize
-        HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    // Create test instant
+    HoodieInstant instant = createTestInstant("commit", "001");
 
-        // Verify
-        assertNotNull(deserialized);
-        assertEquals(0, deserialized.getPartitionToWriteStats().size());
-        assertEquals(false, deserialized.getCompacted());
-        assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
-        assertTrue(deserialized.getExtraMetadata().isEmpty());
-    }
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
+    assertTrue(serialized.isPresent());
 
-    protected void testPopulatedMetadataSerDe() throws Exception {
-        // Create populated commit metadata
-        HoodieCommitMetadata metadata = new HoodieCommitMetadata();
-        HoodieWriteStat writeStat = createTestWriteStat();
-        metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    // Deserialize
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
 
-        // Set other metadata fields
-        metadata.setOperationType(WriteOperationType.INSERT);
-        metadata.setCompacted(true);
-        metadata.addMetadata("test-key", "test-value");
+    // Verify
+    assertNotNull(deserialized);
+    assertEquals(0, deserialized.getPartitionToWriteStats().size());
+    assertEquals(false, deserialized.getCompacted());
+    assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
+    assertTrue(deserialized.getExtraMetadata().isEmpty());
+  }
 
-        // Create SerDe instance and test instant
-        CommitMetadataSerDe serDe = getSerDe();
-        HoodieInstant instant = createTestInstant("commit", "001");
+  protected void testPopulatedMetadataSerDe() throws Exception {
+    // Create populated commit metadata
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat = createTestWriteStat();
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
 
-        // Serialize and deserialize
-        Option<byte[]> serialized = serDe.serialize(metadata);
-        assertTrue(serialized.isPresent());
-        HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.INSERT);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key", "test-value");
 
-        // Verify
-        verifyCommitMetadata(deserialized);
-        verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
-    }
+    // Create SerDe instance and test instant
+    CommitMetadataSerDe serDe = getSerDe();
+    HoodieInstant instant = createTestInstant("commit", "001");
 
-    protected void testReplaceCommitMetadataSerDe() throws Exception {
-        // Create populated replace commit metadata
-        HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
-        HoodieWriteStat writeStat = createTestWriteStat();
-        metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    // Serialize and deserialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
 
-        // Add replace file IDs
-        metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
-        metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
-        metadata.addReplaceFileId("other-partition", "replaced-file-3");
+    // Verify
+    verifyCommitMetadata(deserialized);
+    verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
+  }
 
-        // Set other metadata fields
-        metadata.setOperationType(WriteOperationType.CLUSTER);
-        metadata.setCompacted(true);
-        metadata.addMetadata("test-key-1", "test-value-1");
-        metadata.addMetadata("test-key-2", "test-value-2");
+  protected void testReplaceCommitMetadataSerDe() throws Exception {
+    // Create populated replace commit metadata
+    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+    HoodieWriteStat writeStat = createTestWriteStat();
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
 
-        // Create SerDe instance and test instant
-        CommitMetadataSerDe serDe = getSerDe();
-        HoodieInstant instant = createTestInstant("replacecommit", "001");
+    // Add replace file IDs
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
+    metadata.addReplaceFileId("other-partition", "replaced-file-3");
 
-        // Serialize and deserialize
-        Option<byte[]> serialized = serDe.serialize(metadata);
-        assertTrue(serialized.isPresent());
-        HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.CLUSTER);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key-1", "test-value-1");
+    metadata.addMetadata("test-key-2", "test-value-2");
 
-        // Verify
-        verifyReplaceCommitMetadata(deserialized);
-        verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
-        verifyReplaceFileIds(deserialized.getPartitionToReplaceFileIds());
-    }
+    // Create SerDe instance and test instant
+    CommitMetadataSerDe serDe = getSerDe();
+    HoodieInstant instant = createTestInstant("replacecommit", "001");
 
-    private HoodieWriteStat createTestWriteStat() {
-        HoodieWriteStat writeStat = new HoodieWriteStat();
-        // Set basic fields
-        writeStat.setFileId(TEST_FILE_ID);
-        writeStat.setPath(testPath);
-        writeStat.setPrevCommit(TEST_PREV_COMMIT);
-        writeStat.setNumWrites(100);
-        writeStat.setNumUpdateWrites(50);
-        writeStat.setTotalWriteBytes(1024);
-        writeStat.setTotalWriteErrors(0);
-        writeStat.setPartitionPath(TEST_PARTITION_PATH);
-        writeStat.setFileSizeInBytes(2048);
-        writeStat.setPrevBaseFile(TEST_BASE_FILE);
-        writeStat.setMinEventTime(1000L);
-        writeStat.setMaxEventTime(2000L);
+    // Serialize and deserialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
 
-        // Set CDC stats
-        Map<String, Long> cdcStats = new HashMap<>();
-        cdcStats.put("cdc-file-1.log", 512L);
-        writeStat.setCdcStats(cdcStats);
+    // Verify
+    verifyReplaceCommitMetadata(deserialized);
+    verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
+    verifyReplaceFileIds(deserialized.getPartitionToReplaceFileIds());
+  }
 
-        // Set runtime stats
-        HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
-        runtimeStats.setTotalScanTime(100);
-        runtimeStats.setTotalCreateTime(200);
-        runtimeStats.setTotalUpsertTime(300);
-        writeStat.setRuntimeStats(runtimeStats);
+  private HoodieWriteStat createTestWriteStat() {
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    // Set basic fields
+    writeStat.setFileId(TEST_FILE_ID);
+    writeStat.setPath(testPath);
+    writeStat.setPrevCommit(TEST_PREV_COMMIT);
+    writeStat.setNumWrites(100);
+    writeStat.setNumUpdateWrites(50);
+    writeStat.setTotalWriteBytes(1024);
+    writeStat.setTotalWriteErrors(0);
+    writeStat.setPartitionPath(TEST_PARTITION_PATH);
+    writeStat.setFileSizeInBytes(2048);
+    writeStat.setPrevBaseFile(TEST_BASE_FILE);
+    writeStat.setMinEventTime(1000L);
+    writeStat.setMaxEventTime(2000L);
 
-        // Set new fields
-        writeStat.setTotalLogFilesCompacted(5L);
-        writeStat.setTotalLogReadTimeMs(150L);
-        writeStat.setTotalLogSizeCompacted(1024L);
-        writeStat.setTempPath("temp/path/file1");
+    // Set CDC stats
+    Map<String, Long> cdcStats = new HashMap<>();
+    cdcStats.put("cdc-file-1.log", 512L);
+    writeStat.setCdcStats(cdcStats);
 
-        return writeStat;
-    }
+    // Set runtime stats
+    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(200);
+    runtimeStats.setTotalUpsertTime(300);
+    writeStat.setRuntimeStats(runtimeStats);
 
-    private void verifyCommitMetadata(HoodieCommitMetadata metadata) {
-        assertNotNull(metadata);
-        assertEquals(1, metadata.getPartitionToWriteStats().size());
-        assertEquals(true, metadata.getCompacted());
-        assertEquals(WriteOperationType.INSERT, metadata.getOperationType());
-        assertEquals("test-value", metadata.getExtraMetadata().get("test-key"));
-    }
+    // Set new fields
+    writeStat.setTotalLogFilesCompacted(5L);
+    writeStat.setTotalLogReadTimeMs(150L);
+    writeStat.setTotalLogSizeCompacted(1024L);
+    writeStat.setTempPath("temp/path/file1");
 
-    private void verifyReplaceCommitMetadata(HoodieReplaceCommitMetadata metadata) {
-        assertNotNull(metadata);
-        assertEquals(true, metadata.getCompacted());
-        assertEquals(WriteOperationType.CLUSTER, metadata.getOperationType());
-        assertEquals("test-value-1", metadata.getExtraMetadata().get("test-key-1"));
-        assertEquals("test-value-2", metadata.getExtraMetadata().get("test-key-2"));
-    }
+    return writeStat;
+  }
 
-    private void verifyWriteStat(HoodieWriteStat stat) {
-        assertEquals(TEST_FILE_ID, stat.getFileId());
-        assertEquals(testPath, stat.getPath());
-        assertEquals(TEST_PREV_COMMIT, stat.getPrevCommit());
-        assertEquals(100, stat.getNumWrites());
-        assertEquals(50, stat.getNumUpdateWrites());
-        assertEquals(1024, stat.getTotalWriteBytes());
-        assertEquals(0, stat.getTotalWriteErrors());
-        assertEquals(TEST_PARTITION_PATH, stat.getPartitionPath());
-        assertEquals(2048, stat.getFileSizeInBytes());
-        assertEquals(TEST_BASE_FILE, stat.getPrevBaseFile());
-        assertEquals(1000L, stat.getMinEventTime());
-        assertEquals(2000L, stat.getMaxEventTime());
-        assertEquals(512L, stat.getCdcStats().get("cdc-file-1.log"));
-        assertNotNull(stat.getRuntimeStats());
-        assertEquals(100, stat.getRuntimeStats().getTotalScanTime());
-        assertEquals(200, stat.getRuntimeStats().getTotalCreateTime());
-        assertEquals(300, stat.getRuntimeStats().getTotalUpsertTime());
-        assertEquals(5L, stat.getTotalLogFilesCompacted());
-        assertEquals(150L, stat.getTotalLogReadTimeMs());
-        assertEquals(1024L, stat.getTotalLogSizeCompacted());
-        assertEquals("temp/path/file1", stat.getTempPath());
-        assertEquals(0L, stat.getNumUpdates());
-    }
+  private void verifyCommitMetadata(HoodieCommitMetadata metadata) {
+    assertNotNull(metadata);
+    assertEquals(1, metadata.getPartitionToWriteStats().size());
+    assertEquals(true, metadata.getCompacted());
+    assertEquals(WriteOperationType.INSERT, metadata.getOperationType());
+    assertEquals("test-value", metadata.getExtraMetadata().get("test-key"));
+  }
 
-    private void verifyReplaceFileIds(Map<String, List<String>> replaceFileIds) {
-        assertEquals(2, replaceFileIds.size());
-        assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), 
-            replaceFileIds.get(TEST_PARTITION_PATH));
-        assertEquals(Collections.singletonList("replaced-file-3"), 
-            replaceFileIds.get("other-partition"));
-    }
-} 
+  private void verifyReplaceCommitMetadata(HoodieReplaceCommitMetadata metadata) {
+    assertNotNull(metadata);
+    assertEquals(true, metadata.getCompacted());
+    assertEquals(WriteOperationType.CLUSTER, metadata.getOperationType());
+    assertEquals("test-value-1", metadata.getExtraMetadata().get("test-key-1"));
+    assertEquals("test-value-2", metadata.getExtraMetadata().get("test-key-2"));
+  }
+
+  private void verifyWriteStat(HoodieWriteStat stat) {
+    assertEquals(TEST_FILE_ID, stat.getFileId());
+    assertEquals(testPath, stat.getPath());
+    assertEquals(TEST_PREV_COMMIT, stat.getPrevCommit());
+    assertEquals(100, stat.getNumWrites());
+    assertEquals(50, stat.getNumUpdateWrites());
+    assertEquals(1024, stat.getTotalWriteBytes());
+    assertEquals(0, stat.getTotalWriteErrors());
+    assertEquals(TEST_PARTITION_PATH, stat.getPartitionPath());
+    assertEquals(2048, stat.getFileSizeInBytes());
+    assertEquals(TEST_BASE_FILE, stat.getPrevBaseFile());
+    assertEquals(1000L, stat.getMinEventTime());
+    assertEquals(2000L, stat.getMaxEventTime());
+    assertEquals(512L, stat.getCdcStats().get("cdc-file-1.log"));
+    assertNotNull(stat.getRuntimeStats());
+    assertEquals(100, stat.getRuntimeStats().getTotalScanTime());
+    assertEquals(200, stat.getRuntimeStats().getTotalCreateTime());
+    assertEquals(300, stat.getRuntimeStats().getTotalUpsertTime());
+    assertEquals(5L, stat.getTotalLogFilesCompacted());
+    assertEquals(150L, stat.getTotalLogReadTimeMs());
+    assertEquals(1024L, stat.getTotalLogSizeCompacted());
+    assertEquals("temp/path/file1", stat.getTempPath());
+    assertEquals(0L, stat.getNumUpdates());
+  }
+
+  private void verifyReplaceFileIds(Map<String, List<String>> replaceFileIds) {
+    assertEquals(2, replaceFileIds.size());
+    assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"),
+        replaceFileIds.get(TEST_PARTITION_PATH));
+    assertEquals(Collections.singletonList("replaced-file-3"),
+        replaceFileIds.get("other-partition"));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +56,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     testPath = "file:///path/1/";
   }
 
+  @Test
   protected void testEmptyMetadataSerDe() throws Exception {
     // Create empty commit metadata
     HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
@@ -80,6 +82,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     assertTrue(deserialized.getExtraMetadata().isEmpty());
   }
 
+  @Test
   protected void testPopulatedMetadataSerDe() throws Exception {
     // Create populated commit metadata
     HoodieCommitMetadata metadata = new HoodieCommitMetadata();
@@ -105,6 +108,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
   }
 
+  @Test
   protected void testReplaceCommitMetadataSerDe() throws Exception {
     // Create populated replace commit metadata
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
@@ -18,248 +18,38 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v1;
 
-import org.apache.hudi.common.model.HoodieCommitMetadata;
-import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
-import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.util.Option;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.hudi.common.table.timeline.versioning.BaseTestCommitMetadataSerDe;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestCommitMetadataSerDeV1 {
+public class TestCommitMetadataSerDeV1 extends BaseTestCommitMetadataSerDe {
 
-  private static final String TEST_PARTITION_PATH = "2023/01/01";
-  private static final String TEST_FILE_ID = "test-file-id";
-  private static final String TEST_PREV_COMMIT = "000001";
-  private static final String TEST_BASE_FILE = "test-base-file";
+    @Override
+    protected CommitMetadataSerDe getSerDe() {
+        return new CommitMetadataSerDeV1();
+    }
 
-  private String testPath;
+    @Override
+    protected HoodieInstant createTestInstant(String action, String id) {
+        return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
+    }
 
-  @BeforeEach
-  public void setUp() {
-    testPath = "file:///path/1/";
-  }
+    @Test
+    public void testEmptyMetadataSerDe() throws Exception {
+        super.testEmptyMetadataSerDe();
+    }
 
-  @Test
-  public void testEmptyMetadataSerDe() throws Exception {
-    // Create empty commit metadata
-    HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+    @Test
+    public void testPopulatedMetadataSerDe() throws Exception {
+        super.testPopulatedMetadataSerDe();
+    }
 
-    // Create SerDe instance
-    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-
-    // Verify
-    assertNotNull(deserialized);
-    assertEquals(0, deserialized.getPartitionToWriteStats().size());
-    assertEquals(false, deserialized.getCompacted());
-    assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
-    assertTrue(deserialized.getExtraMetadata().isEmpty());
-  }
-
-  @Test
-  public void testPopulatedMetadataSerDe() throws Exception {
-    // Create populated commit metadata
-    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
-
-    // Add write stats
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId(TEST_FILE_ID);
-    writeStat.setPath(testPath);
-    writeStat.setPrevCommit(TEST_PREV_COMMIT);
-    writeStat.setNumWrites(100);
-    writeStat.setNumUpdateWrites(50);
-    writeStat.setTotalWriteBytes(1024);
-    writeStat.setTotalWriteErrors(0);
-    writeStat.setPartitionPath(TEST_PARTITION_PATH);
-    writeStat.setFileSizeInBytes(2048);
-    writeStat.setPrevBaseFile(TEST_BASE_FILE);
-    writeStat.setMinEventTime(1000L);
-    writeStat.setMaxEventTime(2000L);
-
-    // Add CDC stats
-    Map<String, Long> cdcStats = new HashMap<>();
-    cdcStats.put("cdc-file-1.log", 512L);
-    writeStat.setCdcStats(cdcStats);
-
-    // Add runtime stats
-    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
-    runtimeStats.setTotalScanTime(100);
-    runtimeStats.setTotalCreateTime(200);
-    runtimeStats.setTotalUpsertTime(300);
-    writeStat.setRuntimeStats(runtimeStats);
-
-    // Add new field values
-    writeStat.setTotalLogFilesCompacted(5L);
-    writeStat.setTotalLogReadTimeMs(150L);
-    writeStat.setTotalLogSizeCompacted(1024L);
-    writeStat.setTempPath("temp/path/file1");
-
-    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-
-    // Set other metadata fields
-    metadata.setOperationType(WriteOperationType.INSERT);
-    metadata.setCompacted(true);
-    metadata.addMetadata("test-key", "test-value");
-
-    // Create SerDe instance
-    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-
-    // Verify all fields
-    assertNotNull(deserialized);
-    assertEquals(1, deserialized.getPartitionToWriteStats().size());
-    assertEquals(true, deserialized.getCompacted());
-    assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
-    assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
-
-    // Verify write stats
-    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
-    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
-    assertEquals(testPath, deserializedStat.getPath());
-    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
-    assertEquals(100, deserializedStat.getNumWrites());
-    assertEquals(50, deserializedStat.getNumUpdateWrites());
-    assertEquals(1024, deserializedStat.getTotalWriteBytes());
-    assertEquals(0, deserializedStat.getTotalWriteErrors());
-    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
-    assertEquals(2048, deserializedStat.getFileSizeInBytes());
-    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
-    assertEquals(1000L, deserializedStat.getMinEventTime());
-    assertEquals(2000L, deserializedStat.getMaxEventTime());
-
-    // Verify CDC stats
-    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-
-    // Verify runtime stats
-    assertNotNull(deserializedStat.getRuntimeStats());
-    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
-    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
-    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
-
-    // Verify new fields
-    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
-    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
-    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
-    assertEquals("temp/path/file1", deserializedStat.getTempPath());
-    assertEquals(0L, deserializedStat.getNumUpdates());
-  }
-
-  @Test
-  public void testReplaceCommitMetadataSerDe() throws Exception {
-    // Create populated replace commit metadata
-    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
-
-    // Add write stats
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId(TEST_FILE_ID);
-    writeStat.setPath(testPath);
-    writeStat.setPrevCommit(TEST_PREV_COMMIT);
-    writeStat.setNumWrites(100);
-    writeStat.setNumUpdateWrites(50);
-    writeStat.setTotalWriteBytes(1024);
-    writeStat.setTotalWriteErrors(0);
-    writeStat.setPartitionPath(TEST_PARTITION_PATH);
-    writeStat.setFileSizeInBytes(2048);
-    writeStat.setPrevBaseFile(TEST_BASE_FILE);
-    writeStat.setMinEventTime(1000L);
-    writeStat.setMaxEventTime(2000L);
-    // Add new field values
-    writeStat.setTotalLogFilesCompacted(5L);
-    writeStat.setTotalLogReadTimeMs(150L);
-    writeStat.setTotalLogSizeCompacted(1024L);
-    writeStat.setTempPath("temp/path/file1");
-
-    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-
-    // Add replace file IDs
-    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
-    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
-    metadata.addReplaceFileId("other-partition", "replaced-file-3");
-
-    // Set other metadata fields
-    metadata.setOperationType(WriteOperationType.CLUSTER);
-    metadata.setCompacted(true);
-    metadata.addMetadata("test-key-1", "test-value-1");
-    metadata.addMetadata("test-key-2", "test-value-2");
-
-    // Create SerDe instance
-    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
-
-    // Verify basic fields
-    assertNotNull(deserialized);
-    assertEquals(true, deserialized.getCompacted());
-    assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
-    assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
-    assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
-
-    // Verify write stats
-    assertEquals(1, deserialized.getPartitionToWriteStats().size());
-    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
-    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
-    assertEquals(testPath, deserializedStat.getPath());
-    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
-    assertEquals(100, deserializedStat.getNumWrites());
-    assertEquals(50, deserializedStat.getNumUpdateWrites());
-    assertEquals(1024, deserializedStat.getTotalWriteBytes());
-    assertEquals(0, deserializedStat.getTotalWriteErrors());
-    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
-    assertEquals(2048, deserializedStat.getFileSizeInBytes());
-    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
-    assertEquals(1000L, deserializedStat.getMinEventTime());
-    assertEquals(2000L, deserializedStat.getMaxEventTime());
-
-    // Verify replace file IDs
-    Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
-    assertEquals(2, replaceFileIds.size());
-    assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
-    assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
-
-    // Verify new fields
-    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
-    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
-    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
-    assertEquals("temp/path/file1", deserializedStat.getTempPath());
-    assertEquals(0L, deserializedStat.getNumUpdates());
-  }
+    @Test
+    public void testReplaceCommitMetadataSerDe() throws Exception {
+        super.testReplaceCommitMetadataSerDe();
+    }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
@@ -24,17 +24,14 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.nio.file.Path;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,39 +40,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCommitMetadataSerDeV1 {
 
-  @TempDir
-  Path tempDir;
-
   private static final String TEST_PARTITION_PATH = "2023/01/01";
   private static final String TEST_FILE_ID = "test-file-id";
   private static final String TEST_PREV_COMMIT = "000001";
   private static final String TEST_BASE_FILE = "test-base-file";
-  
+
   private String testPath;
 
   @BeforeEach
   public void setUp() {
-    testPath = tempDir.resolve("test-path").toString();
+    testPath = "file:///path/1/";
   }
 
   @Test
   public void testEmptyMetadataSerDe() throws Exception {
     // Create empty commit metadata
     HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(emptyMetadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-    
+
     // Verify
     assertNotNull(deserialized);
     assertEquals(0, deserialized.getPartitionToWriteStats().size());
@@ -88,7 +82,7 @@ public class TestCommitMetadataSerDeV1 {
   public void testPopulatedMetadataSerDe() throws Exception {
     // Create populated commit metadata
     HoodieCommitMetadata metadata = new HoodieCommitMetadata();
-    
+
     // Add write stats
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(TEST_FILE_ID);
@@ -103,46 +97,52 @@ public class TestCommitMetadataSerDeV1 {
     writeStat.setPrevBaseFile(TEST_BASE_FILE);
     writeStat.setMinEventTime(1000L);
     writeStat.setMaxEventTime(2000L);
-    
+
     // Add CDC stats
     Map<String, Long> cdcStats = new HashMap<>();
     cdcStats.put("cdc-file-1.log", 512L);
     writeStat.setCdcStats(cdcStats);
-    
+
     // Add runtime stats
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalScanTime(100);
     runtimeStats.setTotalCreateTime(200);
     runtimeStats.setTotalUpsertTime(300);
     writeStat.setRuntimeStats(runtimeStats);
-    
+
+    // Add new field values
+    writeStat.setTotalLogFilesCompacted(5L);
+    writeStat.setTotalLogReadTimeMs(150L);
+    writeStat.setTotalLogSizeCompacted(1024L);
+    writeStat.setTempPath("temp/path/file1");
+
     metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-    
+
     // Set other metadata fields
     metadata.setOperationType(WriteOperationType.INSERT);
     metadata.setCompacted(true);
     metadata.addMetadata("test-key", "test-value");
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(metadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-    
+
     // Verify all fields
     assertNotNull(deserialized);
     assertEquals(1, deserialized.getPartitionToWriteStats().size());
     assertEquals(true, deserialized.getCompacted());
     assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
     assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
-    
+
     // Verify write stats
     HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
     assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
@@ -157,22 +157,29 @@ public class TestCommitMetadataSerDeV1 {
     assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
     assertEquals(1000L, deserializedStat.getMinEventTime());
     assertEquals(2000L, deserializedStat.getMaxEventTime());
-    
+
     // Verify CDC stats
     assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-    
+
     // Verify runtime stats
     assertNotNull(deserializedStat.getRuntimeStats());
     assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
     assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
     assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
+
+    // Verify new fields
+    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
+    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
+    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
+    assertEquals("temp/path/file1", deserializedStat.getTempPath());
+    assertEquals(0L, deserializedStat.getNumUpdates());
   }
 
   @Test
   public void testReplaceCommitMetadataSerDe() throws Exception {
     // Create populated replace commit metadata
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
-    
+
     // Add write stats
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(TEST_FILE_ID);
@@ -187,40 +194,45 @@ public class TestCommitMetadataSerDeV1 {
     writeStat.setPrevBaseFile(TEST_BASE_FILE);
     writeStat.setMinEventTime(1000L);
     writeStat.setMaxEventTime(2000L);
-    
+    // Add new field values
+    writeStat.setTotalLogFilesCompacted(5L);
+    writeStat.setTotalLogReadTimeMs(150L);
+    writeStat.setTotalLogSizeCompacted(1024L);
+    writeStat.setTempPath("temp/path/file1");
+
     metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-    
+
     // Add replace file IDs
     metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
     metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
     metadata.addReplaceFileId("other-partition", "replaced-file-3");
-    
+
     // Set other metadata fields
     metadata.setOperationType(WriteOperationType.CLUSTER);
     metadata.setCompacted(true);
     metadata.addMetadata("test-key-1", "test-value-1");
     metadata.addMetadata("test-key-2", "test-value-2");
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(metadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
-    
+
     // Verify basic fields
     assertNotNull(deserialized);
     assertEquals(true, deserialized.getCompacted());
     assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
     assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
     assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
-    
+
     // Verify write stats
     assertEquals(1, deserialized.getPartitionToWriteStats().size());
     HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
@@ -236,11 +248,18 @@ public class TestCommitMetadataSerDeV1 {
     assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
     assertEquals(1000L, deserializedStat.getMinEventTime());
     assertEquals(2000L, deserializedStat.getMaxEventTime());
-    
+
     // Verify replace file IDs
     Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
     assertEquals(2, replaceFileIds.size());
     assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
     assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
+
+    // Verify new fields
+    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
+    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
+    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
+    assertEquals("temp/path/file1", deserializedStat.getTempPath());
+    assertEquals(0L, deserializedStat.getNumUpdates());
   }
-} 
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning.v1;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.nio.file.Path;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestCommitMetadataSerDeV1 {
+
+  @TempDir
+  Path tempDir;
+
+  private static final String TEST_PARTITION_PATH = "2023/01/01";
+  private static final String TEST_FILE_ID = "test-file-id";
+  private static final String TEST_PREV_COMMIT = "000001";
+  private static final String TEST_BASE_FILE = "test-base-file";
+  
+  private String testPath;
+
+  @BeforeEach
+  public void setUp() {
+    testPath = tempDir.resolve("test-path").toString();
+  }
+
+  @Test
+  public void testEmptyMetadataSerDe() throws Exception {
+    // Create empty commit metadata
+    HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    
+    // Verify
+    assertNotNull(deserialized);
+    assertEquals(0, deserialized.getPartitionToWriteStats().size());
+    assertEquals(false, deserialized.getCompacted());
+    assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
+    assertTrue(deserialized.getExtraMetadata().isEmpty());
+  }
+
+  @Test
+  public void testPopulatedMetadataSerDe() throws Exception {
+    // Create populated commit metadata
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    
+    // Add write stats
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(TEST_FILE_ID);
+    writeStat.setPath(testPath);
+    writeStat.setPrevCommit(TEST_PREV_COMMIT);
+    writeStat.setNumWrites(100);
+    writeStat.setNumUpdateWrites(50);
+    writeStat.setTotalWriteBytes(1024);
+    writeStat.setTotalWriteErrors(0);
+    writeStat.setPartitionPath(TEST_PARTITION_PATH);
+    writeStat.setFileSizeInBytes(2048);
+    writeStat.setPrevBaseFile(TEST_BASE_FILE);
+    writeStat.setMinEventTime(1000L);
+    writeStat.setMaxEventTime(2000L);
+    
+    // Add CDC stats
+    Map<String, Long> cdcStats = new HashMap<>();
+    cdcStats.put("cdc-file-1.log", 512L);
+    writeStat.setCdcStats(cdcStats);
+    
+    // Add runtime stats
+    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(200);
+    runtimeStats.setTotalUpsertTime(300);
+    writeStat.setRuntimeStats(runtimeStats);
+    
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.INSERT);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key", "test-value");
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    
+    // Verify all fields
+    assertNotNull(deserialized);
+    assertEquals(1, deserialized.getPartitionToWriteStats().size());
+    assertEquals(true, deserialized.getCompacted());
+    assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
+    assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
+    
+    // Verify write stats
+    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
+    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
+    assertEquals(testPath, deserializedStat.getPath());
+    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
+    assertEquals(100, deserializedStat.getNumWrites());
+    assertEquals(50, deserializedStat.getNumUpdateWrites());
+    assertEquals(1024, deserializedStat.getTotalWriteBytes());
+    assertEquals(0, deserializedStat.getTotalWriteErrors());
+    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
+    assertEquals(2048, deserializedStat.getFileSizeInBytes());
+    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
+    assertEquals(1000L, deserializedStat.getMinEventTime());
+    assertEquals(2000L, deserializedStat.getMaxEventTime());
+    
+    // Verify CDC stats
+    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
+    
+    // Verify runtime stats
+    assertNotNull(deserializedStat.getRuntimeStats());
+    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
+    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
+    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
+  }
+
+  @Test
+  public void testReplaceCommitMetadataSerDe() throws Exception {
+    // Create populated replace commit metadata
+    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+    
+    // Add write stats
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(TEST_FILE_ID);
+    writeStat.setPath(testPath);
+    writeStat.setPrevCommit(TEST_PREV_COMMIT);
+    writeStat.setNumWrites(100);
+    writeStat.setNumUpdateWrites(50);
+    writeStat.setTotalWriteBytes(1024);
+    writeStat.setTotalWriteErrors(0);
+    writeStat.setPartitionPath(TEST_PARTITION_PATH);
+    writeStat.setFileSizeInBytes(2048);
+    writeStat.setPrevBaseFile(TEST_BASE_FILE);
+    writeStat.setMinEventTime(1000L);
+    writeStat.setMaxEventTime(2000L);
+    
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    
+    // Add replace file IDs
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
+    metadata.addReplaceFileId("other-partition", "replaced-file-3");
+    
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.CLUSTER);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key-1", "test-value-1");
+    metadata.addMetadata("test-key-2", "test-value-2");
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV1 serDe = new CommitMetadataSerDeV1();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
+    
+    // Verify basic fields
+    assertNotNull(deserialized);
+    assertEquals(true, deserialized.getCompacted());
+    assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
+    assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
+    assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
+    
+    // Verify write stats
+    assertEquals(1, deserialized.getPartitionToWriteStats().size());
+    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
+    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
+    assertEquals(testPath, deserializedStat.getPath());
+    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
+    assertEquals(100, deserializedStat.getNumWrites());
+    assertEquals(50, deserializedStat.getNumUpdateWrites());
+    assertEquals(1024, deserializedStat.getTotalWriteBytes());
+    assertEquals(0, deserializedStat.getTotalWriteErrors());
+    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
+    assertEquals(2048, deserializedStat.getFileSizeInBytes());
+    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
+    assertEquals(1000L, deserializedStat.getMinEventTime());
+    assertEquals(2000L, deserializedStat.getMaxEventTime());
+    
+    // Verify replace file IDs
+    Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
+    assertEquals(2, replaceFileIds.size());
+    assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
+    assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
+  }
+} 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
@@ -22,10 +22,6 @@ import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.BaseTestCommitMetadataSerDe;
 
-import org.junit.jupiter.api.Test;
-
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
-
 public class TestCommitMetadataSerDeV1 extends BaseTestCommitMetadataSerDe {
 
   @Override
@@ -35,21 +31,6 @@ public class TestCommitMetadataSerDeV1 extends BaseTestCommitMetadataSerDe {
 
   @Override
   protected HoodieInstant createTestInstant(String action, String id) {
-    return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
-  }
-
-  @Test
-  public void testEmptyMetadataSerDe() throws Exception {
-    super.testEmptyMetadataSerDe();
-  }
-
-  @Test
-  public void testPopulatedMetadataSerDe() throws Exception {
-    super.testPopulatedMetadataSerDe();
-  }
-
-  @Test
-  public void testReplaceCommitMetadataSerDe() throws Exception {
-    super.testReplaceCommitMetadataSerDe();
+    return new InstantGeneratorV1().createNewInstant(HoodieInstant.State.COMPLETED, action, id);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCommitMetadataSerDeV1.java
@@ -28,28 +28,28 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR
 
 public class TestCommitMetadataSerDeV1 extends BaseTestCommitMetadataSerDe {
 
-    @Override
-    protected CommitMetadataSerDe getSerDe() {
-        return new CommitMetadataSerDeV1();
-    }
+  @Override
+  protected CommitMetadataSerDe getSerDe() {
+    return new CommitMetadataSerDeV1();
+  }
 
-    @Override
-    protected HoodieInstant createTestInstant(String action, String id) {
-        return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
-    }
+  @Override
+  protected HoodieInstant createTestInstant(String action, String id) {
+    return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
+  }
 
-    @Test
-    public void testEmptyMetadataSerDe() throws Exception {
-        super.testEmptyMetadataSerDe();
-    }
+  @Test
+  public void testEmptyMetadataSerDe() throws Exception {
+    super.testEmptyMetadataSerDe();
+  }
 
-    @Test
-    public void testPopulatedMetadataSerDe() throws Exception {
-        super.testPopulatedMetadataSerDe();
-    }
+  @Test
+  public void testPopulatedMetadataSerDe() throws Exception {
+    super.testPopulatedMetadataSerDe();
+  }
 
-    @Test
-    public void testReplaceCommitMetadataSerDe() throws Exception {
-        super.testReplaceCommitMetadataSerDe();
-    }
+  @Test
+  public void testReplaceCommitMetadataSerDe() throws Exception {
+    super.testReplaceCommitMetadataSerDe();
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -18,272 +18,38 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v2;
 
-import org.apache.hudi.common.model.HoodieCommitMetadata;
-import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
-import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.util.Option;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.hudi.common.table.timeline.versioning.BaseTestCommitMetadataSerDe;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestCommitMetadataSerDeV2 {
+public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
 
-  private static final String TEST_PARTITION_PATH = "2023/01/01";
-  private static final String TEST_FILE_ID = "test-file-id";
-  private static final String TEST_PREV_COMMIT = "000001";
-  private static final String TEST_BASE_FILE = "test-base-file";
+    @Override
+    protected CommitMetadataSerDe getSerDe() {
+        return new CommitMetadataSerDeV2();
+    }
 
-  private String testPath;
+    @Override
+    protected HoodieInstant createTestInstant(String action, String id) {
+        return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
+    }
 
-  @BeforeEach
-  public void setUp() {
-    testPath = "file:///path/1/";
-  }
+    @Test
+    public void testEmptyMetadataSerDe() throws Exception {
+        super.testEmptyMetadataSerDe();
+    }
 
-  @Test
-  public void testEmptyMetadataSerDe() throws Exception {
-    // Create empty commit metadata
-    HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+    @Test
+    public void testPopulatedMetadataSerDe() throws Exception {
+        super.testPopulatedMetadataSerDe();
+    }
 
-    // Create SerDe instance
-    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-
-    // Verify
-    assertNotNull(deserialized);
-    assertEquals(0, deserialized.getPartitionToWriteStats().size());
-    assertEquals(false, deserialized.getCompacted());
-    assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
-    assertTrue(deserialized.getExtraMetadata().isEmpty());
-  }
-
-  @Test
-  public void testPopulatedMetadataSerDe() throws Exception {
-    // Create populated commit metadata
-    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
-
-    // Add write stats
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId(TEST_FILE_ID);
-    writeStat.setPath(testPath);
-    writeStat.setPrevCommit(TEST_PREV_COMMIT);
-    writeStat.setNumWrites(100);
-    writeStat.setNumUpdateWrites(50);
-    writeStat.setTotalWriteBytes(1024);
-    writeStat.setTotalWriteErrors(0);
-    writeStat.setPartitionPath(TEST_PARTITION_PATH);
-    writeStat.setFileSizeInBytes(2048);
-    writeStat.setPrevBaseFile(TEST_BASE_FILE);
-
-    // Set event times
-    writeStat.setMinEventTime(1000L);
-    writeStat.setMaxEventTime(2000L);
-
-    // Add new field values
-    writeStat.setTotalLogFilesCompacted(5L);
-    writeStat.setTotalLogReadTimeMs(150L);
-    writeStat.setTotalLogSizeCompacted(1024L);
-    writeStat.setTempPath("temp/path/file1");
-
-    // Add CDC stats
-    Map<String, Long> cdcStats = new HashMap<>();
-    cdcStats.put("cdc-file-1.log", 512L);
-    writeStat.setCdcStats(cdcStats);
-
-    // Add runtime stats
-    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
-    runtimeStats.setTotalScanTime(100);
-    runtimeStats.setTotalCreateTime(200);
-    runtimeStats.setTotalUpsertTime(300);
-    writeStat.setRuntimeStats(runtimeStats);
-
-    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-
-    // Set other metadata fields
-    metadata.setOperationType(WriteOperationType.INSERT);
-    metadata.setCompacted(true);
-    metadata.addMetadata("test-key", "test-value");
-
-    // Create SerDe instance
-    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-
-    // Verify all fields
-    assertNotNull(deserialized);
-    assertEquals(1, deserialized.getPartitionToWriteStats().size());
-    assertEquals(true, deserialized.getCompacted());
-    assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
-    assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
-
-    // Verify write stats
-    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
-    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
-    assertEquals(testPath, deserializedStat.getPath());
-    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
-    assertEquals(100, deserializedStat.getNumWrites());
-    assertEquals(50, deserializedStat.getNumUpdateWrites());
-    assertEquals(1024, deserializedStat.getTotalWriteBytes());
-    assertEquals(0, deserializedStat.getTotalWriteErrors());
-    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
-    assertEquals(2048, deserializedStat.getFileSizeInBytes());
-    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
-    assertEquals(1000L, deserializedStat.getMinEventTime());
-    assertEquals(2000L, deserializedStat.getMaxEventTime());
-
-    // Verify CDC stats
-    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-
-    // Verify runtime stats
-    assertNotNull(deserializedStat.getRuntimeStats());
-    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
-    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
-    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
-
-    // Verify new fields
-    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
-    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
-    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
-    assertEquals("temp/path/file1", deserializedStat.getTempPath());
-    assertEquals(0L, deserializedStat.getNumUpdates());
-  }
-
-  @Test
-  public void testReplaceCommitMetadataSerDe() throws Exception {
-    // Create populated replace commit metadata
-    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
-
-    // Add write stats
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId(TEST_FILE_ID);
-    writeStat.setPath(testPath);
-    writeStat.setPrevCommit(TEST_PREV_COMMIT);
-    writeStat.setNumWrites(100);
-    writeStat.setNumUpdateWrites(50);
-    writeStat.setTotalWriteBytes(1024);
-    writeStat.setTotalWriteErrors(0);
-    writeStat.setPartitionPath(TEST_PARTITION_PATH);
-    writeStat.setFileSizeInBytes(2048);
-    writeStat.setPrevBaseFile(TEST_BASE_FILE);
-    writeStat.setMinEventTime(1000L);
-    writeStat.setMaxEventTime(2000L);
-
-    // Add new field values
-    writeStat.setTotalLogFilesCompacted(5L);
-    writeStat.setTotalLogReadTimeMs(150L);
-    writeStat.setTotalLogSizeCompacted(1024L);
-    writeStat.setTempPath("temp/path/file1");
-
-    // Add CDC stats
-    Map<String, Long> cdcStats = new HashMap<>();
-    cdcStats.put("cdc-file-1.log", 512L);
-    writeStat.setCdcStats(cdcStats);
-
-    // Add runtime stats
-    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
-    runtimeStats.setTotalScanTime(100);
-    runtimeStats.setTotalCreateTime(200);
-    runtimeStats.setTotalUpsertTime(300);
-    writeStat.setRuntimeStats(runtimeStats);
-
-    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-
-    // Add replace file IDs
-    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
-    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
-    metadata.addReplaceFileId("other-partition", "replaced-file-3");
-
-    // Set other metadata fields
-    metadata.setOperationType(WriteOperationType.CLUSTER);
-    metadata.setCompacted(true);
-    metadata.addMetadata("test-key-1", "test-value-1");
-    metadata.addMetadata("test-key-2", "test-value-2");
-
-    // Create SerDe instance
-    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-
-    // Create test instant
-    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
-
-    // Serialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-
-    // Deserialize
-    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
-
-    // Verify basic fields
-    assertNotNull(deserialized);
-    assertEquals(true, deserialized.getCompacted());
-    assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
-    assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
-    assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
-
-    // Verify write stats
-    assertEquals(1, deserialized.getPartitionToWriteStats().size());
-    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
-    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
-    assertEquals(testPath, deserializedStat.getPath());
-    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
-    assertEquals(100, deserializedStat.getNumWrites());
-    assertEquals(50, deserializedStat.getNumUpdateWrites());
-    assertEquals(1024, deserializedStat.getTotalWriteBytes());
-    assertEquals(0, deserializedStat.getTotalWriteErrors());
-    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
-    assertEquals(2048, deserializedStat.getFileSizeInBytes());
-    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
-    assertEquals(1000L, deserializedStat.getMinEventTime());
-    assertEquals(2000L, deserializedStat.getMaxEventTime());
-
-    // Verify CDC stats
-    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-
-    // Verify runtime stats
-    assertNotNull(deserializedStat.getRuntimeStats());
-    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
-    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
-    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
-
-    // Verify replace file IDs
-    Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
-    assertEquals(2, replaceFileIds.size());
-    assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
-    assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
-
-    // Verify new fields
-    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
-    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
-    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
-    assertEquals("temp/path/file1", deserializedStat.getTempPath());
-    assertEquals(0L, deserializedStat.getNumUpdates());
-  }
+    @Test
+    public void testReplaceCommitMetadataSerDe() throws Exception {
+        super.testReplaceCommitMetadataSerDe();
+    }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning.v2;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.nio.file.Path;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestCommitMetadataSerDeV2 {
+
+  @TempDir
+  Path tempDir;
+
+  private static final String TEST_PARTITION_PATH = "2023/01/01";
+  private static final String TEST_FILE_ID = "test-file-id";
+  private static final String TEST_PREV_COMMIT = "000001";
+  private static final String TEST_BASE_FILE = "test-base-file";
+  
+  private String testPath;
+
+  @BeforeEach
+  public void setUp() {
+    testPath = tempDir.resolve("test-path").toString();
+  }
+
+  @Test
+  public void testEmptyMetadataSerDe() throws Exception {
+    // Create empty commit metadata
+    HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    
+    // Verify
+    assertNotNull(deserialized);
+    assertEquals(0, deserialized.getPartitionToWriteStats().size());
+    assertEquals(false, deserialized.getCompacted());
+    assertEquals(WriteOperationType.UNKNOWN, deserialized.getOperationType());
+    assertTrue(deserialized.getExtraMetadata().isEmpty());
+  }
+
+  @Test
+  public void testPopulatedMetadataSerDe() throws Exception {
+    // Create populated commit metadata
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    
+    // Add write stats
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(TEST_FILE_ID);
+    writeStat.setPath(testPath);
+    writeStat.setPrevCommit(TEST_PREV_COMMIT);
+    writeStat.setNumWrites(100);
+    writeStat.setNumUpdateWrites(50);
+    writeStat.setTotalWriteBytes(1024);
+    writeStat.setTotalWriteErrors(0);
+    writeStat.setPartitionPath(TEST_PARTITION_PATH);
+    writeStat.setFileSizeInBytes(2048);
+    writeStat.setPrevBaseFile(TEST_BASE_FILE);
+    
+    // Set event times
+    writeStat.setMinEventTime(1000L);
+    writeStat.setMaxEventTime(2000L);
+    
+    // Add CDC stats
+    Map<String, Long> cdcStats = new HashMap<>();
+    cdcStats.put("cdc-file-1.log", 512L);
+    writeStat.setCdcStats(cdcStats);
+    
+    // Add runtime stats
+    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(200);
+    runtimeStats.setTotalUpsertTime(300);
+    writeStat.setRuntimeStats(runtimeStats);
+    
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.INSERT);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key", "test-value");
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
+    
+    // Verify all fields
+    assertNotNull(deserialized);
+    assertEquals(1, deserialized.getPartitionToWriteStats().size());
+    assertEquals(true, deserialized.getCompacted());
+    assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
+    assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
+    
+    // Verify write stats
+    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
+    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
+    assertEquals(testPath, deserializedStat.getPath());
+    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
+    assertEquals(100, deserializedStat.getNumWrites());
+    assertEquals(50, deserializedStat.getNumUpdateWrites());
+    assertEquals(1024, deserializedStat.getTotalWriteBytes());
+    assertEquals(0, deserializedStat.getTotalWriteErrors());
+    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
+    assertEquals(2048, deserializedStat.getFileSizeInBytes());
+    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
+    assertEquals(1000L, deserializedStat.getMinEventTime());
+    assertEquals(2000L, deserializedStat.getMaxEventTime());
+    
+    // Verify CDC stats
+    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
+    
+    // Verify runtime stats
+    assertNotNull(deserializedStat.getRuntimeStats());
+    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
+    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
+    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
+  }
+
+  @Test
+  public void testReplaceCommitMetadataSerDe() throws Exception {
+    // Create populated replace commit metadata
+    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+    
+    // Add write stats
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(TEST_FILE_ID);
+    writeStat.setPath(testPath);
+    writeStat.setPrevCommit(TEST_PREV_COMMIT);
+    writeStat.setNumWrites(100);
+    writeStat.setNumUpdateWrites(50);
+    writeStat.setTotalWriteBytes(1024);
+    writeStat.setTotalWriteErrors(0);
+    writeStat.setPartitionPath(TEST_PARTITION_PATH);
+    writeStat.setFileSizeInBytes(2048);
+    writeStat.setPrevBaseFile(TEST_BASE_FILE);
+    writeStat.setMinEventTime(1000L);
+    writeStat.setMaxEventTime(2000L);
+    
+    // Add CDC stats
+    Map<String, Long> cdcStats = new HashMap<>();
+    cdcStats.put("cdc-file-1.log", 512L);
+    writeStat.setCdcStats(cdcStats);
+    
+    // Add runtime stats
+    HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(200);
+    runtimeStats.setTotalUpsertTime(300);
+    writeStat.setRuntimeStats(runtimeStats);
+    
+    metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
+    
+    // Add replace file IDs
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
+    metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
+    metadata.addReplaceFileId("other-partition", "replaced-file-3");
+    
+    // Set other metadata fields
+    metadata.setOperationType(WriteOperationType.CLUSTER);
+    metadata.setCompacted(true);
+    metadata.addMetadata("test-key-1", "test-value-1");
+    metadata.addMetadata("test-key-2", "test-value-2");
+    
+    // Create SerDe instance
+    CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
+    
+    // Create test instant
+    HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
+    
+    // Serialize
+    Option<byte[]> serialized = serDe.serialize(metadata);
+    assertTrue(serialized.isPresent());
+    
+    // Deserialize
+    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
+    
+    // Verify basic fields
+    assertNotNull(deserialized);
+    assertEquals(true, deserialized.getCompacted());
+    assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
+    assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
+    assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
+    
+    // Verify write stats
+    assertEquals(1, deserialized.getPartitionToWriteStats().size());
+    HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
+    assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
+    assertEquals(testPath, deserializedStat.getPath());
+    assertEquals(TEST_PREV_COMMIT, deserializedStat.getPrevCommit());
+    assertEquals(100, deserializedStat.getNumWrites());
+    assertEquals(50, deserializedStat.getNumUpdateWrites());
+    assertEquals(1024, deserializedStat.getTotalWriteBytes());
+    assertEquals(0, deserializedStat.getTotalWriteErrors());
+    assertEquals(TEST_PARTITION_PATH, deserializedStat.getPartitionPath());
+    assertEquals(2048, deserializedStat.getFileSizeInBytes());
+    assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
+    assertEquals(1000L, deserializedStat.getMinEventTime());
+    assertEquals(2000L, deserializedStat.getMaxEventTime());
+    
+    // Verify CDC stats
+    assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
+    
+    // Verify runtime stats
+    assertNotNull(deserializedStat.getRuntimeStats());
+    assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
+    assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
+    assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
+    
+    // Verify replace file IDs
+    Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
+    assertEquals(2, replaceFileIds.size());
+    assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
+    assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -28,28 +28,28 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR
 
 public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
 
-    @Override
-    protected CommitMetadataSerDe getSerDe() {
-        return new CommitMetadataSerDeV2();
-    }
+  @Override
+  protected CommitMetadataSerDe getSerDe() {
+    return new CommitMetadataSerDeV2();
+  }
 
-    @Override
-    protected HoodieInstant createTestInstant(String action, String id) {
-        return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
-    }
+  @Override
+  protected HoodieInstant createTestInstant(String action, String id) {
+    return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
+  }
 
-    @Test
-    public void testEmptyMetadataSerDe() throws Exception {
-        super.testEmptyMetadataSerDe();
-    }
+  @Test
+  public void testEmptyMetadataSerDe() throws Exception {
+    super.testEmptyMetadataSerDe();
+  }
 
-    @Test
-    public void testPopulatedMetadataSerDe() throws Exception {
-        super.testPopulatedMetadataSerDe();
-    }
+  @Test
+  public void testPopulatedMetadataSerDe() throws Exception {
+    super.testPopulatedMetadataSerDe();
+  }
 
-    @Test
-    public void testReplaceCommitMetadataSerDe() throws Exception {
-        super.testReplaceCommitMetadataSerDe();
-    }
+  @Test
+  public void testReplaceCommitMetadataSerDe() throws Exception {
+    super.testReplaceCommitMetadataSerDe();
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -24,17 +24,14 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.nio.file.Path;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,39 +40,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCommitMetadataSerDeV2 {
 
-  @TempDir
-  Path tempDir;
-
   private static final String TEST_PARTITION_PATH = "2023/01/01";
   private static final String TEST_FILE_ID = "test-file-id";
   private static final String TEST_PREV_COMMIT = "000001";
   private static final String TEST_BASE_FILE = "test-base-file";
-  
+
   private String testPath;
 
   @BeforeEach
   public void setUp() {
-    testPath = tempDir.resolve("test-path").toString();
+    testPath = "file:///path/1/";
   }
 
   @Test
   public void testEmptyMetadataSerDe() throws Exception {
     // Create empty commit metadata
     HoodieCommitMetadata emptyMetadata = new HoodieCommitMetadata();
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(emptyMetadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-    
+
     // Verify
     assertNotNull(deserialized);
     assertEquals(0, deserialized.getPartitionToWriteStats().size());
@@ -88,7 +82,7 @@ public class TestCommitMetadataSerDeV2 {
   public void testPopulatedMetadataSerDe() throws Exception {
     // Create populated commit metadata
     HoodieCommitMetadata metadata = new HoodieCommitMetadata();
-    
+
     // Add write stats
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(TEST_FILE_ID);
@@ -101,50 +95,56 @@ public class TestCommitMetadataSerDeV2 {
     writeStat.setPartitionPath(TEST_PARTITION_PATH);
     writeStat.setFileSizeInBytes(2048);
     writeStat.setPrevBaseFile(TEST_BASE_FILE);
-    
+
     // Set event times
     writeStat.setMinEventTime(1000L);
     writeStat.setMaxEventTime(2000L);
-    
+
+    // Add new field values
+    writeStat.setTotalLogFilesCompacted(5L);
+    writeStat.setTotalLogReadTimeMs(150L);
+    writeStat.setTotalLogSizeCompacted(1024L);
+    writeStat.setTempPath("temp/path/file1");
+
     // Add CDC stats
     Map<String, Long> cdcStats = new HashMap<>();
     cdcStats.put("cdc-file-1.log", 512L);
     writeStat.setCdcStats(cdcStats);
-    
+
     // Add runtime stats
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalScanTime(100);
     runtimeStats.setTotalCreateTime(200);
     runtimeStats.setTotalUpsertTime(300);
     writeStat.setRuntimeStats(runtimeStats);
-    
+
     metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-    
+
     // Set other metadata fields
     metadata.setOperationType(WriteOperationType.INSERT);
     metadata.setCompacted(true);
     metadata.addMetadata("test-key", "test-value");
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(metadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieCommitMetadata.class);
-    
+
     // Verify all fields
     assertNotNull(deserialized);
     assertEquals(1, deserialized.getPartitionToWriteStats().size());
     assertEquals(true, deserialized.getCompacted());
     assertEquals(WriteOperationType.INSERT, deserialized.getOperationType());
     assertEquals("test-value", deserialized.getExtraMetadata().get("test-key"));
-    
+
     // Verify write stats
     HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
     assertEquals(TEST_FILE_ID, deserializedStat.getFileId());
@@ -159,22 +159,29 @@ public class TestCommitMetadataSerDeV2 {
     assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
     assertEquals(1000L, deserializedStat.getMinEventTime());
     assertEquals(2000L, deserializedStat.getMaxEventTime());
-    
+
     // Verify CDC stats
     assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-    
+
     // Verify runtime stats
     assertNotNull(deserializedStat.getRuntimeStats());
     assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
     assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
     assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
+
+    // Verify new fields
+    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
+    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
+    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
+    assertEquals("temp/path/file1", deserializedStat.getTempPath());
+    assertEquals(0L, deserializedStat.getNumUpdates());
   }
 
   @Test
   public void testReplaceCommitMetadataSerDe() throws Exception {
     // Create populated replace commit metadata
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
-    
+
     // Add write stats
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(TEST_FILE_ID);
@@ -189,52 +196,58 @@ public class TestCommitMetadataSerDeV2 {
     writeStat.setPrevBaseFile(TEST_BASE_FILE);
     writeStat.setMinEventTime(1000L);
     writeStat.setMaxEventTime(2000L);
-    
+
+    // Add new field values
+    writeStat.setTotalLogFilesCompacted(5L);
+    writeStat.setTotalLogReadTimeMs(150L);
+    writeStat.setTotalLogSizeCompacted(1024L);
+    writeStat.setTempPath("temp/path/file1");
+
     // Add CDC stats
     Map<String, Long> cdcStats = new HashMap<>();
     cdcStats.put("cdc-file-1.log", 512L);
     writeStat.setCdcStats(cdcStats);
-    
+
     // Add runtime stats
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalScanTime(100);
     runtimeStats.setTotalCreateTime(200);
     runtimeStats.setTotalUpsertTime(300);
     writeStat.setRuntimeStats(runtimeStats);
-    
+
     metadata.addWriteStat(TEST_PARTITION_PATH, writeStat);
-    
+
     // Add replace file IDs
     metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-1");
     metadata.addReplaceFileId(TEST_PARTITION_PATH, "replaced-file-2");
     metadata.addReplaceFileId("other-partition", "replaced-file-3");
-    
+
     // Set other metadata fields
     metadata.setOperationType(WriteOperationType.CLUSTER);
     metadata.setCompacted(true);
     metadata.addMetadata("test-key-1", "test-value-1");
     metadata.addMetadata("test-key-2", "test-value-2");
-    
+
     // Create SerDe instance
     CommitMetadataSerDeV2 serDe = new CommitMetadataSerDeV2();
-    
+
     // Create test instant
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "replacecommit", "001");
-    
+
     // Serialize
     Option<byte[]> serialized = serDe.serialize(metadata);
     assertTrue(serialized.isPresent());
-    
+
     // Deserialize
     HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, serialized.get(), HoodieReplaceCommitMetadata.class);
-    
+
     // Verify basic fields
     assertNotNull(deserialized);
     assertEquals(true, deserialized.getCompacted());
     assertEquals(WriteOperationType.CLUSTER, deserialized.getOperationType());
     assertEquals("test-value-1", deserialized.getExtraMetadata().get("test-key-1"));
     assertEquals("test-value-2", deserialized.getExtraMetadata().get("test-key-2"));
-    
+
     // Verify write stats
     assertEquals(1, deserialized.getPartitionToWriteStats().size());
     HoodieWriteStat deserializedStat = deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0);
@@ -250,20 +263,27 @@ public class TestCommitMetadataSerDeV2 {
     assertEquals(TEST_BASE_FILE, deserializedStat.getPrevBaseFile());
     assertEquals(1000L, deserializedStat.getMinEventTime());
     assertEquals(2000L, deserializedStat.getMaxEventTime());
-    
+
     // Verify CDC stats
     assertEquals(512L, deserializedStat.getCdcStats().get("cdc-file-1.log"));
-    
+
     // Verify runtime stats
     assertNotNull(deserializedStat.getRuntimeStats());
     assertEquals(100, deserializedStat.getRuntimeStats().getTotalScanTime());
     assertEquals(200, deserializedStat.getRuntimeStats().getTotalCreateTime());
     assertEquals(300, deserializedStat.getRuntimeStats().getTotalUpsertTime());
-    
+
     // Verify replace file IDs
     Map<String, List<String>> replaceFileIds = deserialized.getPartitionToReplaceFileIds();
     assertEquals(2, replaceFileIds.size());
     assertEquals(Arrays.asList("replaced-file-1", "replaced-file-2"), replaceFileIds.get(TEST_PARTITION_PATH));
     assertEquals(Collections.singletonList("replaced-file-3"), replaceFileIds.get("other-partition"));
+
+    // Verify new fields
+    assertEquals(5L, deserializedStat.getTotalLogFilesCompacted());
+    assertEquals(150L, deserializedStat.getTotalLogReadTimeMs());
+    assertEquals(1024L, deserializedStat.getTotalLogSizeCompacted());
+    assertEquals("temp/path/file1", deserializedStat.getTempPath());
+    assertEquals(0L, deserializedStat.getNumUpdates());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -22,8 +22,6 @@ import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.BaseTestCommitMetadataSerDe;
 
-import org.junit.jupiter.api.Test;
-
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 
 public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
@@ -36,20 +34,5 @@ public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
   @Override
   protected HoodieInstant createTestInstant(String action, String id) {
     return INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, id);
-  }
-
-  @Test
-  public void testEmptyMetadataSerDe() throws Exception {
-    super.testEmptyMetadataSerDe();
-  }
-
-  @Test
-  public void testPopulatedMetadataSerDe() throws Exception {
-    super.testPopulatedMetadataSerDe();
-  }
-
-  @Test
-  public void testReplaceCommitMetadataSerDe() throws Exception {
-    super.testReplaceCommitMetadataSerDe();
   }
 }


### PR DESCRIPTION
## Please start your review from commit with title "fix SerDe implementation", all upstream ones are tracked in PR https://github.com/apache/hudi/pull/12814/commits

### Change Logs

#### Issue 1
Previously for CommitMetadataSerDeV2 to handle the deserialization logic this is how it works:

avro binary array 
   -> deserialize to hoodie commit metadata object of Avro auto generated class, org.apache.hudi.avro.model.HoodieReplaceCommitMetadata
   -> serialize to json binary 
   -> deserialize to commit metadata java pojo class object, org.apache.hudi.common.model.HoodieCommitMetadata
 conversion from  Java POJO

It can be avoided as com.fasterxml.jackson.databind.ObjectMapper provides API for direct conversion from Avro class to Java pojo class.

#### Issue 2
As we wrote comprehensive unit test, we found that the Avro class definitions miss a few data members that are presented in the POJO class definition. As a result, the value of those data members are lost at serialization-deserialization process. Misleading the consumer to wrong behavior.

The PR added those data members with documentations making it clear about this POJO class definiton and Avro schema definition invariant.

### Impact

SerDe is more correct
### Risk level (write none, low medium or high below)

none
### Documentation Update
NA


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
