### PR TITLE
[HUDI-9140] Fix log block io type and other rollback strategy fixes for table version 6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -290,7 +290,8 @@ public abstract class HoodieWriteHandle<T, I, K, O> extends HoodieIOHandle<T, I,
       @Override
       public boolean preFileCreation(HoodieLogFile logFile) {
         WriteMarkers writeMarkers = WriteMarkersFactory.get(config.getMarkersType(), hoodieTable, instantTime);
-        return writeMarkers.createIfNotExists(partitionPath, logFile.getFileName(), IOType.CREATE,
+        IOType ioType = getHoodieTableMetaClient().getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT) ? IOType.APPEND : IOType.CREATE;
+        return writeMarkers.createIfNotExists(partitionPath, logFile.getFileName(), ioType,
             config, fileId, hoodieTable.getMetaClient().getActiveTimeline()).isPresent();
       }
     };

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -162,9 +163,13 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
                     listBaseFilesToBeDeleted(instantToRollback.requestedTime(), baseFileExtension, partitionPath, metaClient.getStorage())));
               } else {
                 // if this is part of a restore operation, we should rollback/delete entire file slice.
-                hoodieRollbackRequests.addAll(getHoodieRollbackRequests(partitionPath,
-                    listAllFilesSinceCommit(instantToRollback.requestedTime(), baseFileExtension, partitionPath,
-                        metaClient)));
+                if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
+                  hoodieRollbackRequests.addAll(getHoodieRollbackRequests(partitionPath, filesToDelete.get()));
+                } else {
+                  hoodieRollbackRequests.addAll(getHoodieRollbackRequests(partitionPath,
+                      listAllFilesSinceCommit(instantToRollback.requestedTime(), baseFileExtension, partitionPath,
+                          metaClient)));
+                }
               }
               break;
             case HoodieTimeline.DELTA_COMMIT_ACTION:
@@ -175,7 +180,34 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
               // delete all files for the corresponding failed commit, if present (same as COW)
               hoodieRollbackRequests.addAll(getHoodieRollbackRequests(partitionPath, filesToDelete.get()));
               if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
-                hoodieRollbackRequests.addAll(getRollbackRequestToAppendForVersionSix(partitionPath, instantToRollback, commitMetadataOptional.get(), table));
+
+                // --------------------------------------------------------------------------------------------------
+                // (A) The following cases are possible if index.canIndexLogFiles and/or index.isGlobal
+                // --------------------------------------------------------------------------------------------------
+                // (A.1) Failed first commit - Inserts were written to log files and HoodieWriteStat has no entries. In
+                // this scenario we would want to delete these log files.
+                // (A.2) Failed recurring commit - Inserts/Updates written to log files. In this scenario,
+                // HoodieWriteStat will have the baseCommitTime for the first log file written, add rollback blocks.
+                // (A.3) Rollback triggered for first commit - Inserts were written to the log files but the commit is
+                // being reverted. In this scenario, HoodieWriteStat will be `null` for the attribute prevCommitTime
+                // and hence will end up deleting these log files. This is done so there are no orphan log files
+                // lying around.
+                // (A.4) Rollback triggered for recurring commits - Inserts/Updates are being rolled back, the actions
+                // taken in this scenario is a combination of (A.2) and (A.3)
+                // ---------------------------------------------------------------------------------------------------
+                // (B) The following cases are possible if !index.canIndexLogFiles and/or !index.isGlobal
+                // ---------------------------------------------------------------------------------------------------
+                // (B.1) Failed first commit - Inserts were written to base files and HoodieWriteStat has no entries.
+                // In this scenario, we delete all the base files written for the failed commit.
+                // (B.2) Failed recurring commits - Inserts were written to base files and updates to log files. In
+                // this scenario, perform (A.1) and for updates written to log files, write rollback blocks.
+                // (B.3) Rollback triggered for first commit - Same as (B.1)
+                // (B.4) Rollback triggered for recurring commits - Same as (B.2) plus we need to delete the log files
+                // as well if the base file gets deleted.
+                HoodieCommitMetadata commitMetadata = TimelineUtils.getCommitMetadata(instantToRollback, table.getMetaClient().getCommitsTimeline());
+                if (commitMetadata.getPartitionToWriteStats().containsKey(partitionPath)) {
+                  hoodieRollbackRequests.addAll(getRollbackRequestToAppendForVersionSix(partitionPath, instantToRollback, commitMetadataOptional.get(), table));
+                }
               }
               break;
             default:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
@@ -90,7 +90,7 @@ public class MarkerBasedRollbackStrategy<T, I, K, O> implements BaseRollbackPlan
         switch (type) {
           case MERGE:
           case CREATE:
-            return createRollbackRequestForCreateAndMerge(fileId, partitionPath, filePath, instantToRollback, filePathStr);
+            return createRollbackRequestForCreateAndMerge(fileId, partitionPath, filePath, instantToRollback);
           case APPEND:
             return createRollbackRequestForAppend(fileId, partitionPath, filePath, instantToRollback, filePathStr);
           default:
@@ -106,8 +106,10 @@ public class MarkerBasedRollbackStrategy<T, I, K, O> implements BaseRollbackPlan
     }
   }
 
