### PR TITLE
[MINOR] Add retries and logs to merging Jacoco execution data files

### DIFF
--- a/scripts/jacoco/merge_jacoco_exec_files.sh
+++ b/scripts/jacoco/merge_jacoco_exec_files.sh
@@ -21,4 +21,17 @@
 shopt -s globstar
 echo "Jacoco CLI jar: $1"
 echo "Hudi source directory: $2"
-java -jar $1 merge $2/**/jacoco-agent/**/*.exec --destfile merged-jacoco.exec
+retry_count=0
+while [[ $retry_count -lt 3 ]]; do
+  ls -l $2/**/jacoco-agent/**/*.exec
+  java -jar $1 merge $2/**/jacoco-agent/**/*.exec --destfile merged-jacoco.exec
+  exit_status=$?
+
+  if [[ $exit_status -eq 0 ]]; then
+    echo "Jacoco merge succeeded on attempt $((retry_count + 1))"
+    exit 0
+  fi
+
+  retry_count=$((retry_count + 1))
+  sleep 10
+done


### PR DESCRIPTION
### Change Logs

This PR adds retries and logs to merging Jacoco execution data files to debug the following error from Jacoco CLI:
```
Jacoco CLI jar: jacoco-lib/lib/jacococli.jar
Hudi source directory: /home/vsts/work/1/s
[INFO] Loading execution data file /home/vsts/work/1/s/hudi-client/hudi-spark-client/target/jacoco-agent/jacoco1.exec.
[INFO] Loading execution data file /home/vsts/work/1/s/hudi-client/hudi-spark-client/target/jacoco-agent/jacoco2.exec.
Exception in thread "main" java.io.EOFException
	at java.base/java.io.DataInputStream.readByte(DataInputStream.java:272)
	at org.jacoco.cli.internal.core.internal.data.CompactDataInput.readBooleanArray(CompactDataInput.java:64)
	at org.jacoco.cli.internal.core.data.ExecutionDataReader.readExecutionData(ExecutionDataReader.java:150)
	at org.jacoco.cli.internal.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:116)
	at org.jacoco.cli.internal.core.data.ExecutionDataReader.read(ExecutionDataReader.java:93)
	at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:60)
	at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:74)
	at org.jacoco.cli.internal.commands.Merge.loadExecutionData(Merge.java:61)
	at org.jacoco.cli.internal.commands.Merge.execute(Merge.java:45)
	at org.jacoco.cli.internal.Main.execute(Main.java:90)
	at org.jacoco.cli.internal.Main.main(Main.java:105)
```

### Impact

Improves CI

### Risk level (write none, low medium or high below)

 none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
