### PR TITLE
[HUDI-9092] Deprecate byte array of serialization of instants

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
@@ -27,6 +27,7 @@ import org.apache.hudi.cli.testutils.HoodieTestCommitMetadataGenerator;
 import org.apache.hudi.client.timeline.HoodieTimelineArchiver;
 import org.apache.hudi.client.timeline.versioning.v2.TimelineArchiverV2;
 import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -35,7 +36,6 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.CompactionTestUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -157,7 +157,7 @@ public class TestCompactionCommand extends CLIFunctionalTestHarness {
     // Create six commits
     Arrays.asList("001", "003", "005", "007").forEach(timestamp -> {
       activeTimeline.transitionCompactionInflightToComplete(true,
-          INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, COMPACTION_ACTION, timestamp), Option.empty());
+          INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, COMPACTION_ACTION, timestamp), new HoodieCommitMetadata());
     });
     // Simulate a compaction commit in metadata table timeline
     // so the archival in data table can happen

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitMetadataGenerator.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitMetadataGenerator.java
@@ -40,10 +40,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.testutils.FileCreateUtilsLegacy.baseFileName;
 import static org.apache.hudi.common.util.CollectionUtils.createImmutableList;
 
 /**
@@ -95,7 +94,7 @@ public class HoodieTestCommitMetadataGenerator extends HoodieTestDataGenerator {
     for (String name : commitFileNames) {
       HoodieCommitMetadata commitMetadata =
               generateCommitMetadata(basePath, commitTime, fileId1, fileId2, writes, updates, extraMetadata, true);
-      createFileWithMetadata(basePath, configuration, name, serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
+      createFileWithMetadata(basePath, configuration, name, commitMetadata);
     }
   }
 
@@ -110,14 +109,14 @@ public class HoodieTestCommitMetadataGenerator extends HoodieTestDataGenerator {
     for (String name : commitFileNames) {
       HoodieCommitMetadata commitMetadata =
           generateCommitMetadata(basePath, commitTime, fileId1, fileId2, writes, updates, extraMetadata, setDefaultFileId);
-      createFileWithMetadata(basePath, configuration, name, serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
+      createFileWithMetadata(basePath, configuration, name, commitMetadata);
     }
   }
 
-  static void createFileWithMetadata(String basePath, StorageConfiguration<?> configuration, String name, byte[] content) throws IOException {
+  static <T> void createFileWithMetadata(String basePath, StorageConfiguration<?> configuration, String name, T metadata) throws IOException {
     Path commitFilePath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + name);
     try (OutputStream os = HadoopFSUtils.getFs(basePath, configuration).create(commitFilePath, true)) {
-      os.write(content);
+      COMMIT_METADATA_SER_DE.getInstantWriter(metadata).get().writeToStream(os);
     }
   }
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitUtilities.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitUtilities.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadata;
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToAvro;
 
 /**
  * Utility methods to commit instant for test.
@@ -36,7 +36,7 @@ public class HoodieTestCommitUtilities {
    * Converter HoodieCommitMetadata to avro format and ordered by partition.
    */
   public static org.apache.hudi.avro.model.HoodieCommitMetadata convertAndOrderCommitMetadata(HoodieCommitMetadata hoodieCommitMetadata) {
-    return orderCommitMetadata(convertCommitMetadata(hoodieCommitMetadata));
+    return orderCommitMetadata(convertCommitMetadataToAvro(hoodieCommitMetadata));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -94,7 +94,6 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.metadata.HoodieTableMetadata.isMetadataTable;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.isIndexingCommit;
 
@@ -550,8 +549,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       LOG.info("Committing Clustering {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
       LOG.debug("Clustering {} finished with result {}", clusteringCommitTime, metadata);
 
-      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant,
-          serializeCommitMetadata(table.getMetaClient().getCommitMetadataSerDe(), metadata), table.getActiveTimeline());
+      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, Option.of(metadata), table.getActiveTimeline());
     } catch (Exception e) {
       throw new HoodieClusteringException("unable to transition clustering inflight to complete: " + clusteringCommitTime, e);
     } finally {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -549,7 +549,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       LOG.info("Committing Clustering {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
       LOG.debug("Clustering {} finished with result {}", clusteringCommitTime, metadata);
 
-      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, Option.of(metadata), table.getActiveTimeline());
+      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, metadata, table.getActiveTimeline());
     } catch (Exception e) {
       throw new HoodieClusteringException("unable to transition clustering inflight to complete: " + clusteringCommitTime, e);
     } finally {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -164,7 +164,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       }
       // Overwrite compaction plan with updated info
       metaClient.getActiveTimeline().saveToCompactionRequested(
-          metaClient.createNewInstant(State.REQUESTED, COMPACTION_ACTION, compactionOperationWithInstant.getLeft()), Option.of(newPlan), true);
+          metaClient.createNewInstant(State.REQUESTED, COMPACTION_ACTION, compactionOperationWithInstant.getLeft()), newPlan, true);
     }
     return new ArrayList<>();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
@@ -165,8 +164,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       }
       // Overwrite compaction plan with updated info
       metaClient.getActiveTimeline().saveToCompactionRequested(
-          metaClient.createNewInstant(State.REQUESTED, COMPACTION_ACTION, compactionOperationWithInstant.getLeft()),
-          TimelineMetadataUtils.serializeCompactionPlan(newPlan), true);
+          metaClient.createNewInstant(State.REQUESTED, COMPACTION_ACTION, compactionOperationWithInstant.getLeft()), Option.of(newPlan), true);
     }
     return new ArrayList<>();
   }
@@ -194,7 +192,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
   private static HoodieCompactionPlan getCompactionPlan(HoodieTableMetaClient metaClient, String compactionInstant)
       throws IOException {
     return metaClient.getActiveTimeline().readCompactionPlan(
-                    metaClient.getInstantGenerator().getCompactionRequestedInstant(compactionInstant));
+        metaClient.getInstantGenerator().getCompactionRequestedInstant(compactionInstant));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -57,7 +57,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToByteArray;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -111,7 +111,7 @@ public class LegacyArchivedMetaEntryReader {
                 () -> instantBytes.length == 0,
                 org.apache.hudi.common.model.HoodieCommitMetadata.class);
             // convert to avro bytes.
-            return convertMetadataToBytArray(commitMetadata, metaClient.getCommitMetadataSerDe());
+            return convertMetadataToByteArray(commitMetadata, metaClient.getCommitMetadataSerDe());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -110,7 +111,7 @@ public class LegacyArchivedMetaEntryReader {
                 () -> instantBytes.length == 0,
                 org.apache.hudi.common.model.HoodieCommitMetadata.class);
             // convert to avro bytes.
-            return metaClient.getCommitMetadataSerDe().serialize(commitMetadata).get();
+            return convertMetadataToBytArray(commitMetadata, metaClient.getCommitMetadataSerDe());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
@@ -53,7 +52,6 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.HASHING_METADATA_COMMIT_FILE_SUFFIX;
 import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.HASHING_METADATA_FILE_SUFFIX;
 import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.getTimestampFromFile;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
  * Utilities class for consistent bucket index metadata management.
@@ -236,7 +234,7 @@ public class ConsistentBucketIndexUtils {
     //prevent exception from race condition. We are ok with the file being created in another thread, so we should
     // check for the marker after catching the exception and we don't need to fail if the file exists
     try {
-      FileIOUtils.createFileInPath(storage, fullPath, Option.of(getUTF8Bytes(StringUtils.EMPTY_STRING)));
+      FileIOUtils.createFileInPath(storage, fullPath, Option.empty());
     } catch (HoodieIOException e) {
       if (!storage.exists(fullPath)) {
         throw e;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.CleanFileInfo;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
@@ -210,8 +209,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     try {
       final HoodieTimer timer = HoodieTimer.start();
       if (cleanInstant.isRequested()) {
-        inflightInstant = table.getActiveTimeline().transitionCleanRequestedToInflight(cleanInstant,
-            TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+        inflightInstant = table.getActiveTimeline().transitionCleanRequestedToInflight(cleanInstant, Option.of(cleanerPlan));
       } else {
         inflightInstant = cleanInstant;
       }
@@ -232,12 +230,9 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         this.txnManager.beginTransaction(Option.of(inflightInstant), Option.empty());
       }
       writeTableMetadata(metadata, inflightInstant.requestedTime());
-      table.getActiveTimeline().transitionCleanInflightToComplete(false,
-          inflightInstant, TimelineMetadataUtils.serializeCleanMetadata(metadata));
+      table.getActiveTimeline().transitionCleanInflightToComplete(false, inflightInstant, Option.of(metadata));
       LOG.info("Marked clean started on " + inflightInstant.requestedTime() + " as complete");
       return metadata;
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to clean up after commit", e);
     } finally {
       if (!skipLocking) {
         this.txnManager.endTransaction(Option.ofNullable(inflightInstant));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.Option;
@@ -211,11 +210,11 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
       final HoodieInstant cleanInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
       // Save to both aux and timeline folder
       try {
-        table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+        table.getActiveTimeline().saveToCleanRequested(cleanInstant, Option.of(cleanerPlan));
         LOG.info("Requesting Cleaning with instant time " + cleanInstant);
-      } catch (IOException e) {
+      } catch (HoodieIOException e) {
         LOG.error("Got exception when saving cleaner requested file", e);
-        throw new HoodieIOException(e.getMessage(), e);
+        throw e;
       }
       option = Option.of(cleanerPlan);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -25,12 +25,10 @@ import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.BaseTableServicePlanActionExecutor;
 import org.apache.hudi.table.action.cluster.strategy.ClusteringPlanStrategy;
@@ -39,7 +37,6 @@ import org.apache.hudi.util.Lazy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -100,17 +97,12 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseTableServicePl
       String action =  TimelineLayoutVersion.LAYOUT_VERSION_2.equals(table.getMetaClient().getTimelineLayoutVersion()) ? HoodieTimeline.CLUSTERING_ACTION : HoodieTimeline.REPLACE_COMMIT_ACTION;
       HoodieInstant clusteringInstant =
           instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, action, instantTime);
-      try {
-        HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
-            .setOperationType(WriteOperationType.CLUSTER.name())
-            .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
-            .setClusteringPlan(planOption.get())
-            .build();
-        table.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant,
-            TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
-      } catch (IOException ioe) {
-        throw new HoodieIOException("Exception scheduling clustering", ioe);
-      }
+      HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
+          .setOperationType(WriteOperationType.CLUSTER.name())
+          .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
+          .setClusteringPlan(planOption.get())
+          .build();
+      table.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
     }
 
     return planOption;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ClusteringPlanActionExecutor.java
@@ -102,7 +102,7 @@ public class ClusteringPlanActionExecutor<T, I, K, O> extends BaseTableServicePl
           .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
           .setClusteringPlan(planOption.get())
           .build();
-      table.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
+      table.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
     }
 
     return planOption;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
@@ -83,7 +83,7 @@ public class CompactHelpers<T, I, K, O> {
       InstantGenerator instantGenerator = table.getInstantGenerator();
       // Callers should already guarantee the lock.
       activeTimeline.transitionCompactionInflightToComplete(false,
-          instantGenerator.getCompactionInflightInstant(compactionCommitTime), Option.of(commitMetadata));
+          instantGenerator.getCompactionInflightInstant(compactionCommitTime), commitMetadata);
     } catch (HoodieIOException e) {
       throw new HoodieCompactionException(
           "Failed to commit " + table.getMetaClient().getBasePath() + " at time " + compactionCommitTime, e);
@@ -96,8 +96,7 @@ public class CompactHelpers<T, I, K, O> {
       // Callers should already guarantee the lock.
       InstantGenerator instantGenerator = table.getInstantGenerator();
       activeTimeline.transitionLogCompactionInflightToComplete(false,
-          instantGenerator.getLogCompactionInflightInstant(logCompactionCommitTime),
-          Option.of(commitMetadata));
+          instantGenerator.getLogCompactionInflightInstant(logCompactionCommitTime), commitMetadata);
     } catch (HoodieIOException e) {
       throw new HoodieCompactionException(
           "Failed to commit " + table.getMetaClient().getBasePath() + " at time " + logCompactionCommitTime, e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieCompactionException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.table.HoodieTable;
@@ -37,8 +38,6 @@ import org.apache.hudi.table.HoodieTable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 
 /**
  * Base class helps to perform compact.
@@ -84,9 +83,8 @@ public class CompactHelpers<T, I, K, O> {
       InstantGenerator instantGenerator = table.getInstantGenerator();
       // Callers should already guarantee the lock.
       activeTimeline.transitionCompactionInflightToComplete(false,
-          instantGenerator.getCompactionInflightInstant(compactionCommitTime),
-          serializeCommitMetadata(table.getMetaClient().getCommitMetadataSerDe(), commitMetadata));
-    } catch (IOException e) {
+          instantGenerator.getCompactionInflightInstant(compactionCommitTime), Option.of(commitMetadata));
+    } catch (HoodieIOException e) {
       throw new HoodieCompactionException(
           "Failed to commit " + table.getMetaClient().getBasePath() + " at time " + compactionCommitTime, e);
     }
@@ -99,8 +97,8 @@ public class CompactHelpers<T, I, K, O> {
       InstantGenerator instantGenerator = table.getInstantGenerator();
       activeTimeline.transitionLogCompactionInflightToComplete(false,
           instantGenerator.getLogCompactionInflightInstant(logCompactionCommitTime),
-          serializeCommitMetadata(table.getMetaClient().getCommitMetadataSerDe(), commitMetadata));
-    } catch (IOException e) {
+          Option.of(commitMetadata));
+    } catch (HoodieIOException e) {
       throw new HoodieCompactionException(
           "Failed to commit " + table.getMetaClient().getBasePath() + " at time " + logCompactionCommitTime, e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.ConfigUtils;
@@ -37,7 +36,6 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieCompactionException;
-import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.BaseTableServicePlanActionExecutor;
 import org.apache.hudi.table.action.compact.plan.generators.BaseHoodieCompactionPlanGenerator;
@@ -121,20 +119,14 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseTableServi
     Option<HoodieCompactionPlan> option = Option.empty();
     if (plan != null && nonEmpty(plan.getOperations())) {
       extraMetadata.ifPresent(plan::setExtraMetadata);
-      try {
-        if (operationType.equals(WriteOperationType.COMPACT)) {
-          HoodieInstant compactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
-              HoodieTimeline.COMPACTION_ACTION, instantTime);
-          table.getActiveTimeline().saveToCompactionRequested(compactionInstant,
-              TimelineMetadataUtils.serializeCompactionPlan(plan));
-        } else {
-          HoodieInstant logCompactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
-              HoodieTimeline.LOG_COMPACTION_ACTION, instantTime);
-          table.getActiveTimeline().saveToLogCompactionRequested(logCompactionInstant,
-              TimelineMetadataUtils.serializeCompactionPlan(plan));
-        }
-      } catch (IOException ioe) {
-        throw new HoodieIOException("Exception scheduling compaction", ioe);
+      if (operationType.equals(WriteOperationType.COMPACT)) {
+        HoodieInstant compactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
+            HoodieTimeline.COMPACTION_ACTION, instantTime);
+        table.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(plan));
+      } else {
+        HoodieInstant logCompactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
+            HoodieTimeline.LOG_COMPACTION_ACTION, instantTime);
+        table.getActiveTimeline().saveToLogCompactionRequested(logCompactionInstant, Option.of(plan));
       }
       option = Option.of(plan);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -122,11 +122,11 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseTableServi
       if (operationType.equals(WriteOperationType.COMPACT)) {
         HoodieInstant compactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
             HoodieTimeline.COMPACTION_ACTION, instantTime);
-        table.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(plan));
+        table.getActiveTimeline().saveToCompactionRequested(compactionInstant, plan);
       } else {
         HoodieInstant logCompactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED,
             HoodieTimeline.LOG_COMPACTION_ACTION, instantTime);
-        table.getActiveTimeline().saveToLogCompactionRequested(logCompactionInstant, Option.of(plan));
+        table.getActiveTimeline().saveToLogCompactionRequested(logCompactionInstant, plan);
       }
       option = Option.of(plan);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -136,7 +136,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
       }
 
       // transition requested indexInstant to inflight
-      table.getActiveTimeline().transitionIndexRequestedToInflight(indexInstant, Option.empty());
+      table.getActiveTimeline().transitionIndexRequestedToInflight(indexInstant);
       List<HoodieIndexPartitionInfo> finalIndexPartitionInfos;
       if (!firstTimeInitializingMetadataTable) {
         // start indexing for each partition

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
@@ -271,7 +270,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
       updateMetadataPartitionsTableConfig(table.getMetaClient(),
           finalIndexPartitionInfos.stream().map(HoodieIndexPartitionInfo::getMetadataPartitionPath).collect(Collectors.toSet()));
       table.getActiveTimeline().saveAsComplete(false, instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, INDEXING_ACTION, indexInstant.requestedTime()),
-          TimelineMetadataUtils.serializeIndexCommitMetadata(indexCommitMetadata));
+          Option.of(indexCommitMetadata));
     } finally {
       txnManager.endTransaction(Option.of(indexInstant));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -117,7 +117,7 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
             .collect(Collectors.toList());
         HoodieIndexPlan indexPlan = new HoodieIndexPlan(LATEST_INDEX_PLAN_VERSION, indexPartitionInfos);
         // update data timeline with requested instant
-        table.getActiveTimeline().saveToPendingIndexAction(indexInstant, Option.of(indexPlan));
+        table.getActiveTimeline().saveToPendingIndexAction(indexInstant, indexPlan);
         return Option.of(indexPlan);
       }
     } catch (HoodieIOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -39,7 +38,6 @@ import org.apache.hudi.table.action.BaseActionExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -119,14 +117,13 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
             .collect(Collectors.toList());
         HoodieIndexPlan indexPlan = new HoodieIndexPlan(LATEST_INDEX_PLAN_VERSION, indexPartitionInfos);
         // update data timeline with requested instant
-        table.getActiveTimeline().saveToPendingIndexAction(indexInstant, TimelineMetadataUtils.serializeIndexPlan(indexPlan));
+        table.getActiveTimeline().saveToPendingIndexAction(indexInstant, Option.of(indexPlan));
         return Option.of(indexPlan);
       }
-    } catch (IOException e) {
+    } catch (HoodieIOException e) {
       LOG.error("Could not initialize file groups", e);
       // abort gracefully
       abort(indexInstant);
-      throw new HoodieIOException(e.getMessage(), e);
     } finally {
       this.txnManager.endTransaction(Option.of(indexInstant));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
@@ -127,7 +127,7 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
         instantTime, durationInMs, instantsRolledBack, instantToMetadata);
     HoodieInstant restoreInflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.RESTORE_ACTION, instantTime);
     writeToMetadata(restoreMetadata, restoreInflightInstant);
-    table.getActiveTimeline().saveAsComplete(restoreInflightInstant, TimelineMetadataUtils.serializeRestoreMetadata(restoreMetadata));
+    table.getActiveTimeline().saveAsComplete(restoreInflightInstant, Option.of(restoreMetadata));
     // get all pending rollbacks instants after restore instant time and delete them.
     // if not, rollbacks will be considered not completed and might hinder metadata table compaction.
     List<HoodieInstant> instantsToRollback = table.getActiveTimeline().getRollbackTimeline()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -266,7 +266,7 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
         // NOTE: no need to lock here, since !skipTimelinePublish is always true,
         // when skipLocking is false, txnManager above-mentioned should lock it.
         // when skipLocking is true, the caller should have already held the lock.
-        table.getActiveTimeline().transitionRollbackInflightToComplete(false, inflightInstant, Option.of(rollbackMetadata));
+        table.getActiveTimeline().transitionRollbackInflightToComplete(false, inflightInstant, rollbackMetadata);
         LOG.info("Rollback of Commits " + rollbackMetadata.getCommitsRollback() + " is complete");
       }
     } finally {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -266,12 +266,9 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
         // NOTE: no need to lock here, since !skipTimelinePublish is always true,
         // when skipLocking is false, txnManager above-mentioned should lock it.
         // when skipLocking is true, the caller should have already held the lock.
-        table.getActiveTimeline().transitionRollbackInflightToComplete(false, inflightInstant,
-            TimelineMetadataUtils.serializeRollbackMetadata(rollbackMetadata));
+        table.getActiveTimeline().transitionRollbackInflightToComplete(false, inflightInstant, Option.of(rollbackMetadata));
         LOG.info("Rollback of Commits " + rollbackMetadata.getCommitsRollback() + " is complete");
       }
-    } catch (IOException e) {
-      throw new HoodieIOException("Error executing rollback at instant " + instantTime, e);
     } finally {
       if (enableLocking) {
         this.txnManager.endTransaction(Option.of(inflightInstant));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
@@ -114,7 +114,7 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
         if (table.getRollbackTimeline().filterInflightsAndRequested().containsInstant(rollbackInstant.requestedTime())) {
           LOG.warn("Request Rollback found with instant time " + rollbackInstant + ", hence skipping scheduling rollback");
         } else {
-          table.getActiveTimeline().saveToRollbackRequested(rollbackInstant, Option.of(rollbackPlan));
+          table.getActiveTimeline().saveToRollbackRequested(rollbackInstant, rollbackPlan);
           table.getMetaClient().reloadActiveTimeline();
           LOG.info("Requesting Rollback with instant time " + rollbackInstant);
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
@@ -24,7 +24,6 @@ import org.apache.hudi.avro.model.HoodieRollbackRequest;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
@@ -34,7 +33,6 @@ import org.apache.hudi.table.action.BaseActionExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,15 +114,15 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
         if (table.getRollbackTimeline().filterInflightsAndRequested().containsInstant(rollbackInstant.requestedTime())) {
           LOG.warn("Request Rollback found with instant time " + rollbackInstant + ", hence skipping scheduling rollback");
         } else {
-          table.getActiveTimeline().saveToRollbackRequested(rollbackInstant, TimelineMetadataUtils.serializeRollbackPlan(rollbackPlan));
+          table.getActiveTimeline().saveToRollbackRequested(rollbackInstant, Option.of(rollbackPlan));
           table.getMetaClient().reloadActiveTimeline();
           LOG.info("Requesting Rollback with instant time " + rollbackInstant);
         }
       }
       return Option.of(rollbackPlan);
-    } catch (IOException e) {
+    } catch (HoodieIOException e) {
       LOG.error("Got exception when saving rollback requested file", e);
-      throw new HoodieIOException(e.getMessage(), e);
+      throw e;
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -88,7 +88,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
               .collect(Collectors.toList());
 
       HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION, savepointToRestoreTimestamp);
-      table.getActiveTimeline().saveToRestoreRequested(restoreInstant, Option.of(restorePlan));
+      table.getActiveTimeline().saveToRestoreRequested(restoreInstant, restorePlan);
       table.getMetaClient().reloadActiveTimeline();
       LOG.info("Requesting Restore with instant time " + restoreInstant);
       return Option.of(restorePlan);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -24,7 +24,6 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -35,7 +34,6 @@ import org.apache.hudi.table.action.BaseActionExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -90,13 +88,13 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
               .collect(Collectors.toList());
 
       HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION, savepointToRestoreTimestamp);
-      table.getActiveTimeline().saveToRestoreRequested(restoreInstant, TimelineMetadataUtils.serializeRestorePlan(restorePlan));
+      table.getActiveTimeline().saveToRestoreRequested(restoreInstant, Option.of(restorePlan));
       table.getMetaClient().reloadActiveTimeline();
       LOG.info("Requesting Restore with instant time " + restoreInstant);
       return Option.of(restorePlan);
-    } catch (IOException e) {
+    } catch (HoodieIOException e) {
       LOG.error("Got exception when saving restore requested file", e);
-      throw new HoodieIOException(e.getMessage(), e);
+      throw e;
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieSavepointException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.BaseActionExecutor;
@@ -143,12 +144,11 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
           instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.SAVEPOINT_ACTION, instantTime));
       table.getActiveTimeline()
           .saveAsComplete(instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.SAVEPOINT_ACTION, instantTime),
-              TimelineMetadataUtils.serializeSavepointMetadata(metadata));
+              Option.of(metadata));
       LOG.info("Savepoint " + instantTime + " created");
       return metadata;
-    } catch (IOException e) {
+    } catch (HoodieIOException e) {
       throw new HoodieSavepointException("Failed to savepoint " + instantTime, e);
     }
   }
-
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -290,9 +290,8 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     if (instant.getAction().equals(COMMIT_ACTION) || instant.getAction().equals(DELTA_COMMIT_ACTION) || (instant.getAction().equals(REPLACE_COMMIT_ACTION) && instant.isCompleted())) {
       Class<? extends HoodieCommitMetadata> clazz = instant.getAction().equals(REPLACE_COMMIT_ACTION) ? HoodieReplaceCommitMetadata.class : HoodieCommitMetadata.class;
       HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().readInstantContent(instant, clazz);
-      Option<byte[]> data = commitMetadataSerDeV2.serialize(commitMetadata);
       String toPathStr = toPath.toUri().toString();
-      activeTimelineV2.createFileInMetaPath(toPathStr, data, true);
+      activeTimelineV2.createFileInMetaPath(toPathStr, Option.of(commitMetadata), true);
       metaClient.getStorage().deleteFile(fromPath);
     } else {
       success = metaClient.getStorage().rename(fromPath, toPath);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToByteArray;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -163,7 +163,7 @@ public class TestCompletionTimeQueryView {
       activeActions.add(
           new DummyActiveAction(
               INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", instantTime, completionTime),
-              convertMetadataToBytArray(metadata)));
+              convertMetadataToByteArray(metadata)));
     }
     testTable.addRequestedCommit(String.format("%08d", 11));
     List<HoodieInstant> instants = TIMELINE_FACTORY.createActiveTimeline(metaClient, false).getInstantsAsStream().sorted().collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
@@ -50,10 +50,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -163,7 +163,7 @@ public class TestCompletionTimeQueryView {
       activeActions.add(
           new DummyActiveAction(
               INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", instantTime, completionTime),
-              serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata).get()));
+              convertMetadataToBytArray(metadata)));
     }
     testTable.addRequestedCommit(String.format("%08d", 11));
     List<HoodieInstant> instants = TIMELINE_FACTORY.createActiveTimeline(metaClient, false).getInstantsAsStream().sorted().collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -136,7 +136,7 @@ public class TestConflictResolutionStrategyUtil {
     String fileId1 = "file-1";
     String fileId2 = "file-2";
 
-    HoodieCommitMetadata inflightReplaceMetadata = new HoodieCommitMetadata();
+    HoodieReplaceCommitMetadata inflightReplaceMetadata = new HoodieReplaceCommitMetadata();
     inflightReplaceMetadata.setOperationType(WriteOperationType.INSERT_OVERWRITE);
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId("file-1");
@@ -307,7 +307,7 @@ public class TestConflictResolutionStrategyUtil {
   }
 
   public static void createClusterInflight(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {
-    Option<HoodieCommitMetadata> inflightReplaceMetadata = Option.empty();
+    Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata = Option.empty();
     if (WriteOperationType.INSERT_OVERWRITE.equals(writeOperationType)) {
       inflightReplaceMetadata = Option.of(createReplaceCommitMetadata(WriteOperationType.INSERT_OVERWRITE));
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToByteArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -101,7 +101,7 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
       String completionTime = String.valueOf(instantTimeTs + 10);
       HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", instantTime, completionTime);
       HoodieCommitMetadata metadata  = testTable.createCommitMetadata(instantTime, WriteOperationType.INSERT, Arrays.asList("par1", "par2"), 10, false);
-      byte[] serializedMetadata = convertMetadataToBytArray(metadata);
+      byte[] serializedMetadata = convertMetadataToByteArray(metadata);
       instantBuffer.add(new DummyActiveAction(instant, serializedMetadata));
       if (i % batchSize == 0) {
         // archive 10 instants each time

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -100,7 +101,7 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
       String completionTime = String.valueOf(instantTimeTs + 10);
       HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", instantTime, completionTime);
       HoodieCommitMetadata metadata  = testTable.createCommitMetadata(instantTime, WriteOperationType.INSERT, Arrays.asList("par1", "par2"), 10, false);
-      byte[] serializedMetadata = TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata).get();
+      byte[] serializedMetadata = convertMetadataToBytArray(metadata);
       instantBuffer.add(new DummyActiveAction(instant, serializedMetadata));
       if (i % batchSize == 0) {
         // archive 10 instants each time

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
@@ -183,8 +183,8 @@ public class HoodieMetadataTestTable extends HoodieTestTable {
   }
 
   @Override
-  public <T> HoodieTestTable addCluster(
-      String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<T> inflightReplaceMetadata,
+  public HoodieTestTable addCluster(
+      String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
     super.addCluster(instantTime, requestedReplaceMetadata, inflightReplaceMetadata, completeReplaceMetadata);
     if (writer != null) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
@@ -183,8 +183,9 @@ public class HoodieMetadataTestTable extends HoodieTestTable {
   }
 
   @Override
-  public HoodieTestTable addCluster(String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<HoodieCommitMetadata> inflightReplaceMetadata,
-                                    HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
+  public <T> HoodieTestTable addCluster(
+      String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<T> inflightReplaceMetadata,
+      HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
     super.addCluster(instantTime, requestedReplaceMetadata, inflightReplaceMetadata, completeReplaceMetadata);
     if (writer != null) {
       writer.update(completeReplaceMetadata, instantTime);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
@@ -181,7 +181,7 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
   public void testConvertCommitMetadata() {
     HoodieCommitMetadata hoodieCommitMetadata = new HoodieCommitMetadata();
     hoodieCommitMetadata.setOperationType(WriteOperationType.INSERT);
-    org.apache.hudi.avro.model.HoodieCommitMetadata expectedCommitMetadata = MetadataConversionUtils.convertCommitMetadata(hoodieCommitMetadata);
+    org.apache.hudi.avro.model.HoodieCommitMetadata expectedCommitMetadata = MetadataConversionUtils.convertCommitMetadataToAvro(hoodieCommitMetadata);
     assertEquals(expectedCommitMetadata.getOperationType(), WriteOperationType.INSERT.toString());
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -136,7 +136,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
           false,
           clusteringInstant,
-          Option.of(metadata),
+          metadata,
           table.getActiveTimeline());
     } catch (HoodieIOException e) {
       throw new HoodieClusteringException(

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -36,6 +36,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieClusteringException;
 import org.apache.hudi.exception.HoodieCommitException;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.metadata.FlinkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.metadata.HoodieBackedTableMetadataWriter;
@@ -50,12 +51,9 @@ import org.apache.hudi.util.FlinkClientUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 
 public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClient<List<HoodieRecord<T>>, List<WriteStatus>, List<WriteStatus>> {
 
@@ -138,9 +136,9 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
           false,
           clusteringInstant,
-          serializeCommitMetadata(table.getMetaClient().getCommitMetadataSerDe(), metadata),
+          Option.of(metadata),
           table.getActiveTimeline());
-    } catch (IOException e) {
+    } catch (HoodieIOException e) {
       throw new HoodieClusteringException(
           "Failed to commit " + table.getMetaClient().getBasePath() + " at time " + clusteringCommitTime, e);
     } finally {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
@@ -26,8 +26,8 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieDeletePartitionException;
@@ -88,7 +88,7 @@ public class FlinkDeletePartitionCommitActionExecutor<T extends HoodieRecordPayl
                 .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
                 .build();
         table.getMetaClient().getActiveTimeline().saveToPendingReplaceCommit(dropPartitionsInstant,
-            TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+            Option.of(requestedReplaceMetadata));
       }
 
       this.saveWorkloadProfileMetadataToInflight(

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.HoodieTimer;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieDeletePartitionException;
@@ -88,7 +87,7 @@ public class FlinkDeletePartitionCommitActionExecutor<T extends HoodieRecordPayl
                 .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
                 .build();
         table.getMetaClient().getActiveTimeline().saveToPendingReplaceCommit(dropPartitionsInstant,
-            Option.of(requestedReplaceMetadata));
+            requestedReplaceMetadata);
       }
 
       this.saveWorkloadProfileMetadataToInflight(

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
@@ -25,8 +25,8 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaPairRDD;
@@ -86,7 +86,7 @@ public class SparkDeletePartitionCommitActionExecutor<T>
                 .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
                 .build();
         table.getMetaClient().getActiveTimeline().saveToPendingReplaceCommit(dropPartitionsInstant,
-            TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+            Option.of(requestedReplaceMetadata));
       }
 
       this.saveWorkloadProfileMetadataToInflight(

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.HoodieTimer;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaPairRDD;
@@ -85,8 +84,7 @@ public class SparkDeletePartitionCommitActionExecutor<T>
                 .setOperationType(WriteOperationType.DELETE_PARTITION.name())
                 .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))
                 .build();
-        table.getMetaClient().getActiveTimeline().saveToPendingReplaceCommit(dropPartitionsInstant,
-            Option.of(requestedReplaceMetadata));
+        table.getMetaClient().getActiveTimeline().saveToPendingReplaceCommit(dropPartitionsInstant, requestedReplaceMetadata);
       }
 
       this.saveWorkloadProfileMetadataToInflight(

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1660,7 +1660,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(REQUESTED, CLUSTERING_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
     return clusteringInstant;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -55,7 +55,6 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
@@ -131,8 +130,8 @@ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_F
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.testutils.Transformations.randomSelectAsHoodieKeys;
 import static org.apache.hudi.common.testutils.Transformations.recordsToRecordKeySet;
@@ -1661,7 +1660,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(REQUESTED, CLUSTERING_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
     return clusteringInstant;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -168,7 +168,7 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
       String compactionTime = instantTimes.get(0);
       table.getActiveTimeline().saveToCompactionRequested(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionTime),
-          Option.of(compactionPlan));
+          compactionPlan);
 
       instantTimes = instantTimes.subList(1, instantTimes.size());
       // Keep doing some writes and clean inline. Make sure we have expected number of files

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -36,7 +36,6 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.CompactionUtils;
@@ -169,7 +168,7 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
       String compactionTime = instantTimes.get(0);
       table.getActiveTimeline().saveToCompactionRequested(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionTime),
-          TimelineMetadataUtils.serializeCompactionPlan(compactionPlan));
+          Option.of(compactionPlan));
 
       instantTimes = instantTimes.subList(1, instantTimes.size());
       // Keep doing some writes and clean inline. Make sure we have expected number of files

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
@@ -34,7 +34,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -61,6 +60,7 @@ import java.util.UUID;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_PARSER;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,7 +138,7 @@ public class TestCleanActionExecutor {
     when(activeTimeline.getCleanerTimeline()).thenReturn(cleanTimeline);
     when(cleanTimeline.getInstants()).thenReturn(Collections.singletonList(cleanInstant));
     when(activeTimeline.readCleanerPlan(cleanInstant)).thenReturn(cleanerPlan);
-    when(activeTimeline.readCleanerInfoAsBytes(cleanInstant)).thenReturn(TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+    when(activeTimeline.readCleanerInfoAsBytes(cleanInstant)).thenReturn(Option.of(convertMetadataToBytArray(cleanerPlan)));
 
     when(mockHoodieTable.getCleanTimeline()).thenReturn(cleanTimeline);
     when(mockHoodieTable.getInstantGenerator()).thenReturn(INSTANT_GENERATOR);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
@@ -60,7 +60,7 @@ import java.util.UUID;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_PARSER;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataToByteArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,7 +138,7 @@ public class TestCleanActionExecutor {
     when(activeTimeline.getCleanerTimeline()).thenReturn(cleanTimeline);
     when(cleanTimeline.getInstants()).thenReturn(Collections.singletonList(cleanInstant));
     when(activeTimeline.readCleanerPlan(cleanInstant)).thenReturn(cleanerPlan);
-    when(activeTimeline.readCleanerInfoAsBytes(cleanInstant)).thenReturn(Option.of(convertMetadataToBytArray(cleanerPlan)));
+    when(activeTimeline.readCleanerInfoAsBytes(cleanInstant)).thenReturn(Option.of(convertMetadataToByteArray(cleanerPlan)));
 
     when(mockHoodieTable.getCleanTimeline()).thenReturn(cleanTimeline);
     when(mockHoodieTable.getInstantGenerator()).thenReturn(INSTANT_GENERATOR);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanPlanExecutor.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -244,7 +243,7 @@ public class TestCleanPlanExecutor extends HoodieCleanerTestBase {
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "00000000000011"));
     metaClient.getActiveTimeline().transitionRequestedToInflight(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "00000000000011"),
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+        Option.of(commitMetadata));
     List<HoodieCleanStat> hoodieCleanStatsFive2 =
         runCleaner(config, simulateFailureRetry, simulateMetadataFailure, 12, true);
     HoodieCleanStat cleanStat = getCleanStat(hoodieCleanStatsFive2, p0);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieCleanerTestBase.java
@@ -52,9 +52,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.bootstrap.index.TestBootstrapIndex.generateBootstrapIndex;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -214,7 +213,7 @@ public class HoodieCleanerTestBase extends HoodieClientTestBase {
       metadataWriter.update(commitMeta, instantTime);
       metaClient.getActiveTimeline().saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, instantTime),
-          serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMeta));
+          Option.of(commitMeta));
       metaClient = HoodieTableMetaClient.reload(metaClient);
     }
   }

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -354,6 +354,12 @@
       <artifactId>tally-core</artifactId>
       <version>${tally.version}</version>
     </dependency>
+      <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.18.0</version>
+          <scope>test</scope>
+      </dependency>
 
   </dependencies>
 </project>

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -354,12 +354,5 @@
       <artifactId>tally-core</artifactId>
       <version>${tally.version}</version>
     </dependency>
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>2.18.0</version>
-          <scope>test</scope>
-      </dependency>
-
   </dependencies>
 </project>

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CommitMetadataSerDe.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CommitMetadataSerDe.java
@@ -18,8 +18,8 @@
 
 package org.apache.hudi.common.table.timeline;
 
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.HoodieInstantWriter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,5 +33,5 @@ public interface CommitMetadataSerDe extends Serializable {
 
   <T> T deserialize(HoodieInstant instant, InputStream instantStream, BooleanSupplier isEmptyInstant, Class<T> clazz) throws IOException;
 
-  Option<byte[]> serialize(HoodieCommitMetadata commitMetadata) throws IOException;
+  <T> Option<HoodieInstantWriter> getInstantWriter(T commitMetadata);
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -58,17 +58,17 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
   /**
    * Save Completed instant in active timeline.
    * @param instant Instant to be saved.
-   * @param data Metadata to be written in the instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveAsComplete(HoodieInstant instant, Option<byte[]> data);
+  <T> void saveAsComplete(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save Completed instant in active timeline.
    * @param shouldLock Lock before writing to timeline.
    * @param instant Instant to be saved.
-   * @param data Metadata to be written in the instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<byte[]> data);
+  <T> void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<T> metadata);
 
   /**
    * Delete Compaction requested instant file from timeline.
@@ -178,22 +178,20 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                       Option<byte[]> data);
+  <T> HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Transition Log Compaction State from inflight to Committed.
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock,
-                                                          HoodieInstant inflightInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   //-----------------------------------------------------------------
   //      END - COMPACTION RELATED META-DATA MANAGEMENT
@@ -204,31 +202,29 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                  Option<byte[]> data);
+  <T> HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Transition Clean State from requested to inflight.
    *
    * @param requestedInstant requested instant
-   * @param data Optional data to be stored
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
 
   /**
    * Transition Rollback State from inflight to Committed.
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock,
-                                                     HoodieInstant inflightInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Transition Rollback State from requested to inflight.
@@ -250,41 +246,39 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * Transition replace requested file to replace inflight.
    *
    * @param requestedInstant Requested instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return inflight instant
    */
-  HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
 
   /**
    * Transition cluster requested file to cluster inflight.
    *
    * @param requestedInstant Requested instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return inflight instant
    */
-  HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
 
   /**
    * Transition replace inflight to Committed.
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock,
-                                                    HoodieInstant inflightInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Transition cluster inflight to replace committed.
    *
    * @param shouldLock Whether to hold the lock when performing transition
    * @param inflightInstant Inflight instant
-   * @param data Extra Metadata
+   * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  HoodieInstant transitionClusterInflightToComplete(boolean shouldLock,
-                                                    HoodieInstant inflightInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionClusterInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Save Restore requested instant with metadata.
@@ -296,82 +290,81 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
   /**
    * Save Restore requested instant with metadata.
    * @param requested Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content);
+  <T> void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata);
 
   /**
    * Save Restore requested instant with metadata.
    * @param requested Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content,
-                                     boolean allowRedundantTransitions);
+  <T> void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata, boolean allowRedundantTransitions);
 
   /**
    * Save Compaction requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save Compaction requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    * @param overwrite Overwrite existing instant file.
    */
-  void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite);
+  <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite);
 
   /**
    * Save Log Compaction requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save Log Compaction requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    * @param overwrite Overwrite existing instant file.
    */
-  void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite);
+  <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite);
 
   /**
    * Save pending replace instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToPendingReplaceCommit(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToPendingReplaceCommit(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save pending cluster instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToPendingClusterCommit(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToPendingClusterCommit(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save clean requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToCleanRequested(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToCleanRequested(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save rollback requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToRollbackRequested(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToRollbackRequested(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Save Restore requested instant with metadata.
    * @param instant Instant to save.
-   * @param content Metadata to be stored in instant file.
+   * @param metadata metadata to write into the instant file
    */
