### PR TITLE
[HUDI-9086] fix test TestHoodieDataSourceHelper

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieDataSourceHelper.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieDataSourceHelper.scala
@@ -18,21 +18,21 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.testutils.HoodieSparkClientTestHarness
+import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.sources.Filter
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
-class TestHoodieDataSourceHelper extends HoodieSparkClientTestHarness with SparkAdapterSupport {
+class TestHoodieDataSourceHelper {
 
   def checkCondition(filter: Option[Filter], outputSet: Set[String], expected: Any): Unit = {
     val actual = HoodieDataSourceHelper.extractPredicatesWithinOutputSet(filter.get, outputSet)
     assertEquals(expected, actual)
   }
 
-  @Disabled("HUDI-9086")
+  @Test
   def testExtractPredicatesWithinOutputSet() : Unit = {
     val dataColsWithNoPartitionCols = Set("id", "extra_col")
 
@@ -52,5 +52,4 @@ class TestHoodieDataSourceHelper extends HoodieSparkClientTestHarness with Spark
     val expectedExpr4 = sparkAdapter.translateFilter(expr("not(id=1)").expr)
     checkCondition(expr4, dataColsWithNoPartitionCols, expectedExpr4)
   }
-
 }


### PR DESCRIPTION
### Change Logs

The error happens during initializing `SessionStateBuilder`; since the test does not need it. 
Remove SparkSession related logic.

### Impact

Stabilize a test.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
