### PR TITLE
[HUDI-9070] Fix Hudi cli bundle script to use HUDI_CONF_DIR environment variable

### DIFF
--- a/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+++ b/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
@@ -33,7 +33,13 @@ fi
 echo "CLI_BUNDLE_JAR: $CLI_BUNDLE_JAR"
 echo "SPARK_BUNDLE_JAR: $SPARK_BUNDLE_JAR"
 
-HUDI_CONF_DIR="${DIR}"/conf
+if [ -z "$HUDI_CONF_DIR" ]; then
+  echo "HUDI_CONF_DIR not set, setting HUDI_CONF_DIR"
+  HUDI_CONF_DIR="${DIR}"/conf
+fi
+
+echo "HUDI_CONF_DIR: $HUDI_CONF_DIR"
+
 # hudi aux lib contains jakarta.el jars, which need to be put directly on class path
 HUDI_AUX_LIB="${DIR}"/auxlib
 


### PR DESCRIPTION
### Change Logs

The Hudi CLI bundle script currently overwrites the user-defined `HUDI_CONF_DIR` environment variable with a hardcoded path. This causes hudi configuration file loading failures when users attempt to use their own custom configuration directory. The issue remained undetected because when `HUDI_CONF_DIR` is not set by users, the script works as expected, the conflict only surfaces when users explicitly set `HUDI_CONF_DIR` environment variable.

https://github.com/apache/hudi/issues/11909

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
