### PR TITLE
[HUDI-8666] Revisit error message when timeline layout version cannot be read

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.table.timeline.TimeGeneratorType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
@@ -149,7 +150,7 @@ public class TableCommand {
     try {
       HoodieTableMetaClient.builder().setConf(HoodieCLI.conf.newInstance()).setBasePath(path).build();
       existing = true;
-    } catch (TableNotFoundException dfe) {
+    } catch (TableNotFoundException | InvalidTableException dfe) {
       // expected
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -65,6 +65,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.io.HoodieMergedReadHandle;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.DirectoryInfo;
@@ -301,7 +302,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
           LOG.info("Re-initiating metadata table properties since populate meta fields have changed");
           metadataMetaClient = initializeMetaClient();
         }
-      } catch (TableNotFoundException e) {
+      } catch (TableNotFoundException | InvalidTableException e) {
         return false;
       }
       final Option<HoodieInstant> latestMetadataInstant =

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -196,7 +196,7 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final ConfigProperty<String> TIMELINE_LAYOUT_VERSION = ConfigProperty
       .key("hoodie.timeline.layout.version")
       .noDefaultValue()
-      .withDocumentation("Version of timeline used, by the table.");
+      .withDocumentation("Version of timeline used by the table.");
   
   public static final ConfigProperty<RecordMergeMode> RECORD_MERGE_MODE = ConfigProperty
       .key("hoodie.record.merge.mode")

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -56,7 +56,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.HoodieInstantWriter;
@@ -182,7 +182,7 @@ public class HoodieTableMetaClient implements Serializable {
           "Layout Version defined in hoodie properties has higher version (" + tableConfigVersion.get()
               + ") than the one passed in config (" + layoutVersion.get() + ")");
     } else if (layoutVersion.isEmpty() && tableConfigVersion.isEmpty()) {
-      throw new TableNotFoundException("Table does not exist");
+      throw new InvalidTableException(basePath, "timeline layout version is not set");
     }
     this.timelineLayoutVersion = layoutVersion.orElseGet(tableConfigVersion::get);
     this.timelineLayout = TimelineLayout.fromVersion(timelineLayoutVersion);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -265,8 +265,9 @@ public class TableSchemaResolver {
             return Option.empty();
           }
         default:
-          LOG.error("Unknown table type {}", metaClient.getTableType());
-          throw new InvalidTableException(metaClient.getBasePath().toString());
+          String errMsg = String.format("Unknown table type %s", metaClient.getTableType());
+          LOG.error(errMsg);
+          throw new InvalidTableException(metaClient.getBasePath().toString(), errMsg);
       }
     } catch (IOException e) {
       throw new HoodieException("Failed to read data schema", e);

--- a/hudi-common/src/main/java/org/apache/hudi/exception/InvalidTableException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/InvalidTableException.java
@@ -18,16 +18,20 @@
 
 package org.apache.hudi.exception;
 
+import org.apache.hudi.common.util.StringUtils;
+
 /**
  * Exception thrown to indicate that a hoodie table is invalid.
  */
 public class InvalidTableException extends HoodieException {
 
-  public InvalidTableException(String basePath) {
-    super(getErrorMessage(basePath));
+  public InvalidTableException(String basePath, String error) {
+    super(buildErrorMessage(basePath, error));
   }
 
-  private static String getErrorMessage(String basePath) {
-    return "Invalid Hoodie Table. " + basePath;
+  private static String buildErrorMessage(String basePath, String error) {
+    return StringUtils.isNullOrEmpty(error)
+        ? "Invalid Hoodie Table: " + basePath
+        : "Invalid Hoodie Table (" + error + "): " + basePath;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.expression.BindVisitor;
 import org.apache.hudi.expression.Expression;
@@ -138,7 +139,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
             .setBasePath(metadataBasePath)
             .build();
         this.metadataTableConfig = metadataMetaClient.getTableConfig();
-      } catch (TableNotFoundException e) {
+      } catch (TableNotFoundException | InvalidTableException e) {
         LOG.warn("Metadata table was not found at path {}", metadataBasePath);
         this.isMetadataTableInitialized = false;
         this.metadataMetaClient = null;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
@@ -226,7 +227,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
                 hoodiePathCache.get(folder.toString()).contains(path)));
           }
           return hoodiePathCache.get(folder.toString()).contains(path);
-        } catch (TableNotFoundException e) {
+        } catch (TableNotFoundException | InvalidTableException e) {
           // Non-hoodie path, accept it.
           if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("(1) Caching non-hoodie path under %s with basePath %s \n", folder, baseDir));

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -40,6 +40,7 @@ import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieDuplicateKeyException;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -296,7 +297,7 @@ public class DataSourceUtils {
       SparkRDDReadClient client = new SparkRDDReadClient<>(engineContext, writeConfig);
       return client.tagLocation(incomingHoodieRecords)
           .filter(r -> shouldIncludeRecord((HoodieRecord<HoodieRecordPayload>) r, failOnDuplicates));
-    } catch (TableNotFoundException e) {
+    } catch (TableNotFoundException | InvalidTableException e) {
       // No table exists yet, so no duplicates to drop
       return incomingHoodieRecords;
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
@@ -26,7 +26,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
 import org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor;
@@ -266,7 +266,7 @@ public class HoodieJavaStreamingApp {
         }
         HoodieTableMetaClient metaClient = createMetaClient(new HadoopStorageConfiguration(fs.getConf()), tablePath);
         System.out.println("Instants :" + metaClient.getActiveTimeline().getInstants());
-      } catch (TableNotFoundException te) {
+      } catch (InvalidTableException te) {
         LOG.info("Got table not found exception. Retrying");
       } finally {
         Thread.sleep(sleepSecsAfterEachRun * 1000);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -29,7 +29,7 @@ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestTabl
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.util.{CollectionUtils, CommitUtils}
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieLockConfig, HoodieWriteConfig}
-import org.apache.hudi.exception.TableNotFoundException
+import org.apache.hudi.exception.InvalidTableException
 import org.apache.hudi.storage.{HoodieStorage, StoragePath}
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieSparkClientTestBase, HoodieSparkDeleteRecordMerger}
 