-  void saveToRestoreRequested(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToRestoreRequested(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Transition index instant state from requested to inflight.
@@ -379,7 +372,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param requestedInstant Inflight Instant
    * @return inflight instant
    */
-  HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
 
   /**
    * Transition index instant state from inflight to completed.
@@ -388,8 +381,8 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param inflightInstant Inflight Instant
    * @return completed instant
    */
-  HoodieInstant transitionIndexInflightToComplete(boolean shouldLock,
-                                                  HoodieInstant inflightInstant, Option<byte[]> data);
+  <T> HoodieInstant transitionIndexInflightToComplete(boolean shouldLock,
+                                                  HoodieInstant inflightInstant, Option<T> metadata);
 
   /**
    * Revert index instant state from inflight to requested.
@@ -401,7 +394,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
   /**
    * Save content for inflight/requested index instant.
    */
-  void saveToPendingIndexAction(HoodieInstant instant, Option<byte[]> content);
+  <T> void saveToPendingIndexAction(HoodieInstant instant, Option<T> metadata);
 
   /**
    * Reloads timeline from storage

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -18,7 +18,16 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieIndexPlan;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRestorePlan;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.storage.StoragePath;
@@ -181,7 +190,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieCommitMetadata metadata);
 
   /**
    * Transition Log Compaction State from inflight to Committed.
@@ -191,7 +200,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieCommitMetadata metadata);
 
   //-----------------------------------------------------------------
   //      END - COMPACTION RELATED META-DATA MANAGEMENT
@@ -205,7 +214,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<HoodieCleanMetadata> metadata);
 
   /**
    * Transition Clean State from requested to inflight.
@@ -214,7 +223,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
+  HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<HoodieCleanerPlan> metadata);
 
   /**
    * Transition Rollback State from inflight to Committed.
@@ -224,7 +233,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieRollbackMetadata metadata);
 
   /**
    * Transition Rollback State from requested to inflight.
@@ -268,7 +277,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieReplaceCommitMetadata metadata);
 
   /**
    * Transition cluster inflight to replace committed.
@@ -278,7 +287,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @return commit instant
    */
-  <T> HoodieInstant transitionClusterInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata);
+  HoodieInstant transitionClusterInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieReplaceCommitMetadata metadata);
 
   /**
    * Save Restore requested instant with metadata.
@@ -306,7 +315,7 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata);
+  void saveToCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata);
 
   /**
    * Save Compaction requested instant with metadata.
@@ -314,14 +323,14 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @param overwrite Overwrite existing instant file.
    */
-  <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite);
+  void saveToCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata, boolean overwrite);
 
   /**
    * Save Log Compaction requested instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata);
+  void saveToLogCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata);
 
   /**
    * Save Log Compaction requested instant with metadata.
@@ -329,42 +338,42 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param metadata metadata to write into the instant file
    * @param overwrite Overwrite existing instant file.
    */
-  <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite);
+  void saveToLogCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata, boolean overwrite);
 
   /**
    * Save pending replace instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToPendingReplaceCommit(HoodieInstant instant, Option<T> metadata);
+  void saveToPendingReplaceCommit(HoodieInstant instant, HoodieRequestedReplaceMetadata metadata);
 
   /**
    * Save pending cluster instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToPendingClusterCommit(HoodieInstant instant, Option<T> metadata);
+  void saveToPendingClusterCommit(HoodieInstant instant, HoodieRequestedReplaceMetadata metadata);
 
   /**
    * Save clean requested instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToCleanRequested(HoodieInstant instant, Option<T> metadata);
+  void saveToCleanRequested(HoodieInstant instant, Option<HoodieCleanerPlan> metadata);
 
   /**
    * Save rollback requested instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToRollbackRequested(HoodieInstant instant, Option<T> metadata);
+  void saveToRollbackRequested(HoodieInstant instant, HoodieRollbackPlan metadata);
 
   /**
    * Save Restore requested instant with metadata.
    * @param instant Instant to save.
    * @param metadata metadata to write into the instant file
    */
-  <T> void saveToRestoreRequested(HoodieInstant instant, Option<T> metadata);
+  void saveToRestoreRequested(HoodieInstant instant, HoodieRestorePlan metadata);
 
   /**
    * Transition index instant state from requested to inflight.
@@ -372,29 +381,12 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
    * @param requestedInstant Inflight Instant
    * @return inflight instant
    */
-  <T> HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata);
-
-  /**
-   * Transition index instant state from inflight to completed.
-   *
-   * @param shouldLock Whether to hold the lock when performing transition
-   * @param inflightInstant Inflight Instant
-   * @return completed instant
-   */
-  <T> HoodieInstant transitionIndexInflightToComplete(boolean shouldLock,
-                                                  HoodieInstant inflightInstant, Option<T> metadata);
-
-  /**
-   * Revert index instant state from inflight to requested.
-   * @param inflightInstant Inflight Instant
-   * @return requested instant
-   */
-  HoodieInstant revertIndexInflightToRequested(HoodieInstant inflightInstant);
+  HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant);
 
   /**
    * Save content for inflight/requested index instant.
    */
-  <T> void saveToPendingIndexAction(HoodieInstant instant, Option<T> metadata);
+  void saveToPendingIndexAction(HoodieInstant instant, HoodieIndexPlan metadata);
 
   /**
    * Reloads timeline from storage

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.storage.HoodieInstantWriter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -350,6 +351,14 @@ public interface HoodieTimeline extends HoodieInstantReader, Serializable {
    * @return New instance of HoodieTimeline with just completed instants
    */
   HoodieTimeline filterCompletedInstants();
+
+  default <T> Option<HoodieInstantWriter> getInstantWriter(Option<T> metadata) {
+    if (metadata.isEmpty()) {
+      return Option.empty();
+    }
+    TimelineLayout layout = TimelineLayout.fromVersion(getTimelineLayoutVersion());
+    return layout.getCommitMetadataSerDe().getInstantWriter(metadata.get());
+  }
 
   // TODO: Check if logcompaction also needs to be included in this API.
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
@@ -18,23 +18,17 @@
 
 package org.apache.hudi.common.table.timeline;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
-import org.apache.hudi.avro.model.HoodieCleanerPlan;
-import org.apache.hudi.avro.model.HoodieCompactionPlan;
-import org.apache.hudi.avro.model.HoodieIndexCommitMetadata;
-import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.avro.model.HoodieInstantInfo;
-import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
-import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
-import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.avro.model.HoodieSavepointPartitionMetadata;
 import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.StoragePathInfo;
 
 import org.apache.avro.file.DataFileReader;
