### PR TITLE
[HUDI-8868] Close cachedAllInputFileSlices in BaseHoodieTableFileIndex

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -203,6 +203,9 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
+    if (cachedAllInputFileSlices instanceof ExternalSpillableMap) {
+      ((ExternalSpillableMap<PartitionPath, List<FileSlice>>) cachedAllInputFileSlices).close();
+    }
     resetTableMetadata(null);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -97,6 +97,7 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR
 import static org.apache.hudi.common.testutils.HoodieTestUtils.RAW_TRIPS_TEST_NAME;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -647,6 +648,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
         Assertions.assertEquals(fileSlicesCachedInMemory, cachedAllInputFileSlices.size());
         Assertions.assertTrue(ObjectSizeCalculator.getObjectSize(cachedAllInputFileSlices) > spillableMemoryBytes);
       }
+      assertDoesNotThrow(hoodieTableFileIndex::close);
       dataset.unpersist();
     });
   }


### PR DESCRIPTION
### Change Logs

cachedAllInputFileSlices is not being closed for fileIndex, this can cause disk usage to not get cleared over time.

### Impact

Clears up disk usage used by ExternalSpillableMap. 

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
