### PR TITLE
[HUDI-9166] Static cleanup method that doesn't hold references to DiskMap instances

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskMap.java
@@ -26,7 +26,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -63,11 +66,9 @@ public abstract class DiskMap<T extends Serializable, R> implements Map<T, R>, K
    * (typically 4 KB) to disk.
    */
   private void addShutDownHook() {
-    shutdownThread = new Thread(() -> {
-      LOG.warn("Failed to properly close DiskMap in application");
-      cleanup();
-    });
-    Runtime.getRuntime().addShutdownHook(shutdownThread);
+    // Register this disk map path with the static cleaner instead of using an
+    // instance-specific hook
+    DiskMapCleaner.registerForCleanup(diskMapPath);
   }
 
   /**
@@ -99,13 +100,63 @@ public abstract class DiskMap<T extends Serializable, R> implements Map<T, R>, K
    * Cleanup all resources, files and folders.
    */
   private void cleanup(boolean isTriggeredFromShutdownHook) {
-    try {
-      FileIOUtils.deleteDirectory(diskMapPathFile);
-    } catch (IOException exception) {
-      LOG.warn("Error while deleting the disk map directory=" + diskMapPath, exception);
+    // Reuse the static cleaner method to clean the directory
+    DiskMapCleaner.cleanupDirectory(diskMapPath);
+
+    // Deregister from the static cleaner
+    if (!isTriggeredFromShutdownHook) {
+      DiskMapCleaner.deregisterFromCleanup(diskMapPath);
     }
-    if (!isTriggeredFromShutdownHook && shutdownThread != null) {
-      Runtime.getRuntime().removeShutdownHook(shutdownThread);
+  }
+
+  /**
+   * Static cleaner class to avoid circular references in shutdown hooks
+   */
+  private static class DiskMapCleaner {
+    private static final Logger CLEANER_LOG = LoggerFactory.getLogger(DiskMapCleaner.class);
+    private static final Set<String> PATHS_TO_CLEAN = Collections.synchronizedSet(new HashSet<>());
+    private static final Thread SHUTDOWN_HOOK;
+
+    static {
+      // Register a single JVM-wide shutdown hook that handles all paths
+      SHUTDOWN_HOOK = new Thread(() -> {
+        synchronized (PATHS_TO_CLEAN) {
+          PATHS_TO_CLEAN.forEach(DiskMapCleaner::cleanupDirectory);
+          PATHS_TO_CLEAN.clear();
+        }
+      });
+      Runtime.getRuntime().addShutdownHook(SHUTDOWN_HOOK);
+    }
+
+    /**
+     * Register a path to be cleaned up when JVM exits
+     * 
+     * @param directoryPath Path to register for cleanup
+     */
+    public static void registerForCleanup(String directoryPath) {
+      PATHS_TO_CLEAN.add(directoryPath);
+    }
+
+    /**
+     * Deregister a path from cleanup when it's manually cleaned
+     * 
+     * @param directoryPath Path to deregister from cleanup
+     */
+    public static void deregisterFromCleanup(String directoryPath) {
+      PATHS_TO_CLEAN.remove(directoryPath);
+    }
+
+    /**
+     * Static cleanup method that doesn't hold references to DiskMap instances
+     * 
+     * @param directoryPath Path to the directory that needs to be cleaned up
+     */
+    public static void cleanupDirectory(String directoryPath) {
+      try {
+        FileIOUtils.deleteDirectory(new File(directoryPath));
+      } catch (IOException exception) {
+        CLEANER_LOG.warn("Error while deleting the disk map directory=" + directoryPath, exception);
+      }
     }
   }
 }


### PR DESCRIPTION
### Change Logs
close: #12918
We have verified in doris that this change avoids the problem that BitCaskDiskMap will not be recycled
https://github.com/apache/doris/pull/48916

### Impact
None

### Risk level (write none, low medium or high below)
high

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
