### PR TITLE
[HUDI-9135] Bloom index data skew bucket index partitioner

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -95,8 +95,8 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
     int configuredBloomIndexParallelism = config.getBloomIndexParallelism();
 
     // NOTE: Target parallelism could be overridden by the config
-    int targetParallelism =
-        configuredBloomIndexParallelism > 0 ? configuredBloomIndexParallelism : inputParallelism;
+    boolean isBloomIndexParallelismConfigured = configuredBloomIndexParallelism > 0;
+    int targetParallelism = isBloomIndexParallelismConfigured ? configuredBloomIndexParallelism : inputParallelism;
 
     LOG.info(String.format("Input parallelism: %d, Index parallelism: %d", inputParallelism, targetParallelism));
 
@@ -164,7 +164,7 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       Map<HoodieFileGroupId, Long> comparisonsPerFileGroup = computeComparisonsPerFileGroup(
           config, recordsPerPartition, partitionToFileInfo, fileComparisonsRDD, context);
       Partitioner partitioner = new BucketizedBloomCheckPartitioner(targetParallelism, comparisonsPerFileGroup,
-          config.getBloomIndexKeysPerBucket());
+          config.getBloomIndexKeysPerBucket(), isBloomIndexParallelismConfigured);
 
       keyLookupResultRDD = fileComparisonsRDD.mapToPair(fileGroupAndRecordKey -> new Tuple2<>(fileGroupAndRecordKey, false))
           .repartitionAndSortWithinPartitions(partitioner, new FileGroupIdComparator())
@@ -172,7 +172,7 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
     } else if (config.isBloomIndexFileGroupIdKeySortingEnabled()) {
       long totalComparisons = fileComparisonsRDD.count();
-      int parallelismForSortPartitioner = (int) Math.max(1L, totalComparisons/((Integer)config.getBloomIndexKeysPerBucket()).longValue());
+      int parallelismForSortPartitioner = (int) Math.max(1L, totalComparisons / ((Integer)config.getBloomIndexKeysPerBucket()).longValue());
       keyLookupResultRDD = fileComparisonsRDD.mapToPair(fileGroupAndRecordKey -> new Tuple2<>(fileGroupAndRecordKey, false))
           .sortByKey(new FileGroupIdAndRecordKeyComparator(), true, parallelismForSortPartitioner)
           .map(Tuple2::_1)
@@ -209,7 +209,6 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       return o1._2.compareTo(o2._2);
     }
   }
