### PR TITLE
[HUDI-9068] Fix cloudwatch metrics

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
@@ -279,7 +279,6 @@ public class CloudWatchReporter extends ScheduledReporter {
             "metricName doesn't follow the naming convention and doesn't contain a dot as splitter! metricName:" + metricName);
     String tableName = metricNameParts[0];
 
-
     metricData.add(MetricDatum.builder()
         .timestamp(Instant.ofEpochMilli(timestampMilliSec))
         .metricName(prefix(metricNameParts[1]))

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
@@ -20,6 +20,7 @@ package org.apache.hudi.aws.cloudwatch;
 
 import org.apache.hudi.aws.credentials.HoodieAWSCredentialsProviderFactory;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Counter;
@@ -274,6 +275,8 @@ public class CloudWatchReporter extends ScheduledReporter {
                                 long timestampMilliSec,
                                 List<MetricDatum> metricData) {
     String[] metricNameParts = metricName.split("\\.", 2);
+    ValidationUtils.checkArgument(metricNameParts.length >= 2,
+            "metricName doesn't follow the naming convention and doesn't contain a dot as splitter! metricName:" + metricName);
     String tableName = metricNameParts[0];
 
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1510,10 +1510,10 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       String tableName = writeClient.getConfig().getTableName();
       boolean tableNameExists = StringUtils.nonEmpty(tableName);
       String executionDurationMetricName = tableNameExists
-              ? String.format("%s.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)
+              ? String.format("%s_mdt.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)
               : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION;
       String executionStatusMetricName = tableNameExists
-              ? String.format("%s.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)
+              ? String.format("%s_mdt.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)
               : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS;
       long timeSpent = metadataTableServicesTimer.endTimer();
       metrics.ifPresent(m -> m.setMetric(executionDurationMetricName, timeSpent));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1507,12 +1507,20 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       allTableServicesExecutedSuccessfullyOrSkipped = false;
       throw e;
     } finally {
+      String tableName = writeClient.getConfig().getTableName();
+      boolean tableNameExists = StringUtils.nonEmpty(tableName);
+      String executionDurationMetricName = tableNameExists
+              ? String.format("%s.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)
+              : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION;
+      String executionStatusMetricName = tableNameExists
+              ? String.format("%s.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)
+              : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS;
       long timeSpent = metadataTableServicesTimer.endTimer();
-      metrics.ifPresent(m -> m.setMetric(HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION, timeSpent));
+      metrics.ifPresent(m -> m.setMetric(executionDurationMetricName, timeSpent));
       if (allTableServicesExecutedSuccessfullyOrSkipped) {
-        metrics.ifPresent(m -> m.setMetric(HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS, 1));
+        metrics.ifPresent(m -> m.setMetric(executionStatusMetricName, 1));
       } else {
-        metrics.ifPresent(m -> m.setMetric(HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS, -1));
+        metrics.ifPresent(m -> m.setMetric(executionStatusMetricName, -1));
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1507,13 +1507,13 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       allTableServicesExecutedSuccessfullyOrSkipped = false;
       throw e;
     } finally {
-      String tableName = writeClient.getConfig().getTableName();
-      boolean tableNameExists = StringUtils.nonEmpty(tableName);
+      String metadataTableName = writeClient.getConfig().getTableName();
+      boolean tableNameExists = StringUtils.nonEmpty(metadataTableName);
       String executionDurationMetricName = tableNameExists
-              ? String.format("%s_mdt.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)
+              ? String.format("%s.%s", metadataTableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)
               : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION;
       String executionStatusMetricName = tableNameExists
-              ? String.format("%s_mdt.%s", tableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)
+              ? String.format("%s.%s", metadataTableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)
               : HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS;
       long timeSpent = metadataTableServicesTimer.endTimer();
       metrics.ifPresent(m -> m.setMetric(executionDurationMetricName, timeSpent));

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -2418,6 +2418,10 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       assertTrue(metrics.getRegistry().getGauges().containsKey(prefix + HoodieMetadataMetrics.STAT_COUNT_LOG_FILES));
       assertTrue(metrics.getRegistry().getGauges().containsKey(prefix + HoodieMetadataMetrics.STAT_TOTAL_BASE_FILE_SIZE));
       assertTrue(metrics.getRegistry().getGauges().containsKey(prefix + HoodieMetadataMetrics.STAT_TOTAL_LOG_FILE_SIZE));
+
+      String metadataTableName = String.format("%s_metadata", writeConfig.getTableName());
+      assertTrue(metrics.getRegistry().getMetrics().containsKey(String.format("%s.%s", metadataTableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_DURATION)));
+      assertTrue(metrics.getRegistry().getMetrics().containsKey(String.format("%s.%s", metadataTableName, HoodieMetadataMetrics.TABLE_SERVICE_EXECUTION_STATUS)));
     }
   }
 


### PR DESCRIPTION
### Change Logs

Cloudwatch metrics broken because of new metrics name that doesn't contain table name. This PR is to change the metric name to be under a table name space. 

### Impact

Changed the metric name to contain table name

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
