### PR TITLE
[HUDI-9141] Handle the case that dbName is empty in HoodieFileIndex

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -538,10 +538,16 @@ object HoodieFileIndex extends Logging {
       properties.setProperty(PARTITIONPATH_FIELD.key, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(tableConfig).orElse(""))
 
       // for simple bucket index, we need to set the INDEX_TYPE, BUCKET_INDEX_HASH_FIELD, BUCKET_INDEX_NUM_BUCKETS
-      val dataBase = Some(tableConfig.getDatabaseName)
+      val database = Some(tableConfig.getDatabaseName)
+      val databaseName = if (database.isDefined && database.get.nonEmpty) {
+        database.get
+      } else {
+        "default"
+      }
       val tableName = tableConfig.getTableName
-      if (spark.catalog.tableExists(dataBase.getOrElse("default"), tableName)) {
-        val tableIdentifier = TableIdentifier(tableName, dataBase)
+
+      if (spark.catalog.tableExists(databaseName, tableName)) {
+        val tableIdentifier = TableIdentifier(tableName, Some(databaseName))
         val table = HoodieCatalogTable(spark, tableIdentifier)
         table.catalogProperties.foreach(kv => properties.setProperty(kv._1, kv._2))
       }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -60,7 +60,9 @@ import scala.collection.mutable
  */
 class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) extends Logging {
 
-  checkArgument(table.provider.map(_.toLowerCase(Locale.ROOT)).orNull == "hudi", s" ${table.qualifiedName} is not a Hudi table")
+  checkArgument(table.provider.map(_.toLowerCase(Locale.ROOT)).orNull == "hudi"
+    || table.provider.map(_.toLowerCase(Locale.ROOT)).orNull == "org.apache.hudi",
+    s" ${table.qualifiedName} is not a Hudi table")
 
   private val storageConf = HadoopFSUtils.getStorageConfWithCopy(spark.sessionState.newHadoopConf)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.HoodieFileIndex

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
@@ -1,0 +1,14 @@
+package org.apache.spark.sql.hudi
+
+import org.apache.hudi.HoodieFileIndex
+import org.apache.hudi.common.table.HoodieTableConfig
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TestHoodieFileIndex {
+  @Test
+  def testDefaultDatabaseName(): Unit = {
+    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig()), "default")
+  }
+}


### PR DESCRIPTION
### Change Logs

Database name can be null or empty, but in either case they should use the default value `default`. Handle this corner case in `HoodieFileIndex`

Issue this can cause:
```
Caused by: org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: Unable to fetch table basic_hudi_test_cow_glue_enabled_d7f80d5c_37ef_4c0a_a2bf_f2777b080a93. dbName cannot be null or empty
	at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:131)
	at org.apache.spark.sql.hive.HiveExternalCatalog.tableExists(HiveExternalCatalog.scala:917)
	at org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener.tableExists(ExternalCatalogWithListener.scala:146)
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.tableExists(SessionCatalog.scala:524)
	at org.apache.spark.sql.internal.CatalogImpl.tableExists(CatalogImpl.scala:536)
	at org.apache.hudi.HoodieFileIndex$.getConfigProperties(HoodieFileIndex.scala:542)
	at org.apache.hudi.HoodieFileIndex.<init>(HoodieFileIndex.scala:97)
	at org.apache.hudi.HoodieMergeOnReadSnapshotHadoopFsRelationFactory.<init>(HoodieHadoopFsRelationFactory.scala:267)
	at org.apache.hudi.HoodieCopyOnWriteSnapshotHadoopFsRelationFactory.<init>(HoodieHadoopFsRelationFactory.scala:355)
	at org.apache.hudi.DefaultSource$.createRelation(DefaultSource.scala:346)
	at org.apache.hudi.DefaultSource.createRelation(DefaultSource.scala:158)
	at org.apache.spark.sql.execution.datasources.DataSource.$anonfun$resolveRelation$6(DataSource.scala:366)
	at org.apache.spark.util.FileAccessContext$.withContext(FileAccessContext.scala:41)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:363)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:345)
	at org.apache.spark.sql.execution.datasources.FindDataSourceTable$$anon$1.call(DataSourceStrategy.scala:268)
	at org.apache.spark.sql.execution.datasources.FindDataSourceTable$$anon$1.call(DataSourceStrategy.scala:255)
	at org.sparkproject.guava.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4792)
	at org.sparkproject.guava.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3599)
	at org.sparkproject.guava.cache.LocalCache$Segment.loadSync(LocalCache.java:2379)
	... 146 more
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Unable to fetch table basic_hudi_test_cow_glue_enabled_d7f80d5c_37ef_4c0a_a2bf_f2777b080a93. dbName cannot be null or empty
	at org.apache.hadoop.hive.ql.metadata.Hive.getTable(Hive.java:1307)
	at org.apache.spark.sql.hive.client.Shim_v0_12.getTable(HiveShim.scala:628)
	at org.apache.spark.sql.hive.client.HiveClientImpl.getRawTableOption(HiveClientImpl.scala:414)
	at org.apache.spark.sql.hive.client.HiveClientImpl.$anonfun$tableExists$1(HiveClientImpl.scala:429)
	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
	at org.apache.spark.sql.hive.client.HiveClientImpl.$anonfun$withHiveState$1(HiveClientImpl.scala:303)
	at org.apache.spark.sql.hive.client.HiveClientImpl.liftedTree1$1(HiveClientImpl.scala:234)
	at org.apache.spark.sql.hive.client.HiveClientImpl.retryLocked(HiveClientImpl.scala:233)
	at org.apache.spark.sql.hive.client.HiveClientImpl.withHiveState(HiveClientImpl.scala:283)
	at org.apache.spark.sql.hive.client.HiveClientImpl.tableExists(HiveClientImpl.scala:429)
	at org.apache.spark.sql.hive.HiveExternalCatalog.$anonfun$tableExists$1(HiveExternalCatalog.scala:917)
	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
	at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:102)
	... 165 more
Caused by: java.lang.IllegalArgumentException: dbName cannot be null or empty
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:92)
	at com.amazonaws.glue.catalog.metastore.GlueMetastoreClientDelegate.getTable(GlueMetastoreClientDelegate.java:556)
	at com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient.getTable(AWSCatalogMetastoreClient.java:1104)
	at org.apache.hadoop.hive.ql.metadata.Hive.getTable(Hive.java:1299)
	... 177 more
```


### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
