### PR TITLE
[HUDI-9016] Fix the HoodieCompactor schedule parameter alias name

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -96,7 +96,7 @@ public class HoodieCompactor {
     public int retry = 0;
     @Parameter(names = {"--skip-clean", "-sc"}, description = "do not trigger clean after compaction", required = false)
     public Boolean skipClean = true;
-    @Parameter(names = {"--schedule", "-sc"}, description = "Schedule compaction", required = false)
+    @Parameter(names = {"--schedule", "-sch"}, description = "Schedule compaction", required = false)
     public Boolean runSchedule = false;
     @Parameter(names = {"--mode", "-m"}, description = "Set job mode: Set \"schedule\" means make a compact plan; "
         + "Set \"execute\" means execute a compact plan at given instant which means --instant-time is needed here; "


### PR DESCRIPTION
### Change Logs

Fixed the **schedule** alias name from **sc** to **sch**.

**Before fixing the issue:**

```sh
% spark-submit \
  --class org.apache.hudi.utilities.HoodieCompactor \
  packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.12-1.1.0-SNAPSHOT.jar \
  --base-path /tmp/hudi/hudi-test-topic \
  --table-name hudi-test-topic
```
```sh
25/02/13 15:33:59 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
Exception in thread "main" org.apache.hudi.com.beust.jcommander.ParameterException: Found the option -sc multiple times
  at org.apache.hudi.com.beust.jcommander.JCommander.addDescription(JCommander.java:627)
  at org.apache.hudi.com.beust.jcommander.JCommander.createDescriptions(JCommander.java:594)
  at org.apache.hudi.com.beust.jcommander.JCommander.<init>(JCommander.java:249)
  at org.apache.hudi.utilities.HoodieCompactor.main(HoodieCompactor.java:173)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
  at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
  at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
  at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
  at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
  at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
  at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
  at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
25/02/13 15:33:59 INFO ShutdownHookManager: Shutdown hook called
```

**After fixing the issue:**

```sh
% spark-submit \                
  --class org.apache.hudi.utilities.HoodieCompactor \
  packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.12-1.1.0-SNAPSHOT.jar \
  --base-path /tmp/hudi/hudi-test-topic \
  --table-name hudi-test-topic
```
```sh
.....
25/02/13 15:56:52 INFO HoodieTableMetaClient: Loading HoodieTableMetaClient from /tmp/hudi/hudi-test-topic
25/02/13 15:56:52 INFO HoodieTableConfig: Loading table properties from /tmp/hudi/hudi-test-topic/.hoodie/hoodie.properties
25/02/13 15:56:52 INFO HoodieTableMetaClient: Finished Loading Table of type COPY_ON_WRITE(version=1) from /tmp/hudi/hudi-test-topic
25/02/13 15:56:52 INFO HoodieTableMetaClient: Loading Active commit timeline for /tmp/hudi/hudi-test-topic
25/02/13 15:56:52 INFO ActiveTimelineV1: Loaded instants upto : Option{val=[20250213153114368__20250213153136000__commit__COMPLETED]}
25/02/13 15:56:52 INFO HoodieCompactor: HoodieCompactorConfig {
   --base-path /tmp/hudi/hudi-test-topic, 
   --table-name hudi-test-topic, 
   --instant-time null, 
   --parallelism 200, 
   --schema-file null, 
   --spark-master null, 
   --spark-memory null, 
   --skipClean true, 
   --retry 0, 
   --schedule false, 
   --mode execute, 
   --strategy org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy, 
   --props null, 
   --hoodie-conf []
}
25/02/13 15:56:52 INFO HoodieCompactor: Running Mode: [execute]; Do compaction
25/02/13 15:56:52 INFO HoodieCompactor: Schema --> : {"type":"record","name":"hudi__test__topic_record","namespace":"hoodie.hudi__test__topic","fields":[{"name":"id","type":["null","string"],"default":null},{"name":"field1","type":["null","string"],"default":null},{"name":"field2","type":["null","string"],"default":null},{"name":"field3","type":["null","string"],"default":null},{"name":"field4","type":"boolean"},{"name":"field5","type":"long"},{"name":"ts","type":"long"},{"name":"partition","type":["null","string"],"default":null},{"name":"fruits","type":["null","string"],"default":null}]}
....
25/02/13 15:56:53 INFO HoodieTableMetaClient: Loading HoodieTableMetaClient from /tmp/hudi/hudi-test-topic
25/02/13 15:56:53 INFO HoodieTableConfig: Loading table properties from /tmp/hudi/hudi-test-topic/.hoodie/hoodie.properties
25/02/13 15:56:53 INFO HoodieTableMetaClient: Finished Loading Table of type COPY_ON_WRITE(version=1) from /tmp/hudi/hudi-test-topic
25/02/13 15:56:53 INFO HoodieTableMetaClient: Loading Active commit timeline for /tmp/hudi/hudi-test-topic
25/02/13 15:56:53 INFO ActiveTimelineV1: Loaded instants upto : Option{val=[20250213153114368__20250213153136000__commit__COMPLETED]}
25/02/13 15:56:53 INFO HoodieCompactor: There is no scheduled compaction in the table.
25/02/13 15:56:53 INFO BaseHoodieClient: Stopping Timeline service !!
25/02/13 15:56:53 INFO EmbeddedTimelineService: Closing Timeline server
25/02/13 15:56:53 INFO TimelineService: Closing Timeline Service
25/02/13 15:56:53 INFO Javalin: Stopping Javalin ...
25/02/13 15:56:53 INFO Javalin: Javalin has stopped
25/02/13 15:56:53 INFO TimelineService: Closed Timeline Service
25/02/13 15:56:53 INFO EmbeddedTimelineService: Closed Timeline server
25/02/13 15:56:53 INFO TransactionManager: Transaction manager closed
....
25/02/13 15:56:53 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
25/02/13 15:56:53 INFO SparkContext: Successfully stopped SparkContext
25/02/13 15:56:58 INFO ShutdownHookManager: Shutdown hook called
```

### Impact

Corrected the **schedule** alias name.

### Risk level (write none, low medium or high below)

none

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