-  protected HoodieRollbackRequest createRollbackRequestForCreateAndMerge(String fileId, String partitionPath, StoragePath filePath,
-                                                                         HoodieInstant instantToRollback, String filePathToRollback) {
+  protected HoodieRollbackRequest createRollbackRequestForCreateAndMerge(String fileId,
+                                                                         String partitionPath,
+                                                                         StoragePath filePath,
+                                                                         HoodieInstant instantToRollback) {
     if (table.version().greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
       return new HoodieRollbackRequest(partitionPath, fileId, instantToRollback.requestedTime(),
           Collections.singletonList(filePath.toString()), Collections.emptyMap());
@@ -118,7 +120,7 @@ public class MarkerBasedRollbackStrategy<T, I, K, O> implements BaseRollbackPlan
         fileId = baseFileToDelete.getFileId();
         baseInstantTime = baseFileToDelete.getCommitTime();
       } else if (FSUtils.isLogFile(filePath)) {
-        return createRollbackRequestForAppend(fileId, partitionPath, filePath, instantToRollback, filePathToRollback);
+        throw new HoodieRollbackException("Log files should have only APPEND as IOTypes " + filePath);
       }
       Objects.requireNonNull(fileId, "Cannot find valid fileId from path: " + filePath);
       Objects.requireNonNull(baseInstantTime, "Cannot find valid base instant from path: " + filePath);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -355,6 +355,10 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     return HoodieTestTable.of(table.getMetaClient()).listAllBaseFiles(table.getBaseFileExtension());
   }
 
+  protected List<StoragePathInfo> listAllLogFilesInPath(HoodieTable table) throws IOException {
+    return HoodieTestTable.of(table.getMetaClient()).listAllLogFiles();
+  }
+
   protected Properties getPropertiesForKeyGen() {
     return getPropertiesForKeyGen(false);
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.table.functional;
 
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -31,11 +32,14 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
@@ -53,6 +57,8 @@ import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
+import org.apache.hudi.table.marker.WriteMarkers;
+import org.apache.hudi.table.marker.WriteMarkersFactory;
 import org.apache.hudi.testutils.HoodieMergeOnReadTestUtils;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
@@ -164,6 +170,8 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
     HoodieWriteConfig cfg = cfgBuilder.build();
     cfg.setValue(HoodieTableConfig.VERSION, String.valueOf(tableVersion));
     cfg.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(tableVersion));
+    String timelineLayoutVersion = tableVersion < 8 ? String.valueOf(TimelineLayoutVersion.VERSION_1) : String.valueOf(TimelineLayoutVersion.VERSION_2);
+    cfg.setValue(HoodieWriteConfig.TIMELINE_LAYOUT_VERSION_NUM, timelineLayoutVersion);
 
     Properties properties = CollectionUtils.copy(cfg.getProps());
     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
@@ -213,6 +221,8 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       HoodieWriteConfig secondCfg = getHoodieWriteConfigWithSmallFileHandlingOff(true);
       secondCfg.setValue(HoodieTableConfig.VERSION, String.valueOf(tableVersion));
       secondCfg.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(tableVersion));
+      secondCfg.setValue(HoodieWriteConfig.TIMELINE_LAYOUT_VERSION_NUM, timelineLayoutVersion);
+
       /*
        * Write 2 (inserts + updates - testing failed delta commit)
        */
@@ -237,8 +247,31 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         // Verify there are no errors
         assertNoWriteErrors(statuses);
 
+        WriteMarkers markers = WriteMarkersFactory.get(secondCfg.getMarkersType(), hoodieTable, commitTime1);
+        IOType logFileIOType = tableVersion >= 8 ? IOType.CREATE : IOType.APPEND;
+        assertTrue(markers.allMarkerFilePaths().stream().anyMatch(name -> name.contains("log") && name.contains(logFileIOType.name())));
+
         // Test failed delta commit rollback
         secondClient.rollback(commitTime1);
+        // After rollback for table version 6, there should be new
+        metaClient = HoodieTableMetaClient.reload(metaClient);
+        HoodieInstant rollbackInstant = metaClient.getActiveTimeline().getRollbackTimeline().firstInstant().get();
+        HoodieRollbackMetadata rollbackMetadata = metaClient.getActiveTimeline().readInstantContent(rollbackInstant, HoodieRollbackMetadata.class);
+        List<StoragePathInfo> logFiles = listAllLogFilesInPath(hoodieTable);
+        if (tableVersion < HoodieTableVersion.EIGHT.versionCode()) {
+          // Ensure rollback metadata contains rollback log files for table version 6
+          assertTrue(rollbackMetadata.getPartitionMetadata().values().stream()
+              .noneMatch(rollbackPartitionMetadata -> rollbackPartitionMetadata.getRollbackLogFiles().isEmpty()));
+          // Total 3 partitions would contain 6 log files - one rollback log file and one log file with data block
+          assertEquals(6, logFiles.size());
+        } else {
+          // Ensure rollback metadata does not contain rollback log files for table version 8
+          assertFalse(rollbackMetadata.getPartitionMetadata().values().stream()
+              .noneMatch(rollbackPartitionMetadata -> rollbackPartitionMetadata.getRollbackLogFiles().isEmpty()));
+          // After rollback log files should be deleted
+          assertEquals(0, logFiles.size());
+        }
+
         allFiles = listAllBaseFilesInPath(hoodieTable);
         // After rollback, there should be no base file with the failed commit time
         List<String> remainingFiles = allFiles.stream()


### PR DESCRIPTION
### Change Logs

The PR fixes the iotype as APPEND for log blocks in table version 6. It also reverts some changes made to MarkerBasedRollbackStrategy for table version 6 in HUDI-9030.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
