### PR TITLE
[DOCS] Fix minor website typos

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -2,7 +2,7 @@
 title: "Spark Quick Start"
 sidebar_position: 2
 toc: true
-last_modified_at: 2023-08-23T21:14:52+09:00
+last_modified_at: 2025-02-21T03:17:02+09:00
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -458,10 +458,11 @@ values={[
 val adjustedFareDF = spark.read.format("hudi").
   load(basePath).limit(2).
   withColumn("fare", col("fare") * 10)
+
 adjustedFareDF.write.format("hudi").
-option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
-mode(Append).
-save(basePath)
+  option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
+  mode(Append).
+  save(basePath)
 // Notice Fare column has been updated but all other columns remain intact.
 spark.read.format("hudi").load(basePath).show()
 ```

--- a/website/docs/write_operations.md
+++ b/website/docs/write_operations.md
@@ -68,7 +68,7 @@ Hudi supports migrating your existing large tables into a Hudi table using the `
 ### INSERT_OVERWRITE
 **Type**: _Batch_, **Action**: _REPLACE_COMMIT (CoW + MoR)_
 
-This operation is used to rerwrite the all the partitions that are present in the input. This operation can be faster 
+This operation is used to rewrite the all the partitions that are present in the input. This operation can be faster 
 than `upsert` for batch ETL jobs, that are recomputing entire target partitions at once (as opposed to incrementally 
 updating the target tables). This is because, we are able to bypass indexing, precombining and other repartitioning 
 steps in the upsert write path completely. This comes in handy if you are doing any backfill or any such type of use-cases.

--- a/website/versioned_docs/version-1.0.1/quick-start-guide.md
+++ b/website/versioned_docs/version-1.0.1/quick-start-guide.md
@@ -2,7 +2,7 @@
 title: "Spark Quick Start"
 sidebar_position: 2
 toc: true
-last_modified_at: 2023-08-23T21:14:52+09:00
+last_modified_at: 2025-02-21T03:17:02+09:00
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -458,10 +458,11 @@ values={[
 val adjustedFareDF = spark.read.format("hudi").
   load(basePath).limit(2).
   withColumn("fare", col("fare") * 10)
+
 adjustedFareDF.write.format("hudi").
-option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
-mode(Append).
-save(basePath)
+  option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
+  mode(Append).
+  save(basePath)
 // Notice Fare column has been updated but all other columns remain intact.
 spark.read.format("hudi").load(basePath).show()
 ```

--- a/website/versioned_docs/version-1.0.1/write_operations.md
+++ b/website/versioned_docs/version-1.0.1/write_operations.md
@@ -68,7 +68,7 @@ Hudi supports migrating your existing large tables into a Hudi table using the `
 ### INSERT_OVERWRITE
 **Type**: _Batch_, **Action**: _REPLACE_COMMIT (CoW + MoR)_
 
-This operation is used to rerwrite the all the partitions that are present in the input. This operation can be faster 
+This operation is used to rewrite the all the partitions that are present in the input. This operation can be faster 
 than `upsert` for batch ETL jobs, that are recomputing entire target partitions at once (as opposed to incrementally 
 updating the target tables). This is because, we are able to bypass indexing, precombining and other repartitioning 
 steps in the upsert write path completely. This comes in handy if you are doing any backfill or any such type of use-cases.


### PR DESCRIPTION
### Documentation Update
* Missing indentation formatting for "Merging Data" code example.
* Typo: rerwrite -> rewrite

For the following:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/82f54500-492a-4ff0-a532-2403cb504714" />