@@ -55,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -63,6 +58,19 @@ import java.util.stream.Collectors;
 public class TimelineMetadataUtils {
 
   private static final Integer DEFAULT_VERSION = 1;
+  private static final Map<Class<?>, DatumWriter<?>> DATUM_WRITERS = new ConcurrentHashMap<>();
+
+  // Legacy method to handle cases where byte [] is still used as opposed to leveraging HoodieInstantWriter.
+  @Deprecated
+  public static <T> byte[] convertMetadataToBytArray(T metadata, CommitMetadataSerDe serDe) {
+    try {
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      serDe.getInstantWriter(metadata).get().writeToStream(outputStream);
+      return outputStream.toByteArray();
+    } catch (Exception ex) {
+      throw new HoodieException(ex);
+    }
+  }
 
   public static HoodieRestoreMetadata convertRestoreMetadata(String startRestoreTime,
                                                              long durationInMs,
@@ -104,55 +112,6 @@ public class TimelineMetadataUtils {
         Collections.unmodifiableMap(partitionMetadataBuilder), DEFAULT_VERSION);
   }
 
-  public static Option<byte[]> serializeCompactionPlan(HoodieCompactionPlan compactionWorkload) throws IOException {
-    return serializeAvroMetadata(compactionWorkload, HoodieCompactionPlan.class);
-  }
-
-  public static Option<byte[]> serializeCleanerPlan(HoodieCleanerPlan cleanPlan) throws IOException {
-    return serializeAvroMetadata(cleanPlan, HoodieCleanerPlan.class);
-  }
-
-  public static Option<byte[]> serializeRollbackPlan(HoodieRollbackPlan rollbackPlan) throws IOException {
-    return serializeAvroMetadata(rollbackPlan, HoodieRollbackPlan.class);
-  }
-
-  public static Option<byte[]> serializeRestorePlan(HoodieRestorePlan restorePlan) throws IOException {
-    return serializeAvroMetadata(restorePlan, HoodieRestorePlan.class);
-  }
-
-  public static Option<byte[]> serializeCleanMetadata(HoodieCleanMetadata metadata) throws IOException {
-    return serializeAvroMetadata(metadata, HoodieCleanMetadata.class);
-  }
-
-  public static Option<byte[]> serializeSavepointMetadata(HoodieSavepointMetadata metadata) throws IOException {
-    return serializeAvroMetadata(metadata, HoodieSavepointMetadata.class);
-  }
-
-  public static Option<byte[]> serializeRollbackMetadata(HoodieRollbackMetadata rollbackMetadata) throws IOException {
-    return serializeAvroMetadata(rollbackMetadata, HoodieRollbackMetadata.class);
-  }
-
-  public static Option<byte[]> serializeRestoreMetadata(HoodieRestoreMetadata restoreMetadata) throws IOException {
-    return serializeAvroMetadata(restoreMetadata, HoodieRestoreMetadata.class);
-  }
-
-  public static Option<byte[]> serializeRequestedReplaceMetadata(HoodieRequestedReplaceMetadata clusteringPlan) throws IOException {
-    return serializeAvroMetadata(clusteringPlan, HoodieRequestedReplaceMetadata.class);
-  }
-
-  public static Option<byte[]> serializeIndexPlan(HoodieIndexPlan indexPlan) throws IOException {
-    return serializeAvroMetadata(indexPlan, HoodieIndexPlan.class);
-  }
-
-  public static Option<byte[]> serializeIndexCommitMetadata(HoodieIndexCommitMetadata indexCommitMetadata) throws IOException {
-    return serializeAvroMetadata(indexCommitMetadata, HoodieIndexCommitMetadata.class);
-  }
-
-  public static Option<byte[]> serializeCommitMetadata(CommitMetadataSerDe commitMetadataSerDe,
-                                                       org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata) throws IOException {
-    return commitMetadataSerDe.serialize(commitMetadata);
-  }
-
   public static <T extends SpecificRecordBase> Option<byte[]> serializeAvroMetadata(T metadata, Class<T> clazz)
       throws IOException {
     DatumWriter<T> datumWriter = new SpecificDatumWriter<>(clazz);
@@ -180,5 +139,18 @@ public class TimelineMetadataUtils {
       ValidationUtils.checkArgument(fileReader.hasNext(), "Could not deserialize metadata of type " + clazz);
       return fileReader.next();
     }
+  }
+
+  public static <T extends SpecificRecordBase> Option<HoodieInstantWriter> getInstantWriter(Option<T> metadata) {
+    if (metadata.isEmpty()) {
+      return Option.empty();
+    }
+    return Option.of(outputStream -> {
+      DatumWriter<T> datumWriter = (DatumWriter<T>) DATUM_WRITERS.computeIfAbsent(metadata.get().getClass(), SpecificDatumWriter::new);
+      try (DataFileWriter<T> fileWriter = new DataFileWriter<>(datumWriter)) {
+        fileWriter.create(metadata.get().getSchema(), outputStream);
+        fileWriter.append(metadata.get());
+      }
+    });
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieTimeTravelException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -622,5 +623,16 @@ public class TimelineUtils {
       return Option.empty();
     }
     return Option.of(new ByteArrayInputStream(bytes.get()));
+  }
+
+  // TODO[HUDI-9094]: work around when caller needs to write byte array in raw. This method should be removed.
+  public static <T> Option<HoodieInstantWriter> getHoodieInstantWriterOption(HoodieTimeline timeline, Option<T> metadata) {
+    Option<HoodieInstantWriter> writerOption;
+    if (metadata.isPresent() && metadata.get() instanceof HoodieInstantWriter) {
+      writerOption = (Option<HoodieInstantWriter>) metadata;
+    } else {
+      writerOption = timeline.getInstantWriter(metadata);
+    }
+    return writerOption;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -547,7 +547,7 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
-  public <T>  void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata) {
+  public <T> void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata) {
     transitionRequestedToInflight(requested, metadata, false);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -143,14 +143,10 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
 
   @Override
   public void createRequestedCommitWithReplaceMetadata(String instantTime, String actionType) {
-    try {
-      HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
-      LOG.info("Creating a new instant " + instant);
-      // Create the request replace file
-      createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
-    } catch (HoodieIOException e) {
-      throw e;
-    }
+    HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
+    LOG.info("Creating a new instant " + instant);
+    // Create the request replace file
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstantReader;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
@@ -51,6 +50,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import static org.apache.hudi.common.table.timeline.TimelineUtils.getHoodieInstantWriterOption;
 
 public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTimeline {
 
@@ -138,25 +139,24 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
       HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
       LOG.info("Creating a new instant " + instant);
       // Create the request replace file
-      createFileInMetaPath(instantFileNameGenerator.getFileName(instant),
-          TimelineMetadataUtils.serializeRequestedReplaceMetadata(new HoodieRequestedReplaceMetadata()), false);
-    } catch (IOException e) {
-      throw new HoodieIOException("Error create requested replace commit ", e);
+      createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
+    } catch (HoodieIOException e) {
+      throw e;
     }
   }
 
   @Override
-  public void saveAsComplete(HoodieInstant instant, Option<byte[]> data) {
+  public <T> void saveAsComplete(HoodieInstant instant, Option<T> metadata) {
     LOG.info("Marking instant complete " + instant);
     ValidationUtils.checkArgument(instant.isInflight(),
         "Could not mark an already completed instant as complete again " + instant);
-    transitionState(instant, instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, instant.getAction(), instant.requestedTime()), data);
+    transitionState(instant, instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, instant.getAction(), instant.requestedTime()), metadata);
     LOG.info("Completed " + instant);
   }
 
   @Override
-  public void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<byte[]> data) {
-    saveAsComplete(instant, data);
+  public <T> void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<T> metadata) {
+    saveAsComplete(instant, metadata);
   }
 
   @Override
@@ -359,24 +359,22 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
-  public HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                              Option<byte[]> data) {
+  public <T> HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     // Lock is not honored in 0.x mode.
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock,
-                                                                 HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     // Lock is not honored in 0.x mode.
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, DELTA_COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
   //-----------------------------------------------------------------
@@ -384,33 +382,31 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   //-----------------------------------------------------------------
 
   @Override
-  public HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                         Option<byte[]> data) {
+  public <T> HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, CLEAN_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflight = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, CLEAN_ACTION, requestedInstant.requestedTime());
-    transitionState(requestedInstant, inflight, data);
+    transitionState(requestedInstant, inflight, metadata);
     return inflight;
   }
 
   @Override
-  public HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock,
-                                                            HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, ROLLBACK_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
@@ -434,50 +430,49 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
-  public HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, REPLACE_COMMIT_ACTION, requestedInstant.requestedTime());
     // Then write to timeline
-    transitionState(requestedInstant, inflightInstant, data);
+    transitionState(requestedInstant, inflightInstant, metadata);
     return inflightInstant;
   }
 
   @Override
-  public HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     // In 0.x, no separate clustering action, reuse replace action.
-    return transitionReplaceRequestedToInflight(requestedInstant, data);
+    return transitionReplaceRequestedToInflight(requestedInstant, metadata);
   }
 
   @Override
-  public HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock,
-                                                           HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionReplaceInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionClusterInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionClusterInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     // In 0.x, no separate clustering action, reuse replace action.
-    return transitionReplaceInflightToComplete(shouldLock, inflightInstant, data);
+    return transitionReplaceInflightToComplete(shouldLock, inflightInstant, metadata);
   }
 
-  private void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data) {
-    transitionState(fromInstant, toInstant, data, false);
+  private <T> void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata) {
+    transitionState(fromInstant, toInstant, metadata, false);
   }
 
-  protected void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data,
-                                 boolean allowRedundantTransitions) {
+  protected <T> void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata, boolean allowRedundantTransitions) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()), String.format("%s and %s are not consistent when transition state.", fromInstant, toInstant));
     try {
       HoodieStorage storage = metaClient.getStorage();
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         // Re-create the .inflight file by opening a new file and write the commit metadata in
-        createFileInMetaPath(instantFileNameGenerator.getFileName(fromInstant), data, allowRedundantTransitions);
+        createFileInMetaPath(instantFileNameGenerator.getFileName(fromInstant), metadata, allowRedundantTransitions);
         StoragePath fromInstantPath = getInstantFileNamePath(instantFileNameGenerator.getFileName(fromInstant));
         StoragePath toInstantPath = getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant));
         boolean success = storage.rename(fromInstantPath, toInstantPath);
@@ -490,9 +485,9 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
             "File " + getInstantFileNamePath(instantFileNameGenerator.getFileName(fromInstant)) + " does not exist!");
         // Use Write Once to create Target File
         if (allowRedundantTransitions) {
-          FileIOUtils.createFileInPath(storage, getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant)), data);
+          FileIOUtils.createFileInPath(storage, getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant)), getHoodieInstantWriterOption(this, metadata));
         } else {
-          storage.createImmutableFileInPath(getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant)), data.map(HoodieInstantWriter::convertByteArrayToWriter));
+          storage.createImmutableFileInPath(getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant)), getHoodieInstantWriterOption(this, metadata));
         }
         LOG.info("Create new file for toInstant ?" + getInstantFileNamePath(instantFileNameGenerator.getFileName(toInstant)));
       }
@@ -548,96 +543,95 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
-  public void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content) {
-    transitionRequestedToInflight(requested, content, false);
+  public <T>  void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata) {
+    transitionRequestedToInflight(requested, metadata, false);
   }
 
   @Override
-  public void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content,
-                                            boolean allowRedundantTransitions) {
+  public <T> void transitionRequestedToInflight(
+      HoodieInstant requested, Option<T> metadata, boolean allowRedundantTransitions) {
     HoodieInstant inflight = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, requested.getAction(), requested.requestedTime());
     ValidationUtils.checkArgument(requested.isRequested(), "Instant " + requested + " in wrong state");
-    transitionState(requested, inflight, content, allowRedundantTransitions);
+    transitionState(requested, inflight, metadata, allowRedundantTransitions);
   }
 
   @Override
-  public void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content) {
-    saveToCompactionRequested(instant, content, false);
+  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+    saveToCompactionRequested(instant, metadata, false);
   }
 
   @Override
-  public void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite) {
+  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
   }
 
   @Override
-  public void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content) {
-    saveToLogCompactionRequested(instant, content, false);
+  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+    saveToLogCompactionRequested(instant, metadata, false);
   }
 
   @Override
-  public void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite) {
+  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
   }
 
   @Override
-  public void saveToPendingReplaceCommit(HoodieInstant instant, Option<byte[]> content) {
+  public <T>  void saveToPendingReplaceCommit(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToPendingClusterCommit(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToPendingClusterCommit(HoodieInstant instant, Option<T> metadata) {
     // In 0.x, no separate clustering action, reuse replace action.
-    saveToPendingReplaceCommit(instant, content);
+    saveToPendingReplaceCommit(instant, metadata);
   }
 
   @Override
-  public void saveToCleanRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToCleanRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToRollbackRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToRollbackRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToRestoreRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToRestoreRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.RESTORE_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", requestedInstant.getAction(), INDEXING_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested(),
         String.format("Instant %s not in requested state", requestedInstant.requestedTime()));
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, INDEXING_ACTION, requestedInstant.requestedTime());
-    transitionState(requestedInstant, inflightInstant, data);
+    transitionState(requestedInstant, inflightInstant, metadata);
     return inflightInstant;
   }
 
   @Override
-  public HoodieInstant transitionIndexInflightToComplete(boolean shouldLock,
-                                                         HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionIndexInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", inflightInstant.getAction(), INDEXING_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight(),
         String.format("Instant %s not inflight", inflightInstant.requestedTime()));
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, INDEXING_ACTION, inflightInstant.requestedTime());
-    transitionState(inflightInstant, commitInstant, data);
+    transitionState(inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
@@ -657,18 +651,19 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
-  public void saveToPendingIndexAction(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToPendingIndexAction(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", instant.getAction(), INDEXING_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
-  public void createFileInMetaPath(String filename, Option<byte[]> content, boolean allowOverwrite) {
+  public <T> void createFileInMetaPath(String filename, Option<T> metadata, boolean allowOverwrite) {
     StoragePath fullPath = getInstantFileNamePath(filename);
+    Option<HoodieInstantWriter> writerOption = getHoodieInstantWriterOption(this, metadata);
     if (allowOverwrite || metaClient.getTimelineLayoutVersion().isNullVersion()) {
-      FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, content);
+      FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, writerOption);
     } else {
-      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
+      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, writerOption);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CommitMetadataSerDeV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CommitMetadataSerDeV1.java
@@ -22,7 +22,6 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.HoodieInstantWriter;
@@ -85,6 +84,6 @@ public class CommitMetadataSerDeV1 implements CommitMetadataSerDe {
     // For others, write avro format.
     @SuppressWarnings("unchecked")
     SpecificRecordBase avroMetadata = (SpecificRecordBase) metadata;
-    return TimelineMetadataUtils.getInstantWriter(Option.of(avroMetadata));
+    return CommitMetadataSerDe.getInstantWriter(Option.of(avroMetadata));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CommitMetadataSerDeV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CommitMetadataSerDeV1.java
@@ -19,20 +19,27 @@
 package org.apache.hudi.common.table.timeline.versioning.v1;
 
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.HoodieInstantWriter;
 
 import org.apache.avro.specific.SpecificRecordBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.BooleanSupplier;
 
+import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.removeNullKeyFromMapMembersForCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeAvroMetadata;
 
 public class CommitMetadataSerDeV1 implements CommitMetadataSerDe {
+  private static final Logger LOG = LoggerFactory.getLogger(CommitMetadataSerDeV1.class);
 
   @Override
   public <T> T deserialize(HoodieInstant instant, InputStream inputStream, BooleanSupplier isEmptyInstant, Class<T> clazz) throws IOException {
@@ -62,7 +69,22 @@ public class CommitMetadataSerDeV1 implements CommitMetadataSerDe {
   }
 
   @Override
-  public Option<byte[]> serialize(HoodieCommitMetadata commitMetadata) throws IOException {
-    return Option.ofNullable(commitMetadata.toJsonString().getBytes());
+  public <T> Option<HoodieInstantWriter> getInstantWriter(T metadata) {
+    // If it is hoodie commit metadata, write json string.
+    removeNullKeyFromMapMembersForCommitMetadata(metadata);
+
+    if (metadata instanceof HoodieReplaceCommitMetadata) {
+      return Option.of(outputStream -> JsonUtils.getObjectMapper().writerFor(HoodieReplaceCommitMetadata.class)
+          .withDefaultPrettyPrinter().writeValue(outputStream, metadata));
+    }
+    if (metadata instanceof HoodieCommitMetadata) {
+      return Option.of(outputStream -> JsonUtils.getObjectMapper().writerFor(HoodieCommitMetadata.class)
+          .withDefaultPrettyPrinter().writeValue(outputStream, metadata));
+    }
+
+    // For others, write avro format.
+    @SuppressWarnings("unchecked")
+    SpecificRecordBase avroMetadata = (SpecificRecordBase) metadata;
+    return TimelineMetadataUtils.getInstantWriter(Option.of(avroMetadata));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -18,8 +18,16 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v2;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRestorePlan;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -375,22 +383,22 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public <T> HoodieInstant transitionCompactionInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionCompactionInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, HoodieCommitMetadata metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, Option.of(metadata));
     return commitInstant;
   }
 
   @Override
-  public <T> HoodieInstant transitionLogCompactionInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionLogCompactionInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, HoodieCommitMetadata metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, DELTA_COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, Option.of(metadata));
     return commitInstant;
   }
 
@@ -399,8 +407,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   //-----------------------------------------------------------------
 
   @Override
-  public <T> HoodieInstant transitionCleanInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, Option<HoodieCleanMetadata> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, CLEAN_ACTION, inflightInstant.requestedTime());
@@ -410,7 +417,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public <T> HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
+  public HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<HoodieCleanerPlan> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflight = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, CLEAN_ACTION, requestedInstant.requestedTime());
@@ -419,13 +426,12 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public <T> HoodieInstant transitionRollbackInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant, HoodieRollbackMetadata metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, ROLLBACK_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, Option.of(metadata));
     return commitInstant;
   }
 
@@ -469,24 +475,24 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public <T> HoodieInstant transitionReplaceInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionReplaceInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, HoodieReplaceCommitMetadata metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, Option.of(metadata));
     return commitInstant;
   }
 
   @Override
-  public <T> HoodieInstant transitionClusterInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
+  public HoodieInstant transitionClusterInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, HoodieReplaceCommitMetadata metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, Option.of(metadata));
     return commitInstant;
   }
 
@@ -494,8 +500,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     transitionPendingState(fromInstant, toInstant, metadata, false);
   }
 
-  protected <T> void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant,
-                                           HoodieInstant toInstant, Option<T> metadata) {
+  protected <T> void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()), String.format("%s and %s are not consistent when transition state.", fromInstant, toInstant));
     String fromInstantFileName = instantFileNameGenerator.getFileName(fromInstant);
     try {
@@ -615,38 +620,38 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     transitionPendingState(requested, inflight, metadata, allowRedundantTransitions);
   }
 
-  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+  public void saveToCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata) {
     saveToCompactionRequested(instant, metadata, false);
   }
 
-  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
+  public void saveToCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), overwrite);
   }
 
-  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+  public void saveToLogCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata) {
     saveToLogCompactionRequested(instant, metadata, false);
   }
 
-  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
+  public void saveToLogCompactionRequested(HoodieInstant instant, HoodieCompactionPlan metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), overwrite);
   }
 
   @Override
-  public <T> void saveToPendingReplaceCommit(HoodieInstant instant, Option<T> metadata) {
+  public void saveToPendingReplaceCommit(HoodieInstant instant, HoodieRequestedReplaceMetadata metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), false);
   }
 
   @Override
-  public <T> void saveToPendingClusterCommit(HoodieInstant instant, Option<T> metadata) {
+  public void saveToPendingClusterCommit(HoodieInstant instant, HoodieRequestedReplaceMetadata metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), false);
   }
 
   @Override
-  public <T> void saveToCleanRequested(HoodieInstant instant, Option<T> metadata) {
+  public void saveToCleanRequested(HoodieInstant instant, Option<HoodieCleanerPlan> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
@@ -654,64 +659,37 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public <T> void saveToRollbackRequested(HoodieInstant instant, Option<T> metadata) {
+  public void saveToRollbackRequested(HoodieInstant instant, HoodieRollbackPlan metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), false);
   }
 
   @Override
-  public <T> void saveToRestoreRequested(HoodieInstant instant, Option<T> metadata) {
+  public void saveToRestoreRequested(HoodieInstant instant, HoodieRestorePlan metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.RESTORE_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), false);
   }
 
   @Override
-  public <T> HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
+  public HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", requestedInstant.getAction(), INDEXING_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested(),
         String.format("Instant %s not in requested state", requestedInstant.requestedTime()));
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, INDEXING_ACTION, requestedInstant.requestedTime());
-    transitionPendingState(requestedInstant, inflightInstant, metadata);
+    transitionPendingState(requestedInstant, inflightInstant, Option.empty());
     return inflightInstant;
   }
 
   @Override
-  public <T> HoodieInstant transitionIndexInflightToComplete(
-      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
-    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
-        String.format("%s is not equal to %s action", inflightInstant.getAction(), INDEXING_ACTION));
-    ValidationUtils.checkArgument(inflightInstant.isInflight(),
-        String.format("Instant %s not inflight", inflightInstant.requestedTime()));
-    HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, INDEXING_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
-    return commitInstant;
-  }
-
-  @Override
-  public HoodieInstant revertIndexInflightToRequested(HoodieInstant inflightInstant) {
-    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
-        String.format("%s is not equal to %s action", inflightInstant.getAction(), INDEXING_ACTION));
-    ValidationUtils.checkArgument(inflightInstant.isInflight(),
-        String.format("Instant %s not inflight", inflightInstant.requestedTime()));
-    HoodieInstant requestedInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, INDEXING_ACTION, inflightInstant.requestedTime());
-    if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
-      transitionPendingState(inflightInstant, requestedInstant, Option.empty());
-    } else {
-      deleteInflight(inflightInstant);
-    }
-    return requestedInstant;
-  }
-
-  @Override
-  public <T> void saveToPendingIndexAction(HoodieInstant instant, Option<T> metadata) {
+  public void saveToPendingIndexAction(HoodieInstant instant, HoodieIndexPlan metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", instant.getAction(), INDEXING_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(metadata), false);
   }
 
   public <T> void createFileInMetaPath(String filename, Option<T> metadata, boolean allowOverwrite) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -30,7 +30,6 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.TimeGenerator;
 import org.apache.hudi.common.table.timeline.TimeGenerators;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
@@ -55,6 +54,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import static org.apache.hudi.common.table.timeline.TimelineUtils.getHoodieInstantWriterOption;
 
 public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTimeline {
 
@@ -143,25 +144,24 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
       LOG.info("Creating a new instant " + instant);
       // Create the request replace file
-      createFileInMetaPath(instantFileNameGenerator.getFileName(instant),
-          TimelineMetadataUtils.serializeRequestedReplaceMetadata(new HoodieRequestedReplaceMetadata()), false);
-    } catch (IOException e) {
-      throw new HoodieIOException("Error create requested replace commit ", e);
+      createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
+    } catch (HoodieIOException e) {
+      throw e;
     }
   }
 
   @Override
-  public void saveAsComplete(HoodieInstant instant, Option<byte[]> data) {
-    saveAsComplete(true, instant, data);
+  public <T> void saveAsComplete(HoodieInstant instant, Option<T> metadata) {
+    saveAsComplete(true, instant, metadata);
   }
 
   @Override
-  public void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<byte[]> data) {
+  public <T> void saveAsComplete(boolean shouldLock, HoodieInstant instant, Option<T> metadata) {
     LOG.info("Marking instant complete " + instant);
     ValidationUtils.checkArgument(instant.isInflight(),
         "Could not mark an already completed instant as complete again " + instant);
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, instant.getAction(), instant.requestedTime());
-    transitionStateToComplete(shouldLock, instant, commitInstant, data);
+    transitionStateToComplete(shouldLock, instant, commitInstant, metadata);
     LOG.info("Completed " + instant);
   }
 
@@ -375,22 +375,22 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public HoodieInstant transitionCompactionInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                              Option<byte[]> data) {
+  public <T> HoodieInstant transitionCompactionInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionLogCompactionInflightToComplete(boolean shouldLock,
-                                                                 HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionLogCompactionInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, DELTA_COMMIT_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
@@ -399,33 +399,33 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   //-----------------------------------------------------------------
 
   @Override
-  public HoodieInstant transitionCleanInflightToComplete(boolean shouldLock, HoodieInstant inflightInstant,
-                                                         Option<byte[]> data) {
+  public <T> HoodieInstant transitionCleanInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, CLEAN_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionCleanRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflight = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, CLEAN_ACTION, requestedInstant.requestedTime());
-    transitionPendingState(requestedInstant, inflight, data);
+    transitionPendingState(requestedInstant, inflight, metadata);
     return inflight;
   }
 
   @Override
-  public HoodieInstant transitionRollbackInflightToComplete(boolean shouldLock,
-                                                            HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionRollbackInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, ROLLBACK_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
@@ -449,59 +449,59 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionReplaceRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, REPLACE_COMMIT_ACTION, requestedInstant.requestedTime());
     // Then write to timeline
-    transitionPendingState(requestedInstant, inflightInstant, data);
+    transitionPendingState(requestedInstant, inflightInstant, metadata);
     return inflightInstant;
   }
 
   @Override
-  public HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionClusterRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested());
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, CLUSTERING_ACTION, requestedInstant.requestedTime());
     // Then write to timeline
-    transitionPendingState(requestedInstant, inflightInstant, data);
+    transitionPendingState(requestedInstant, inflightInstant, metadata);
     return inflightInstant;
   }
 
   @Override
-  public HoodieInstant transitionReplaceInflightToComplete(boolean shouldLock,
-                                                           HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionReplaceInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
   @Override
-  public HoodieInstant transitionClusterInflightToComplete(boolean shouldLock,
-                                                           HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionClusterInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight());
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, REPLACE_COMMIT_ACTION, inflightInstant.requestedTime());
     // Then write to timeline
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
-  private void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data) {
-    transitionPendingState(fromInstant, toInstant, data, false);
+  private <T> void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata) {
+    transitionPendingState(fromInstant, toInstant, metadata, false);
   }
 
