### PR TITLE
[HUDI-9038] Enable Codecov tracking and comment on code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,13 +23,6 @@ coverage:
   precision: 2
   round: down
   range: "50...100"
-  status:
-    project: # settings affecting project coverage
-      enabled: yes
-
-    # do not run coverage on patch nor changes
-    patch: no
-    changes: no
 
 # Ignoring Paths
 # --------------
@@ -54,7 +47,13 @@ ignore:
   - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieInputFormat.java"
   - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeInputFormat.java"
 
-comment: false
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
 
 flags:
   hudicli:


### PR DESCRIPTION
### Change Logs

As above, by changing `.codecov.yml`.

### Impact

Enables code coverage report on master and PRs.

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
