### PR TITLE
[HUDI-9154] Allow bootstrap to complete without updating col stats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -235,11 +235,15 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
       LOG.info("Committed " + instantTime);
       result.setCommitMetadata(Option.of(metadata));
       // update cols to Index as applicable
-      HoodieColumnStatsIndexUtils.updateColsToIndex(table, config, metadata,
-          (Functions.Function2<HoodieTableMetaClient, List<String>, Void>) (metaClient, columnsToIndex) -> {
-            updateColumnsToIndexForColumnStats(metaClient, columnsToIndex);
-            return null;
-          });
+      try {
+        HoodieColumnStatsIndexUtils.updateColsToIndex(table, config, metadata,
+                (Functions.Function2<HoodieTableMetaClient, List<String>, Void>) (metaClient, columnsToIndex) -> {
+                  updateColumnsToIndexForColumnStats(metaClient, columnsToIndex);
+                  return null;
+                });
+      } catch (UnsupportedOperationException uoe) {
+        LOG.warn("Failed to update col stats, bootstrap doesn't support col stats", uoe);
+      }
     } catch (HoodieIOException e) {
       throw new HoodieCommitException("Failed to complete commit " + config.getBasePath() + " at time " + instantTime,
           e);


### PR DESCRIPTION
### Change Logs

Since #12529 , `BaseCommitActionExecutor` would update col stats by default. But bootstrap operation doesn't support col stats and will fail the bootstraping. This PR is to allow bootstrap to complete without updating col stats.

```
Caused by: org.apache.hudi.exception.HoodieNotSupportedException: col stats is not supported with bootstrap operation
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.updateColumnsToIndexForColumnStats(SparkBootstrapCommitActionExecutor.java:225)
	at org.apache.hudi.table.action.commit.BaseCommitActionExecutor.lambda$commit$b950a45b$1(BaseCommitActionExecutor.java:239)
	at org.apache.hudi.client.HoodieColumnStatsIndexUtils.updateColsToIndex(HoodieColumnStatsIndexUtils.java:73)
	... 63 more
```

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None
- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