-  protected void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant,
-                                           HoodieInstant toInstant, Option<byte[]> data) {
+  protected <T> void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant,
+                                           HoodieInstant toInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()), String.format("%s and %s are not consistent when transition state.", fromInstant, toInstant));
     String fromInstantFileName = instantFileNameGenerator.getFileName(fromInstant);
     try {
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         // Re-create the .inflight file by opening a new file and write the commit metadata in
-        createFileInMetaPath(fromInstantFileName, data, false);
+        createFileInMetaPath(fromInstantFileName, metadata, false);
         StoragePath fromInstantPath = getInstantFileNamePath(fromInstantFileName);
         HoodieInstant instantWithCompletionTime =
             instantGenerator.createNewInstant(toInstant.getState(), toInstant.getAction(),
@@ -518,15 +518,15 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
         ValidationUtils.checkArgument(
             metaClient.getStorage().exists(getInstantFileNamePath(fromInstantFileName)),
             "File " + getInstantFileNamePath(fromInstantFileName) + " does not exist!");
-        createCompleteFileInMetaPath(shouldLock, toInstant, data);
+        createCompleteFileInMetaPath(shouldLock, toInstant, metadata);
       }
     } catch (IOException e) {
       throw new HoodieIOException("Could not complete " + fromInstant, e);
     }
   }
 
-  protected void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data,
-                                        boolean allowRedundantTransitions) {
+  protected <T> void transitionPendingState(
+      HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata, boolean allowRedundantTransitions) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()), String.format("%s and %s are not consistent when transition state.", fromInstant, toInstant));
     String fromInstantFileName = instantFileNameGenerator.getFileName(fromInstant);
     String toInstantFileName = instantFileNameGenerator.getFileName(toInstant);
@@ -534,7 +534,7 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       HoodieStorage storage = metaClient.getStorage();
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         // Re-create the .inflight file by opening a new file and write the commit metadata in
-        createFileInMetaPath(fromInstantFileName, data, allowRedundantTransitions);
+        createFileInMetaPath(fromInstantFileName, metadata, allowRedundantTransitions);
         StoragePath fromInstantPath = getInstantFileNamePath(fromInstantFileName);
         StoragePath toInstantPath = getInstantFileNamePath(toInstantFileName);
         boolean success = storage.rename(fromInstantPath, toInstantPath);
@@ -547,9 +547,9 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
             "File " + getInstantFileNamePath(fromInstantFileName) + " does not exist!");
         // Use Write Once to create Target File
         if (allowRedundantTransitions) {
-          FileIOUtils.createFileInPath(storage, getInstantFileNamePath(toInstantFileName), data);
+          FileIOUtils.createFileInPath(storage, getInstantFileNamePath(toInstantFileName), getInstantWriter(metadata));
         } else {
-          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), data.map(HoodieInstantWriter::convertByteArrayToWriter));
+          storage.createImmutableFileInPath(getInstantFileNamePath(toInstantFileName), getInstantWriter(metadata));
         }
         LOG.info("Create new file for toInstant ?" + getInstantFileNamePath(toInstantFileName));
       }
@@ -605,91 +605,90 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     transitionRequestedToInflight(requested, Option.empty(), false);
   }
 
-  public void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content) {
-    transitionRequestedToInflight(requested, content, false);
+  public <T> void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata) {
+    transitionRequestedToInflight(requested, metadata, false);
   }
 
-  public void transitionRequestedToInflight(HoodieInstant requested, Option<byte[]> content,
-                                            boolean allowRedundantTransitions) {
+  public <T> void transitionRequestedToInflight(HoodieInstant requested, Option<T> metadata, boolean allowRedundantTransitions) {
     HoodieInstant inflight = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, requested.getAction(), requested.requestedTime());
     ValidationUtils.checkArgument(requested.isRequested(), "Instant " + requested + " in wrong state");
-    transitionPendingState(requested, inflight, content, allowRedundantTransitions);
+    transitionPendingState(requested, inflight, metadata, allowRedundantTransitions);
   }
 
-  public void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content) {
-    saveToCompactionRequested(instant, content, false);
+  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+    saveToCompactionRequested(instant, metadata, false);
   }
 
-  public void saveToCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite) {
+  public <T> void saveToCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
   }
 
-  public void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content) {
-    saveToLogCompactionRequested(instant, content, false);
+  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata) {
+    saveToLogCompactionRequested(instant, metadata, false);
   }
 
-  public void saveToLogCompactionRequested(HoodieInstant instant, Option<byte[]> content, boolean overwrite) {
+  public <T> void saveToLogCompactionRequested(HoodieInstant instant, Option<T> metadata, boolean overwrite) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.LOG_COMPACTION_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, overwrite);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, overwrite);
   }
 
   @Override
-  public void saveToPendingReplaceCommit(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToPendingReplaceCommit(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToPendingClusterCommit(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToPendingClusterCommit(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToCleanRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToCleanRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.CLEAN_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToRollbackRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToRollbackRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public void saveToRestoreRequested(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToRestoreRequested(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.RESTORE_ACTION));
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     // Plan is stored in meta path
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
   @Override
-  public HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionIndexRequestedToInflight(HoodieInstant requestedInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", requestedInstant.getAction(), INDEXING_ACTION));
     ValidationUtils.checkArgument(requestedInstant.isRequested(),
         String.format("Instant %s not in requested state", requestedInstant.requestedTime()));
     HoodieInstant inflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, INDEXING_ACTION, requestedInstant.requestedTime());
-    transitionPendingState(requestedInstant, inflightInstant, data);
+    transitionPendingState(requestedInstant, inflightInstant, metadata);
     return inflightInstant;
   }
 
   @Override
-  public HoodieInstant transitionIndexInflightToComplete(boolean shouldLock,
-                                                         HoodieInstant inflightInstant, Option<byte[]> data) {
+  public <T> HoodieInstant transitionIndexInflightToComplete(
+      boolean shouldLock, HoodieInstant inflightInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", inflightInstant.getAction(), INDEXING_ACTION));
     ValidationUtils.checkArgument(inflightInstant.isInflight(),
         String.format("Instant %s not inflight", inflightInstant.requestedTime()));
     HoodieInstant commitInstant = instantGenerator.createNewInstant(HoodieInstant.State.COMPLETED, INDEXING_ACTION, inflightInstant.requestedTime());
-    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, data);
+    transitionStateToComplete(shouldLock, inflightInstant, commitInstant, metadata);
     return commitInstant;
   }
 
@@ -709,22 +708,24 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
-  public void saveToPendingIndexAction(HoodieInstant instant, Option<byte[]> content) {
+  public <T> void saveToPendingIndexAction(HoodieInstant instant, Option<T> metadata) {
     ValidationUtils.checkArgument(instant.getAction().equals(HoodieTimeline.INDEXING_ACTION),
         String.format("%s is not equal to %s action", instant.getAction(), INDEXING_ACTION));
-    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), content, false);
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), metadata, false);
   }
 
-  public void createFileInMetaPath(String filename, Option<byte[]> content, boolean allowOverwrite) {
+  public <T> void createFileInMetaPath(String filename, Option<T> metadata, boolean allowOverwrite) {
     StoragePath fullPath = getInstantFileNamePath(filename);
+    Option<HoodieInstantWriter> writerOption = getHoodieInstantWriterOption(this, metadata);
     if (allowOverwrite || metaClient.getTimelineLayoutVersion().isNullVersion()) {
-      FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, content);
+      FileIOUtils.createFileInPath(metaClient.getStorage(metaClient.getTimelinePath()), fullPath, writerOption);
     } else {
-      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
+      metaClient.getStorage(metaClient.getTimelinePath()).createImmutableFileInPath(fullPath, writerOption);
     }
   }
 
-  protected void createCompleteFileInMetaPath(boolean shouldLock, HoodieInstant instant, Option<byte[]> content) {
+  protected <T> void createCompleteFileInMetaPath(boolean shouldLock, HoodieInstant instant, Option<T> metadata) {
+    Option<HoodieInstantWriter> writerOption = getHoodieInstantWriterOption(this, metadata);
     TimeGenerator timeGenerator = TimeGenerators
         .getTimeGenerator(metaClient.getTimeGeneratorConfig(), metaClient.getStorageConf());
     timeGenerator.consumeTime(!shouldLock, currentTimeMillis -> {
@@ -732,9 +733,9 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
       String fileName = instantFileNameGenerator.getFileName(completionTime, instant);
       StoragePath fullPath = getInstantFileNamePath(fileName);
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
-        FileIOUtils.createFileInPath(metaClient.getStorage(), fullPath, content);
+        FileIOUtils.createFileInPath(metaClient.getStorage(), fullPath, writerOption);
       } else {
-        metaClient.getStorage().createImmutableFileInPath(fullPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
+        metaClient.getStorage().createImmutableFileInPath(fullPath, writerOption);
       }
       LOG.info("Created new file for toInstant ?" + fullPath);
     });

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -148,14 +148,10 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
 
   @Override
   public void createRequestedCommitWithReplaceMetadata(String instantTime, String actionType) {
-    try {
-      HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
-      LOG.info("Creating a new instant " + instant);
-      // Create the request replace file
-      createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
-    } catch (HoodieIOException e) {
-      throw e;
-    }
+    HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, actionType, instantTime);
+    LOG.info("Creating a new instant " + instant);
+    // Create the request replace file
+    createFileInMetaPath(instantFileNameGenerator.getFileName(instant), Option.of(new HoodieRequestedReplaceMetadata()), false);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
@@ -23,16 +23,14 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.MetadataConversionUtils;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.HoodieInstantWriter;
 
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecordBase;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.BooleanSupplier;
@@ -93,23 +91,10 @@ public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
   }
 
   @Override
-  public Option<byte[]> serialize(org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata) throws IOException {
-    if (commitMetadata instanceof org.apache.hudi.common.model.HoodieReplaceCommitMetadata) {
-      return serializeAvroMetadata(MetadataConversionUtils.convertCommitMetadata(commitMetadata), HoodieReplaceCommitMetadata.class);
+  public <T> Option<HoodieInstantWriter> getInstantWriter(T metadata) {
+    if (metadata instanceof org.apache.hudi.common.model.HoodieCommitMetadata) {
+      return TimelineMetadataUtils.getInstantWriter(Option.of(MetadataConversionUtils.convertCommitMetadataToAvro((HoodieCommitMetadata) metadata)));
     }
-    return serializeAvroMetadata(
-        MetadataConversionUtils.convertCommitMetadata(commitMetadata),
-        org.apache.hudi.avro.model.HoodieCommitMetadata.class);
-  }
-
-  public static <T extends SpecificRecordBase> Option<byte[]> serializeAvroMetadata(T metadata, Class<T> clazz)
-      throws IOException {
-    DatumWriter<T> datumWriter = new SpecificDatumWriter<>(clazz);
-    DataFileWriter<T> fileWriter = new DataFileWriter<>(datumWriter);
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    fileWriter.create(metadata.getSchema(), baos);
-    fileWriter.append(metadata);
-    fileWriter.flush();
-    return Option.of(baos.toByteArray());
+    return TimelineMetadataUtils.getInstantWriter(Option.of((SpecificRecordBase) metadata));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CommitMetadataSerDeV2.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.MetadataConversionUtils;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.Option;
@@ -93,8 +92,8 @@ public class CommitMetadataSerDeV2 implements CommitMetadataSerDe {
   @Override
   public <T> Option<HoodieInstantWriter> getInstantWriter(T metadata) {
     if (metadata instanceof org.apache.hudi.common.model.HoodieCommitMetadata) {
-      return TimelineMetadataUtils.getInstantWriter(Option.of(MetadataConversionUtils.convertCommitMetadataToAvro((HoodieCommitMetadata) metadata)));
+      return CommitMetadataSerDe.getInstantWriter(Option.of(MetadataConversionUtils.convertCommitMetadataToAvro((HoodieCommitMetadata) metadata)));
     }
-    return TimelineMetadataUtils.getInstantWriter(Option.of((SpecificRecordBase) metadata));
+    return CommitMetadataSerDe.getInstantWriter(Option.of((SpecificRecordBase) metadata));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -122,7 +123,7 @@ public class ClusteringUtils {
    * action type. After HUDI-7905, the new clustering commits are written with clustering action.
    */
   public static <T> void transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
-                                                                         Option<T> metadata, HoodieActiveTimeline activeTimeline) {
+                                                                         HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline) {
     if (clusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
       activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata);
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -121,12 +121,12 @@ public class ClusteringUtils {
    * Transitions the provided clustering instant fron inflight to complete based on the clustering
    * action type. After HUDI-7905, the new clustering commits are written with clustering action.
    */
-  public static void transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
-                                                                     Option<byte[]> commitMetadata, HoodieActiveTimeline activeTimeline) {
+  public static <T> void transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
+                                                                         Option<T> metadata, HoodieActiveTimeline activeTimeline) {
     if (clusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, commitMetadata);
+      activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata);
     } else {
-      activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, commitMetadata);
+      activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, metadata);
     }
   }
 
@@ -134,12 +134,12 @@ public class ClusteringUtils {
    * Transitions the provided clustering instant fron requested to inflight based on the clustering
    * action type. After HUDI-7905, the new clustering commits are written with clustering action.
    */
-  public static void transitionClusteringOrReplaceRequestedToInflight(HoodieInstant requestedClusteringInstant, Option<byte[]> data,
-                                                                      HoodieActiveTimeline activeTimeline) {
+  public static <T> void transitionClusteringOrReplaceRequestedToInflight(
+      HoodieInstant requestedClusteringInstant, Option<T> metadata, HoodieActiveTimeline activeTimeline) {
     if (requestedClusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      activeTimeline.transitionClusterRequestedToInflight(requestedClusteringInstant, data);
+      activeTimeline.transitionClusterRequestedToInflight(requestedClusteringInstant, metadata);
     } else {
-      activeTimeline.transitionReplaceRequestedToInflight(requestedClusteringInstant, data);
+      activeTimeline.transitionReplaceRequestedToInflight(requestedClusteringInstant, metadata);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/io/FileBasedInternalSchemaStorageManager.java
@@ -29,6 +29,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.utils.InternalSchemaUtils;
 import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -91,7 +92,10 @@ public class FileBasedInternalSchemaStorageManager extends AbstractInternalSchem
     timeline.createNewInstant(hoodieInstant);
     byte[] writeContent = getUTF8Bytes(historySchemaStr);
     timeline.transitionRequestedToInflight(hoodieInstant, Option.empty());
-    timeline.saveAsComplete(false, metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, hoodieInstant.getAction(), hoodieInstant.requestedTime()), Option.of(writeContent));
+    // TODO[HUDI-9094]: we should not write raw byte array directly.
+    timeline.saveAsComplete(false, metaClient.createNewInstant(
+        HoodieInstant.State.INFLIGHT, hoodieInstant.getAction(), hoodieInstant.requestedTime()),
+        Option.of(HoodieInstantWriter.convertByteArrayToWriter(writeContent)));
     LOG.info(String.format("persist history schema success on commit time: %s", instantTime));
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.AvroSchemaUtils.isSchemaCompatible;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToByteArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -181,7 +181,7 @@ public class TestHoodieCommitMetadata {
     // Case: Reading 0.x written commit metadata
     HoodieInstant legacyInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "1", "1", true);
     CommitMetadataSerDe v1SerDe = new CommitMetadataSerDeV1();
-    byte[] v1Bytes = convertMetadataToBytArray(commitMetadata1, v1SerDe);
+    byte[] v1Bytes = convertMetadataToByteArray(commitMetadata1, v1SerDe);
     System.out.println(new String(v1Bytes));
     org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata2 =
         COMMIT_METADATA_SER_DE.deserialize(legacyInstant, new ByteArrayInputStream(v1Bytes), () -> false, org.apache.hudi.common.model.HoodieCommitMetadata.class);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.AvroSchemaUtils.isSchemaCompatible;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -180,7 +181,7 @@ public class TestHoodieCommitMetadata {
     // Case: Reading 0.x written commit metadata
     HoodieInstant legacyInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, "commit", "1", "1", true);
     CommitMetadataSerDe v1SerDe = new CommitMetadataSerDeV1();
-    byte[] v1Bytes = v1SerDe.serialize(commitMetadata1).get();
+    byte[] v1Bytes = convertMetadataToBytArray(commitMetadata1, v1SerDe);
     System.out.println(new String(v1Bytes));
     org.apache.hudi.common.model.HoodieCommitMetadata commitMetadata2 =
         COMMIT_METADATA_SER_DE.deserialize(legacyInstant, new ByteArrayInputStream(v1Bytes), () -> false, org.apache.hudi.common.model.HoodieCommitMetadata.class);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.StoragePath;
@@ -46,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -81,12 +81,10 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("commit", "001");
 
     // Serialize
-    Option<byte[]> serialized = serDe.serialize(emptyMetadata);
-    assertTrue(serialized.isPresent());
+    byte[] serialized = convertMetadataToBytArray(emptyMetadata, serDe);
 
     // Deserialize
-    HoodieCommitMetadata deserialized =
-        serDe.deserialize(instant, new ByteArrayInputStream(serialized.get()), () -> false, HoodieCommitMetadata.class);
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
 
     // Verify
     assertNotNull(deserialized);
@@ -113,9 +111,8 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("commit", "001");
 
     // Serialize and deserialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-    HoodieCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized.get()), () -> false, HoodieCommitMetadata.class);
+    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    HoodieCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
 
     // Verify
     verifyCommitMetadata(deserialized);
@@ -145,9 +142,8 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("replacecommit", "001");
 
     // Serialize and deserialize
-    Option<byte[]> serialized = serDe.serialize(metadata);
-    assertTrue(serialized.isPresent());
-    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized.get()), () -> false, HoodieReplaceCommitMetadata.class);
+    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieReplaceCommitMetadata.class);
 
     // Verify
     verifyReplaceCommitMetadata(deserialized);
@@ -190,9 +186,8 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("rollback", "002");
 
     // Serialize and deserialize
-    Option<byte[]> serialized = TimelineMetadataUtils.serializeRollbackMetadata(metadata);
-    assertTrue(serialized.isPresent());
-    HoodieRollbackMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized.get()), () -> false, HoodieRollbackMetadata.class);
+    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    HoodieRollbackMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieRollbackMetadata.class);
 
     // Verify
     assertNotNull(deserialized);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/BaseTestCommitMetadataSerDe.java
@@ -45,7 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToByteArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -81,7 +81,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("commit", "001");
 
     // Serialize
-    byte[] serialized = convertMetadataToBytArray(emptyMetadata, serDe);
+    byte[] serialized = convertMetadataToByteArray(emptyMetadata, serDe);
 
     // Deserialize
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
@@ -111,7 +111,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("commit", "001");
 
     // Serialize and deserialize
-    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    byte[] serialized = convertMetadataToByteArray(metadata, serDe);
     HoodieCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
 
     // Verify
@@ -142,7 +142,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("replacecommit", "001");
 
     // Serialize and deserialize
-    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    byte[] serialized = convertMetadataToByteArray(metadata, serDe);
     HoodieReplaceCommitMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieReplaceCommitMetadata.class);
 
     // Verify
@@ -186,7 +186,7 @@ public abstract class BaseTestCommitMetadataSerDe {
     HoodieInstant instant = createTestInstant("rollback", "002");
 
     // Serialize and deserialize
-    byte[] serialized = convertMetadataToBytArray(metadata, serDe);
+    byte[] serialized = convertMetadataToByteArray(metadata, serDe);
     HoodieRollbackMetadata deserialized = serDe.deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieRollbackMetadata.class);
 
     // Verify

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -26,14 +26,13 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.BaseTestCommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
-import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
 
@@ -65,9 +64,8 @@ public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
 
 
     // Serialize and deserialize
-    Option<byte[]> serialized = serDeV1.serialize(metadata);
-    assertTrue(serialized.isPresent());
-    HoodieCommitMetadata deserialized = getSerDe().deserialize(instant, new ByteArrayInputStream(serialized.get()), () -> false, HoodieCommitMetadata.class);
+    byte[] serialized = convertMetadataToBytArray(metadata, serDeV1);
+    HoodieCommitMetadata deserialized = getSerDe().deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
     verifyCommitMetadata(deserialized);
     verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v2/TestCommitMetadataSerDeV2.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToByteArray;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 
 public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
@@ -64,7 +64,7 @@ public class TestCommitMetadataSerDeV2 extends BaseTestCommitMetadataSerDe {
 
 
     // Serialize and deserialize
-    byte[] serialized = convertMetadataToBytArray(metadata, serDeV1);
+    byte[] serialized = convertMetadataToByteArray(metadata, serDeV1);
     HoodieCommitMetadata deserialized = getSerDe().deserialize(instant, new ByteArrayInputStream(serialized), () -> false, HoodieCommitMetadata.class);
     verifyCommitMetadata(deserialized);
     verifyWriteStat(deserialized.getPartitionToWriteStats().get(TEST_PARTITION_PATH).get(0));

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
@@ -139,7 +138,7 @@ public class CompactionTestUtils {
       HoodieCompactionPlan compactionPlan) throws IOException {
     metaClient.getActiveTimeline().saveToCompactionRequested(
         INSTANT_GENERATOR.createNewInstant(State.REQUESTED, COMPACTION_ACTION, instantTime),
-        TimelineMetadataUtils.serializeCompactionPlan(compactionPlan));
+        Option.of(compactionPlan));
   }
 
   public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
@@ -138,7 +138,7 @@ public class CompactionTestUtils {
       HoodieCompactionPlan compactionPlan) throws IOException {
     metaClient.getActiveTimeline().saveToCompactionRequested(
         INSTANT_GENERATOR.createNewInstant(State.REQUESTED, COMPACTION_ACTION, instantTime),
-        Option.of(compactionPlan));
+        compactionPlan);
   }
 
   public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -38,12 +38,12 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -64,16 +64,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCleanerPlan;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCompactionPlan;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRestoreMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackPlan;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
