### PR TITLE
[HUDI-9132] Avoid empty string row key for delete and update operations

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -550,7 +550,8 @@ object ProvidesHoodieConfig {
     val tableConfig = hoodieCatalogTable.tableConfig
     val baseOpts = Map(
       "path" -> hoodieCatalogTable.tableLocation,
-      TABLE_NAME.key -> tableConfig.getTableName,
+      TBL_NAME.key -> tableConfig.getTableName,
+      DATABASE_NAME.key -> hoodieCatalogTable.table.database,
       HIVE_STYLE_PARTITIONING.key -> tableConfig.getHiveStylePartitioningEnable,
       URL_ENCODE_PARTITIONING.key -> tableConfig.getUrlEncodePartitioning,
       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.datasources.FileStatusCache
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hudi.HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{filterHoodieConfigs, isUsingHiveCatalog}
-import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{buildOverridingOpts, combineOptions, getPartitionPathFieldWriteConfig}
+import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{buildOverridingOpts, buildOverridingOptsForDelete, combineOptions, getPartitionPathFieldWriteConfig}
 import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.PARTITION_OVERWRITE_MODE
@@ -411,7 +411,7 @@ trait ProvidesHoodieConfig extends Logging {
       HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key -> hiveSyncConfig.getStringOrDefault(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS)
     )
 
-    val overridingOpts = buildOverridingOpts(hoodieCatalogTable)
+    val overridingOpts = buildOverridingOptsForDelete(hoodieCatalogTable)
     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
   }
@@ -539,7 +539,7 @@ object ProvidesHoodieConfig {
     )
   }
 