@@ -228,8 +228,8 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
         success = true
       }
     } catch {
-      case _: TableNotFoundException =>
-        log.info("Got table not found exception. Retrying")
+      case _: InvalidTableException =>
+        log.info("Got invalid table exception. Retrying")
     } finally {
       if (!success) {
         Thread.sleep(sleepSecsAfterEachRun * 1000)
@@ -455,8 +455,8 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
         success = true
       }
     } catch {
-      case _: TableNotFoundException =>
-        log.info("Got table not found exception. Retrying")
+      case _: InvalidTableException =>
+        log.info("Got invalid table exception. Retrying")
     } finally {
       Thread.sleep(sleepSecsAfterEachRun * 1000)
       currTime = System.currentTimeMillis

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -158,10 +158,15 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
               : Option.of(tableName + SUFFIX_READ_OPTIMIZED_TABLE);
           break;
         default:
-          LOG.error("Unknown table type " + syncClient.getTableType());
-          throw new InvalidTableException(syncClient.getBasePath());
+          throwInvalidTableTypeException();
       }
     }
+  }
+
+  private void throwInvalidTableTypeException() {
+    String errMsg = String.format("Unknown table type %s", syncClient.getTableType());
+    LOG.error(errMsg);
+    throw new InvalidTableException(syncClient.getBasePath(), errMsg);
   }
 
   @Override
@@ -210,8 +215,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
         }
         break;
       default:
-        LOG.error("Unknown table type " + syncClient.getTableType());
-        throw new InvalidTableException(syncClient.getBasePath());
+        throwInvalidTableTypeException();
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -73,6 +73,7 @@ import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.storage.HoodieFileReader;
@@ -229,7 +230,7 @@ public class HoodieMetadataTableValidator implements Serializable {
           .setBasePath(cfg.basePath)
           .setLoadActiveTimelineOnLoad(true)
           .build());
-    } catch (TableNotFoundException tbe) {
+    } catch (TableNotFoundException | InvalidTableException tbe) {
       // Suppress the TableNotFound exception, table not yet created for a new stream
       LOG.warn("Data table is not found. Skip current validation for: " + cfg.basePath);
     }
@@ -717,7 +718,7 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
       }
       return true;
-    } catch (TableNotFoundException tbe) {
+    } catch (TableNotFoundException | InvalidTableException tbe) {
       // Suppress the TableNotFound exception if Metadata table is not available to read for now
       LOG.warn("Metadata table is not found for table: {}. Skip current validation.", cfg.basePath);
       return false;


### PR DESCRIPTION
### Change Logs

Changed exception class from `TableNotFoundException` to `InvalidTableException`, made error message of `InvalidTableException` more detailed.

### Impact

Exception type and error message are accurate.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
