### PR TITLE
[HUDI-8474] Adding upsert partitoner for metadata table

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
@@ -1,0 +1,46 @@
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.util.Option;
+
+import java.util.List;
+import java.util.Map;
+
+import scala.Tuple2;
+
+/**
+ * Upsert Partitioner to be used for metadata table in spark. All records are prepped (location known) already wrt metadata table. So, we could optimize the upsert partitioner by avoiding certain
+ * unnecessary computations.
+ * @param <T>
+ */
+public class SparkMetadataTableUpsertPartitioner<T> extends SparkHoodiePartitioner<T> {
+
+  private final List<BucketInfo> bucketInfoList;
+  private final int totalPartitions;
+  private final Map<String, Integer> fileIdToSparkPartitionIndexMap;
+
+  public SparkMetadataTableUpsertPartitioner(List<BucketInfo> bucketInfoList, Map<String, Integer> fileIdToSparkPartitionIndexMap) {
+    super(null, null);
+    this.bucketInfoList = bucketInfoList;
+    this.totalPartitions = bucketInfoList.size();
+    this.fileIdToSparkPartitionIndexMap = fileIdToSparkPartitionIndexMap;
+  }
+
+  @Override
+  public int numPartitions() {
+    return totalPartitions;
+  }
+
+  @Override
+  public int getPartition(Object key) {
+    Tuple2<HoodieKey, Option<HoodieRecordLocation>> keyLocation = (Tuple2<HoodieKey, Option<HoodieRecordLocation>>) key;
+    HoodieRecordLocation location = keyLocation._2().get();
+    return fileIdToSparkPartitionIndexMap.get(location.getFileId());
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return bucketInfoList.get(bucketNumber);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.table.action.commit;
 
 import org.apache.hudi.common.model.HoodieKey;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
@@ -1,0 +1,79 @@
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestSparkMetadataTableUpsertPartitioner extends HoodieClientTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestSparkMetadataTableUpsertPartitioner.class);
+  private static final Random RANDOM = new Random(0xDEED);
+  private static final String RANDOM_INSTANT_TIME = "100000";
+
+  @Test
+  public void testUpsertPartitioner() throws Exception {
+
+    List<BucketInfo> bucketInfoList = new ArrayList<>();
+    Map<String, Integer> fileIdToSparkPartitionIndexMap = new HashMap<>();
+    Map<String, BucketInfo> fileIdToBucketInfoMapping = new HashMap<>();
+
+    // lets generate 5 file groups for each partition.
+    Map<String, List<String>> fileIdsPerPartition = new HashMap<>();
+    int counter = 0;
+    for (String partition : HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS) {
+      for (int i = 0; i < 5; i++) {
+        String fileIdPrefix = UUID.randomUUID().toString();
+        BucketInfo bucketInfo = new BucketInfo(BucketType.UPDATE, fileIdPrefix, partition);
+        bucketInfoList.add(bucketInfo);
+        fileIdToBucketInfoMapping.put(fileIdPrefix, bucketInfo);
+        fileIdsPerPartition.computeIfAbsent(partition, s -> new ArrayList<>());
+        fileIdsPerPartition.get(partition).add(fileIdPrefix);
+        fileIdToSparkPartitionIndexMap.put(fileIdPrefix, counter++);
+      }
+    }
+
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+
+    List<HoodieRecord> records = dataGenerator.generateInserts(RANDOM_INSTANT_TIME, 300);
+    // generate expected values
+    Map<String, BucketInfo> expectedBucketInfoForRecordKey = new HashMap<>();
+
+    List<Tuple2<HoodieKey, Option<HoodieRecordLocation>>> keysToProbe = records.stream().map(record -> {
+      HoodieKey hoodieKey = record.getKey();
+      String partition = hoodieKey.getPartitionPath();
+      List<String> fileIdsForThisPartition = fileIdsPerPartition.get(partition);
+      String fileId = fileIdsForThisPartition.get(RANDOM.nextInt(fileIdsForThisPartition.size()));
+      expectedBucketInfoForRecordKey.put(hoodieKey.getRecordKey(), fileIdToBucketInfoMapping.get(fileId));
+      return new Tuple2<>(hoodieKey, Option.of(new HoodieRecordLocation(RANDOM_INSTANT_TIME, fileId)));
+    }).collect(Collectors.toList());
+
+    SparkHoodiePartitioner partitioner = new SparkMetadataTableUpsertPartitioner(bucketInfoList, fileIdToSparkPartitionIndexMap);
+    keysToProbe.stream().forEach(keyToProbe -> {
+      int sparkPartitionIndex = partitioner.getPartition(keyToProbe);
+      BucketInfo bucketInfo = partitioner.getBucketInfo(sparkPartitionIndex);
+      // validate expected values.
+      assertEquals(expectedBucketInfoForRecordKey.get(keyToProbe._1.getRecordKey()), bucketInfo);
+      assertEquals(bucketInfoList.get(sparkPartitionIndex), bucketInfo);
+    });
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.table.action.commit;
 
 import org.apache.hudi.common.model.HoodieKey;


### PR DESCRIPTION
### Change Logs

- Adding upsert partitoner for metadata table. For Metadata table, every record is an update by the time we reach UpsertPartitioner. So, we could optimize it to avoid regular computation that we do for data table upserts.  This is not yet integrated w/ any write dag yet. As part of https://issues.apache.org/jira/browse/HUDI-8462, we will have follow up patches to integrate. 

### Impact

Optimized writes to Metadata table. Avoid dag triggers (count by key) for metadata writes. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