-  private def buildOverridingOpts(hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
+  private def buildOverridingOptsForDelete(hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
     buildCommonOverridingOpts(hoodieCatalogTable) ++ Map(
       OPERATION.key -> DataSourceWriteOptions.DELETE_OPERATION_OPT_VAL
     )

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -33,6 +33,7 @@ import org.apache.hudi.hive.ddl.HiveSyncMode
 import org.apache.hudi.keygen.{ComplexKeyGenerator, CustomAvroKeyGenerator, CustomKeyGenerator}
 import org.apache.hudi.sql.InsertMode
 import org.apache.hudi.sync.common.HoodieSyncConfig
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
@@ -49,6 +50,7 @@ import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
 import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 trait ProvidesHoodieConfig extends Logging {
@@ -389,7 +391,6 @@ trait ProvidesHoodieConfig extends Logging {
 
   def buildHoodieDeleteTableConfig(hoodieCatalogTable: HoodieCatalogTable,
                                    sparkSession: SparkSession): Map[String, String] = {
-    val path = hoodieCatalogTable.tableLocation
     val tableConfig = hoodieCatalogTable.tableConfig
     val tableSchema = hoodieCatalogTable.tableSchema
     val partitionColumns = tableConfig.getPartitionFieldProp.split(",").map(_.toLowerCase(Locale.ROOT))
@@ -549,6 +550,7 @@ object ProvidesHoodieConfig {
     val tableConfig = hoodieCatalogTable.tableConfig
     val baseOpts = Map(
       "path" -> hoodieCatalogTable.tableLocation,
+      TABLE_NAME.key -> tableConfig.getTableName,
       HIVE_STYLE_PARTITIONING.key -> tableConfig.getHiveStylePartitioningEnable,
       URL_ENCODE_PARTITIONING.key -> tableConfig.getUrlEncodePartitioning,
       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
@@ -173,10 +173,13 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
           Seq(3, "a2", 30.0, 1000)
         )
 
+        // Update the row with id = 2 by setting price to 25.0
+        spark.sql(s"update $tableName set price = cast(25.0 as double) where id = 2")
+
         // delete data from table
         spark.sql(s"delete from $tableName where id = 1")
         checkAnswer(s"select id, name, price, ts from $tableName")(
-          Seq(2, "a2", 20.0, 1000),
+          Seq(2, "a2", 25.0, 1000),
           Seq(3, "a2", 30.0, 1000)
         )
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
@@ -134,6 +134,54 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test Delete From Partitioned Table Without Primary Key") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        // create table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |  type = '$tableType',
+             |  preCombineField = 'price'
+             |)
+             |partitioned by (ts)
+   """.stripMargin)
+
+        // test with optimized sql writes enabled.
+        spark.sql(s"set ${SPARK_SQL_OPTIMIZED_WRITES.key()}=true")
+
+        // insert data to table
+        spark.sql(
+          s"""
+             |insert into $tableName
+             |values
+             |  (1, 'a1', cast(10.0 as double), 1000),
+             |  (2, 'a2', cast(20.0 as double), 1000),
+             |  (3, 'a2', cast(30.0 as double), 1000)
+             |""".stripMargin)
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 10.0, 1000),
+          Seq(2, "a2", 20.0, 1000),
+          Seq(3, "a2", 30.0, 1000)
+        )
+
+        // delete data from table
+        spark.sql(s"delete from $tableName where id = 1")
+        checkAnswer(s"select count(1) from $tableName")(
+          Seq(2)
+        )
+      }
+    }
+  }
+
   test("Test Delete Table On Non-PK Condition") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach {tableType =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
@@ -153,7 +153,7 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
              |  preCombineField = 'price'
              |)
              |partitioned by (ts)
-   """.stripMargin)
+             |""".stripMargin)
 
         // test with optimized sql writes enabled.
         spark.sql(s"set ${SPARK_SQL_OPTIMIZED_WRITES.key()}=true")
@@ -173,13 +173,11 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
           Seq(3, "a2", 30.0, 1000)
         )
 
-        // Update the row with id = 2 by setting price to 25.0
-        spark.sql(s"update $tableName set price = cast(25.0 as double) where id = 2")
-
         // delete data from table
         spark.sql(s"delete from $tableName where id = 1")
+
         checkAnswer(s"select id, name, price, ts from $tableName")(
-          Seq(2, "a2", 25.0, 1000),
+          Seq(2, "a2", 20.0, 1000),
           Seq(3, "a2", 30.0, 1000)
         )
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestDeleteTable.scala
@@ -175,8 +175,9 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
 
         // delete data from table
         spark.sql(s"delete from $tableName where id = 1")
-        checkAnswer(s"select count(1) from $tableName")(
-          Seq(2)
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(2, "a2", 20.0, 1000),
+          Seq(3, "a2", 30.0, 1000)
         )
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestUpdateTable.scala
@@ -437,4 +437,55 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
       }
     })
   }
+
+  test("Test Update Partitioned Table Without Primary Key") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        // create table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |  type = '$tableType',
+             |  preCombineField = 'price'
+             |)
+             |partitioned by (ts)
+             |""".stripMargin)
+
+        // test with optimized sql writes enabled.
+        spark.sql(s"set ${SPARK_SQL_OPTIMIZED_WRITES.key()}=true")
+
+        // insert data to table
+        spark.sql(
+          s"""
+             |insert into $tableName
+             |values
+             |  (1, 'a1', cast(10.0 as double), 1000),
+             |  (2, 'a2', cast(20.0 as double), 1000),
+             |  (3, 'a2', cast(30.0 as double), 1000)
+             |""".stripMargin)
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 10.0, 1000),
+          Seq(2, "a2", 20.0, 1000),
+          Seq(3, "a2", 30.0, 1000)
+        )
+
+        // Update the row with id = 2 by setting price to 25.0
+        spark.sql(s"update $tableName set price = cast(25.0 as double) where id = 2")
+
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 10.0, 1000),
+          Seq(2, "a2", 25.0, 1000),
+          Seq(3, "a2", 30.0, 1000)
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION

### Change Logs

Empty row key string could fail the initialization of SimpleKeyGenerator during its validation.

### Impact

Fixes a corner case.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