-
 
   /**
    * Compute the estimated number of bloom filter comparisons to be performed on each file group.

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -171,8 +171,10 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
           .map(Tuple2::_1)
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
     } else if (config.isBloomIndexFileGroupIdKeySortingEnabled()) {
+      long totalComparisons = fileComparisonsRDD.count();
+      int parallelismForSortPartitioner = (int) Math.max(1L, totalComparisons/((Integer)config.getBloomIndexKeysPerBucket()).longValue());
       keyLookupResultRDD = fileComparisonsRDD.mapToPair(fileGroupAndRecordKey -> new Tuple2<>(fileGroupAndRecordKey, false))
-          .sortByKey(new FileGroupIdAndRecordKeyComparator(), true, targetParallelism)
+          .sortByKey(new FileGroupIdAndRecordKeyComparator(), true, parallelismForSortPartitioner)
           .map(Tuple2::_1)
           .mapPartitions(new HoodieSparkBloomIndexCheckFunction(hoodieTable, config), true);
     } else {
@@ -207,6 +209,7 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       return o1._2.compareTo(o2._2);
     }
   }
+
 
   /**
    * Compute the estimated number of bloom filter comparisons to be performed on each file group.

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
@@ -22,6 +22,8 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,8 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBucketizedBloomCheckPartitioner {
 
-  @Test
-  public void testAssignmentCorrectness() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testAssignmentCorrectness(boolean isParallelismConfigured) {
     HoodieFileGroupId fg1 = new HoodieFileGroupId("p1", "f1");
     HoodieFileGroupId fg2 = new HoodieFileGroupId("p1", "f2");
     HoodieFileGroupId fg3 = new HoodieFileGroupId("p1", "f3");
@@ -50,25 +53,32 @@ public class TestBucketizedBloomCheckPartitioner {
         put(fg3, 20L);
       }
     };
-    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(4, fileToComparisons, 10);
+    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(4, fileToComparisons, 10, isParallelismConfigured);
     Map<HoodieFileGroupId, List<Integer>> assignments = p.getFileGroupToPartitions();
     assertEquals(4, assignments.get(fg1).size(), "f1 should have 4 buckets");
     assertEquals(4, assignments.get(fg2).size(), "f2 should have 4 buckets");
     assertEquals(2, assignments.get(fg3).size(), "f3 should have 2 buckets");
-    assertArrayEquals(new Integer[] {0, 0, 1, 3}, assignments.get(fg1).toArray(), "f1 spread across 3 partitions");
-    assertArrayEquals(new Integer[] {2, 2, 3, 1}, assignments.get(fg2).toArray(), "f2 spread across 3 partitions");
-    assertArrayEquals(new Integer[] {1, 0}, assignments.get(fg3).toArray(), "f3 spread across 2 partitions");
+    if (isParallelismConfigured) {
+      assertArrayEquals(new Integer[] {0, 0, 1, 3}, assignments.get(fg1).toArray(), "f1 spread across 3 partitions");
+      assertArrayEquals(new Integer[] {1, 2, 2, 0}, assignments.get(fg2).toArray(), "f2 spread across 3 partitions");
+      assertArrayEquals(new Integer[] {3, 1}, assignments.get(fg3).toArray(), "f3 spread across 2 partitions");
+    } else {
+      assertArrayEquals(new Integer[] {0, 1, 2, 7}, assignments.get(fg1).toArray(), "f1 spread across 4 partitions");
+      assertArrayEquals(new Integer[] {3, 4, 5, 8}, assignments.get(fg2).toArray(), "f2 spread across 4 partitions");
+      assertArrayEquals(new Integer[] {6, 9}, assignments.get(fg3).toArray(), "f3 spread across 2 partitions");
+    }
   }
 
-  @Test
-  public void testUniformPacking() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testUniformPacking(boolean isParallelismConfigured) {
     // evenly distribute 10 buckets/file across 100 partitions
     Map<HoodieFileGroupId, Long> comparisons1 = new HashMap<HoodieFileGroupId, Long>() {
       {
         IntStream.range(0, 10).forEach(f -> put(new HoodieFileGroupId("p1", "f" + f), 100L));
       }
     };
-    BucketizedBloomCheckPartitioner partitioner = new BucketizedBloomCheckPartitioner(100, comparisons1, 10);
+    BucketizedBloomCheckPartitioner partitioner = new BucketizedBloomCheckPartitioner(100, comparisons1, 10, isParallelismConfigured);
     Map<HoodieFileGroupId, List<Integer>> assignments = partitioner.getFileGroupToPartitions();
     assignments.forEach((key, value) -> assertEquals(10, value.size()));
     Map<Integer, Long> partitionToNumBuckets =
@@ -77,15 +87,20 @@ public class TestBucketizedBloomCheckPartitioner {
     partitionToNumBuckets.forEach((key, value) -> assertEquals(1L, value.longValue()));
   }
 
-  @Test
-  public void testNumPartitions() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testNumPartitions(boolean isParallelismConfigured) {
     Map<HoodieFileGroupId, Long> comparisons1 = new HashMap<HoodieFileGroupId, Long>() {
       {
         IntStream.range(0, 10).forEach(f -> put(new HoodieFileGroupId("p1", "f" + f), 100L));
       }
     };
-    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(10000, comparisons1, 10);
-    assertEquals(100, p.numPartitions(), "num partitions must equal total buckets");
+    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(10000, comparisons1, 10, isParallelismConfigured);
+    if (isParallelismConfigured) {
+      assertEquals(100, p.numPartitions(), "num partitions must equal total buckets");
+    } else {
+      assertEquals(10000, p.numPartitions(), "num partitions must equal target partitions");
+    }
   }
 
   @Test
@@ -95,7 +110,7 @@ public class TestBucketizedBloomCheckPartitioner {
         IntStream.range(0, 100000).forEach(f -> put(new HoodieFileGroupId("p1", "f" + f), 100L));
       }
     };
-    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(1000, comparisons1, 10);
+    BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(1000, comparisons1, 10, true);
 
     IntStream.range(0, 100000).forEach(f -> {
       int partition = p.getPartition(Tuple2.apply(new HoodieFileGroupId("p1", "f" + f), "value"));


### PR DESCRIPTION
### Change Logs

Bloom index data skew bucket index partitioner.

Fixing bloom index to tackle data skews in write path.

For bucketized bloom, fixing the way we deduce the buckets per file group.
Fixing the parallelism value for sort partitioner w/ bloom index.
[Within each filegroup, we were determining the parallelism](https://github.com/apache/hudi/blob/aeebfcfcec271e8ff8f37e7f7ef2418d386f4c76/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/BucketizedBloomCheckPartitioner.java#L86) as Math.min(targetParallelism, totalBuckets). In this case, if incoming dataframe has 1 just spark partition, even though we could have computed the required buckets to be 10 (for eg), we might confine to just 1 bucket due to Math.min(). hence, resulting in 1 spark partition dealing with too many keys to be compared against. So, fixing this with this patch.

Fix: If the bloom index parallelism is dynamically derived, we can go with Math.max instead of Math.min. This will ensure, we honor the total computed buckets instead of relying on dynamically derived parallelism from higher layer.
But if the bloom index parallelism is explicitly overridden by the user, we can leave it as Math.min.

### Impact

No data skews with bucketized partitioner with bloom index. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
