### PR TITLE
[HUDI-9025] perf: improve append performance by reducing avro schema comparisons

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -829,6 +829,13 @@ public class HoodieWriteConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Whether to enable incremental table service. So far Clustering and Compaction support incremental processing.");
 
+  public static final ConfigProperty<Boolean> ENGINE_SPECIFIC_SCHEMA_OPTIMIZED_ENABLE = ConfigProperty
+      .key("hoodie.write.schema.engine.specific.optimized.enabled")
+      .defaultValue(true)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Whether to prepend meta fields with engine specific schema");
+
   /**
    * Config key with boolean value that indicates whether record being written during MERGE INTO Spark SQL
    * operation are already prepped.
@@ -2882,6 +2889,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public int getSecondaryIndexParallelism() {
     return metadataConfig.getSecondaryIndexParallelism();
+  }
+
+  public boolean isEngineSpecificSchemaOptimizedEnable() {
+    return getBoolean(ENGINE_SPECIFIC_SCHEMA_OPTIMIZED_ENABLE);
   }
 
   public static class Builder {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EngineSpecificRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EngineSpecificRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.avro.Schema;
+
+import java.util.Properties;
+
+public interface EngineSpecificRecord<S/*engine specific schema*/> {
+
+  HoodieRecord prependMetaFields(EngineSpecificRecordSchema<S> recordSchema, EngineSpecificRecordSchema<S> targetSchema, MetadataValues metadataValues, Properties props);
+
+  Comparable<?> getOrderingValue(EngineSpecificRecordSchema<S> recordSchema, Properties props);
+
+  EngineSpecificRecordSchema<S> getEngineSpecificSchema(Schema schema);
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EngineSpecificRecordSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EngineSpecificRecordSchema.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.avro.Schema;
+
+import java.io.Serializable;
+
+public abstract class EngineSpecificRecordSchema<S> implements Serializable {
+
+  S schema;
+  Schema avroSchema;
+
+  public EngineSpecificRecordSchema(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+    this.schema = parseSchemaFromAvro(avroSchema);
+  }
+
+  public S getSchema() {
+    return schema;
+  }
+
+  abstract S parseSchemaFromAvro(Schema avroSchema);
+}


### PR DESCRIPTION
For engine specific record merger mode, i.e. spark record：
For each record, we need to use cpu time to do some unnecessary operation, such as schema comparison, even if we have a global `avro schema` -> `spark schema` cache, but for the `cache.get()` operation, It will eventually call the `avro schema::equals` method, which will go through all the columns to compare. In the append scenario, our cache will hit every time, but each record will need to compare the `avro schema` completely, which will waste a lot of cpu time.

In my perf result:

`HoodieInternalRowUtils::getCachedSchema` cost almost 10% cpu time during `doAppend`.
And then we can analyze the results and figure out that basically all the time in this function is used to compare `avro schema` with `cache::key`.
<img width="2524" alt="image" src="https://github.com/user-attachments/assets/240cc715-66d7-4356-a879-1eff35604337" />

As the number of columns increases, the proportion of this consumption will be higher.

### Change Logs
1. improve append performance by reducing comparisons

### Impact
add a new interface for engine specific record for using engine specific schema rather than avro schema

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
