### PR TITLE
[HUDI-9173] Fix issue with inflight compaction and global index lookup

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
@@ -112,7 +112,7 @@ public class HoodieMergedReadHandle<T, I, K, O> extends HoodieReadHandle<T, I, K
         && hoodieTable.getMetaClient().getCommitsTimeline().filterCompletedInstants().lastInstant().isPresent()) {
       return Option.fromJavaOptional(hoodieTable
           .getHoodieView()
-          .getLatestFileSlices(partitionPathFileIDPair.getLeft())
+          .getLatestMergedFileSlicesBeforeOrOn(partitionPathFileIDPair.getLeft(), instantTime)
           .filter(fileSlice -> fileSlice.getFileId().equals(partitionPathFileIDPair.getRight()))
           .findFirst());
     }


### PR DESCRIPTION
### Change Logs

- Updates the `getLatestFileSlice` method to inspect the latest merged slice to avoid an empty base file option
- Add functional test that triggers the issue

### Impact

- Fixes the index lookup to allow writes to succeed  when there is an inflight compaction

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