-
 /**
  * Utils for creating dummy Hudi files in testing.
  * TODO[Davis Zhang]: For all function calls with preTableVersion8, they should be derive directly by consulting metaClient. Remove the
@@ -92,11 +82,12 @@ public class FileCreateUtils extends FileCreateUtilsBase {
   }
 
   private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix) throws IOException {
-    createMetaFile(metaClient, instantTime, suffix, getUTF8Bytes(""));
+    createMetaFile(metaClient, instantTime, suffix, Option.empty());
   }
 
-  private static void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix, byte[] content) throws IOException {
-    createMetaFileInTimelinePath(metaClient, instantTime, InProcessTimeGenerator::createNewInstantTime, suffix, content);
+  private static <T> void createMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix, Option<T> metadata) throws IOException {
+    createMetaFileInTimelinePath(metaClient, instantTime, InProcessTimeGenerator::createNewInstantTime, suffix,
+        metadata.flatMap(m -> metaClient.getCommitMetadataSerDe().getInstantWriter(m)));
   }
 
   private static void deleteMetaFile(HoodieTableMetaClient metaClient, String instantTime, String suffix,
@@ -115,18 +106,16 @@ public class FileCreateUtils extends FileCreateUtilsBase {
     if (metadata.isPresent()) {
       HoodieCommitMetadata commitMetadata = metadata.get();
       createMetaFileInTimelinePath(metaClient, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, commitMetadata).get());
+          metaClient.getCommitMetadataSerDe().getInstantWriter(commitMetadata));
     } else {
-      createMetaFileInTimelinePath(metaClient, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
-          getUTF8Bytes(""));
+      createMetaFileInTimelinePath(metaClient, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION, Option.empty());
     }
   }
 
   public static void createSavepointCommit(HoodieTableMetaClient metaClient, String instantTime,
                                            HoodieSavepointMetadata savepointMetadata)
       throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION,
-        TimelineMetadataUtils.serializeSavepointMetadata(savepointMetadata).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.SAVEPOINT_EXTENSION, Option.of(savepointMetadata));
   }
 
   public static void createCommit(HoodieTableMetaClient metaClient, String instantTime)
@@ -144,8 +133,7 @@ public class FileCreateUtils extends FileCreateUtilsBase {
 
   public static void createDeltaCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe, String instantTime,
                                        HoodieCommitMetadata metadata) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION,
-        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, Option.of(metadata));
   }
 
   public static void createDeltaCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
@@ -185,29 +173,28 @@ public class FileCreateUtils extends FileCreateUtilsBase {
   public static void createReplaceCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
                                          String instantTime, HoodieReplaceCommitMetadata metadata) throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
-        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+        Option.of(metadata));
   }
 
   public static void createReplaceCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
                                          String instantTime, String completionTime, HoodieReplaceCommitMetadata metadata) throws IOException {
     createMetaFileInTimelinePath(
         metaClient, instantTime, () -> completionTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
-        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+        metaClient.getCommitMetadataSerDe().getInstantWriter(metadata));
   }
 
   public static void createRequestedClusterCommit(HoodieTableMetaClient metaClient, String instantTime,
                                                   HoodieRequestedReplaceMetadata requestedReplaceMetadata)
       throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLUSTERING_COMMIT_EXTENSION,
-        serializeRequestedReplaceMetadata(requestedReplaceMetadata).get());
+        Option.of(requestedReplaceMetadata));
   }
 
-  public static void createInflightClusterCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
-                                                 String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
+  public static <T> void createInflightClusterCommit(HoodieTableMetaClient metaClient, CommitMetadataSerDe commitMetadataSerDe,
+                                                     String instantTime, Option<T> inflightReplaceMetadata)
       throws IOException {
     if (inflightReplaceMetadata.isPresent()) {
-      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION, inflightReplaceMetadata);
     } else {
       createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION);
     }
@@ -217,8 +204,7 @@ public class FileCreateUtils extends FileCreateUtilsBase {
                                                   Option<HoodieRequestedReplaceMetadata> requestedReplaceMetadata)
       throws IOException {
     if (requestedReplaceMetadata.isPresent()) {
-      createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION,
-          serializeRequestedReplaceMetadata(requestedReplaceMetadata.get()).get());
+      createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION, requestedReplaceMetadata);
     } else {
       createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
     }
@@ -228,8 +214,7 @@ public class FileCreateUtils extends FileCreateUtilsBase {
                                                  String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata)
       throws IOException {
     if (inflightReplaceMetadata.isPresent()) {
-      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, inflightReplaceMetadata.get()).get());
+      createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION, inflightReplaceMetadata);
     } else {
       createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
     }
@@ -239,54 +224,54 @@ public class FileCreateUtils extends FileCreateUtilsBase {
                                                      HoodieCompactionPlan requestedCompactionPlan)
       throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION,
-        serializeCompactionPlan(requestedCompactionPlan).get());
+        Option.of(requestedCompactionPlan));
   }
 
   public static void createCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                      HoodieCleanMetadata metadata) throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.CLEAN_EXTENSION,
-        serializeCleanMetadata(metadata).get());
+        Option.of(metadata));
   }
 
   public static void createCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                      HoodieCleanMetadata metadata, boolean isEmpty)
       throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanMetadata(metadata).get());
+        isEmpty ? Option.empty() : Option.of(metadata));
   }
 
   public static void createRequestedCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                               HoodieCleanerPlan cleanerPlan) throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
-        serializeCleanerPlan(cleanerPlan).get());
+        Option.of(cleanerPlan));
   }
 
   public static void createRequestedCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                               HoodieCleanerPlan cleanerPlan, boolean isEmpty)
       throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
+        isEmpty ? Option.empty() : Option.of(cleanerPlan));
   }
 
   public static void createInflightCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                              HoodieCleanerPlan cleanerPlan) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
-        serializeCleanerPlan(cleanerPlan).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION, Option.of(cleanerPlan));
   }
 
   public static void createInflightCleanFile(HoodieTableMetaClient metaClient, String instantTime,
                                              HoodieCleanerPlan cleanerPlan, boolean isEmpty)
       throws IOException {
     createMetaFile(metaClient, instantTime, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION,
-        isEmpty ? EMPTY_BYTES : serializeCleanerPlan(cleanerPlan).get());
+        isEmpty ? Option.empty() : Option.of(cleanerPlan));
   }
 
   public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRollbackPlan plan) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, serializeRollbackPlan(plan).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, Option.of(plan));
   }
 
   public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime, byte[] content) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, content);
+    createMetaFileInTimelinePath(metaClient, instantTime, InProcessTimeGenerator::createNewInstantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION,
+        Option.of(HoodieInstantWriter.convertByteArrayToWriter(content)));
   }
 
   public static void createRequestedRollbackFile(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
@@ -298,11 +283,11 @@ public class FileCreateUtils extends FileCreateUtilsBase {
   }
 
   public static void createRollbackFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRollbackMetadata hoodieRollbackMetadata, boolean isEmpty) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.ROLLBACK_EXTENSION, isEmpty ? EMPTY_BYTES : serializeRollbackMetadata(hoodieRollbackMetadata).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.ROLLBACK_EXTENSION, isEmpty ? Option.empty() : Option.of(hoodieRollbackMetadata));
   }
 
   public static void createRestoreFile(HoodieTableMetaClient metaClient, String instantTime, HoodieRestoreMetadata hoodieRestoreMetadata) throws IOException {
-    createMetaFile(metaClient, instantTime, HoodieTimeline.RESTORE_ACTION, serializeRestoreMetadata(hoodieRestoreMetadata).get());
+    createMetaFile(metaClient, instantTime, HoodieTimeline.RESTORE_ACTION, Option.of(hoodieRestoreMetadata));
   }
 
   public static void createRequestedCompaction(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
@@ -318,17 +303,17 @@ public class FileCreateUtils extends FileCreateUtilsBase {
   }
 
   protected static void createMetaFileInTimelinePath(
-      HoodieTableMetaClient metaClient, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
+      HoodieTableMetaClient metaClient, String instantTime, Supplier<String> completionTimeSupplier, String suffix, Option<HoodieInstantWriter> writer) throws IOException {
     try {
       Path parentPath = Paths.get(metaClient.getTimelinePath().makeQualified(new URI("file:///")).toUri());
       Files.createDirectories(parentPath);
       if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
         Path metaFilePath = parentPath.resolve(instantTime + suffix);
         if (Files.notExists(metaFilePath)) {
-          if (content.length == 0) {
+          if (writer.isEmpty()) {
             Files.createFile(metaFilePath);
           } else {
-            Files.write(metaFilePath, content);
+            Files.write(metaFilePath, writer.map(Transformations::writeInstantContentToBytes).get());
           }
         }
       } else {
@@ -343,10 +328,10 @@ public class FileCreateUtils extends FileCreateUtilsBase {
               completedInstantFilePrefix = instantTime + "_" + completionTimeSupplier.get();
             }
             Path metaFilePath = parentPath.resolve(completedInstantFilePrefix + suffix);
-            if (content.length == 0) {
+            if (writer.isEmpty()) {
               Files.createFile(metaFilePath);
             } else {
-              Files.write(metaFilePath, content);
+              Files.write(metaFilePath, writer.map(Transformations::writeInstantContentToBytes).get());
             }
           }
         }
@@ -451,19 +436,19 @@ public class FileCreateUtils extends FileCreateUtilsBase {
     removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
   }
 
-  public static void deleteInflightCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+  public static void deleteInflightCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
     removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
   }
 
-  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
     removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION);
   }
 
-  public static void deleteReplaceCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+  public static void deleteReplaceCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
     removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
   }
 
-  public static void deleteRollbackCommit(HoodieTableMetaClient metaClient,String instantTime) throws IOException {
+  public static void deleteRollbackCommit(HoodieTableMetaClient metaClient, String instantTime) throws IOException {
     removeMetaFileInTimelinePath(metaClient.getTimelinePath().toUri().getPath(), instantTime, HoodieTimeline.ROLLBACK_EXTENSION);
   }
 
@@ -477,7 +462,7 @@ public class FileCreateUtils extends FileCreateUtilsBase {
     Files.move(tempFilePath, destPath);
   }
 
-  public static long getTotalMarkerFileCount(HoodieTableMetaClient metaClient,String partitionPath, String instantTime, IOType ioType) throws IOException {
+  public static long getTotalMarkerFileCount(HoodieTableMetaClient metaClient, String partitionPath, String instantTime, IOType ioType) throws IOException {
     Path parentPath = Paths.get(metaClient.getTempFolderPath(), instantTime, partitionPath);
     if (Files.notExists(parentPath)) {
       return 0;
@@ -525,7 +510,7 @@ public class FileCreateUtils extends FileCreateUtilsBase {
     }
   }
 
-  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient,String instantTime,
+  public static void deleteDeltaCommit(HoodieTableMetaClient metaClient, String instantTime,
                                        HoodieStorage storage) throws IOException {
     deleteMetaFile(metaClient, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, storage);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
@@ -86,8 +86,7 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
 
   private static <T> void createMetaFile(String basePath, String instantTime, String suffix, Option<T> metadata) throws IOException {
     createMetaFile(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime,
-        InProcessTimeGenerator::createNewInstantTime, suffix,
-        metadata.isEmpty() ? Option.empty() : COMMIT_METADATA_SER_DE.getInstantWriter(metadata.get()));
+        InProcessTimeGenerator::createNewInstantTime, suffix, metadata.flatMap(COMMIT_METADATA_SER_DE::getInstantWriter));
   }
 
   private static void createMetaFile(String basePath, String instantTime, String suffix, HoodieInstantWriter writer) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtilsLegacy.java
@@ -34,10 +34,12 @@ import org.apache.hudi.common.table.timeline.CommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,11 +54,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCompactionPlan;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackPlan;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 
 /**
  * Utils for creating dummy Hudi files in testing.
@@ -83,11 +81,18 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
   }
 
   private static void createMetaFile(String basePath, String instantTime, String suffix) throws IOException {
-    createMetaFile(basePath, instantTime, suffix, getUTF8Bytes(""));
+    createMetaFile(basePath, instantTime, suffix, Option.empty());
   }
 
-  private static void createMetaFile(String basePath, String instantTime, String suffix, byte[] content) throws IOException {
-    createMetaFile(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime, InProcessTimeGenerator::createNewInstantTime, suffix, content);
+  private static <T> void createMetaFile(String basePath, String instantTime, String suffix, Option<T> metadata) throws IOException {
+    createMetaFile(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime,
+        InProcessTimeGenerator::createNewInstantTime, suffix,
+        metadata.isEmpty() ? Option.empty() : COMMIT_METADATA_SER_DE.getInstantWriter(metadata.get()));
+  }
+
+  private static void createMetaFile(String basePath, String instantTime, String suffix, HoodieInstantWriter writer) throws IOException {
+    createMetaFile(getTimelinePath(new StoragePath(basePath)).toUri().getPath(), instantTime,
+        InProcessTimeGenerator::createNewInstantTime, suffix, Option.of(writer));
   }
 
   public static void createCommit(String basePath, String instantTime) throws IOException {
@@ -106,10 +111,9 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
     if (metadata.isPresent()) {
       HoodieCommitMetadata commitMetadata = metadata.get();
       createMetaFile(timelinePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
-          serializeCommitMetadata(commitMetadataSerDe, commitMetadata).get());
+          COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata));
     } else {
-      createMetaFile(timelinePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION,
-          getUTF8Bytes(""));
+      createMetaFile(timelinePath, instantTime, completionTimeSupplier, HoodieTimeline.COMMIT_EXTENSION, Option.empty());
     }
   }
 
@@ -124,8 +128,7 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
 
   public static void createDeltaCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath, String instantTime,
                                        HoodieCommitMetadata metadata) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION,
-        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+    createMetaFile(basePath, instantTime, HoodieTimeline.DELTA_COMMIT_EXTENSION, Option.of(metadata));
   }
 
   public static void createDeltaCommit(String basePath, String instantTime) throws IOException {
@@ -149,30 +152,26 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
 
   public static void createReplaceCommit(CommitMetadataSerDe commitMetadataSerDe, String basePath,
                                          String instantTime, HoodieReplaceCommitMetadata metadata) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION,
-        serializeCommitMetadata(commitMetadataSerDe, metadata).get());
+    createMetaFile(basePath, instantTime, HoodieTimeline.REPLACE_COMMIT_EXTENSION, Option.of(metadata));
   }
 
   public static void createRequestedClusterCommit(String basePath, String instantTime,
-                                                  HoodieRequestedReplaceMetadata requestedReplaceMetadata)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_CLUSTERING_COMMIT_EXTENSION,
-        serializeRequestedReplaceMetadata(requestedReplaceMetadata).get());
+                                                  HoodieRequestedReplaceMetadata requestedReplaceMetadata) throws IOException {
+    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_CLUSTERING_COMMIT_EXTENSION, Option.of(requestedReplaceMetadata));
   }
 
   public static void createRequestedCompactionCommit(String basePath, String instantTime,
-                                                     HoodieCompactionPlan requestedCompactionPlan)
-      throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION,
-        serializeCompactionPlan(requestedCompactionPlan).get());
+                                                     HoodieCompactionPlan requestedCompactionPlan) throws IOException {
+    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION, Option.of(requestedCompactionPlan));
   }
 
   public static void createRequestedRollbackFile(String basePath, String instantTime, HoodieRollbackPlan plan) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, serializeRollbackPlan(plan).get());
+    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, Option.of(plan));
   }
 
   public static void createRequestedRollbackFile(String basePath, String instantTime, byte[] content) throws IOException {
-    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION, content);
+    createMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION,
+        HoodieInstantWriter.convertByteArrayToWriter(content));
   }
 
   public static void createInflightCompaction(String basePath, String instantTime) throws IOException {
@@ -253,18 +252,20 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
     return markerFilePath.toAbsolutePath().toString();
   }
 
-  private static void createMetaFile(String timelinePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix, byte[] content) throws IOException {
+  private static void createMetaFile(String timelinePath, String instantTime, Supplier<String> completionTimeSupplier, String suffix,
+                                     Option<HoodieInstantWriter> writerOption) throws IOException {
     try {
       Path parentPath = Paths.get(new StoragePath(timelinePath).makeQualified(new URI("file:///")).toUri());
-
       Files.createDirectories(parentPath);
       if (suffix.contains(HoodieTimeline.INFLIGHT_EXTENSION) || suffix.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
         Path metaFilePath = parentPath.resolve(instantTime + suffix);
         if (Files.notExists(metaFilePath)) {
-          if (content.length == 0) {
+          if (writerOption.isEmpty()) {
             Files.createFile(metaFilePath);
           } else {
-            Files.write(metaFilePath, content);
+            try (OutputStream outputStream = Files.newOutputStream(metaFilePath)) {
+              writerOption.get().writeToStream(outputStream);
+            }
           }
         }
       } else {
@@ -274,10 +275,12 @@ public class FileCreateUtilsLegacy extends FileCreateUtilsBase {
             // doesn't contains completion time
             String instantTimeAndCompletionTime = instantTime + "_" + completionTimeSupplier.get();
             Path metaFilePath = parentPath.resolve(instantTimeAndCompletionTime + suffix);
-            if (content.length == 0) {
+            if (writerOption.isEmpty()) {
               Files.createFile(metaFilePath);
             } else {
-              Files.write(metaFilePath, content);
+              try (OutputStream outputStream = Files.newOutputStream(metaFilePath)) {
+                writerOption.get().writeToStream(outputStream);
+              }
             }
           }
         }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -393,8 +393,8 @@ public class HoodieTestUtils {
     return getCompleteInstantFileInfo(storage, parent, instantTime, action).getPath();
   }
 
-  public static <T> byte[] convertMetadataToBytArray(T metadata) {
-    return TimelineMetadataUtils.convertMetadataToBytArray(metadata, COMMIT_METADATA_SER_DE);
+  public static <T> byte[] convertMetadataToByteArray(T metadata) {
+    return TimelineMetadataUtils.convertMetadataToByteArray(metadata, COMMIT_METADATA_SER_DE);
   }
 
   private static StoragePathInfo getCompleteInstantFileInfo(HoodieStorage storage,

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.InstantFileNameParser;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.DefaultCommitMetadataSerDe;
 import org.apache.hudi.common.table.timeline.versioning.DefaultInstantComparator;
 import org.apache.hudi.common.table.timeline.versioning.DefaultInstantFileNameGenerator;
@@ -390,6 +391,10 @@ public class HoodieTestUtils {
   public static StoragePath getCompleteInstantPath(HoodieStorage storage, StoragePath parent,
                                                    String instantTime, String action) {
     return getCompleteInstantFileInfo(storage, parent, instantTime, action).getPath();
+  }
+
+  public static <T> byte[] convertMetadataToBytArray(T metadata) {
+    return TimelineMetadataUtils.convertMetadataToBytArray(metadata, COMMIT_METADATA_SER_DE);
   }
 
   private static StoragePathInfo getCompleteInstantFileInfo(HoodieStorage storage,

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/Transformations.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/Transformations.java
@@ -21,7 +21,11 @@ package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieInstantWriter;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -78,5 +82,15 @@ public final class Transformations {
 
   public static List<HoodieKey> randomSelectAsHoodieKeys(List<HoodieRecord> records, int n) {
     return randomSelect(recordsToHoodieKeys(records), n);
+  }
+
+  public static byte[] writeInstantContentToBytes(HoodieInstantWriter writer) {
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      writer.writeToStream(outputStream);
+      outputStream.flush();
+      return outputStream.toByteArray();
+    } catch (IOException ex) {
+      throw new HoodieIOException("Failed to convert to bytes", ex);
+    }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/Transformations.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/Transformations.java
@@ -21,11 +21,7 @@ package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.storage.HoodieInstantWriter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -82,15 +78,5 @@ public final class Transformations {
 
   public static List<HoodieKey> randomSelectAsHoodieKeys(List<HoodieRecord> records, int n) {
     return randomSelect(recordsToHoodieKeys(records), n);
-  }
-
-  public static byte[] writeInstantContentToBytes(HoodieInstantWriter writer) {
-    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      writer.writeToStream(outputStream);
-      outputStream.flush();
-      return outputStream.toByteArray();
-    } catch (IOException ex) {
-      throw new HoodieIOException("Failed to convert to bytes", ex);
-    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -21,6 +21,7 @@ package org.apache.hudi.source;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.log.InstantRange;
@@ -172,7 +173,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionClusterInflightToComplete(true, INSTANT_GENERATOR.getClusteringCommitInflightInstant(commit3.requestedTime()),
-        Option.of(commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
     // commit4: insert overwrite
     HoodieInstant commit4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");
     timelineMOR.createNewInstant(commit4);
@@ -185,7 +186,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit4.requestedTime()),
-            Option.of(commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
     // commit5: insert overwrite table
     HoodieInstant commit5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "5");
     timelineMOR.createNewInstant(commit5);
@@ -198,12 +199,12 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit5.requestedTime()),
-            Option.of(commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
     // commit6:  compaction
     HoodieInstant commit6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "6");
     timelineMOR.createNewInstant(commit6);
     commit6 = timelineMOR.transitionCompactionRequestedToInflight(commit6);
-    commit6 = timelineMOR.transitionCompactionInflightToComplete(false, commit6, Option.empty());
+    commit6 = timelineMOR.transitionCompactionInflightToComplete(false, commit6, new HoodieCommitMetadata());
     timelineMOR.createCompleteInstant(commit6);
     timelineMOR = timelineMOR.reload();
 
@@ -251,7 +252,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionClusterInflightToComplete(true,
             INSTANT_GENERATOR.getClusteringCommitInflightInstant(commit3.requestedTime()),
-            Option.of(commitMetadata));
+            (HoodieReplaceCommitMetadata) commitMetadata);
     // commit4: insert overwrite
     HoodieInstant commit4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");
     timelineCOW.createNewInstant(commit4);
@@ -264,7 +265,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit4.requestedTime()),
-            Option.of(commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
     // commit5: insert overwrite table
     HoodieInstant commit5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "5");
     timelineCOW.createNewInstant(commit5);
@@ -277,7 +278,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit5.requestedTime()),
-        Option.of(commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
 
     timelineCOW = timelineCOW.reload();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -72,7 +72,6 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,7 +172,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionClusterInflightToComplete(true, INSTANT_GENERATOR.getClusteringCommitInflightInstant(commit3.requestedTime()),
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+        Option.of(commitMetadata));
     // commit4: insert overwrite
     HoodieInstant commit4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");
     timelineMOR.createNewInstant(commit4);
@@ -186,7 +185,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit4.requestedTime()),
-            serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+            Option.of(commitMetadata));
     // commit5: insert overwrite table
     HoodieInstant commit5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "5");
     timelineMOR.createNewInstant(commit5);
@@ -199,7 +198,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineMOR.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit5.requestedTime()),
-            serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+            Option.of(commitMetadata));
     // commit6:  compaction
     HoodieInstant commit6 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "6");
     timelineMOR.createNewInstant(commit6);
@@ -252,7 +251,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionClusterInflightToComplete(true,
             INSTANT_GENERATOR.getClusteringCommitInflightInstant(commit3.requestedTime()),
-            serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+            Option.of(commitMetadata));
     // commit4: insert overwrite
     HoodieInstant commit4 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "4");
     timelineCOW.createNewInstant(commit4);
@@ -265,7 +264,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit4.requestedTime()),
-            serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+            Option.of(commitMetadata));
     // commit5: insert overwrite table
     HoodieInstant commit5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, "5");
     timelineCOW.createNewInstant(commit5);
@@ -278,7 +277,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
             "",
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     timelineCOW.transitionReplaceInflightToComplete(true, INSTANT_GENERATOR.getReplaceCommitInflightInstant(commit5.requestedTime()),
-            serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+        Option.of(commitMetadata));
 
     timelineCOW = timelineCOW.reload();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -135,7 +135,7 @@ public class TestClusteringUtil {
     String instantTime = table.getMetaClient().createNewInstantTime();
     HoodieInstant clusteringInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, instantTime);
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(metadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, metadata);
     table.getActiveTimeline().transitionClusterRequestedToInflight(clusteringInstant, Option.empty());
     metaClient.reloadActiveTimeline();
     return instantTime;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -27,11 +27,9 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.util.ClusteringUtil;
@@ -114,12 +112,12 @@ public class TestClusteringUtil {
         .stream().map(HoodieInstant::requestedTime).collect(Collectors.toList());
     assertThat(actualInstants, is(oriInstants));
   }
-  
+
   @Test
   void validateClusteringScheduling() throws Exception {
     beforeEach();
     ClusteringUtil.validateClusteringScheduling(this.conf);
-    
+
     // validate bucket index
     this.conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     ClusteringUtil.validateClusteringScheduling(this.conf);
@@ -137,13 +135,8 @@ public class TestClusteringUtil {
     String instantTime = table.getMetaClient().createNewInstantTime();
     HoodieInstant clusteringInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, instantTime);
-    try {
-      metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant,
-          TimelineMetadataUtils.serializeRequestedReplaceMetadata(metadata));
-      table.getActiveTimeline().transitionClusterRequestedToInflight(clusteringInstant, Option.empty());
-    } catch (IOException ioe) {
-      throw new HoodieIOException("Exception scheduling clustering", ioe);
-    }
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(metadata));
+    table.getActiveTimeline().transitionClusterRequestedToInflight(clusteringInstant, Option.empty());
     metaClient.reloadActiveTimeline();
     return instantTime;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -24,10 +24,8 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.FlinkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.util.CompactionUtil;
@@ -178,13 +176,8 @@ public class TestCompactionUtil {
     String instantTime = table.getMetaClient().createNewInstantTime();
     HoodieInstant compactionInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instantTime);
-    try {
-      metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant,
-          TimelineMetadataUtils.serializeCompactionPlan(plan));
-      table.getActiveTimeline().transitionCompactionRequestedToInflight(compactionInstant);
-    } catch (IOException ioe) {
-      throw new HoodieIOException("Exception scheduling compaction", ioe);
-    }
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(plan));
+    table.getActiveTimeline().transitionCompactionRequestedToInflight(compactionInstant);
     metaClient.reloadActiveTimeline();
     return instantTime;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -176,7 +176,7 @@ public class TestCompactionUtil {
     String instantTime = table.getMetaClient().createNewInstantTime();
     HoodieInstant compactionInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instantTime);
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(plan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, plan);
     table.getActiveTimeline().transitionCompactionRequestedToInflight(compactionInstant);
     metaClient.reloadActiveTimeline();
     return instantTime;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -43,7 +44,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -142,9 +142,9 @@ public class TestUtils {
     return metadata;
   }
 
-  public static void saveInstantAsComplete(HoodieTableMetaClient metaClient, HoodieInstant instant, HoodieCommitMetadata metadata) throws Exception {
+  public static void saveInstantAsComplete(HoodieTableMetaClient metaClient, HoodieInstant instant, HoodieCommitMetadata metadata) {
     metaClient.getActiveTimeline().saveAsComplete(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, instant.getAction(), instant.requestedTime()),
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata));
+        Option.of(metadata));
   }
 
   public static String amendCompletionTimeToLatest(HoodieTableMetaClient metaClient, java.nio.file.Path sourcePath, String instantTime) throws IOException {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -73,7 +73,6 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_AC
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRequestedReplaceMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSimpleSchema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -90,7 +89,6 @@ import static org.mockito.Mockito.when;
  * Tests {@link TableSchemaResolver}.
  */
 public class TestTableSchemaResolver extends HoodieCommonTestHarness {
-
   @BeforeEach
   public void setUp() throws Exception {
     initMetaClient();
@@ -154,8 +152,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     Map<String, String> extraMetadata = new HashMap<>();
     extraMetadata.put(HoodieCommitMetadata.SCHEMA_KEY, originalSchema.toString());
 
-    activeTimeline.saveAsComplete(instant1,
-        Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, extraMetadata)));
+    activeTimeline.saveAsComplete(instant1, getCommitMetadata(basePath, "partition1", commitTime1, 2, extraMetadata));
     metaClient.reloadActiveTimeline();
 
     TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
