### PR TITLE
[HUDI-9040] Set the correct table path when renaming tables

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableRenameCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableRenameCommand.scala
@@ -52,8 +52,7 @@ case class AlterHoodieTableRenameCommand(
       // update table properties path in every op
       if (hoodieCatalogTable.table.properties.contains("path")) {
         val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(newName)
-        val path = catalogTable.storage.locationUri.get.getPath
-        AlterTableSetPropertiesCommand(newName, Map("path" -> path), isView).run(sparkSession)
+        AlterTableSetPropertiesCommand(newName, Map("path" -> catalogTable.location.toString), isView).run(sparkSession)
       }
 
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
@@ -333,7 +333,8 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
         val newTableName = s"${tableName}_1"
         val oldLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(tableName)).properties.get("path")
         spark.sql(s"alter table $tableName rename to $newTableName")
-        val newLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(newTableName)).properties.get("path")
+        val newTable = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(newTableName))
+        val newLocation = newTable.properties.get("path")
         // only hoodieCatalog will set path to tblp
         if (oldLocation.nonEmpty) {
           assertResult(false)(
@@ -342,6 +343,9 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
         } else {
           assertResult(None) (newLocation)
         }
+        assert(newTable.location.toString.equals(newLocation.get))
+        // newTable.storage.locationUri.get.getPath should remove the scheme of path, thus won't match the location
+        assertResult(false)(newTable.storage.locationUri.get.getPath.equals(newLocation.get))
 
 
         // Create table with location

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
@@ -310,38 +310,36 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
   }
 
   test("Test Alter Rename Table") {
-    withTempDir { tmp =>
-      Seq("cow", "mor").foreach { tableType =>
-        val tableName = generateTableName
-        // Create table
-        spark.sql(
-          s"""
-             |create table $tableName (
-             |  id int,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) using hudi
-             | tblproperties (
-             |  type = '$tableType',
-             |  primaryKey = 'id',
-             |  preCombineField = 'ts'
-             | )
-        """.stripMargin)
+    Seq("cow", "mor").foreach { tableType =>
+      val tableName = generateTableName
+      // Create table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | tblproperties (
+           |  type = '$tableType',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           | )
+     """.stripMargin)
 
-        // alter table name.
-        val newTableName = s"${tableName}_1"
-        val oldLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(tableName)).properties.get("path")
-        spark.sql(s"alter table $tableName rename to $newTableName")
-        val newLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(newTableName)).properties.get("path")
-        // only hoodieCatalog will set path to tblp
-        if (oldLocation.nonEmpty) {
-          assertResult(false)(
-            newLocation.equals(oldLocation)
-          )
-        } else {
-          assertResult(None)(newLocation)
-        }
+      // alter table name.
+      val newTableName = s"${tableName}_1"
+      val oldLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(tableName)).properties.get("path")
+      spark.sql(s"alter table $tableName rename to $newTableName")
+      val newLocation = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(newTableName)).properties.get("path")
+      // only hoodieCatalog will set path to tblp
+      if (oldLocation.nonEmpty) {
+        assertResult(false)(
+          newLocation.equals(oldLocation)
+        )
+      } else {
+        assertResult(None)(newLocation)
       }
     }
   }


### PR DESCRIPTION
### Change Logs

Instead of using `catalogTable.storage.locationUri.get.getPath` that could remove scheme and authority, simply use `catalogTable.location` instead when resetting table path in rename command.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
