### PR TITLE
[DNM][HUDI-XXXX] Avoid caching base path in `HoodieROTablePathFilter`

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -176,13 +176,6 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
       }
 
       if (baseDir != null) {
-        // Check whether baseDir in nonHoodiePathCache
-        if (nonHoodiePathCache.contains(baseDir.toString())) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Accepting non-hoodie path from cache: " + path);
-          }
-          return true;
-        }
         HoodieTableFileSystemView fsView = null;
         try {
           HoodieTableMetaClient metaClient = metaClientCache.get(baseDir.toString());
@@ -232,7 +225,6 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
             LOG.debug(String.format("(1) Caching non-hoodie path under %s with basePath %s \n", folder.toString(), baseDir.toString()));
           }
           nonHoodiePathCache.add(folder.toString());
-          nonHoodiePathCache.add(baseDir.toString());
           return true;
         } finally {
           if (fsView != null) {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
@@ -85,7 +85,7 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     java.nio.file.Path path2 = Paths.get(basePath, "nonhoodiefolder/somefile");
     Files.createFile(path2);
     assertTrue(pathFilter.accept(new Path(path2.toUri())));
-    assertEquals(2, pathFilter.nonHoodiePathCache.size(), "NonHoodiePathCache size should be 2");
+    assertEquals(1, pathFilter.nonHoodiePathCache.size());
   }
 
   @Test
@@ -97,6 +97,6 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     Path partitionPath2 = testTable.getPartitionPath(p2).getParent();
     assertTrue(pathFilter.accept(partitionPath1), "Directories should be accepted");
     assertTrue(pathFilter.accept(partitionPath2), "Directories should be accepted");
-    assertEquals(2, pathFilter.nonHoodiePathCache.size(), "NonHoodiePathCache size should be 2");
+    assertEquals(1, pathFilter.nonHoodiePathCache.size());
   }
 }


### PR DESCRIPTION
### Change Logs

When table is non-Hudi, base path could be unintended due to `org.apache.hudi.hadoop.HoodieROTablePathFilter#safeGetParentsParent`.


### Impact

Affects planning the query for non Hudi table with RO table filter.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