@@ -176,7 +173,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     String commitTime1 = "001";
     HoodieInstant instant1 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, commitTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     activeTimeline.createNewInstant(instant1);
-    activeTimeline.saveAsComplete(instant1, Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, emptyMetadata)));
+    activeTimeline.saveAsComplete(instant1, getCommitMetadata(basePath, "partition1", commitTime1, 2, emptyMetadata));
     metaClient.reloadActiveTimeline();
     metaClient.getTableConfig().setValue(HoodieTableConfig.CREATE_SCHEMA, originalSchema.toString());
 
@@ -371,8 +368,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
       HoodieInstant requestedInstant = new HoodieInstant(
           HoodieInstant.State.REQUESTED, CLUSTERING_ACTION, clusteringInstant.get().requestedTime(),
           InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
-      when(mockActiveTimeline.getInstantDetails(requestedInstant)).thenReturn(
-          serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+      when(mockActiveTimeline.readRequestedReplaceMetadata(requestedInstant)).thenReturn(requestedReplaceMetadata);
     }
     return mockMetaClient;
   }
@@ -432,7 +428,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     extraMetadata.put(HoodieCommitMetadata.SCHEMA_KEY, originalSchema.toString());
 
     activeTimeline.saveAsComplete(instant,
-        Option.of(getCommitMetadata(basePath, "partition1", commitTime, 2, extraMetadata)));
+        getCommitMetadata(basePath, "partition1", commitTime, 2, extraMetadata));
     metaClient.reloadActiveTimeline();
 
     TableSchemaResolver resolver = new TableSchemaResolver(metaClient);
@@ -505,7 +501,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     Map<String, String> metadata1 = new HashMap<>();
     metadata1.put(HoodieCommitMetadata.SCHEMA_KEY, schema1.toString());
     activeTimeline.saveAsComplete(instant1,
-        Option.of(getCommitMetadata(basePath, "partition1", commitTime1, 2, metadata1)));
+        getCommitMetadata(basePath, "partition1", commitTime1, 2, metadata1));
 
     // Second commit with schema2
     String commitTime2 = "002";
@@ -514,7 +510,7 @@ public class TestTableSchemaResolver extends HoodieCommonTestHarness {
     Map<String, String> metadata2 = new HashMap<>();
     metadata2.put(HoodieCommitMetadata.SCHEMA_KEY, schema2.toString());
     activeTimeline.saveAsComplete(instant2,
-        Option.of(getCommitMetadata(basePath, "partition1", commitTime2, 2, metadata2)));
+        getCommitMetadata(basePath, "partition1", commitTime2, 2, metadata2));
 
     metaClient.reloadActiveTimeline();
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -115,8 +115,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // create replace metadata only with replaced file Ids (no new files created)
     if (withReplace) {
       activeTimeline.saveAsComplete(instant1,
-          getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
-              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER));
+          Option.of(getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
+              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER)));
     } else {
       activeTimeline.transitionClusterInflightToComplete(true, instant1,
           getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
@@ -135,8 +135,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // create replace metadata only with replaced file Ids (no new files created)
     if (withReplace) {
       activeTimeline.saveAsComplete(instant2,
-          getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
-              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER));
+          Option.of(getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
+              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER)));
     } else {
       activeTimeline.transitionClusterInflightToComplete(true, instant2,
           getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
@@ -529,7 +529,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     return TimelineMetadataUtils.convertRollbackMetadata(commitTs, Option.empty(), rollbacks, rollbackStats);
   }
 
-  private Option<HoodieReplaceCommitMetadata> getReplaceCommitMetadata(String basePath, String commitTs, String replacePartition, int replaceCount,
+  private HoodieReplaceCommitMetadata getReplaceCommitMetadata(String basePath, String commitTs, String replacePartition, int replaceCount,
                                                                        String newFilePartition, int newFileCount, Map<String, String> extraMetadata,
                                                                        WriteOperationType operationType) {
     HoodieReplaceCommitMetadata commit = new HoodieReplaceCommitMetadata();
@@ -552,7 +552,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     for (Map.Entry<String, String> extraEntries : extraMetadata.entrySet()) {
       commit.addMetadata(extraEntries.getKey(), extraEntries.getValue());
     }
-    return Option.of(commit);
+    return commit;
   }
 
   private Option<HoodieCleanMetadata> getCleanMetadata(String partition, String time, boolean isPartitionDeleted) throws IOException {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -71,7 +71,6 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTIO
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACTION;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -116,12 +115,12 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // create replace metadata only with replaced file Ids (no new files created)
     if (withReplace) {
       activeTimeline.saveAsComplete(instant1,
-          Option.of(getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
-              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER)));
+          getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
+              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER));
     } else {
       activeTimeline.transitionClusterInflightToComplete(true, instant1,
-          Option.of(getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
-              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER)));
+          getReplaceCommitMetadata(basePath, ts1, replacePartition, 2,
+              newFilePartition, 0, Collections.emptyMap(), WriteOperationType.CLUSTER));
     }
     metaClient.reloadActiveTimeline();
 
@@ -136,12 +135,12 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // create replace metadata only with replaced file Ids (no new files created)
     if (withReplace) {
       activeTimeline.saveAsComplete(instant2,
-          Option.of(getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
-              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER)));
+          getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
+              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER));
     } else {
       activeTimeline.transitionClusterInflightToComplete(true, instant2,
-          Option.of(getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
-              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER)));
+          getReplaceCommitMetadata(basePath, ts2, replacePartition, 0,
+              newFilePartition, 3, Collections.emptyMap(), WriteOperationType.CLUSTER));
     }
     metaClient.reloadActiveTimeline();
     partitions = TimelineUtils.getAffectedPartitions(metaClient.getActiveTimeline().findInstantsAfter("1", 10));
@@ -165,7 +164,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
       String ts = i + "";
       HoodieInstant instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, ts, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
       activeTimeline.createNewInstant(instant);
-      activeTimeline.saveAsComplete(instant, Option.of(getCommitMetadata(basePath, ts, ts, 2, Collections.emptyMap())));
+      activeTimeline.saveAsComplete(instant, getCommitMetadata(basePath, ts, ts, 2, Collections.emptyMap()));
 
       HoodieInstant cleanInstant = INSTANT_GENERATOR.createNewInstant(INFLIGHT, CLEAN_ACTION, ts);
       activeTimeline.createNewInstant(cleanInstant);
@@ -204,7 +203,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
       String ts = i + "";
       HoodieInstant instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, ts, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
       activeTimeline.createNewInstant(instant);
-      activeTimeline.saveAsComplete(instant, Option.of(getCommitMetadata(basePath, partitionPath, ts, 2, Collections.emptyMap())));
+      activeTimeline.saveAsComplete(instant, getCommitMetadata(basePath, partitionPath, ts, 2, Collections.emptyMap()));
 
       HoodieInstant cleanInstant = new HoodieInstant(INFLIGHT, CLEAN_ACTION, ts, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
       activeTimeline.createNewInstant(cleanInstant);
@@ -256,14 +255,14 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     String ts = "0";
     HoodieInstant instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, ts, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     activeTimeline.createNewInstant(instant);
-    activeTimeline.saveAsComplete(instant, Option.of(getCommitMetadata(basePath, ts, ts, 2, Collections.emptyMap())));
+    activeTimeline.saveAsComplete(instant, getCommitMetadata(basePath, ts, ts, 2, Collections.emptyMap()));
 
     ts = "1";
     instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, ts, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     activeTimeline.createNewInstant(instant);
     Map<String, String> extraMetadata = new HashMap<>();
     extraMetadata.put(extraMetadataKey, extraMetadataValue1);
-    activeTimeline.saveAsComplete(instant, Option.of(getCommitMetadata(basePath, ts, ts, 2, extraMetadata)));
+    activeTimeline.saveAsComplete(instant, getCommitMetadata(basePath, ts, ts, 2, extraMetadata));
 
     metaClient.reloadActiveTimeline();
 
@@ -278,8 +277,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     String newValueForMetadata = "newValue2";
     extraMetadata.put(extraMetadataKey, newValueForMetadata);
     activeTimeline.transitionClusterInflightToComplete(true, instant2,
-        Option.of(getReplaceCommitMetadata(basePath, ts2, "p2", 0,
-            "p2", 3, extraMetadata, WriteOperationType.CLUSTER)));
+        getReplaceCommitMetadata(basePath, ts2, "p2", 0,
+            "p2", 3, extraMetadata, WriteOperationType.CLUSTER));
     metaClient.reloadActiveTimeline();
 
     verifyExtraMetadataLatestValue(extraMetadataKey, extraMetadataValue1, false);
@@ -506,14 +505,13 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     assertEquals(expected, extraLatestValue.get());
   }
 
-  private byte[] getRestoreMetadata(String basePath, String partition, String commitTs, int count, String actionType) throws IOException {
+  private HoodieRestoreMetadata getRestoreMetadata(String basePath, String partition, String commitTs, int count, String actionType) throws IOException {
     List<HoodieRollbackMetadata> rollbackM = new ArrayList<>();
     rollbackM.add(getRollbackMetadataInstance(basePath, partition, commitTs, count, actionType));
     List<HoodieInstant> rollbackInstants = new ArrayList<>();
     rollbackInstants.add(new HoodieInstant(COMPLETED, commitTs, actionType, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR));
-    HoodieRestoreMetadata metadata = TimelineMetadataUtils.convertRestoreMetadata(commitTs, 200, rollbackInstants,
+    return TimelineMetadataUtils.convertRestoreMetadata(commitTs, 200, rollbackInstants,
         Collections.singletonMap(commitTs, rollbackM));
-    return TimelineMetadataUtils.serializeRestoreMetadata(metadata).get();
   }
 
   private HoodieRollbackMetadata getRollbackMetadataInstance(String basePath, String partition, String commitTs, int count, String actionType) {
@@ -531,10 +529,9 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     return TimelineMetadataUtils.convertRollbackMetadata(commitTs, Option.empty(), rollbacks, rollbackStats);
   }
 
-  private byte[] getReplaceCommitMetadata(String basePath, String commitTs, String replacePartition, int replaceCount,
-                                          String newFilePartition, int newFileCount, Map<String, String> extraMetadata,
-                                          WriteOperationType operationType)
-      throws IOException {
+  private Option<HoodieReplaceCommitMetadata> getReplaceCommitMetadata(String basePath, String commitTs, String replacePartition, int replaceCount,
+                                                                       String newFilePartition, int newFileCount, Map<String, String> extraMetadata,
+                                                                       WriteOperationType operationType) {
     HoodieReplaceCommitMetadata commit = new HoodieReplaceCommitMetadata();
     commit.setOperationType(operationType);
     for (int i = 1; i <= newFileCount; i++) {
@@ -555,10 +552,10 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     for (Map.Entry<String, String> extraEntries : extraMetadata.entrySet()) {
       commit.addMetadata(extraEntries.getKey(), extraEntries.getValue());
     }
-    return serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commit).get();
+    return Option.of(commit);
   }
 
-  private Option<byte[]> getCleanMetadata(String partition, String time, boolean isPartitionDeleted) throws IOException {
+  private Option<HoodieCleanMetadata> getCleanMetadata(String partition, String time, boolean isPartitionDeleted) throws IOException {
     Map<String, HoodieCleanPartitionMetadata> partitionToFilesCleaned = new HashMap<>();
     List<String> filesDeleted = new ArrayList<>();
     filesDeleted.add("file-" + partition + "-" + time + "1");
@@ -572,16 +569,14 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         .setIsPartitionDeleted(isPartitionDeleted)
         .build();
     partitionToFilesCleaned.putIfAbsent(partition, partitionMetadata);
-    HoodieCleanMetadata cleanMetadata = HoodieCleanMetadata.newBuilder()
+    return Option.of(HoodieCleanMetadata.newBuilder()
         .setVersion(1)
         .setTimeTakenInMillis(100)
         .setTotalFilesDeleted(1)
         .setStartCleanTime(time)
         .setEarliestCommitToRetain(time)
         .setLastCompletedCommitTimestamp("")
-        .setPartitionMetadata(partitionToFilesCleaned).build();
-
-    return TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata);
+        .setPartitionMetadata(partitionToFilesCleaned).build());
   }
 
   @Test
@@ -594,7 +589,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // first insert to the older partition
     HoodieInstant instant1 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, "00001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     activeTimeline.createNewInstant(instant1);
-    activeTimeline.saveAsComplete(instant1, Option.of(getCommitMetadata(basePath, olderPartition, "00001", 2, Collections.emptyMap())));
+    activeTimeline.saveAsComplete(instant1, getCommitMetadata(basePath, olderPartition, "00001", 2, Collections.emptyMap()));
 
     metaClient.reloadActiveTimeline();
     List<String> droppedPartitions = TimelineUtils.getDroppedPartitions(metaClient, Option.empty(), Option.empty());
@@ -604,7 +599,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // another commit inserts to new partition
     HoodieInstant instant2 = new HoodieInstant(INFLIGHT, COMMIT_ACTION, "00002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     activeTimeline.createNewInstant(instant2);
-    activeTimeline.saveAsComplete(instant2, Option.of(getCommitMetadata(basePath, "p2", "00002", 2, Collections.emptyMap())));
+    activeTimeline.saveAsComplete(instant2, getCommitMetadata(basePath, "p2", "00002", 2, Collections.emptyMap()));
 
     metaClient.reloadActiveTimeline();
     droppedPartitions = TimelineUtils.getDroppedPartitions(metaClient, Option.empty(), Option.empty());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -69,7 +69,6 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.util.CleanerUtils.getCleanerPlan;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -217,9 +216,8 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
       HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "1");
       timeline.createNewInstant(instant1);
 
-      byte[] data = getUTF8Bytes("commit");
       timeline.saveAsComplete(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, instant1.getAction(),
-          instant1.requestedTime()), Option.of(data));
+          instant1.requestedTime()), Option.of(new HoodieCommitMetadata()));
 
       timeline = timeline.reload();
 
@@ -645,7 +643,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     timeline.createNewInstant(commitInstant);
     timeline.transitionRequestedToInflight(commitInstant, Option.empty());
     HoodieInstant completeCommitInstant = metaClient.createNewInstant(State.INFLIGHT, commitInstant.getAction(), commitInstant.requestedTime());
-    timeline.saveAsComplete(completeCommitInstant, metaClient.getCommitMetadataSerDe().serialize(commitMetadata));
+    timeline.saveAsComplete(completeCommitInstant, Option.of(commitMetadata));
     HoodieActiveTimeline timelineAfterFirstInstant = timeline.reload();
 
     HoodieInstant completedCommitInstant = timelineAfterFirstInstant.lastInstant().get();
@@ -657,7 +655,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     cleanerPlan.setPolicy("policy");
     cleanerPlan.setVersion(TimelineLayoutVersion.CURR_VERSION);
     cleanerPlan.setPartitionsToBeDeleted(Collections.singletonList("partition1"));
-    timeline.saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+    timeline.saveToCleanRequested(cleanInstant, Option.of(cleanerPlan));
 
     assertEquals(cleanerPlan, getCleanerPlan(metaClient, cleanInstant));
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -432,7 +432,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     assertFalse(timeline.filterPendingExcludingCompaction().containsInstant(compaction));
     assertTrue(timeline.filterPendingCompactionTimeline().containsInstant(compaction));
     assertTrue(timeline.filterPendingMajorOrMinorCompactionTimeline().containsInstant(compaction));
-    compaction = timeline.transitionCompactionInflightToComplete(false, inflight, Option.empty());
+    compaction = timeline.transitionCompactionInflightToComplete(false, inflight, new HoodieCommitMetadata());
     timeline = timeline.reload();
     assertTrue(timeline.containsInstant(compaction));
     assertFalse(timeline.containsInstant(inflight));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
@@ -47,7 +47,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -150,7 +149,7 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
     saveAsComplete(
         commitTimeline,
         instant1,
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+        Option.of(commitMetadata));
     refreshFsView();
     assertEquals(0, roView.getLatestBaseFiles(partitionPath1)
         .filter(dfile -> dfile.getFileId().equals(fileId1)).count());
@@ -181,17 +180,17 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
     assertEquals(actualReplacedFileIds, allReplacedFileIds);
   }
 
-  private void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<byte[]> data) {
+  private <T> void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<T> metadata) {
     if (inflight.getAction().equals(HoodieTimeline.COMPACTION_ACTION)) {
-      timeline.transitionCompactionInflightToComplete(true, inflight, data);
+      timeline.transitionCompactionInflightToComplete(true, inflight, metadata);
     } else {
       HoodieInstant requested = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, inflight.getAction(), inflight.requestedTime());
       timeline.createNewInstant(requested);
       timeline.transitionRequestedToInflight(requested, Option.empty());
       if (inflight.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-        timeline.transitionClusterInflightToComplete(true, inflight, data);
+        timeline.transitionClusterInflightToComplete(true, inflight, metadata);
       } else {
-        timeline.saveAsComplete(inflight, data);
+        timeline.saveAsComplete(inflight, metadata);
       }
     }
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFSViewWithClustering.java
@@ -22,6 +22,7 @@ package org.apache.hudi.common.table.view;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -149,7 +150,7 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
     saveAsComplete(
         commitTimeline,
         instant1,
-        Option.of(commitMetadata));
+        commitMetadata);
     refreshFsView();
     assertEquals(0, roView.getLatestBaseFiles(partitionPath1)
         .filter(dfile -> dfile.getFileId().equals(fileId1)).count());
@@ -180,7 +181,7 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
     assertEquals(actualReplacedFileIds, allReplacedFileIds);
   }
 
-  private <T> void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<T> metadata) {
+  private void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
     if (inflight.getAction().equals(HoodieTimeline.COMPACTION_ACTION)) {
       timeline.transitionCompactionInflightToComplete(true, inflight, metadata);
     } else {
@@ -188,9 +189,9 @@ public class TestHoodieTableFSViewWithClustering extends HoodieCommonTestHarness
       timeline.createNewInstant(requested);
       timeline.transitionRequestedToInflight(requested, Option.empty());
       if (inflight.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-        timeline.transitionClusterInflightToComplete(true, inflight, metadata);
+        timeline.transitionClusterInflightToComplete(true, inflight, (HoodieReplaceCommitMetadata) metadata);
       } else {
-        timeline.saveAsComplete(inflight, metadata);
+        timeline.saveAsComplete(inflight, Option.of(metadata));
       }
     }
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -206,14 +206,13 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         CommitUtils.buildMetadata(Collections.emptyList(), partitionToReplaceFileIds,
             Option.empty(), WriteOperationType.CLUSTER, "", HoodieTimeline.REPLACE_COMMIT_ACTION);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, instant2, Option.empty());
-    saveAsCompleteCluster(commitTimeline, clusteringInstant3,
-        Option.of((HoodieReplaceCommitMetadata) commitMetadata));
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, instant2, new HoodieCommitMetadata());
+    saveAsCompleteCluster(commitTimeline, clusteringInstant3, (HoodieReplaceCommitMetadata) commitMetadata);
     saveAsCompleteCluster(
         commitTimeline,
         clusteringInstant4,
-        Option.of((HoodieReplaceCommitMetadata) commitMetadata));
+        (HoodieReplaceCommitMetadata) commitMetadata);
 
     refreshFsView();
 
@@ -258,9 +257,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant deltaInstant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime2);
     HoodieInstant deltaInstant3 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime3);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant2, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant3, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant2, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant3, new HoodieCommitMetadata());
 
     refreshFsView();
 
@@ -352,7 +351,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
 
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
 
     List<FileSlice> fileSlices =
@@ -385,7 +384,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
 
     // create 2 fileId in partition2
     String fileId3 = UUID.randomUUID().toString();
@@ -397,7 +396,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     new File(basePath + "/" + partitionPath2 + "/" + fileName4).createNewFile();
 
     HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime2);
-    saveAsComplete(commitTimeline, instant2, Option.empty());
+    saveAsComplete(commitTimeline, instant2, new HoodieCommitMetadata());
 
     fsView.sync();
     // invokes the stateless API first then the normal API, assert the result equality with different file group objects
@@ -444,7 +443,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
 
     // create 2 fileId in partition2
     String fileId3 = UUID.randomUUID().toString();
@@ -456,7 +455,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     new File(basePath + "/" + partitionPath2 + "/" + fileName4).createNewFile();
 
     HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime2);
-    saveAsComplete(commitTimeline, instant2, Option.empty());
+    saveAsComplete(commitTimeline, instant2, new HoodieCommitMetadata());
 
     fsView.sync();
 
@@ -512,9 +511,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant deltaInstant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime1);
     HoodieInstant deltaInstant3 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime2);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant2, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant3, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant2, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant3, new HoodieCommitMetadata());
 
     refreshFsView();
 
@@ -592,9 +591,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     // delta instant 3 starts but finishes in the last
     metaClient.getActiveTimeline().createNewInstant(deltaInstant3);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant2, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant2, new HoodieCommitMetadata());
 
     refreshFsView();
     List<FileSlice> fileSlices = rtView.getLatestFileSlices(partitionPath).collect(Collectors.toList());
@@ -619,7 +618,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     Paths.get(basePath, partitionPath, compactionFile1).toFile().createNewFile();
     HoodieInstant compactionInstant = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, compactionInstantTime1);
     HoodieInstant requested = INSTANT_GENERATOR.getCompactionRequestedInstant(compactionInstant.requestedTime());
-    commitTimeline.saveToCompactionRequested(requested, Option.of(compactionPlan));
+    commitTimeline.saveToCompactionRequested(requested, compactionPlan);
     commitTimeline.transitionCompactionRequestedToInflight(requested);
 
     // check the view immediately
@@ -634,7 +633,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertEquals(0, logFiles.size(), "Correct number of log-files shows up in file-slice");
 
     // now finished the compaction
-    saveAsComplete(commitTimeline, compactionInstant, Option.empty());
+    saveAsComplete(commitTimeline, compactionInstant, new HoodieCommitMetadata());
 
     refreshFsView();
     fileSlices = rtView.getAllFileSlices(partitionPath).collect(Collectors.toList());
@@ -701,7 +700,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, instantTime1);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
 
     // Assert that no base files are returned without the partitions being loaded
@@ -731,7 +730,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, instantTime1);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
 
     // Assert that no base files are returned without the partitions being loaded
@@ -809,8 +808,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant deltaInstant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime1);
 
     // just commit instant1 and deltaInstant2, keep deltaInstant3 inflight
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant2, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant2, new HoodieCommitMetadata());
     refreshFsView(preTableVersion8);
 
     // getLatestFileSlices should return just 1 log file due to deltaInstant2
@@ -919,9 +918,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         writer.finish();
       }
     }
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant2, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant3, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant2, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant3, new HoodieCommitMetadata());
 
     refreshFsView(preTableVersion8);
 
@@ -951,11 +950,11 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
           compactionRequestedTime);
       HoodieInstant requested =
           INSTANT_GENERATOR.getCompactionRequestedInstant(compactionInstant.requestedTime());
-      commitTimeline.saveToCompactionRequested(requested, Option.of(compactionPlan));
+      commitTimeline.saveToCompactionRequested(requested, compactionPlan);
       commitTimeline.transitionCompactionRequestedToInflight(requested);
     } else {
       compactionInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionRequestedTime);
-      commitTimeline.saveToCompactionRequested(compactionInstant, Option.of(compactionPlan));
+      commitTimeline.saveToCompactionRequested(compactionInstant, compactionPlan);
     }
 
     // View immediately after scheduling compaction
@@ -984,8 +983,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     new File(basePath + "/" + partitionPath + "/" + fileName4).createNewFile();
     HoodieInstant deltaInstant4 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime4);
     HoodieInstant deltaInstant5 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime5);
-    saveAsComplete(commitTimeline, deltaInstant4, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant5, Option.empty());
+    saveAsComplete(commitTimeline, deltaInstant4, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant5, new HoodieCommitMetadata());
 
     refreshFsView(preTableVersion8);
 
@@ -1258,7 +1257,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     // Make this commit safe
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
     assertEquals(fileName1, roView.getLatestBaseFiles(partitionPath)
         .filter(dfile -> dfile.getFileId().equals(fileId)).findFirst().get().getFileName());
@@ -1273,7 +1272,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     // Make it safe
     HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime2);
-    saveAsComplete(commitTimeline, instant2, Option.empty());
+    saveAsComplete(commitTimeline, instant2, new HoodieCommitMetadata());
     refreshFsView();
     assertEquals(fileName2, roView.getLatestBaseFiles(partitionPath)
         .filter(dfile -> dfile.getFileId().equals(fileId)).findFirst().get().getFileName());
@@ -1755,9 +1754,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant deltaInstant4 =
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime4);
 
-    saveAsComplete(commitTimeline, instant1, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant3, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant4, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant3, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant4, new HoodieCommitMetadata());
 
     // Now we list all partitions
     List<StoragePath> list = new ArrayList<>();
