### PR TITLE
[HUDI-8418] Throw an error if the table configs of record merge are about to change

### DIFF
--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
@@ -122,6 +123,19 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
     assertEquals(8, config.getProps().size());
     assertEquals("test-table2", config.getTableName());
     assertEquals("new_field", config.getPreCombineField());
+  }
+
+  @Test
+  public void testRecordMergeModeValidation() {
+    Exception ex = assertThrows(HoodieValidationException.class,
+        () -> new HoodieTableConfig(storage, metaPath, CUSTOM, null, null));
+    assertEquals("The merge mode and payload configs should not change in the table configs after table creation", ex.getMessage());
+    ex = assertThrows(HoodieValidationException.class,
+        () -> new HoodieTableConfig(storage, metaPath, null, "payload-class-name", null));
+    assertEquals("The merge mode and payload configs should not change in the table configs after table creation", ex.getMessage());
+    ex = assertThrows(HoodieValidationException.class,
+        () -> new HoodieTableConfig(storage, metaPath, null, null, "strategy-id"));
+    assertEquals("The merge mode and payload configs should not change in the table configs after table creation", ex.getMessage());
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
@@ -82,7 +82,7 @@ class TestSqlConf extends HoodieSparkSqlTestBase with BeforeAndAfter {
       assertResult(true)(Files.exists(Paths.get(s"$tablePath/$partitionVal")))
       assertResult(HoodieTableType.MERGE_ON_READ)(new HoodieTableConfig(
         HoodieStorageUtils.getStorage(tablePath, HoodieTestUtils.getDefaultStorageConf),
-        new StoragePath(tablePath, HoodieTableMetaClient.METAFOLDER_NAME), RecordMergeMode.COMMIT_TIME_ORDERING, null, null).getTableType)
+        new StoragePath(tablePath, HoodieTableMetaClient.METAFOLDER_NAME), null, null, null).getTableType)
 
       // Manually pass incremental configs to global configs to make sure Hudi query is able to load the
       // global configs

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2EAutoUpgrade.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2EAutoUpgrade.java
@@ -20,7 +20,7 @@ package org.apache.hudi.utilities.streamer;
 
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -95,7 +95,7 @@ public class TestHoodieIncrSourceE2EAutoUpgrade extends S3EventsHoodieIncrSource
     return HoodieTableMetaClient.newTableBuilder()
         .setTableName(RAW_TRIPS_TEST_NAME)
         .setTableType(COPY_ON_WRITE)
-        .setPayloadClass(HoodieAvroPayload.class)
+        .setPayloadClass(DefaultHoodieRecordPayload.class)
         .setTableVersion(ConfigUtils.getIntWithAltKeys(new TypedProperties(props), WRITE_TABLE_VERSION))
         .setTableCreateSchema(schemaStr)
         .fromProperties(props)


### PR DESCRIPTION
### Change Logs

By design, the merge mode configs should not change in the table configs after table creation.  So we add this strict check and throw an error.

### Impact

Merge mode and payload configs now unable to change after table creation.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
