### PR TITLE
[HUDI-9071] MDT validator can configure if log truncation applies

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -383,6 +383,10 @@ public class StringUtils {
     if (objectList == null || objectList.isEmpty()) {
       return "";
     }
+    // For non-positive value, we will not do any truncation.
+    if (lengthThreshold <= 0) {
+      return objectList.toString();
+    }
     StringBuilder sb = new StringBuilder();
 
     for (Object obj : objectList) {

--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -233,6 +233,8 @@ public class TestStringUtils {
         toStringWithThreshold(Collections.singletonList(str1), 2));
     assertEquals("string_...",
         toStringWithThreshold(Collections.singletonList(str1), str1.length() - 3));
+    assertEquals("[string_value1]",
+        toStringWithThreshold(Collections.singletonList(str1), 0));
     assertEquals(str1,
         toStringWithThreshold(Collections.singletonList(str1), str1.length()));
     assertEquals(str1,
@@ -253,6 +255,8 @@ public class TestStringUtils {
         toStringWithThreshold(stringList, str1.length() + str2.length() + str3.length() - 3));
     assertEquals("string_value1,string_value2,string_value3",
         toStringWithThreshold(stringList, str1.length() + str2.length() + str3.length() + 2));
+    assertEquals("[string_value1, string_value2, string_value3]",
+        toStringWithThreshold(stringList, - 1));
   }
 
   @Test


### PR DESCRIPTION
bump up unit test coverage

### Change Logs

MDT validator should be configurable on if log truncation is required. Otherwise, we might stuck in a situation where we could not get the full list of mismatches at all.

Now to avoid truncation, just give a none positive value to --log-detail-max-length option. By default it uses value 1e5.

### Impact

Better operation experience when using this utility.

### Risk level (write none, low medium or high below)

none
### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
