### PR TITLE
[HUDI-9062] Make meta sync tools use global Hudi configs

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -70,7 +70,7 @@ public class BigQuerySyncTool extends HoodieSyncTool {
   public BigQuerySyncTool(Properties props) {
     // will build file writer, client, etc. from configs
     super(props);
-    this.config = new BigQuerySyncConfig(props);
+    this.config = new BigQuerySyncConfig(this.props);
     this.tableName = config.getString(BIGQUERY_SYNC_TABLE_NAME);
     this.manifestTableName = tableName + SUFFIX_MANIFEST;
     this.versionsTableName = tableName + SUFFIX_VERSIONS;

--- a/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncTool.java
+++ b/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncTool.java
@@ -83,7 +83,7 @@ public class AdbSyncTool extends HoodieSyncTool {
 
   public AdbSyncTool(Properties props) {
     super(props);
-    this.config = new AdbSyncConfig(props);
+    this.config = new AdbSyncConfig(this.props);
     this.databaseName = config.getString(META_SYNC_DATABASE_NAME);
     this.tableName = config.getString(META_SYNC_TABLE_NAME);
     this.syncClient = new HoodieAdbJdbcClient(config);

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
@@ -61,7 +61,7 @@ public class DataHubSyncTool extends HoodieSyncTool {
 
   public DataHubSyncTool(Properties props, Configuration hadoopConf, Option<HoodieTableMetaClient> metaClientOption) {
     super(props, hadoopConf);
-    this.config = new DataHubSyncConfig(props);
+    this.config = new DataHubSyncConfig(this.props);
     this.tableName = config.getString(META_SYNC_TABLE_NAME);
     this.metaClient = metaClientOption.orElseGet(() -> HoodieTableMetaClient.builder()
         .setConf(HadoopFSUtils.getStorageConfWithCopy(config.getHadoopConf()))

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -113,7 +113,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       hadoopConfForSync = hadoopConf;
     }
 
-    this.config = new HiveSyncConfig(props, hadoopConfForSync);
+    this.config = new HiveSyncConfig(this.props, hadoopConfForSync);
     this.databaseName = config.getStringOrDefault(META_SYNC_DATABASE_NAME);
     this.tableName = config.getStringOrDefault(META_SYNC_TABLE_NAME);
     initSyncClient(config);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncTool.java
@@ -39,7 +39,7 @@ public class GlobalHiveSyncTool extends HiveSyncTool {
 
   public GlobalHiveSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf);
-    this.config = new GlobalHiveSyncConfig(props, hadoopConf);
+    this.config = new GlobalHiveSyncConfig(this.props, hadoopConf);
   }
 
   @Override

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncTool.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncTool.java
@@ -18,6 +18,7 @@
 package org.apache.hudi.sync.common;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.HadoopConfigUtils;
 
 import org.apache.hadoop.conf.Configuration;
@@ -39,7 +40,9 @@ public abstract class HoodieSyncTool implements AutoCloseable {
   }
 
   public HoodieSyncTool(Properties props, Configuration hadoopConf) {
-    this.props = props;
+    TypedProperties mergedProps = ConfigUtils.loadGlobalProperties();
+    mergedProps.putAll(props);
+    this.props = mergedProps;
     this.hadoopConf = hadoopConf;
   }
 


### PR DESCRIPTION
### Change Logs

Load global Hudi configs when creating meta sync tools.

### Impact

Running meta sync is affected due to considering global configs.

### Risk level

Medium

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
