### PR TITLE
[SITE] Add developer sync call page

### DIFF
--- a/website/contribute/developer-setup.md
+++ b/website/contribute/developer-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Developer Setup
-sidebar_position: 4
+sidebar_position: 3
 keywords: [ hudi, ide, developer, setup]
 toc: true
 last_modified_at: 2024-08-12T10:47:57-07:00

--- a/website/contribute/developer-sync-call.md
+++ b/website/contribute/developer-sync-call.md
@@ -1,0 +1,11 @@
+---
+title: "Developer Sync Call"
+sidebar_position: 1
+toc: true
+last_modified_at: 2020-09-01T15:59:57-04:00
+---
+
+The Hudi community is hosting monthly developer sync calls. Join us for the latest development in the community, tips to start contributing, and more!
+
+- The call will be hosted using this [Zoom meeting](https://us06web.zoom.us/j/83672013162?pwd=tFGbo2OaTbkLNiIglnTavgi55RaPw3.1).
+- The call schedule is available in this [Google calendar](https://calendar.google.com/calendar/embed?src=rgpb1ta2mgp5au38fr2834poa8%40group.calendar.google.com). The iCal format is also available for [download](https://calendar.google.com/calendar/ical/rgpb1ta2mgp5au38fr2834poa8%40group.calendar.google.com/public/basic.ics).

--- a/website/contribute/report-security-issues.md
+++ b/website/contribute/report-security-issues.md
@@ -1,6 +1,6 @@
 ---
 title: Report Security Issues
-sidebar_position: 6
+sidebar_position: 5
 keywords: [ hudi, security]
 toc: true
 last_modified_at: 2019-12-30T15:59:57-04:00

--- a/website/contribute/rfc-process.md
+++ b/website/contribute/rfc-process.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: "RFC Process"
 toc: true
 last_modified_at: 2020-09-01T15:59:57-04:00

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -209,6 +209,10 @@ module.exports = {
           position: "left",
           items: [
             {
+              label: "Developer Sync Call",
+              to: "/contribute/developer-sync-call",
+            },
+            {
               label: "How to Contribute",
               to: "/contribute/how-to-contribute",
             },


### PR DESCRIPTION
Add page for developer sync call. And align the ordering of the items between drop down and sidebar.

<img width="1399" alt="Screenshot 2025-02-11 at 9 55 15 PM" src="https://github.com/user-attachments/assets/451ea0b8-9f49-4258-ac16-f299b97b23ec" />

