### PR TITLE
[HUDI-8745] Add tests for record index and secondary index with insert dups policy

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
@@ -20,11 +20,10 @@
 package org.apache.hudi
 
 import org.apache.hudi.DataSourceWriteOptions._
-import org.apache.hudi.common.config.HoodieReaderConfig
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieUpsertException
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
-
 import org.apache.spark.sql.{Dataset, Row, SaveMode}
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -74,6 +73,7 @@ class TestInsertDedupPolicy extends SparkClientFunctionalTestHarness {
       option(TABLE_TYPE.key, tableType).
       option(DataSourceWriteOptions.TABLE_NAME.key, "test_table").
       option(HoodieCompactionConfig.INLINE_COMPACT.key, "false").
+      option(HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key, "true").
       options(opts).
       mode(SaveMode.Overwrite).
       save(basePath)
@@ -87,13 +87,33 @@ class TestInsertDedupPolicy extends SparkClientFunctionalTestHarness {
       )
     } else {
       // Write data.
-      insertsWithDup.write.format("hudi").options(opts).mode(SaveMode.Append).save(basePath)
+      insertsWithDup.write.format("hudi").
+        option(HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key, "true").
+        option(HoodieMetadataConfig.SECONDARY_INDEX_NAME.key, "idx_rider").
+        option(HoodieMetadataConfig.SECONDARY_INDEX_COLUMN.key, "rider").
+        options(opts).
+        mode(SaveMode.Append).
+        save(basePath)
       // Validate the data.
       val df = spark.read.format("hudi").options(opts).load(basePath)
       val finalDf = df.select("ts", "key", "rider", "driver", "fare", "number").sort("key")
       val expected = if (dedupPolicy.equals(DROP_INSERT_DUP_POLICY)) expectedForDrop else expectedForNone
       val expectedDf = spark.createDataFrame(expected).toDF(columns: _*).sort("key")
       TestInsertDedupPolicy.validate(expectedDf, finalDf)
+
+      // Validate data with record key filter
+      // RLI will be used with record key filter
+      val recordKeyFilterDf = df.filter("key = '5'").select("ts", "key", "rider", "driver", "fare", "number").sort("key")
+      val expectedRecordKeyFilter = if (dedupPolicy.equals(DROP_INSERT_DUP_POLICY)) expectedForDrop.filter(_._2 == "5") else expectedForNone.filter(_._2 == "5")
+      val expectedRecordKeyFilterDf = spark.createDataFrame(expectedRecordKeyFilter).toDF(columns: _*).sort("key")
+      TestInsertDedupPolicy.validate(expectedRecordKeyFilterDf, recordKeyFilterDf)
+
+      // Validate data with secondary key filter
+      // Secondary index will be used with secondary key filter
+      val secondaryKeyFilterDf = df.filter("rider = 'rider-C'").select("ts", "key", "rider", "driver", "fare", "number").sort("key")
+      val expectedSecondaryKeyFilter = if (dedupPolicy.equals(DROP_INSERT_DUP_POLICY)) expectedForDrop.filter(_._3 == "rider-C") else expectedForNone.filter(_._3 == "rider-C")
+      val expectedSecondaryKeyFilterDf = spark.createDataFrame(expectedSecondaryKeyFilter).toDF(columns: _*).sort("key")
+      TestInsertDedupPolicy.validate(expectedSecondaryKeyFilterDf, secondaryKeyFilterDf)
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieUpsertException
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
 import org.apache.spark.sql.{Dataset, Row, SaveMode}
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION
### Change Logs

The issue was already fixed in https://github.com/apache/hudi/commit/ef9ab24cff93a4130c1b3477454dbc8e9eb7eeee. Just adding a test here to validate that RLI/SI return correct data with different insert dups plocies.

### Impact

Test coverage

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
