### PR TITLE
[MINOR] Fix flaky TestHoodieAvroDataBlock

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieAvroDataBlock.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/block/TestHoodieAvroDataBlock.java
@@ -327,11 +327,8 @@ public class TestHoodieAvroDataBlock {
    * @return A list of randomly selected HoodieRecord objects.
    */
   private static List<HoodieRecord> selectRandomRecords(List<HoodieRecord> records, boolean fullKey) {
-    // number of sampled records
-    int count = new Random().nextInt(records.size());
-    // set of record keys of the sampled records
     Set<String> keys = new Random()
-        .ints(count, 0, records.size())
+        .ints(records.size() / 4, 0, records.size())
         .mapToObj(records::get)
         .map(r -> r.getRecordKey(SCHEMA, RECORD_KEY_FIELD))
         .collect(Collectors.toSet());


### PR DESCRIPTION
### Change Logs

Recently i faced this failure:  
`Error:    TestHoodieAvroDataBlock.testGetRecordIteratorWithInputStream:188->verifyRecords:360 Record count mismatch ==> expected: <0> but was: <1000>`  
That happened because of unnecessary random value generation in `selectRandomRecords`: as a number of selected records was randomly generated 0 value, so it returned an empty list `recordsForFilter` (and `keysForFilter`). Later, when we call `dataBlock.getRecordIterator` with empty list as `keysForFilter`, it returns all records, and it causes records verification to fail.  

This PR fixes it by not using Random for generating number of selected records, just use value `allRecordsNum/4`.

### Impact

fix flaky test

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
