### PR TITLE
[HUDI-9059] Fix ordering of getInstantTimes in CompletionTimeQueryViewV2

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
@@ -191,7 +191,6 @@ public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Seria
   }
 
   @Override
-
   public List<String> getInstantTimes(
       HoodieTimeline timeline,
       Option<String> startCompletionTime,
@@ -256,7 +255,7 @@ public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Seria
       // fallback to archived timeline
       return this.instantTimeToCompletionTimeMap.entrySet().stream()
           .filter(entry -> InstantComparison.compareTimestamps(entry.getValue(), LESSER_THAN_OR_EQUALS, endCompletionTime.get()))
-          .map(Map.Entry::getKey).collect(Collectors.toList());
+          .map(Map.Entry::getKey).sorted().collect(Collectors.toList());
     }
 
     if (startFromEarliest) {


### PR DESCRIPTION
### Change Logs

- Fixes bug in `getInstantTimes` where the output is not sorted

### Impact

- The interface declares that the output is expected to be sorted but there is a case where it is not and ordering is random. This breaks the contract of the interface. The code change here fixes that.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
