### PR TITLE
[MINOR] Remove storage instance variable from HoodieIngestionMetrics

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -20,7 +20,6 @@ package org.apache.hudi.utilities.ingestion;
 
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
-import org.apache.hudi.storage.HoodieStorage;
 
 import com.codahale.metrics.Timer;
 
@@ -31,17 +30,14 @@ import java.io.Serializable;
  */
 public abstract class HoodieIngestionMetrics implements Serializable {
 
-  protected final HoodieStorage storage;
-
   protected final HoodieMetricsConfig writeConfig;
 
-  public HoodieIngestionMetrics(HoodieWriteConfig writeConfig, HoodieStorage storage) {
-    this(writeConfig.getMetricsConfig(), storage);
+  public HoodieIngestionMetrics(HoodieWriteConfig writeConfig) {
+    this(writeConfig.getMetricsConfig());
   }
 
-  public HoodieIngestionMetrics(HoodieMetricsConfig writeConfig, HoodieStorage storage) {
+  public HoodieIngestionMetrics(HoodieMetricsConfig writeConfig) {
     this.writeConfig = writeConfig;
-    this.storage = storage;
   }
 
   public abstract Timer.Context getOverallTimerContext();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionMetrics.java
@@ -23,12 +23,10 @@ import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 
 import com.codahale.metrics.Timer;
 
-import java.io.Serializable;
-
 /**
  * For reporting metrics related to ingesting data via {@link HoodieIngestionService}.
  */
-public abstract class HoodieIngestionMetrics implements Serializable {
+public abstract class HoodieIngestionMetrics {
 
   protected final HoodieMetricsConfig writeConfig;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerMetrics.java
@@ -46,7 +46,7 @@ public class HoodieStreamerMetrics extends HoodieIngestionMetrics {
   }
 
   public HoodieStreamerMetrics(HoodieMetricsConfig writeConfig, HoodieStorage storage) {
-    super(writeConfig, storage);
+    super(writeConfig);
     if (writeConfig.isMetricsOn()) {
       metrics = Metrics.getInstance(writeConfig, storage);
       this.overallTimerName = getMetricsName("deltastreamer", "timer");


### PR DESCRIPTION
### Change Logs

- Removes the storage variable from the HoodieIngestionMetrics class

### Impact

- The HoodieIngestionMetrics class is marked as serializable but the Storage class is not so it breaks serializability 

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
