### PR TITLE
[HUDI-7037] Fix colstats reading for Decimal field

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -42,6 +42,7 @@ import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.avro.model.DecimalWrapper
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
@@ -52,6 +53,8 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{EnumSource, MethodSource, ValueSource}
 
+import java.math.{BigInteger, BigDecimal => JBigDecimal}
+import java.nio.ByteBuffer
 import java.util.Collections
 import java.util.stream.Collectors
 
@@ -1055,5 +1058,59 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
       assertNotNull(max)
       assertTrue(r.getMinValue.asInstanceOf[Comparable[Object]].compareTo(r.getMaxValue.asInstanceOf[Object]) <= 0)
     })
+  }
+
+  @Test
+  def testDeserializeFromByteBuffer(): Unit = {
+    // Original decimal value: 123.45 (scale 2)
+    val original: JBigDecimal = new JBigDecimal("123.45")
+    // Get the unscaled value (12345) as a byte array.
+    val unscaled: BigInteger = original.unscaledValue()
+    val unscaledBytes: Array[Byte] = unscaled.toByteArray
+    val buffer: ByteBuffer = ByteBuffer.wrap(unscaledBytes)
+
+    // Create a dummy DecimalWrapper that returns a ByteBuffer.
+    val wrapper: DecimalWrapper = new DecimalWrapper(buffer)
+    // Call tryUnpackValueWrapper – it should match the DecimalWrapper case and return the ByteBuffer.
+    val unwrapped: Any = ColumnStatsIndexSupport.tryUnpackValueWrapper(wrapper)
+    assertTrue(unwrapped.isInstanceOf[ByteBuffer], "Expected a ByteBuffer")
+
+    // Now deserialize the ByteBuffer to a BigDecimal.
+    val dt = DecimalType(10, 2)
+    val deserialized: Any = ColumnStatsIndexSupport.deserialize(unwrapped, dt)
+    assertTrue(deserialized.isInstanceOf[JBigDecimal], "Deserialized value should be a java.math.BigDecimal")
+    assertEquals(original, deserialized.asInstanceOf[JBigDecimal], "Decimal value from ByteBuffer does not match")
+  }
+
+  @Test
+  def testDeserializeFromJavaBigDecimal(): Unit = {
+    // Original decimal value: 543.21
+    val original: JBigDecimal = new JBigDecimal("543.21")
+    // Create a dummy DecimalWrapper that returns a java.math.BigDecimal directly.
+    val wrapper: DecimalWrapper = new DecimalWrapper {
+      override def getValue: ByteBuffer = ByteBuffer.wrap(original.unscaledValue().toByteArray)
+    }
+
+    val dt = DecimalType(10, 2)
+    val deserialized: Any = ColumnStatsIndexSupport.deserialize(ColumnStatsIndexSupport.tryUnpackValueWrapper(wrapper), dt)
+    assertTrue(deserialized.isInstanceOf[JBigDecimal], "Deserialized value should be a java.math.BigDecimal")
+    assertEquals(original, deserialized.asInstanceOf[JBigDecimal], "Decimal value from java.math.BigDecimal does not match")
+  }
+
+  @Test
+  def testDeserializeFromScalaBigDecimal(): Unit = {
+    // Original Scala BigDecimal value
+    val original = scala.math.BigDecimal("987.65")
+    // Create an anonymous DecimalWrapper that returns a Scala BigDecimal.
+    val wrapper: DecimalWrapper = new DecimalWrapper {
+      override def getValue: ByteBuffer = ByteBuffer.wrap(original.bigDecimal.unscaledValue().toByteArray)
+    }
+    // In this case, unwrapped is a Scala BigDecimal.
+    val dt = DecimalType(10, 2)
+    val deserialized: Any = ColumnStatsIndexSupport.deserialize(ColumnStatsIndexSupport.tryUnpackValueWrapper(wrapper), dt)
+    // The deserialize method should convert a Scala BigDecimal to a java.math.BigDecimal.
+    assertTrue(deserialized.isInstanceOf[JBigDecimal], "Deserialized value should be a java.math.BigDecimal")
+    // Compare via string representations.
+    assertEquals(original.bigDecimal.toString, deserialized.asInstanceOf[JBigDecimal].toString, "Decimal value from Scala BigDecimal does not match")
   }
 }


### PR DESCRIPTION
### Change Logs

When reading column statistics for Decimal fields from the metadata table, the unwrapped decimal values are incorrectly handled. Specifically:

- **Type Loss in Unwrapping:**  
  The `tryUnpackValueWrapper` method was matching a `BytesWrapper` before a `DecimalWrapper`, causing values written as `DecimalWrapper` (which are actually decimals) to be interpreted as raw bytes.

- **Incorrect Deserialization:**  
  In the `deserialize` method, the decimal conversion was not robust enough:
  - It only handled the case where the unwrapped value is a `ByteBuffer`.
  - It did not enforce the correct scale/precision when the value was already a decimal (either as a Scala `BigDecimal` or a `java.math.BigDecimal`).
  - Additionally, it was using a private Avro constructor for `Decimal`, which prevented proper conversion.

This PR addresses these issues with the following changes:

1. **Reordering in `tryUnpackValueWrapper`:**  
   - The `DecimalWrapper` case is moved before the `BytesWrapper` case. This ensures that values written as decimals are unwrapped correctly.

2. **Enhancements to `deserialize`:**  
   - **ByteBuffer Handling:**  
     The conversion now uses Avro’s public factory method (`org.apache.avro.LogicalTypes.decimal(precision, scale)`) to create a Decimal logical type with the correct precision and scale.
   - **Direct Decimal Values:**  
     The method now properly handles cases where the unwrapped value is already a `scala.math.BigDecimal` or a `java.math.BigDecimal`. In both cases, it enforces the target scale using `.setScale(dt.scale, java.math.RoundingMode.UNNECESSARY)`.
     
3. **Unit Tests:**  
   - New unit tests have been added to cover:
     - Decimal values unwrapped as a `ByteBuffer`.
     - Decimal values unwrapped as a `java.math.BigDecimal`.
     - Decimal values unwrapped as a Scala `BigDecimal`.
   - Additionally, we reuse the existing utility method to generate a DataFrame with decimals to ensure that our logic works correctly in an integrated scenario.

### Impact

Decimal values retain their intended semantics when read from the metadata table, ensuring that comparisons and filtering, and hence data skipping, based on these values work correctly.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