@@ -1806,7 +1805,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION,
             compactionRequestedTime);
     HoodieInstant requested = INSTANT_GENERATOR.getCompactionRequestedInstant(compactionInstant.requestedTime());
-    metaClient.getActiveTimeline().saveToCompactionRequested(requested, Option.of(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(requested, compactionPlan);
     metaClient.getActiveTimeline().transitionCompactionRequestedToInflight(requested);
 
     // Fake delta-ingestion after compaction-requested
@@ -1825,8 +1824,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieInstant deltaInstant5 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime5);
     HoodieInstant deltaInstant7 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, deltaInstantTime7);
-    saveAsComplete(commitTimeline, deltaInstant5, Option.empty());
-    saveAsComplete(commitTimeline, deltaInstant7, Option.empty());
+    saveAsComplete(commitTimeline, deltaInstant5, new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline, deltaInstant7, new HoodieCommitMetadata());
     refreshFsView(preTableVersion8);
 
     // Test Data Files
@@ -1890,18 +1889,18 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertTrue(fileIdsInCompaction.contains(fileId));
   }
 
-  private <T> void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<T> metadata) {
+  private void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
     if (inflight.getAction().equals(HoodieTimeline.COMPACTION_ACTION)) {
       timeline.transitionCompactionInflightToComplete(true, inflight, metadata);
     } else {
       HoodieInstant requested = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, inflight.getAction(), inflight.requestedTime());
       timeline.createNewInstant(requested);
       timeline.transitionRequestedToInflight(requested, Option.empty());
-      timeline.saveAsComplete(inflight, metadata);
+      timeline.saveAsComplete(inflight, Option.of(metadata));
     }
   }
 
-  private <T> void saveAsCompleteCluster(HoodieActiveTimeline timeline, HoodieInstant inflight, Option<T> metadata) {
+  private <T> void saveAsCompleteCluster(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
     assertEquals(HoodieTimeline.CLUSTERING_ACTION, inflight.getAction());
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, inflight.getAction(), inflight.requestedTime());
     HoodieClusteringPlan plan = new HoodieClusteringPlan();
@@ -1915,9 +1914,9 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         .setExtraMetadata(Collections.emptyMap())
         .setClusteringPlan(plan)
         .build();
-    timeline.saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
+    timeline.saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
     timeline.transitionRequestedToInflight(clusteringInstant, Option.empty());
-    timeline.transitionClusterInflightToComplete(true, inflight, metadata);
+    timeline.transitionClusterInflightToComplete(true, inflight, (HoodieReplaceCommitMetadata) metadata);
   }
 
   @Test
@@ -1941,7 +1940,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
     assertEquals(1, roView.getLatestBaseFiles(partitionPath1)
         .filter(dfile -> dfile.getFileId().equals(fileId1)).count());
@@ -1967,10 +1966,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
             HoodieTimeline.REPLACE_COMMIT_ACTION);
     commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, commitTime2);
-    saveAsComplete(
-        commitTimeline,
-        instant2,
-        Option.of(commitMetadata));
+    saveAsComplete(commitTimeline, instant2, commitMetadata);
 
     //make sure view doesn't include fileId1
     refreshFsView();
@@ -2057,10 +2053,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, commitTime1);
-    saveAsComplete(
-        commitTimeline,
-        instant1,
-        Option.of(commitMetadata));
+    saveAsComplete(commitTimeline, instant1, commitMetadata);
     refreshFsView();
     assertEquals(0, roView.getLatestBaseFiles(partitionPath1)
         .filter(dfile -> dfile.getFileId().equals(fileId1)).count());
@@ -2108,7 +2101,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
     HoodieInstant instant1 = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, commitTime1);
-    saveAsComplete(commitTimeline, instant1, Option.empty());
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
     refreshFsView();
     assertEquals(1, roView.getLatestBaseFiles(partitionPath1)
         .filter(dfile -> dfile.getFileId().equals(fileId1)).count());
@@ -2130,7 +2123,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant instant2 = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(plan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(instant2, Option.of(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(instant2, requestedReplaceMetadata);
 
     //make sure view doesn't include fileId1
     refreshFsView();
@@ -2229,10 +2222,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     HoodieCommitMetadata commitMetadata1 =
         CommitUtils.buildMetadata(writeStats1, new HashMap<>(), Option.empty(), WriteOperationType.INSERT, "", HoodieTimeline.COMMIT_ACTION);
-    saveAsComplete(
-        commitTimeline,
-        instant1,
-        Option.of(commitMetadata1));
+    saveAsComplete(commitTimeline, instant1, commitMetadata1);
     commitTimeline.reload();
 
     // replace commit
@@ -2258,7 +2248,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     saveAsCompleteCluster(
         commitTimeline,
         instant2,
-        Option.of(commitMetadata2));
+        commitMetadata2);
 
     // another insert commit
     String commitTime3 = "3";
@@ -2274,10 +2264,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     List<HoodieWriteStat> writeStats3 = buildWriteStats(partitionToFile3, commitTime3);
     HoodieCommitMetadata commitMetadata3 =
         CommitUtils.buildMetadata(writeStats3, new HashMap<>(), Option.empty(), WriteOperationType.INSERT, "", HoodieTimeline.COMMIT_ACTION);
-    saveAsComplete(
-        commitTimeline,
-        instant3,
-        Option.of(commitMetadata3));
+    saveAsComplete(commitTimeline, instant3, commitMetadata3);
 
     metaClient.reloadActiveTimeline();
     refreshFsView();
@@ -2419,7 +2406,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     saveAsComplete(
         commitTimeline,
         instant1,
-        Option.of(commitMetadata));
+        commitMetadata);
 
     SyncableFileSystemView fileSystemView = getFileSystemView(metaClient.reloadActiveTimeline(), true);
 
@@ -2441,7 +2428,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     saveAsComplete(
         commitTimeline,
         instant2,
-        Option.of(commitMetadata));
+        commitMetadata);
 
     // Verify file system view after 2nd commit.
     verifyFileSystemView(partitionPath, expectedState, fileSystemView);
@@ -2459,8 +2446,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant compactionInstant =
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, commitTime3);
     HoodieInstant compactionRequested = INSTANT_GENERATOR.getCompactionRequestedInstant(compactionInstant.requestedTime());
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequested,
-        Option.of(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequested, compactionPlan);
     metaClient.getActiveTimeline().transitionCompactionRequestedToInflight(compactionRequested);
 
     // Verify file system view after 3rd commit which is compaction.requested.
@@ -2477,8 +2463,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     HoodieInstant logCompactionInstant =
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.LOG_COMPACTION_ACTION, commitTime4);
     HoodieInstant logCompactionRequested = INSTANT_GENERATOR.getLogCompactionRequestedInstant(logCompactionInstant.requestedTime());
-    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequested,
-        Option.of(logCompactionPlan));
+    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequested, logCompactionPlan);
     metaClient.getActiveTimeline().transitionLogCompactionRequestedToInflight(logCompactionRequested);
 
     // Verify file system view after 4th commit which is logcompaction.requested.

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -1900,7 +1900,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     }
   }
 
-  private <T> void saveAsCompleteCluster(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
+  private void saveAsCompleteCluster(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
     assertEquals(HoodieTimeline.CLUSTERING_ACTION, inflight.getAction());
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, inflight.getAction(), inflight.requestedTime());
     HoodieClusteringPlan plan = new HoodieClusteringPlan();

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
@@ -82,9 +82,8 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_AC
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.createMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -256,7 +255,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, firstEmptyInstantTs));
     metaClient.getActiveTimeline().saveAsComplete(
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, firstEmptyInstantTs),
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata));
+        Option.of(metadata));
 
     view.sync();
     assertTrue(view.getLastInstant().isPresent());
@@ -299,7 +298,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, firstEmptyInstantTs));
     metaClient.getActiveTimeline().saveAsComplete(
         INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, firstEmptyInstantTs),
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata));
+        Option.of(metadata));
 
     view.sync();
     assertTrue(view.getLastInstant().isPresent());
@@ -639,8 +638,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     HoodieInstant cleanInflightInstant = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, cleanInstant);
     metaClient.getActiveTimeline().createNewInstant(cleanInflightInstant);
     HoodieCleanMetadata cleanMetadata = CleanerUtils.convertCleanMetadata(cleanInstant, Option.empty(), cleanStats, Collections.EMPTY_MAP);
-    metaClient.getActiveTimeline().saveAsComplete(cleanInflightInstant,
-        TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
+    metaClient.getActiveTimeline().saveAsComplete(cleanInflightInstant, Option.of(cleanMetadata));
   }
 
   /**
@@ -672,14 +670,13 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
       HoodieInstant restoreInstant =
           INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.RESTORE_ACTION, rollbackInstant);
       metaClient.getActiveTimeline().createNewInstant(restoreInstant);
-      metaClient.getActiveTimeline()
-          .saveAsComplete(restoreInstant, TimelineMetadataUtils.serializeRestoreMetadata(metadata));
+      metaClient.getActiveTimeline().saveAsComplete(restoreInstant, Option.of(metadata));
     } else {
       metaClient.getActiveTimeline().createNewInstant(
           INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstant));
       metaClient.getActiveTimeline().saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstant),
-          TimelineMetadataUtils.serializeRollbackMetadata(rollbackMetadata));
+          Option.of(rollbackMetadata));
     }
     StoragePath instantPath = HoodieTestUtils
         .getCompleteInstantPath(metaClient.getStorage(),
@@ -720,8 +717,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     long initialExpTotalFileSlices = PARTITIONS.stream().mapToLong(p -> view.getAllFileSlices(p).count()).sum();
     HoodieInstant compactionRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, COMPACTION_ACTION, instantTime);
     HoodieCompactionPlan plan = CompactionUtils.buildFromFileSlices(slices, Option.empty(), Option.empty());
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequestedInstant,
-        TimelineMetadataUtils.serializeCompactionPlan(plan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequestedInstant, Option.of(plan));
 
     view.sync();
     PARTITIONS.forEach(p -> {
@@ -755,8 +751,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     long initialExpTotalFileSlices = PARTITIONS.stream().mapToLong(p -> view.getAllFileSlices(p).count()).sum();
     HoodieInstant logCompactionRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, LOG_COMPACTION_ACTION, instantTime);
     HoodieCompactionPlan plan = CompactionUtils.buildFromFileSlices(slices, Option.empty(), Option.empty());
-    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequestedInstant,
-        TimelineMetadataUtils.serializeCompactionPlan(plan));
+    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequestedInstant, Option.of(plan));
 
     view.sync();
     PARTITIONS.forEach(p -> {
@@ -1008,7 +1003,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     HoodieInstant inflightInstant = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT,
         deltaCommit ? HoodieTimeline.DELTA_COMMIT_ACTION : HoodieTimeline.COMMIT_ACTION, instant);
     metaClient.getActiveTimeline().createNewInstant(inflightInstant);
-    metaClient.getActiveTimeline().saveAsComplete(inflightInstant, serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), metadata));
+    metaClient.getActiveTimeline().saveAsComplete(inflightInstant, Option.of(metadata));
     return writeStats.stream().map(e -> e.getValue().getPath()).collect(Collectors.toList());
   }
 
@@ -1019,8 +1014,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     HoodieInstant newRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setOperationType(WriteOperationType.UNKNOWN.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant,
-        TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, Option.of(requestedReplaceMetadata));
     
     metaClient.reloadActiveTimeline();
     // transition to inflight
@@ -1031,7 +1025,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     replaceCommitMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
     metaClient.getActiveTimeline().saveAsComplete(
         inflightInstant,
-        serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), replaceCommitMetadata));
+        Option.of(replaceCommitMetadata));
     return writeStats.stream().map(e -> e.getValue().getPath()).collect(Collectors.toList());
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
@@ -717,7 +717,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     long initialExpTotalFileSlices = PARTITIONS.stream().mapToLong(p -> view.getAllFileSlices(p).count()).sum();
     HoodieInstant compactionRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, COMPACTION_ACTION, instantTime);
     HoodieCompactionPlan plan = CompactionUtils.buildFromFileSlices(slices, Option.empty(), Option.empty());
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequestedInstant, Option.of(plan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionRequestedInstant, plan);
 
     view.sync();
     PARTITIONS.forEach(p -> {
@@ -751,7 +751,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     long initialExpTotalFileSlices = PARTITIONS.stream().mapToLong(p -> view.getAllFileSlices(p).count()).sum();
     HoodieInstant logCompactionRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, LOG_COMPACTION_ACTION, instantTime);
     HoodieCompactionPlan plan = CompactionUtils.buildFromFileSlices(slices, Option.empty(), Option.empty());
-    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequestedInstant, Option.of(plan));
+    metaClient.getActiveTimeline().saveToLogCompactionRequested(logCompactionRequestedInstant, plan);
 
     view.sync();
     PARTITIONS.forEach(p -> {
@@ -1014,7 +1014,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     HoodieInstant newRequestedInstant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setOperationType(WriteOperationType.UNKNOWN.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, Option.of(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, requestedReplaceMetadata);
     
     metaClient.reloadActiveTimeline();
     // transition to inflight

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -76,7 +76,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 
 /**
  * The common hoodie test harness to provide the basic infrastructure.
@@ -396,12 +395,12 @@ public class HoodieCommonTestHarness {
     }
   }
 
-  public byte[] getCommitMetadata(String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
+  public Option<HoodieCommitMetadata> getCommitMetadata(String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
       throws IOException {
     return getCommitMetadata(metaClient, basePath, partition, commitTs, count, extraMetadata);
   }
 
-  public static byte[] getCommitMetadata(HoodieTableMetaClient metaClient, String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
+  public static Option<HoodieCommitMetadata> getCommitMetadata(HoodieTableMetaClient metaClient, String basePath, String partition, String commitTs, int count, Map<String, String> extraMetadata)
       throws IOException {
     HoodieCommitMetadata commit = new HoodieCommitMetadata();
     for (int i = 1; i <= count; i++) {
@@ -414,6 +413,6 @@ public class HoodieCommonTestHarness {
     for (Map.Entry<String, String> extraEntries : extraMetadata.entrySet()) {
       commit.addMetadata(extraEntries.getKey(), extraEntries.getValue());
     }
-    return serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commit).get();
+    return Option.of(commit);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -550,7 +550,7 @@ public class HoodieTestTable implements AutoCloseable {
     return savepointMetadata;
   }
 
-  public HoodieTestTable addRequestedCompaction(String instantTime) throws IOException {
+  public HoodieTestTable addRequestedCompaction(String instantTime) {
     List<FileSlice> fileSlices = new ArrayList<>();
     fileSlices.add(new FileSlice("par1", instantTime, "fg-1"));
     fileSlices.add(new FileSlice("par2", instantTime, "fg-2"));
@@ -558,19 +558,19 @@ public class HoodieTestTable implements AutoCloseable {
         .buildFromFileSlices(fileSlices.stream().map(fs -> Pair.of(fs.getPartitionPath(), fs))
             .collect(Collectors.toList()), Option.empty(), Option.empty());
     HoodieInstant compactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instantTime);
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, compactionPlan);
     currentInstantTime = instantTime;
     return this;
   }
 
-  public HoodieTestTable addRequestedCompaction(String instantTime, HoodieCompactionPlan compactionPlan) throws IOException {
+  public HoodieTestTable addRequestedCompaction(String instantTime, HoodieCompactionPlan compactionPlan) {
     HoodieInstant compactionInstant = instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instantTime);
-    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, Option.of(compactionPlan));
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, compactionPlan);
     currentInstantTime = instantTime;
     return this;
   }
 
-  public HoodieTestTable addRequestedCompaction(String instantTime, FileSlice... fileSlices) throws IOException {
+  public HoodieTestTable addRequestedCompaction(String instantTime, FileSlice... fileSlices) {
     HoodieCompactionPlan plan = CompactionUtils
         .buildFromFileSlices(Arrays.stream(fileSlices).map(fs -> Pair.of(fs.getPartitionPath(), fs))
             .collect(Collectors.toList()), Option.empty(), Option.empty());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -68,7 +68,6 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
-import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -348,7 +347,7 @@ public class HoodieTestTable implements AutoCloseable {
     return this;
   }
 
-  public HoodieTestTable addPendingCluster(String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
+  public HoodieTestTable addPendingCluster(String instantTime, HoodieRequestedReplaceMetadata requestedReplaceMetadata, Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata) throws Exception {
     createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
     createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
@@ -361,16 +360,16 @@ public class HoodieTestTable implements AutoCloseable {
     return this;
   }
 
-  public HoodieTestTable addInflightCluster(String instantTime, Option<HoodieCommitMetadata> inflightReplaceMetadata) throws Exception {
+  public HoodieTestTable addInflightCluster(String instantTime, Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata) throws Exception {
     createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
     currentInstantTime = instantTime;
     return this;
   }
 
-  public <T> HoodieTestTable addCluster(
+  public HoodieTestTable addCluster(
       String instantTime,
       HoodieRequestedReplaceMetadata requestedReplaceMetadata,
-      Option<T> inflightReplaceMetadata,
+      Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata) throws Exception {
     createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);
     createInflightClusterCommit(metaClient, COMMIT_METADATA_SER_DE, instantTime, inflightReplaceMetadata);
@@ -382,7 +381,7 @@ public class HoodieTestTable implements AutoCloseable {
   public HoodieTestTable addCluster(
       String instantTime,
       HoodieRequestedReplaceMetadata requestedReplaceMetadata,
-      Option<HoodieInstantWriter> inflightReplaceMetadata,
+      Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata,
       HoodieReplaceCommitMetadata completeReplaceMetadata,
       String completionTime) throws Exception {
     createRequestedClusterCommit(metaClient, instantTime, requestedReplaceMetadata);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -115,7 +116,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     assertEquals("2", lastPendingClustering.get().requestedTime());
 
     //now that it is complete, the first instant should be picked
-    HoodieInstant complete = metaClient.getActiveTimeline().transitionClusterInflightToComplete(false, inflight, Option.empty());
+    HoodieInstant complete = metaClient.getActiveTimeline().transitionClusterInflightToComplete(false, inflight, new HoodieReplaceCommitMetadata());
     assertEquals(HoodieInstant.State.COMPLETED, complete.getState());
     lastPendingClustering = metaClient.reloadActiveTimeline().getLastPendingClusterInstant();
     assertEquals("1", lastPendingClustering.get().requestedTime());
@@ -148,14 +149,14 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     String clusterTime1 = "1";
     HoodieInstant requestedInstant1 = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
     HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant1, Option.empty());
-    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, new HoodieReplaceCommitMetadata());
     List<String> fileIds2 = new ArrayList<>();
     fileIds2.add(UUID.randomUUID().toString());
     fileIds2.add(UUID.randomUUID().toString());
     String clusterTime2 = "2";
     HoodieInstant requestedInstant2 = createRequestedClusterInstant(partitionPath1, clusterTime2, fileIds2);
     HoodieInstant inflightInstant2 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant2, Option.empty());
-    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant2, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant2, new HoodieReplaceCommitMetadata());
     List<String> fileIds3 = new ArrayList<>();
     fileIds3.add(UUID.randomUUID().toString());
     fileIds3.add(UUID.randomUUID().toString());
@@ -163,7 +164,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     String clusterTime3 = "3";
     HoodieInstant requestedInstant3 = createRequestedClusterInstant(partitionPath1, clusterTime3, fileIds3);
     HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
-    HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
+    HoodieInstant completedInstant3 = metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, new HoodieReplaceCommitMetadata());
     metaClient.reloadActiveTimeline();
     Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null);
     assertTrue(actual.isPresent());
@@ -184,8 +185,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant inflightInstant4 = metaClient.getActiveTimeline().transitionCleanRequestedToInflight(requestedInstant4, Option.empty());
     HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(cleanTime1, 1L, 1,
         completedInstant3.requestedTime(), "", Collections.emptyMap(), 0, Collections.emptyMap(), Collections.emptyMap());
-    metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant4,
-        Option.of(cleanMetadata));
+    metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant4, Option.of(cleanMetadata));
     metaClient.reloadActiveTimeline();
     actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null);
     assertEquals(clusterTime3, actual.get().requestedTime(),
@@ -203,7 +203,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     String clusterTime1 = "1";
     HoodieInstant requestedInstant1 = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
     HoodieInstant inflightInstant1 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant1, Option.empty());
-    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant1, new HoodieReplaceCommitMetadata());
 
     String cleanTime1 = "2";
     HoodieInstant requestedInstant2 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, cleanTime1);
@@ -223,7 +223,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     String clusterTime2 = "3";
     HoodieInstant requestedInstant3 = createRequestedClusterInstant(partitionPath1, clusterTime2, fileIds2);
     HoodieInstant inflightInstant3 = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant3, Option.empty());
-    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, Option.empty());
+    metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant3, new HoodieReplaceCommitMetadata());
     metaClient.reloadActiveTimeline();
 
     Option<HoodieInstant> actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS);
@@ -242,7 +242,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant newRequestedInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setOperationType(WriteOperationType.UNKNOWN.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, Option.of(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, requestedReplaceMetadata);
     return newRequestedInstant;
   }
 
@@ -258,7 +258,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
     return clusteringInstant;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 
@@ -181,19 +180,21 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
         .setFilesToBeDeletedPerPartition(new HashMap<>())
         .setVersion(CleanPlanV2MigrationHandler.VERSION)
         .build();
-    metaClient.getActiveTimeline().saveToCleanRequested(requestedInstant4, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan1));
+    metaClient.getActiveTimeline().saveToCleanRequested(requestedInstant4, Option.of(cleanerPlan1));
     HoodieInstant inflightInstant4 = metaClient.getActiveTimeline().transitionCleanRequestedToInflight(requestedInstant4, Option.empty());
     HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(cleanTime1, 1L, 1,
         completedInstant3.requestedTime(), "", Collections.emptyMap(), 0, Collections.emptyMap(), Collections.emptyMap());
     metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant4,
-        TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
+        Option.of(cleanMetadata));
     metaClient.reloadActiveTimeline();
     actual = ClusteringUtils.getEarliestInstantToRetainForClustering(metaClient.getActiveTimeline(), metaClient, null);
     assertEquals(clusterTime3, actual.get().requestedTime(),
         "retain the first replace commit after the earliestInstantToRetain ");
   }
 
-  /** test getOldestInstantToRetainForClustering with KEEP_LATEST_FILE_VERSIONS as clean policy */
+  /**
+   * test getOldestInstantToRetainForClustering with KEEP_LATEST_FILE_VERSIONS as clean policy
+   */
   @Test
   public void testGetOldestInstantToRetainForClusteringKeepFileVersion() throws IOException {
     String partitionPath1 = "partition1";
@@ -209,12 +210,11 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieCleanerPlan cleanerPlan1 = new HoodieCleanerPlan(null, clusterTime1,
         HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS.name(), Collections.emptyMap(),
         CleanPlanV2MigrationHandler.VERSION, Collections.emptyMap(), Collections.emptyList(), Collections.EMPTY_MAP);
-    metaClient.getActiveTimeline().saveToCleanRequested(requestedInstant2, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan1));
+    metaClient.getActiveTimeline().saveToCleanRequested(requestedInstant2, Option.of(cleanerPlan1));
     HoodieInstant inflightInstant2 = metaClient.getActiveTimeline().transitionCleanRequestedToInflight(requestedInstant2, Option.empty());
     HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(cleanTime1, 1L, 1,
         "", "", Collections.emptyMap(), 0, Collections.emptyMap(), Collections.emptyMap());
-    metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant2,
-        TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata));
+    metaClient.getActiveTimeline().transitionCleanInflightToComplete(true, inflightInstant2, Option.of(cleanMetadata));
     metaClient.reloadActiveTimeline();
 
     List<String> fileIds2 = new ArrayList<>();
@@ -238,11 +238,11 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     }
   }
 
-  private HoodieInstant createRequestedReplaceInstantNotClustering(String instantTime) throws IOException {
+  private HoodieInstant createRequestedReplaceInstantNotClustering(String instantTime) {
     HoodieInstant newRequestedInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setOperationType(WriteOperationType.UNKNOWN.name()).build();
-    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingReplaceCommit(newRequestedInstant, Option.of(requestedReplaceMetadata));
     return newRequestedInstant;
   }
 
@@ -258,7 +258,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
-    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata));
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, Option.of(requestedReplaceMetadata));
     return clusteringInstant;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -170,11 +169,11 @@ public class TestCommitUtils {
     commitMetadata.addMetadata(SINK_CHECKPOINT_KEY,
         getCheckpointValueAsString(id, batchId));
     timeline.createNewInstant(instant);
-    timeline.transitionRequestedToInflight(instant, TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+    timeline.transitionRequestedToInflight(instant, Option.of(commitMetadata));
     if (isCompleted) {
       timeline.saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, instant.getAction(), instant.requestedTime()),
-          TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+          Option.of(commitMetadata));
     }
   }
 
