### PR TITLE
[HUDI-9166] Introduce schema pruning for delete-record

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -735,15 +735,6 @@ object DataSourceWriteOptions {
     .withDocumentation("Controls whether overwrite use dynamic or static mode, if not configured, " +
       "respect spark.sql.sources.partitionOverwriteMode")
 
-  val DELETE_RECORD_SCHEMA_PRUNING: ConfigProperty[String] = ConfigProperty
-    .key("hoodie.datasource.delete.record.schema.pruning.enabled")
-    .defaultValue("true")
-    .withValidValues("true", "false")
-    .markAdvanced
-    .sinceVersion("1.0.0")
-    .withDocumentation("Whether to pruning the schema of delete record." +
-      "If enabled, only hoodie metadata fields, record keys, and columns involved in delete condition are required")
-
   /** @deprecated Use {@link HIVE_USE_PRE_APACHE_INPUT_FORMAT} and its methods instead */
   @Deprecated
   val HIVE_USE_PRE_APACHE_INPUT_FORMAT_OPT_KEY = HiveSyncConfigHolder.HIVE_USE_PRE_APACHE_INPUT_FORMAT.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -735,6 +735,15 @@ object DataSourceWriteOptions {
     .withDocumentation("Controls whether overwrite use dynamic or static mode, if not configured, " +
       "respect spark.sql.sources.partitionOverwriteMode")
 
+  val DELETE_RECORD_SCHEMA_PRUNING: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.delete.record.schema.pruning.enabled")
+    .defaultValue("true")
+    .withValidValues("true", "false")
+    .markAdvanced
+    .sinceVersion("1.0.0")
+    .withDocumentation("Whether to pruning the schema of delete record." +
+      "If enabled, only hoodie metadata fields, record keys, and columns involved in delete condition are required")
+
   /** @deprecated Use {@link HIVE_USE_PRE_APACHE_INPUT_FORMAT} and its methods instead */
   @Deprecated
   val HIVE_USE_PRE_APACHE_INPUT_FORMAT_OPT_KEY = HiveSyncConfigHolder.HIVE_USE_PRE_APACHE_INPUT_FORMAT.key()

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/DeleteHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/DeleteHoodieTableCommand.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hudi.command
 
-import org.apache.hudi.DataSourceWriteOptions.{DELETE_RECORD_SCHEMA_PRUNING, SPARK_SQL_OPTIMIZED_WRITES, SPARK_SQL_WRITES_PREPPED_KEY}
+import org.apache.hudi.DataSourceWriteOptions.{SPARK_SQL_OPTIMIZED_WRITES, SPARK_SQL_WRITES_PREPPED_KEY}
 import org.apache.hudi.SparkAdapterSupport
 import org.apache.hudi.common.table.HoodieTableConfig
 
@@ -64,13 +64,7 @@ case class DeleteHoodieTableCommand(dft: DeleteFromTable) extends HoodieLeafRunn
 
     val targetLogicalPlan = if (sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
       , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true") {
-      if (sparkSession.sqlContext.conf.getConfString(DELETE_RECORD_SCHEMA_PRUNING.key(),
-        DELETE_RECORD_SCHEMA_PRUNING.defaultValue()) == "true") {
-        logInfo(s"Pruning delete record schema for $tableId, required columns: ${requiredCols.mkString(",")}")
-        tryPruningDeleteRecordSchema(dft.table, requiredCols)
-      } else {
-        dft.table
-      }
+      tryPruningDeleteRecordSchema(dft.table, requiredCols)
     } else {
       stripMetaFieldAttributes(dft.table)
     }


### PR DESCRIPTION
For the record we need to delete, we only need to read the `hoodie_meta_fields`, `record_keys` and the columns involved in the delete condition from the table, which can greatly reduce the amount of read data when deleting.

> benchmark in our production

- 1000 columns
- execute `delete from table where col-a = 'xxx'`
- 50,000,000 records per partition

> before optimized

<img width="2508" alt="image" src="https://github.com/user-attachments/assets/79b1a53b-3ff4-4fdc-bc35-ee8989fb20b5" />

> after optimized

<img width="2524" alt="image" src="https://github.com/user-attachments/assets/350af7ee-38cf-477e-800b-7dfb6f16517c" />

In our wide table scenario, column pruning will greatly reduce the amount of data scanning and shuffle overhead in the entire process.


### Change Logs
1. introduce schema pruning for delete record

### Impact

improve delete performance especially tables with more columns

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
