### PR TITLE
[HUDI-9167] Remove redundant classes in hudi-utilities-slim-bundle

### DIFF
--- a/packaging/bundle-validation/validate.sh
+++ b/packaging/bundle-validation/validate.sh
@@ -128,7 +128,7 @@ test_utilities_bundle () {
     EXTRA_JARS="${EXTRA_JARS%,}"
     OPT_JARS=""
     if [[ -n $EXTRA_JARS ]]; then
-        OPT_JARS="--jars $EXTRA_JARS"
+        OPT_JARS="--jars $EXTRA_JARS,$MAIN_JAR"
     fi
     OUTPUT_DIR=/tmp/hudi-utilities-test/
     rm -r $OUTPUT_DIR

--- a/packaging/bundle-validation/validate.sh
+++ b/packaging/bundle-validation/validate.sh
@@ -128,7 +128,7 @@ test_utilities_bundle () {
     EXTRA_JARS="${EXTRA_JARS%,}"
     OPT_JARS=""
     if [[ -n $EXTRA_JARS ]]; then
-        OPT_JARS="--jars $EXTRA_JARS,$MAIN_JAR"
+        OPT_JARS="--jars $EXTRA_JARS"
     fi
     OUTPUT_DIR=/tmp/hudi-utilities-test/
     rm -r $OUTPUT_DIR

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -90,7 +90,6 @@
                   <include>org.eclipse.jetty.websocket:*</include>
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.antlr:stringtemplate</include>
                   <!-- Bundle Jackson JSR310 library since it is not present in spark 2.x. For spark 3.x this will
                        bundle the same JSR310 version that is included in spark runtime -->
                   <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -99,8 +99,6 @@
                   <include>com.github.davidmoten:hilbert-curve</include>
                   <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.apache.parquet:parquet-avro</include>
-                  <include>com.twitter:bijection-avro_${scala.binary.version}</include>
-                  <include>com.twitter:bijection-core_${scala.binary.version}</include>
                   <include>com.twitter:chill-protobuf</include>
 
                   <include>io.dropwizard.metrics:metrics-core</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -114,8 +114,6 @@
                   <include>com.uber.m3:tally-m3</include>
                   <include>com.uber.m3:tally-core</include>
 
-                  <include>com.yammer.metrics:metrics-core</include>
-
                   <include>org.apache.hive:hive-common</include>
                   <include>org.apache.hive:hive-service</include>
                   <include>org.apache.hive:hive-service-rpc</include>
@@ -141,10 +139,6 @@
                 <relocation>
                   <pattern>javax.servlet.</pattern>
                   <shadedPattern>org.apache.hudi.javax.servlet.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.yammer.metrics.</pattern>
-                  <shadedPattern>org.apache.hudi.com.yammer.metrics.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -93,8 +93,12 @@
                 <includes combine.children="append">
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
 
+                  <include>org.antlr:stringtemplate</include>
+                  <include>com.yammer.metrics:metrics-core</include>
                   <!-- SPARK-43489 Spark 3.5+ has marked protobuf as provided -->
                   <include>com.google.protobuf:protobuf-java</include>
+                  <include>com.twitter:bijection-avro_${scala.binary.version}</include>
+                  <include>com.twitter:bijection-core_${scala.binary.version}</include>
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
                   <include>io.confluent:kafka-json-schema-serializer</include>
@@ -104,6 +108,7 @@
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.confluent:kafka-protobuf-serializer</include>
                   <include>io.confluent:kafka-protobuf-provider</include>
+                  <include>io.dropwizard.metrics:metrics-core</include>
                   <include>org.apache.spark:spark-streaming-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.spark:spark-token-provider-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.kafka:kafka_${scala.binary.version}</include>
@@ -118,10 +123,6 @@
                 <relocation>
                   <pattern>org.apache.spark.sql.avro.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.yammer.metrics.</pattern>
-                  <shadedPattern>org.apache.hudi.com.yammer.metrics.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -94,7 +94,6 @@
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
 
                   <include>org.antlr:stringtemplate</include>
-                  <include>com.yammer.metrics:metrics-core</include>
                   <!-- SPARK-43489 Spark 3.5+ has marked protobuf as provided -->
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.twitter:bijection-avro_${scala.binary.version}</include>
@@ -108,7 +107,6 @@
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.confluent:kafka-protobuf-serializer</include>
                   <include>io.confluent:kafka-protobuf-provider</include>
-                  <include>io.dropwizard.metrics:metrics-core</include>
                   <include>org.apache.spark:spark-streaming-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.spark:spark-token-provider-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.kafka:kafka_${scala.binary.version}</include>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -91,30 +91,10 @@
               </transformers>
               <artifactSet>
                 <includes combine.children="append">
-                  <include>org.apache.hudi:hudi-hadoop-common</include>
-                  <include>org.apache.hudi:hudi-common</include>
-                  <include>org.apache.hudi:hudi-client-common</include>
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
-                  <include>org.apache.hudi:hudi-hadoop-mr</include>
-                  <include>org.apache.hudi:hudi-timeline-service</include>
 
-                  <include>com.yammer.metrics:metrics-core</include>
-                  <include>com.beust:jcommander</include>
-                  <include>io.javalin:javalin</include>
-                  <!-- Spark only has mortbay jetty -->
-                  <include>org.eclipse.jetty:*</include>
-                  <include>org.eclipse.jetty.websocket:*</include>
-                  <include>org.jetbrains.kotlin:*</include>
-                  <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.antlr:stringtemplate</include>
-
-                  <include>com.github.davidmoten:guava-mini</include>
-                  <include>com.github.davidmoten:hilbert-curve</include>
                   <!-- SPARK-43489 Spark 3.5+ has marked protobuf as provided -->
                   <include>com.google.protobuf:protobuf-java</include>
-                  <include>com.twitter:bijection-avro_${scala.binary.version}</include>
-                  <include>com.twitter:bijection-core_${scala.binary.version}</include>
-                  <include>com.twitter:chill-protobuf</include>
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:kafka-schema-serializer</include>
                   <include>io.confluent:kafka-json-schema-serializer</include>
@@ -124,27 +104,11 @@
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.confluent:kafka-protobuf-serializer</include>
                   <include>io.confluent:kafka-protobuf-provider</include>
-                  <include>io.dropwizard.metrics:metrics-core</include>
-                  <include>io.dropwizard.metrics:metrics-graphite</include>
-                  <include>io.dropwizard.metrics:metrics-jmx</include>
-                  <include>io.prometheus:simpleclient</include>
-                  <include>io.prometheus:simpleclient_httpserver</include>
-                  <include>io.prometheus:simpleclient_dropwizard</include>
-                  <include>io.prometheus:simpleclient_pushgateway</include>
-                  <include>io.prometheus:simpleclient_common</include>
-                  <include>com.uber.m3:tally-m3</include>
-                  <include>com.uber.m3:tally-core</include>
                   <include>org.apache.spark:spark-streaming-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.spark:spark-token-provider-kafka-0-10_${scala.binary.version}</include>
                   <include>org.apache.kafka:kafka_${scala.binary.version}</include>
                   <include>com.101tec:zkclient</include>
                   <include>org.apache.kafka:kafka-clients</include>
-                  <include>org.apache.curator:curator-framework</include>
-                  <include>org.apache.curator:curator-client</include>
-                  <include>org.apache.curator:curator-recipes</include>
-                  <include>commons-codec:commons-codec</include>
-                  <include>commons-io:commons-io</include>
-                  <include>org.openjdk.jol:jol-core</include>
                 </includes>
               </artifactSet>
               <relocations combine.children="append">


### PR DESCRIPTION
### Change Logs

This PR removes redundant classes in `hudi-spark-bundle` and in `hudi-utilities-slim-bundle` that have already been packaged by `hudi-spark-bundle` to avoid conflicting dependency version, including Avro, with `hudi-spark-bundle`, so that `hudi-utilities-slim-bundle` and `hudi-spark-bundle` can be used together in all Spark versions without any problem.  Note that we always build `hudi-utilities-slim-bundle` with Spark 3.5 profile as part of the maven release assuming that the dependencies included in the `hudi-utilities-slim-bundle` do not depend on the Spark profile (which was not the case for Avro before this PR).

### Impact

Fixes issues with Avro classes included in `hudi-utilities-slim-bundle` that conflict with different versions of `hudi-spark-bundle`.

The number of classes in Spark bundle is not changed before and after this PR.
Size of `hudi-utilities-slim-bundle` is significantly reduced: 109.7 MB -> 41.5 MB.
(See below for details)

```
> ls -l *
master:
total 871192
-rw-r--r--  1 ethan  staff  110296062 Mar 27 14:52 hudi-spark3.3-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff  110328191 Mar 27 14:38 hudi-spark3.4-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff  110351892 Mar 27 14:15 hudi-spark3.5-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff  115064919 Mar 27 14:16 hudi-utilities-slim-bundle_2.12-1.1.0-SNAPSHOT.jar

pr:
total 731384
-rw-r--r--  1 ethan  staff  110296004 Mar 27 16:57 hudi-spark3.3-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff  110328133 Mar 27 16:45 hudi-spark3.4-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff  110351834 Mar 27 16:11 hudi-spark3.5-bundle_2.12-1.1.0-SNAPSHOT.jar
-rw-r--r--  1 ethan  staff   43483780 Mar 27 16:11 hudi-utilities-slim-bundle_2.12-1.1.0-SNAPSHOT.jar
> jar tf master/hudi-spark3.3-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25604
> jar tf pr/hudi-spark3.3-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25604
> jar tf master/hudi-spark3.4-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25623
> jar tf pr/hudi-spark3.4-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25623
> jar tf master/hudi-spark3.5-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25628
> jar tf pr/hudi-spark3.5-bundle_2.12-1.1.0-SNAPSHOT.jar | grep '\.class$' | wc -l
   25628
```

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