@@ -185,14 +184,13 @@ public class TestCommitUtils {
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     commitMetadata.setOperationType(WriteOperationType.COMPACT);
     timeline.createNewInstant(instant);
-    timeline.transitionRequestedToInflight(instant, TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+    timeline.transitionRequestedToInflight(instant, Option.of(commitMetadata));
     timeline.saveAsComplete(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, instant.getAction(), instant.requestedTime()),
-        TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+        Option.of(commitMetadata));
   }
 
-  private void addRequestedCompaction(HoodieActiveTimeline timeline,
-                                      String ts) throws IOException {
+  private void addRequestedCompaction(HoodieActiveTimeline timeline, String ts) {
     HoodieCompactionPlan compactionPlan = HoodieCompactionPlan.newBuilder()
         .setOperations(Collections.emptyList())
         .setVersion(CompactionUtils.LATEST_COMPACTION_METADATA_VERSION)
@@ -201,12 +199,11 @@ public class TestCommitUtils {
         .build();
     timeline.saveToCompactionRequested(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, COMPACTION_ACTION, ts),
-        TimelineMetadataUtils.serializeCompactionPlan(compactionPlan)
+        Option.of(compactionPlan)
     );
   }
 
-  private void addRequestedReplaceCommit(HoodieActiveTimeline timeline,
-                                         String ts) throws IOException {
+  private void addRequestedReplaceCommit(HoodieActiveTimeline timeline, String ts) {
     HoodieRequestedReplaceMetadata requestedReplaceMetadata =
         HoodieRequestedReplaceMetadata.newBuilder()
             .setOperationType(WriteOperationType.CLUSTER.name())
@@ -215,7 +212,7 @@ public class TestCommitUtils {
             .build();
     timeline.saveToPendingClusterCommit(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, CLUSTERING_ACTION, ts),
-        TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata)
+        Option.of(requestedReplaceMetadata)
     );
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
@@ -199,7 +199,7 @@ public class TestCommitUtils {
         .build();
     timeline.saveToCompactionRequested(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, COMPACTION_ACTION, ts),
-        Option.of(compactionPlan)
+        compactionPlan
     );
   }
 
@@ -212,7 +212,7 @@ public class TestCommitUtils {
             .build();
     timeline.saveToPendingClusterCommit(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, CLUSTERING_ACTION, ts),
-        Option.of(requestedReplaceMetadata)
+        requestedReplaceMetadata
     );
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
@@ -53,10 +52,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -347,10 +345,10 @@ public class TestHoodieHFileInputFormat {
     File file = basePath.resolve(".hoodie/timeline")
         .resolve(commitNumber + "_" + InProcessTimeGenerator.createNewInstantTime() + ".commit").toFile();
     file.createNewFile();
-    FileOutputStream fileOutputStream = new FileOutputStream(file);
-    fileOutputStream.write(serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
-    fileOutputStream.flush();
-    fileOutputStream.close();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+      COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata).get().writeToStream(fileOutputStream);
+      fileOutputStream.flush();
+    }
   }
 
   private File createCompactionFile(java.nio.file.Path basePath, String commitTime)
@@ -358,14 +356,11 @@ public class TestHoodieHFileInputFormat {
     File file = basePath.resolve(".hoodie/timeline")
         .resolve(INSTANT_FILE_NAME_GENERATOR.makeRequestedCompactionFileName(commitTime)).toFile();
     assertTrue(file.createNewFile());
-    FileOutputStream os = new FileOutputStream(file);
-    try {
+    try (FileOutputStream os = new FileOutputStream(file)) {
       HoodieCompactionPlan compactionPlan = HoodieCompactionPlan.newBuilder().setVersion(2).build();
       // Write empty commit metadata
-      os.write(TimelineMetadataUtils.serializeCompactionPlan(compactionPlan).get());
+      COMMIT_METADATA_SER_DE.getInstantWriter(compactionPlan).get().writeToStream(os);
       return file;
-    } finally {
-      os.close();
     }
   }
 

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
@@ -79,10 +78,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
 import static org.apache.hudi.hadoop.HoodieColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR;
@@ -503,10 +501,10 @@ public class TestHoodieParquetInputFormat {
     File file = basePath.resolve(".hoodie/timeline")
         .resolve(commitNumber + "_" + InProcessTimeGenerator.createNewInstantTime() + ".commit").toFile();
     file.createNewFile();
-    FileOutputStream fileOutputStream = new FileOutputStream(file);
-    fileOutputStream.write(serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
-    fileOutputStream.flush();
-    fileOutputStream.close();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+      COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata).get().writeToStream(fileOutputStream);
+      fileOutputStream.flush();
+    }
   }
 
   private File createCompactionFile(java.nio.file.Path basePath, String commitTime)
@@ -514,14 +512,11 @@ public class TestHoodieParquetInputFormat {
     File file = basePath.resolve(".hoodie/timeline")
         .resolve(INSTANT_FILE_NAME_GENERATOR.makeRequestedCompactionFileName(commitTime)).toFile();
     assertTrue(file.createNewFile());
-    FileOutputStream os = new FileOutputStream(file);
-    try {
+    try (FileOutputStream os = new FileOutputStream(file)) {
       HoodieCompactionPlan compactionPlan = HoodieCompactionPlan.newBuilder().setVersion(2).build();
       // Write empty commit metadata
-      os.write(TimelineMetadataUtils.serializeCompactionPlan(compactionPlan).get());
+      COMMIT_METADATA_SER_DE.getInstantWriter(compactionPlan).get().writeToStream(os);
       return file;
-    } finally {
-      os.close();
     }
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -191,8 +191,8 @@ public class FileIOUtils {
     }
   }
 
-  public static void createFileInPath(HoodieStorage fileSystem, StoragePath fullPath, Option<HoodieInstantWriter> contentWriter) {
-    createFileInPath(fileSystem, fullPath, contentWriter, false);
+  public static void createFileInPath(HoodieStorage storage, StoragePath fullPath, Option<HoodieInstantWriter> contentWriter) {
+    createFileInPath(storage, fullPath, contentWriter, false);
   }
 
   public static boolean copy(HoodieStorage srcStorage, StoragePath src,

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -191,8 +191,8 @@ public class FileIOUtils {
     }
   }
 
-  public static void createFileInPath(HoodieStorage storage, StoragePath fullPath, Option<byte[]> content) {
-    createFileInPath(storage, fullPath, content.map(bytes -> (outputStream) -> outputStream.write(bytes)), false);
+  public static void createFileInPath(HoodieStorage fileSystem, StoragePath fullPath, Option<HoodieInstantWriter> contentWriter) {
+    createFileInPath(fileSystem, fullPath, contentWriter, false);
   }
 
   public static boolean copy(HoodieStorage srcStorage, StoragePath src,

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.HoodieMetaserverConfig;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2;
+import org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantGeneratorV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantFileNameGeneratorV2;
 import org.apache.hudi.common.util.Option;
@@ -32,6 +33,8 @@ import org.apache.hudi.metaserver.client.HoodieMetaserverClientProxy;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+
 /**
  * Active timeline for hoodie table whose metadata is stored in the hoodie meta server instead of file system.
  * Note. MetadataServer only works with 1.x table version and will be disabled when in prior table version.
@@ -41,6 +44,7 @@ public class HoodieMetaserverBasedTimeline extends ActiveTimelineV2 {
   private final String tableName;
   private final HoodieMetaserverClient metaserverClient;
   private final InstantGeneratorV2 instantGenerator = new InstantGeneratorV2();
+  private final CommitMetadataSerDeV2 metadataSerDeV2 = new CommitMetadataSerDeV2();
   private final InstantFileNameGeneratorV2 instantFileNameGenerator = new InstantFileNameGeneratorV2();
   public HoodieMetaserverBasedTimeline(HoodieTableMetaClient metaClient, HoodieMetaserverConfig config) {
     this.metaClient = metaClient;
@@ -56,23 +60,26 @@ public class HoodieMetaserverBasedTimeline extends ActiveTimelineV2 {
   }
 
   @Override
-  protected void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data) {
+  protected <T> void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()));
-    metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant, data);
+    metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant,
+        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
   }
 
   @Override
-  public void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data, boolean allowRedundantTransitions) {
+  public <T> void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata, boolean allowRedundantTransitions) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()));
-    metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant, data);
+    metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant,
+        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
   }
 
   @Override
-  public void createFileInMetaPath(String filename, Option<byte[]> content, boolean allowOverwrite) {
+  public <T> void createFileInMetaPath(String filename, Option<T> metadata, boolean allowOverwrite) {
     StoragePathInfo pathInfo = new StoragePathInfo(new StoragePath(filename), 0, false, (short) 0, 0, 0);
     HoodieInstant instant = instantGenerator.createNewInstant(pathInfo);
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
-    metaserverClient.createNewInstant(databaseName, tableName, instant, Option.empty());
+    metaserverClient.createNewInstant(databaseName, tableName, instant,
+        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
   }
 
   @Override

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
@@ -33,7 +33,7 @@ import org.apache.hudi.metaserver.client.HoodieMetaserverClientProxy;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToBytArray;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.convertMetadataToByteArray;
 
 /**
  * Active timeline for hoodie table whose metadata is stored in the hoodie meta server instead of file system.
@@ -63,14 +63,14 @@ public class HoodieMetaserverBasedTimeline extends ActiveTimelineV2 {
   protected <T> void transitionStateToComplete(boolean shouldLock, HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()));
     metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant,
-        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
+        metadata.map(m -> convertMetadataToByteArray(m, metadataSerDeV2)));
   }
 
   @Override
   public <T> void transitionPendingState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<T> metadata, boolean allowRedundantTransitions) {
     ValidationUtils.checkArgument(fromInstant.requestedTime().equals(toInstant.requestedTime()));
     metaserverClient.transitionInstantState(databaseName, tableName, fromInstant, toInstant,
-        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
+        metadata.map(m -> convertMetadataToByteArray(m, metadataSerDeV2)));
   }
 
   @Override
@@ -79,7 +79,7 @@ public class HoodieMetaserverBasedTimeline extends ActiveTimelineV2 {
     HoodieInstant instant = instantGenerator.createNewInstant(pathInfo);
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     metaserverClient.createNewInstant(databaseName, tableName, instant,
-        metadata.map(m -> convertMetadataToBytArray(m, metadataSerDeV2)));
+        metadata.map(m -> convertMetadataToByteArray(m, metadataSerDeV2)));
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
@@ -21,8 +21,7 @@ import org.apache.hudi.{AvroConversionUtils, DataSourceUtils, HoodieWriterUtils,
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieFailedWritesCleaningPolicy, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.timeline.HoodieInstant.State
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata
-import org.apache.hudi.common.util.CommitUtils
+import org.apache.hudi.common.util.{CommitUtils, Option}
 import org.apache.hudi.config.{HoodieArchivalConfig, HoodieCleanConfig}
 import org.apache.hudi.table.HoodieSparkTable
 
@@ -119,7 +118,7 @@ object AlterHoodieTableAddColumnsCommand extends SparkAdapterSupport with Loggin
     val requested = hoodieTable.getInstantGenerator.createNewInstant(State.REQUESTED, commitActionType, instantTime)
     val metadata = new HoodieCommitMetadata
     metadata.setOperationType(WriteOperationType.ALTER_SCHEMA)
-    timeLine.transitionRequestedToInflight(requested, serializeCommitMetadata(hoodieTable.getMetaClient.getTimelineLayout.getCommitMetadataSerDe, metadata))
+    timeLine.transitionRequestedToInflight(requested, Option.of(metadata))
 
     client.commit(instantTime, jsc.emptyRDD)
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
@@ -23,10 +23,9 @@ import org.apache.hudi.client.common.HoodieJavaEngineContext
 import org.apache.hudi.client.timeline.versioning.v2.LSMTimelineWriter
 import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieCommitMetadata, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.timeline.{ActiveAction, HoodieInstant, LSMTimeline}
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata
 import org.apache.hudi.common.table.timeline.versioning.v2.CompletionTimeQueryViewV2
 import org.apache.hudi.common.testutils.{HoodieTestTable, HoodieTestUtils}
-import org.apache.hudi.common.testutils.HoodieTestUtils.{INSTANT_GENERATOR, TIMELINE_FACTORY}
+import org.apache.hudi.common.testutils.HoodieTestUtils.{convertMetadataToBytArray, INSTANT_GENERATOR, TIMELINE_FACTORY}
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.index.HoodieIndex.IndexType
 import org.apache.hudi.table.HoodieJavaTable
@@ -73,8 +72,7 @@ object LSMTimelineReadBenchmark extends HoodieBenchmarkBase {
         val action = if (i % 2 == 0) "delta_commit" else "commit"
         val instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, instantTime, completionTime)
         val metadata: HoodieCommitMetadata = HoodieTestTable.of(metaClient).createCommitMetadata(instantTime, WriteOperationType.INSERT, util.Arrays.asList("par1", "par2"), 10, false)
-        val serializedMetadata = serializeCommitMetadata(metaClient.getTimelineLayout.getCommitMetadataSerDe, metadata).get()
-        instantBuffer.add(new DummyActiveAction(instant, serializedMetadata))
+        instantBuffer.add(new DummyActiveAction(instant, convertMetadataToBytArray(metadata)))
         if (i % batchSize == 0) {
           // archive 10 instants each time
           writer.write(instantBuffer, org.apache.hudi.common.util.Option.empty(), org.apache.hudi.common.util.Option.empty())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/execution/benchmark/LSMTimelineReadBenchmark.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieCommitMetadata, Ho
 import org.apache.hudi.common.table.timeline.{ActiveAction, HoodieInstant, LSMTimeline}
 import org.apache.hudi.common.table.timeline.versioning.v2.CompletionTimeQueryViewV2
 import org.apache.hudi.common.testutils.{HoodieTestTable, HoodieTestUtils}
-import org.apache.hudi.common.testutils.HoodieTestUtils.{convertMetadataToBytArray, INSTANT_GENERATOR, TIMELINE_FACTORY}
+import org.apache.hudi.common.testutils.HoodieTestUtils.{convertMetadataToByteArray, INSTANT_GENERATOR, TIMELINE_FACTORY}
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.index.HoodieIndex.IndexType
 import org.apache.hudi.table.HoodieJavaTable
@@ -72,7 +72,7 @@ object LSMTimelineReadBenchmark extends HoodieBenchmarkBase {
         val action = if (i % 2 == 0) "delta_commit" else "commit"
         val instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, action, instantTime, completionTime)
         val metadata: HoodieCommitMetadata = HoodieTestTable.of(metaClient).createCommitMetadata(instantTime, WriteOperationType.INSERT, util.Arrays.asList("par1", "par2"), 10, false)
-        instantBuffer.add(new DummyActiveAction(instant, convertMetadataToBytArray(metadata)))
+        instantBuffer.add(new DummyActiveAction(instant, convertMetadataToByteArray(metadata)))
         if (i % batchSize == 0) {
           // archive 10 instants each time
           writer.write(instantBuffer, org.apache.hudi.common.util.Option.empty(), org.apache.hudi.common.util.Option.empty())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
@@ -22,7 +22,6 @@ import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieRecord, WriteOp
 import org.apache.hudi.common.table.TableSchemaResolver
 import org.apache.hudi.common.table.timeline.HoodieInstant.State
 import org.apache.hudi.common.table.timeline.HoodieTimeline
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
@@ -256,7 +255,7 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
         val requested = hoodieTable.getInstantGenerator.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, firstInstant)
         val metadata = new HoodieCommitMetadata
         metadata.setOperationType(WriteOperationType.ALTER_SCHEMA)
-        timeLine.transitionRequestedToInflight(requested, serializeCommitMetadata(hoodieTable.getMetaClient.getTimelineLayout.getCommitMetadataSerDe, metadata))
+        timeLine.transitionRequestedToInflight(requested, org.apache.hudi.common.util.Option.of(metadata))
         // Executing ALTER TABLE
         spark.sql(s"alter table $tableName change column id id int comment 'primary id'")
         var catalogTable = spark.sessionState.catalog.getTableMetadata(new TableIdentifier(tableName))

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
@@ -23,7 +23,6 @@ import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieFailedWritesCleaningPolicy, WriteOperationType}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.HoodieInstant.State
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata
 import org.apache.hudi.common.util.{CommitUtils, Option}
 import org.apache.hudi.config.{HoodieArchivalConfig, HoodieCleanConfig}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -284,7 +283,7 @@ object AlterTableCommand extends Logging {
     val requested = instantGenerator.createNewInstant(State.REQUESTED, commitActionType, instantTime)
     val metadata = new HoodieCommitMetadata
     metadata.setOperationType(WriteOperationType.ALTER_SCHEMA)
-    timeLine.transitionRequestedToInflight(requested, serializeCommitMetadata(metaClient.getTimelineLayout.getCommitMetadataSerDe, metadata))
+    timeLine.transitionRequestedToInflight(requested, Option.of(metadata))
     val extraMeta = new util.HashMap[String, String]()
     extraMeta.put(SerDeHelper.LATEST_SCHEMA, SerDeHelper.toJson(internalSchema.setSchemaId(instantTime.toLong)))
     val schemaManager = new FileBasedInternalSchemaStorageManager(metaClient)

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -58,6 +58,7 @@ import org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor;
 import org.apache.hudi.hive.ddl.HiveQueryDDLExecutor;
 import org.apache.hudi.hive.ddl.QueryBasedDDLExecutor;
 import org.apache.hudi.hive.util.IMetaStoreClientUtil;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
@@ -102,11 +103,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.TIMELINEFOLDER_NAME;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
-import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
@@ -368,15 +366,15 @@ public class HiveTestUtil {
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeRequestedRollbackFileName(instantTime),
-        getUTF8Bytes(""));
+        Option.empty());
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeInflightRollbackFileName(instantTime),
-        getUTF8Bytes(""));
+        Option.empty());
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeRollbackFileName(instantTime + "_" + InProcessTimeGenerator.createNewInstantTime()),
-        serializeRollbackMetadata(rollbackMetadata).get());
+        COMMIT_METADATA_SER_DE.getInstantWriter(rollbackMetadata));
   }
 
   public static void createCOWTableWithSchema(String instantTime, String schemaFileName)
@@ -775,14 +773,14 @@ public class HiveTestUtil {
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeCommitFileName(instantTime + "_" + InProcessTimeGenerator.createNewInstantTime()),
-        serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
+        COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata));
   }
 
   public static void createReplaceCommitFile(HoodieReplaceCommitMetadata commitMetadata, String instantTime) throws IOException {
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeReplaceFileName(instantTime + "_" + InProcessTimeGenerator.createNewInstantTime()),
-        serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
+        COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata));
   }
 
   public static void createCommitFileWithSchema(HoodieCommitMetadata commitMetadata, String instantTime, boolean isSimpleSchema) throws IOException {
@@ -795,7 +793,7 @@ public class HiveTestUtil {
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeCommitFileName(instantTime + "_" + InProcessTimeGenerator.createNewInstantTime()),
-        serializeCommitMetadata(COMMIT_METADATA_SER_DE, commitMetadata).get());
+        COMMIT_METADATA_SER_DE.getInstantWriter(commitMetadata));
   }
 
   private static void createDeltaCommitFile(HoodieCommitMetadata deltaCommitMetadata, String deltaCommitTime)
@@ -803,15 +801,17 @@ public class HiveTestUtil {
     createMetaFile(
         basePath,
         INSTANT_FILE_NAME_GENERATOR.makeDeltaFileName(deltaCommitTime + "_" + InProcessTimeGenerator.createNewInstantTime()),
-        serializeCommitMetadata(COMMIT_METADATA_SER_DE, deltaCommitMetadata).get());
+        COMMIT_METADATA_SER_DE.getInstantWriter(deltaCommitMetadata));
   }
 
-  private static void createMetaFile(String basePath, String fileName, byte[] bytes)
+  private static void createMetaFile(String basePath, String fileName, Option<HoodieInstantWriter> writer)
       throws IOException {
     Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/" + TIMELINEFOLDER_NAME + "/" + fileName);
-    OutputStream out = fileSystem.create(fullPath, true);
-    out.write(bytes);
-    out.close();
+    try (OutputStream fsout = fileSystem.create(fullPath, true)) {
+      if (writer.isPresent()) {
+        writer.get().writeToStream(fsout);
+      }
+    }
   }
 
   public static Set<String> getCreatedTablesSet() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -516,7 +516,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
 
   static void addCommitToTimeline(HoodieTableMetaClient metaClient, WriteOperationType writeOperationType, String commitActiontype,
                                   Map<String, String> extraMetadata) {
-    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieCommitMetadata commitMetadata = commitActiontype.equals(HoodieTimeline.CLUSTERING_ACTION)
+        ? new HoodieReplaceCommitMetadata() : new HoodieCommitMetadata();
     commitMetadata.setOperationType(writeOperationType);
     extraMetadata.forEach((k, v) -> commitMetadata.getExtraMetadata().put(k, v));
     String commitTime = metaClient.createNewInstantTime();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -514,7 +515,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
   }
 
   static void addCommitToTimeline(HoodieTableMetaClient metaClient, WriteOperationType writeOperationType, String commitActiontype,
-                                  Map<String, String> extraMetadata) throws IOException {
+                                  Map<String, String> extraMetadata) {
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     commitMetadata.setOperationType(writeOperationType);
     extraMetadata.forEach((k, v) -> commitMetadata.getExtraMetadata().put(k, v));
@@ -523,7 +524,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     HoodieInstant inflightInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, commitActiontype, commitTime);
     metaClient.getActiveTimeline().createNewInstant(inflightInstant);
     if (commitActiontype.equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant, Option.of(commitMetadata));
+      metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant, (HoodieReplaceCommitMetadata) commitMetadata);
     } else {
       metaClient.getActiveTimeline().saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, commitActiontype, commitTime),

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -32,8 +32,8 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.TestAvroOrcUtils;
 import org.apache.hudi.common.util.collection.Triple;
@@ -523,12 +523,11 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     HoodieInstant inflightInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, commitActiontype, commitTime);
     metaClient.getActiveTimeline().createNewInstant(inflightInstant);
     if (commitActiontype.equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant,
-          TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+      metaClient.getActiveTimeline().transitionClusterInflightToComplete(true, inflightInstant, Option.of(commitMetadata));
     } else {
       metaClient.getActiveTimeline().saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, commitActiontype, commitTime),
-          TimelineMetadataUtils.serializeCommitMetadata(metaClient.getCommitMetadataSerDe(), commitMetadata));
+          Option.of(commitMetadata));
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -298,7 +299,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
       HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
       HoodieInstant instant4 = activeTimeline
           .filter(instant -> instant.requestedTime().equals(inserts.get(4).getInstantTime())).firstInstant().get();
-      Option<byte[]> instant4CommitData = activeTimeline.getInstantDetails(instant4);
+      HoodieCommitMetadata instant4CommitData = metaClient.reloadActiveTimeline().readCommitMetadata(instant4);
       activeTimeline.revertToInflight(instant4);
       metaClient.reloadActiveTimeline();
 
@@ -346,7 +347,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
       activeTimeline.reload().saveAsComplete(
           INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, instant4.getAction(), inserts.get(4).getInstantTime()),
-          instant4CommitData);
+          Option.of(instant4CommitData));
 
       // find instant4's new completion time
       String instant4CompletionTime = activeTimeline.reload().getInstantsAsStream()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamerCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamerCheckpointUtils.java
@@ -211,8 +211,7 @@ public class TestStreamerCheckpointUtils extends SparkClientFunctionalTestHarnes
     HoodieInstant instant = new HoodieInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.COMMIT_ACTION, commitTime, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     timeline.createNewInstant(instant);
-    timeline.saveAsComplete(instant,
-        Option.of(HoodieCommonTestHarness.getCommitMetadata(metaClient, basePath(), "partition1", commitTime, 2, extraMetadata)));
+    timeline.saveAsComplete(instant, HoodieCommonTestHarness.getCommitMetadata(metaClient, basePath(), "partition1", commitTime, 2, extraMetadata));
     metaClient.reloadActiveTimeline();
   }
 
@@ -318,8 +317,7 @@ public class TestStreamerCheckpointUtils extends SparkClientFunctionalTestHarnes
     HoodieInstant instant = new HoodieInstant(HoodieInstant.State.INFLIGHT,
         HoodieTimeline.DELTA_COMMIT_ACTION, deltaCommitTime, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
     timeline.createNewInstant(instant);
-    timeline.saveAsComplete(instant,
-        Option.of(HoodieCommonTestHarness.getCommitMetadata(metaClient, basePath(), "partition1", deltaCommitTime, 2, extraMetadata)));
+    timeline.saveAsComplete(instant, HoodieCommonTestHarness.getCommitMetadata(metaClient, basePath(), "partition1", deltaCommitTime, 2, extraMetadata));
     metaClient.reloadActiveTimeline();
   }
 


### PR DESCRIPTION
### Change Logs

instant file serialization now use write stream as opposed to byte []
### Impact

serialization can handle large instant file write.
### Risk level (write none, low medium or high below)

low
### Documentation Update
na
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
