### PR TITLE
[HUDI-9057] Fixing ClassNotFound issue w/ ProtoBufSchemaProvider

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -445,6 +445,16 @@
       <version>${hive.version}</version>
     </dependency>
 
+    <!-- Kakfa .-->
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-protobuf-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-json-schema-provider</artifactId>
+    </dependency>
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -130,10 +130,12 @@
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
                   <include>io.confluent:kafka-json-schema-serializer</include>
+                  <include>io.confluent:kafka-json-schema-provider</include>
                   <include>io.confluent:common-config</include>
                   <include>io.confluent:common-utils</include>
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.confluent:kafka-protobuf-serializer</include>
+                  <include>io.confluent:kafka-protobuf-provider</include>
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>
                   <include>io.dropwizard.metrics:metrics-jmx</include>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -117,10 +117,13 @@
                   <include>com.twitter:chill-protobuf</include>
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
+                  <include>io.confluent:kafka-json-schema-serializer</include>
+                  <include>io.confluent:kafka-json-schema-provider</include>
                   <include>io.confluent:common-config</include>
                   <include>io.confluent:common-utils</include>
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.confluent:kafka-protobuf-serializer</include>
+                  <include>io.confluent:kafka-protobuf-provider</include>
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>
                   <include>io.dropwizard.metrics:metrics-jmx</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1845,7 +1845,23 @@
       </dependency>
       <dependency>
         <groupId>io.confluent</groupId>
+        <artifactId>kafka-protobuf-provider</artifactId>
+        <version>${confluent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.confluent</groupId>
         <artifactId>kafka-json-schema-serializer</artifactId>
+        <version>${confluent.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.kjetland</groupId>
+            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-json-schema-provider</artifactId>
         <version>${confluent.version}</version>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
### Change Logs

With 1.0 release, OSS users reported ClassNotFound issue due to ProtoBufSchemaProvider w/ schema registry client. Fixing the same in this patch by including the jar of interest to utilities bundle jar and utilities slim bundle jar.

Offending commit of interest: https://github.com/apache/hudi/pull/11660/files#r1973933358 

Essentially, we are introducing 
```
new ProtobufSchemaProvider() and  new JsonSchemaProvider()
```

in this commit which expects these classes to be present in CP during runtime. 


Before the fix: 
```
[INFO] -------------< org.apache.hudi:hudi-utilities-bundle_2.12 >-------------
[INFO] Building hudi-utilities-bundle_2.12 1.1.0-SNAPSHOT               [22/22]
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from confluent: https://packages.confluent.io/maven/org/apache/hudi/hudi-utilities_2.12/1.1.0-SNAPSHOT/maven-metadata.xml
Downloading from apache.snapshots: https://repository.apache.org/snapshots/org/apache/hudi/hudi-utilities_2.12/1.1.0-SNAPSHOT/maven-metadata.xml
[WARNING] net.minidev:json-smart/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/net/minidev/json-smart/maven-metadata.xml
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hudi-utilities-bundle_2.12 ---
[WARNING] net.minidev:json-smart/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/net/minidev/json-smart/maven-metadata.xml
Downloading from confluent: https://packages.confluent.io/maven/org/apache/hudi/hudi-utilities_2.12/1.1.0-SNAPSHOT/hudi-utilities_2.12-1.1.0-SNAPSHOT.jar
Downloading from apache.snapshots: https://repository.apache.org/snapshots/org/apache/hudi/hudi-utilities_2.12/1.1.0-SNAPSHOT/hudi-utilities_2.12-1.1.0-SNAPSHOT.jar
[INFO] org.apache.hudi:hudi-utilities-bundle_2.12:jar:1.1.0-SNAPSHOT
[INFO] \- org.apache.hudi:hudi-utilities_2.12:jar:1.1.0-SNAPSHOT:compile
[INFO]    \- io.confluent:kafka-protobuf-serializer:jar:5.5.0:compile
[INFO]       \- io.confluent:kafka-protobuf-provider:jar:5.5.0:compile
[INFO] ------------------------------------------------------------------------
```

After the fix: 
```
[INFO] -------------< org.apache.hudi:hudi-utilities-bundle_2.12 >-------------
[INFO] Building hudi-utilities-bundle_2.12 1.1.0-SNAPSHOT               [22/22]
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] net.minidev:json-smart/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/net/minidev/json-smart/maven-metadata.xml
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hudi-utilities-bundle_2.12 ---
[WARNING] net.minidev:json-smart/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/net/minidev/json-smart/maven-metadata.xml
[INFO] org.apache.hudi:hudi-utilities-bundle_2.12:jar:1.1.0-SNAPSHOT
[INFO] \- org.apache.hudi:hudi-utilities_2.12:jar:1.1.0-SNAPSHOT:compile
[INFO]    \- io.confluent:kafka-protobuf-provider:jar:5.5.0:compile
[INFO] ------------------------------------------------------------------------
```

Also, validated using `jar -tvf` that both the ProtobufSchemaProvider and JsonSchemaProvider are present in the utilities bundle and slim bundlr jars. 

### Impact

Will help unblock users to bootstrap a new table if schema registry is used. 

### Risk level (write none, low medium or high below)
low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
