### PR TITLE
[HUDI-9079] Log the exception message properly to handle the "default" partition

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
@@ -50,18 +50,18 @@ public class FourToFiveUpgradeHandler implements UpgradeHandler {
       HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
 
       if (!config.doSkipDefaultPartitionValidation() && hasDefaultPartitionPath(config, table)) {
-        LOG.error(String.format("\"%s\" partition detected. From 0.12, we are changing the default partition in hudi to %s "
+        LOG.error(String.format("\"%s\" partition detected. From 0.12, we are changing the default partition in hudi to \"%s\"."
                 + " Please read and write back the data in \"%s\" partition in hudi to new partition path \"%s\". \"\n"
-                + " Sample spark command to use to re-write the data: \n\n"
-                + " val df = spark.read.format(\"hudi\").load(HUDI_TABLE_PATH).filter(col(\"PARTITION_PATH_COLUMN\") === \"%s\"); \t \n\n"
-                + " df.drop(\"_hoodie_commit_time\").drop(\"_hoodie_commit_seqno\").drop(\"_hoodie_record_key\")\"\n"
-                + " .drop(\"_hoodie_partition_path\").drop(\"_hoodie_file_name\").withColumn(PARTITION_PATH_COLUMN,\"%s\")\"\n"
-                + " .write.options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);\t\n\"\n"
-                + " Please fix values for PARTITION_PATH_COLUMN, HUDI_TABLE_PATH and set all write configs in above command before running. "
-                + " Also do delete the records in old partition once above command succeeds. "
-                + " Sample spark command to delete old partition records: \n\n"
-                + " val df = spark.read.format(\"hudi\").load(HUDI_TABLE_PATH).filter(col(\"PARTITION_PATH_COLUMN\") === \"%s\"); \t \n\n"
-                + " df.write.option(\"hoodie.datasource.write.operation\",\"delete\").options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);\t\n\"\n",
+                + "Sample spark command to use to re-write the data: \n\n"
+                + "val df = spark.read.format(\"hudi\").load(HUDI_TABLE_PATH).filter(col(\"PARTITION_PATH_COLUMN\") === \"%s\"); \t \n\n"
+                + "df.drop(\"_hoodie_commit_time\").drop(\"_hoodie_commit_seqno\").drop(\"_hoodie_record_key\")\n"
+                + " .drop(\"_hoodie_partition_path\").drop(\"_hoodie_file_name\").withColumn(PARTITION_PATH_COLUMN,\"%s\")\n"
+                + " .write.format(\"hudi\").options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);\n\n"
+                + "Please fix values for PARTITION_PATH_COLUMN, HUDI_TABLE_PATH and set all write configs in above command before running. "
+                + "Also do delete the records in old partition once above command succeeds. "
+                + "Sample spark command to delete old partition records: \n\n"
+                + "val df = spark.read.format(\"hudi\").load(HUDI_TABLE_PATH).filter(col(\"PARTITION_PATH_COLUMN\") === \"%s\");\n\n"
+                + "df.write.format(\"hudi\").option(\"hoodie.datasource.write.operation\",\"delete\").options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);\t\n\n",
             DEPRECATED_DEFAULT_PARTITION_PATH, DEFAULT_PARTITION_PATH, DEPRECATED_DEFAULT_PARTITION_PATH, DEFAULT_PARTITION_PATH,
             DEPRECATED_DEFAULT_PARTITION_PATH, DEFAULT_PARTITION_PATH, DEPRECATED_DEFAULT_PARTITION_PATH));
         throw new HoodieException(String.format("Old deprecated \"%s\" partition found in hudi table. This needs a migration step before we can upgrade ",


### PR DESCRIPTION
### Change Logs

Fixed the default partition migration steps.

```scala
"default" partition detected. From 0.12, we are changing the default partition in hudi to "__HIVE_DEFAULT_PARTITION__". Please read and write back the data in "default" partition in hudi to new partition path "__HIVE_DEFAULT_PARTITION__". "
Sample spark command to use to re-write the data: 

val df = spark.read.format("hudi").load(HUDI_TABLE_PATH).filter(col("PARTITION_PATH_COLUMN") === "default"); 	 

df.drop("_hoodie_commit_time").drop("_hoodie_commit_seqno").drop("_hoodie_record_key")
 .drop("_hoodie_partition_path").drop("_hoodie_file_name").withColumn(PARTITION_PATH_COLUMN,"__HIVE_DEFAULT_PARTITION__")
 .write.format("hudi").options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);

Please fix values for PARTITION_PATH_COLUMN, HUDI_TABLE_PATH and set all write configs in above command before running. Also do delete the records in old partition once above command succeeds. Sample spark command to delete old partition records: 

val df = spark.read.format("hudi").load(HUDI_TABLE_PATH).filter(col("PARTITION_PATH_COLUMN") === "default");

df.write.format("hudi").option("hoodie.datasource.write.operation","delete").options(writeOptions).mode(Append).save(HUDI_TABLE_PATH);
```

**Hudi Table data before migration:**

<img width="1430" alt="Screenshot 2025-03-03 at 8 45 18 PM" src="https://github.com/user-attachments/assets/6ff64a96-2323-433c-83ef-68842e5a010e" />

**Hudi Table data after migration:**

<img width="1441" alt="Screenshot 2025-03-03 at 8 48 16 PM" src="https://github.com/user-attachments/assets/b694e6db-eb54-45a0-82b3-373b5d110c30" />

**Hudi Table data before deleting default partition:**

<img width="1200" alt="Screenshot 2025-03-03 at 8 48 46 PM" src="https://github.com/user-attachments/assets/b385c369-e749-46cc-8d30-74c0d582c5c5" />

**Hudi Table data after deleting default partition:**

<img width="1204" alt="Screenshot 2025-03-03 at 8 50 53 PM" src="https://github.com/user-attachments/assets/03d7701a-949b-42aa-a5ba-7bda508dad35" />

### Impact

Update the default partition log message.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed

