### PR TITLE
[HUDI-9067] Fixing num spark tasks for clean action

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -148,6 +148,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
                 .map(e -> new Tuple2<>(e.getKey(), e.getValue())).iterator()
         )
         .reduceByKey(reduceFunc::apply)
+        .coalesce(parallelism)
         .map(e -> new ImmutablePair<>(e._1, e._2))
         .collect().stream();
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -144,7 +144,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
       SerializableBiFunction<V, V, V> reduceFunc, int parallelism) {
     return javaSparkContext.parallelize(data.collect(Collectors.toList()), parallelism)
         .mapPartitionsToPair((PairFlatMapFunction<Iterator<I>, K, V>) iterator ->
-            flatMapToPairFunc.call(iterator).collect(Collectors.toList()).stream()
+            flatMapToPairFunc.call(iterator)
                 .map(e -> new Tuple2<>(e.getKey(), e.getValue())).iterator()
         )
         .reduceByKey(reduceFunc::apply, parallelism)

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -147,8 +147,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
             flatMapToPairFunc.call(iterator).collect(Collectors.toList()).stream()
                 .map(e -> new Tuple2<>(e.getKey(), e.getValue())).iterator()
         )
-        .reduceByKey(reduceFunc::apply)
-        .coalesce(parallelism)
+        .reduceByKey(reduceFunc::apply, parallelism)
         .map(e -> new ImmutablePair<>(e._1, e._2))
         .collect().stream();
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
@@ -19,13 +19,24 @@
 
 package org.apache.hudi.client.common;
 
