### PR TITLE
[MINOR] Skip merging Jacoco execution data file from Azure Job 1 FT

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -154,7 +154,8 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests $(JACOCO_AGENT_DESTFILE2_ARG) -pl hudi-client/hudi-spark-client
+              # TODO(HUDI-9143): Investigate why Jacoco execution data file is corrupt
+              options: $(MVN_OPTS_TEST) -Pfunctional-tests -Djacoco.agent.dest.filename=jacoco2.corrupt -pl hudi-client/hudi-spark-client
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               jdkVersionOption: '1.8'


### PR DESCRIPTION
### Change Logs

The merging of Jacoco execution data files may fail because the file is corrupt from Azure CI Job 1 FT.  The merge can succeed when the file is empty, which is also abnormal.  This PR temporarily skips merging Jacoco execution data file from Azure Job 1 FT to avoid Azure CI failure during investigation (HUDI-9143).

### Impact

Makes Azure CI stable.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