+import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodieData.HoodieDataCacheKey;
+import org.apache.hudi.common.function.SerializableBiFunction;
+import org.apache.hudi.common.function.SerializablePairFlatMapFunction;
+import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,5 +77,50 @@ class TestHoodieSparkEngineContext extends SparkClientFunctionalTestHarness {
     assertEquals(expectedJobDescription, context.getJavaSparkContext().getLocalProperty("spark.job.description"));
     // Assert jobGroupId does not change
     assertEquals(jobGroupId, context.getJavaSparkContext().getLocalProperty("spark.jobGroup.id"));
+  }
+
+  @Test
+  void testMapPartitionsToPairAndReduceByKey() {
+    int numPartitions = 6;
+    HoodieData<Integer> rddData = context.parallelize(
+        IntStream.rangeClosed(0, 99).boxed().collect(Collectors.toList()), numPartitions);
+
+    //
+    /* output from map to pair.
+    1 = 0, 1
+    2 = 1, 5
+    3 = 1, 5
+    4 = 2, 10
+    5 = 2, 10
+    6 = 3, 15
+    7 = 3, 15
+    8 = 4, 20
+
+    And then we do reduce by key, where we sum up the values.
+    */
+    Stream<ImmutablePair<Integer, Integer>> result = context.mapPartitionsToPairAndReduceByKey(rddData.collectAsList().stream(),
+        new SerializablePairFlatMapTestFunc(), new SerializableReduceTestFunc(), 6);
+    result.forEach(entry -> {
+      assertEquals(entry.getKey() * 10, entry.getValue());
+    });
+  }
+
+  static class SerializablePairFlatMapTestFunc implements SerializablePairFlatMapFunction<Iterator<java.lang.Integer>, java.lang.Integer, java.lang.Integer> {
+    @Override
+    public Stream<Pair<Integer, Integer>> call(Iterator<Integer> t) throws Exception {
+      List<Pair<Integer, Integer>> toReturn = new ArrayList<>();
+      while (t.hasNext()) {
+        Integer next = t.next();
+        toReturn.add(Pair.of(next / 2, next / 2 * 5));
+      }
+      return toReturn.stream();
+    }
+  }
+
+  static class SerializableReduceTestFunc implements SerializableBiFunction<Integer, Integer, Integer> {
+    @Override
+    public Integer apply(Integer integer, Integer integer2) {
+      return integer + integer2;
+    }
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
@@ -98,8 +98,9 @@ class TestHoodieSparkEngineContext extends SparkClientFunctionalTestHarness {
 
     And then we do reduce by key, where we sum up the values.
     */
-    Stream<ImmutablePair<Integer, Integer>> result = context.mapPartitionsToPairAndReduceByKey(rddData.collectAsList().stream(),
-        new SerializablePairFlatMapTestFunc(), new SerializableReduceTestFunc(), 6);
+    List<ImmutablePair<Integer, Integer>> result = context.mapPartitionsToPairAndReduceByKey(rddData.collectAsList().stream(),
+        new SerializablePairFlatMapTestFunc(), new SerializableReduceTestFunc(), 6).collect(Collectors.toList());
+    assertEquals(50, result.size());
     result.forEach(entry -> {
       assertEquals(entry.getKey() * 10, entry.getValue());
     });


### PR DESCRIPTION
### Change Logs

- Fixing num spark tasks for clean action. 

Validated the fix using simple quick start. 
```

import scala.collection.JavaConversions._
import org.apache.spark.sql.SaveMode._
import org.apache.hudi.DataSourceReadOptions._
import org.apache.hudi.DataSourceWriteOptions._
import org.apache.hudi.common.table.HoodieTableConfig._
import org.apache.hudi.config.HoodieWriteConfig._
import org.apache.hudi.keygen.constant.KeyGeneratorOptions._
import org.apache.hudi.common.model.HoodieRecord
import spark.implicits._

val tableName = "trips_table1"
val basePath = "file:///tmp/trips_table1"

val columns = Seq("ts","uuid","rider","driver","fare","city")
val data =
  Seq((1695159649087L,"334e26e9-8355-45cc-97c6-c31daf0df330","rider-A","driver-K",19.10,"san_francisco"),
    (1695091554788L,"e96c4396-3fad-413a-a942-4cb36106d721","rider-C","driver-M",27.70 ,"san_francisco"),
    (1695046462179L,"9909a8b1-2d15-4d3d-8ec9-efc48c536a00","rider-D","driver-L",33.90 ,"san_francisco"),
    (1695516137016L,"e3cf430c-889d-4015-bc98-59bdce1e530c","rider-F","driver-P",34.15,"sao_paulo"    ),
    (1695115999911L,"c8abbe79-8d89-47ea-b4ce-4d224bae5bfa","rider-J","driver-T",17.85,"chennai"));

var inserts = spark.createDataFrame(data).toDF(columns:_*)

inserts.write.format("hudi").
  option("hoodie.datasource.write.partitionpath.field", "city").
  option("hoodie.datasource.write.recordkey.field","uuid").
  option("hoodie.table.name", tableName).
  option("hoodie.datasource.write.operation","INSERT").
  mode(Overwrite).
  save(basePath)

val df1 = inserts.limit(1)

for (i <- 1 to 10) {
      df1.write.format("hudi").
        option("hoodie.datasource.write.partitionpath.field", "city").
        option("hoodie.datasource.write.recordkey.field","uuid").
        option("hoodie.datasource.write.operation", "INSERT").
        mode(Append).
        save(basePath)
    }
```

Launch command used: 
```
./bin/spark-shell --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' --conf 'spark.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension' --jars PATH/hudi-spark3.5-bundle_2.12-1.1.0-SNAPSHOT.jar --conf "spark.sql.shuffle.partitions=100" --conf "spark.default.parallelism=100"
```

Note the value we have set for "spark.sql.shuffle.partitions" and "spark.default.parallelism" is 100. 

Validated from spark UI 

Before fix: 
<img width="1770" alt="image" src="https://github.com/user-attachments/assets/e532460b-c8b5-4453-b2bd-60767db11444" />


After fix: 
<img width="1774" alt="image" src="https://github.com/user-attachments/assets/dbbb8657-12fc-487b-842e-93bbbd4aa35a" />
 

### Impact

Avoids Unnecessary spark tasks during clean

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
