### PR TITLE
[HUDI-9206] Support reading inflight instants with HoodieLogRecordReader

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -473,20 +473,11 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
         Configuration conf = broadcastManager.retrieveStorageConfig().get();
 
         // instantiate FG reader
-        HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
-            readerContextOpt.get(),
+        HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(readerContextOpt.get(),
             getHoodieTable().getMetaClient().getStorage().newInstance(new StoragePath(basePath), new HadoopStorageConfiguration(conf)),
-            basePath,
-            instantTime,
-            fileSlice,
-            readerSchema,
-            readerSchema,
-            internalSchemaOption,
-            getHoodieTable().getMetaClient(),
-            getHoodieTable().getMetaClient().getTableConfig().getProps(),
-            0,
-            Long.MAX_VALUE,
-            usePosition);
+            basePath, instantTime, fileSlice, readerSchema, readerSchema, internalSchemaOption,
+            getHoodieTable().getMetaClient(), getHoodieTable().getMetaClient().getTableConfig().getProps(),
+            0, Long.MAX_VALUE, usePosition, false);
         fileGroupReader.initRecordIterators();
         // read records from the FG reader
         HoodieFileGroupReader.HoodieFileGroupReaderIterator<InternalRow> recordIterator

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
@@ -185,20 +185,11 @@ public class HoodieSparkFileGroupReaderBasedMergeHandle<T, I, K, O> extends Hood
     hoodieTable.getMetaClient().getTableConfig().getProps().forEach(props::putIfAbsent);
     config.getProps().forEach(props::putIfAbsent);
     // Initializes file group reader
-    try (HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
-        readerContext,
+    try (HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(readerContext,
         storage.newInstance(hoodieTable.getMetaClient().getBasePath(), new HadoopStorageConfiguration(conf)),
-        hoodieTable.getMetaClient().getBasePath().toString(),
-        instantTime,
-        fileSlice,
-        writeSchemaWithMetaFields,
-        writeSchemaWithMetaFields,
-        internalSchemaOption,
-        hoodieTable.getMetaClient(),
-        props,
-        0,
-        Long.MAX_VALUE,
-        usePosition)) {
+        hoodieTable.getMetaClient().getBasePath().toString(), instantTime, fileSlice,
+        writeSchemaWithMetaFields, writeSchemaWithMetaFields, internalSchemaOption,
+        hoodieTable.getMetaClient(), props, 0, Long.MAX_VALUE, usePosition, false)) {
       fileGroupReader.initRecordIterators();
       // Reads the records from the file slice
       try (HoodieFileGroupReaderIterator<InternalRow> recordIterator

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -194,6 +194,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
 
     this.partitionNameOverrideOpt = partitionNameOverride;
     this.recordBuffer = recordBuffer;
+    // When the allowInflightInstants flag is enabled, records written by inflight instants are also read
     this.allowInflightInstants = allowInflightInstants;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -255,8 +255,8 @@ public abstract class BaseHoodieLogRecordReader<T> {
             // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
             continue;
           }
-          if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
-              || (inflightInstantsTimeline.containsInstant(instantTime) && !allowInflightInstants)) {
+          if (!allowInflightInstants
+              && (inflightInstantsTimeline.containsInstant(instantTime) || !completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime))) {
             // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
             continue;
           }
@@ -587,8 +587,8 @@ public abstract class BaseHoodieLogRecordReader<T> {
           continue;
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
-          if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
-              || (inflightInstantsTimeline.containsInstant(instantTime) && !allowInflightInstants)) {
+          if (!allowInflightInstants
+              && (inflightInstantsTimeline.containsInstant(instantTime)) || !completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)) {
             // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
             continue;
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -136,16 +136,14 @@ public abstract class BaseHoodieLogRecordReader<T> {
   // Use scanV2 method.
   private final boolean enableOptimizedLogBlocksScan;
   protected FileGroupRecordBuffer<T> recordBuffer;
+  // Allows to consider inflight instants while merging log records
+  protected boolean allowInflightInstants;
 
-  protected BaseHoodieLogRecordReader(HoodieReaderContext readerContext,
-                                      HoodieStorage storage,
-                                      List<String> logFilePaths,
+  protected BaseHoodieLogRecordReader(HoodieReaderContext readerContext, HoodieStorage storage, List<String> logFilePaths,
                                       boolean reverseReader, int bufferSize, Option<InstantRange> instantRange,
-                                      boolean withOperationField, boolean forceFullScan,
-                                      Option<String> partitionNameOverride,
-                                      Option<String> keyFieldOverride,
-                                      boolean enableOptimizedLogBlocksScan,
-                                      FileGroupRecordBuffer<T> recordBuffer) {
+                                      boolean withOperationField, boolean forceFullScan, Option<String> partitionNameOverride,
+                                      Option<String> keyFieldOverride, boolean enableOptimizedLogBlocksScan, FileGroupRecordBuffer<T> recordBuffer,
+                                      boolean allowInflightInstants) {
     this.readerContext = readerContext;
     this.readerSchema = readerContext.getSchemaHandler().getRequiredSchema();
     this.latestInstantTime = readerContext.getLatestCommitTime();
@@ -196,6 +194,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
 
     this.partitionNameOverrideOpt = partitionNameOverride;
     this.recordBuffer = recordBuffer;
+    this.allowInflightInstants = allowInflightInstants;
   }
 
   /**
@@ -257,7 +256,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
             continue;
           }
           if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
-              || inflightInstantsTimeline.containsInstant(instantTime)) {
+              || (inflightInstantsTimeline.containsInstant(instantTime) && !allowInflightInstants)) {
             // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
             continue;
           }
@@ -589,7 +588,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
           if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
-              || inflightInstantsTimeline.containsInstant(instantTime)) {
+              || (inflightInstantsTimeline.containsInstant(instantTime) && !allowInflightInstants)) {
             // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
             continue;
           }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
@@ -63,16 +63,12 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
   private long totalTimeTakenToReadAndMergeBlocks;
 
   @SuppressWarnings("unchecked")
-  private HoodieMergedLogRecordReader(HoodieReaderContext<T> readerContext,
-                                      HoodieStorage storage, List<String> logFilePaths, boolean reverseReader,
-                                      int bufferSize, Option<InstantRange> instantRange,
-                                      boolean withOperationField, boolean forceFullScan,
-                                      Option<String> partitionName,
-                                      Option<String> keyFieldOverride,
-                                      boolean enableOptimizedLogBlocksScan,
-                                      FileGroupRecordBuffer<T> recordBuffer) {
+  private HoodieMergedLogRecordReader(HoodieReaderContext<T> readerContext, HoodieStorage storage, List<String> logFilePaths, boolean reverseReader,
+                                      int bufferSize, Option<InstantRange> instantRange, boolean withOperationField, boolean forceFullScan,
+                                      Option<String> partitionName, Option<String> keyFieldOverride, boolean enableOptimizedLogBlocksScan,
+                                      FileGroupRecordBuffer<T> recordBuffer, boolean allowInflightInstants) {
     super(readerContext, storage, logFilePaths, reverseReader, bufferSize, instantRange, withOperationField,
-        forceFullScan, partitionName, keyFieldOverride, enableOptimizedLogBlocksScan, recordBuffer);
+        forceFullScan, partitionName, keyFieldOverride, enableOptimizedLogBlocksScan, recordBuffer, allowInflightInstants);
     this.scannedPrefixes = new HashSet<>();
 
     if (forceFullScan) {
@@ -220,6 +216,7 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
     private boolean enableOptimizedLogBlocksScan = false;
 
     private FileGroupRecordBuffer<T> recordBuffer;
+    private boolean allowInflightInstants = false;
 
     @Override
     public Builder<T> withHoodieReaderContext(HoodieReaderContext<T> readerContext) {
@@ -292,6 +289,11 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
       return this;
     }
 
+    public Builder<T> withAllowInflightInstants(boolean allowInflightInstants) {
+      this.allowInflightInstants = allowInflightInstants;
+      return this;
+    }
+
     @Override
     public HoodieMergedLogRecordReader<T> build() {
       ValidationUtils.checkArgument(recordBuffer != null, "Record Buffer is null in Merged Log Record Reader");
@@ -307,7 +309,8 @@ public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
           withOperationField, forceFullScan,
           Option.ofNullable(partitionName),
           Option.ofNullable(keyFieldOverride),
-          enableOptimizedLogBlocksScan, recordBuffer);
+          enableOptimizedLogBlocksScan, recordBuffer,
+          allowInflightInstants);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -83,6 +83,10 @@ public final class HoodieFileGroupReader<T> implements Closeable {
   private final Option<UnaryOperator<T>> outputConverter;
   private final HoodieReadStats readStats;
   // Allows to consider inflight instants while merging log records using HoodieMergedLogRecordReader
+  // The inflight instants need to be considered while updating RLI records. RLI needs to fetch the revived
+  // and deleted keys from the log files written as part of active data commit. During the RLI update,
+  // the allowInflightInstants flag would need to be set to true. This would ensure the HoodieMergedLogRecordReader
+  // considers the log records which are inflight.
   private boolean allowInflightInstants;
 
   public HoodieFileGroupReader(HoodieReaderContext<T> readerContext, HoodieStorage storage, String tablePath,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -82,20 +82,13 @@ public final class HoodieFileGroupReader<T> implements Closeable {
   private ClosableIterator<T> baseFileIterator;
   private final Option<UnaryOperator<T>> outputConverter;
   private final HoodieReadStats readStats;
+  // Allows to consider inflight instants while merging log records using HoodieMergedLogRecordReader
+  private boolean allowInflightInstants;
 
-  public HoodieFileGroupReader(HoodieReaderContext<T> readerContext,
-                               HoodieStorage storage,
-                               String tablePath,
-                               String latestCommitTime,
-                               FileSlice fileSlice,
-                               Schema dataSchema,
-                               Schema requestedSchema,
-                               Option<InternalSchema> internalSchemaOpt,
-                               HoodieTableMetaClient hoodieTableMetaClient,
-                               TypedProperties props,
-                               long start,
-                               long length,
-                               boolean shouldUseRecordPosition) {
+  public HoodieFileGroupReader(HoodieReaderContext<T> readerContext, HoodieStorage storage, String tablePath,
+                               String latestCommitTime, FileSlice fileSlice, Schema dataSchema, Schema requestedSchema,
+                               Option<InternalSchema> internalSchemaOpt, HoodieTableMetaClient hoodieTableMetaClient, TypedProperties props,
+                               long start, long length, boolean shouldUseRecordPosition, boolean allowInflightInstants) {
     this.readerContext = readerContext;
     this.storage = storage;
     this.hoodieBaseFileOption = fileSlice.getBaseFile();
@@ -134,6 +127,7 @@ public final class HoodieFileGroupReader<T> implements Closeable {
     this.recordBuffer = getRecordBuffer(readerContext, hoodieTableMetaClient,
         recordMergeMode, props, hoodieBaseFileOption, this.logFiles.isEmpty(),
         isSkipMerge, shouldUseRecordPosition, readStats);
+    this.allowInflightInstants = allowInflightInstants;
   }
 
   /**
@@ -290,6 +284,7 @@ public final class HoodieFileGroupReader<T> implements Closeable {
         .withPartition(getRelativePartitionPath(
             new StoragePath(path), logFiles.get(0).getPath().getParent()))
         .withRecordBuffer(recordBuffer)
+        .withAllowInflightInstants(allowInflightInstants)
         .build()) {
       readStats.setTotalLogReadTimeMs(logRecordReader.getTotalTimeTakenToReadAndMergeBlocks());
       readStats.setTotalUpdatedRecordsCompacted(logRecordReader.getNumMergedRecordsInLog());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -994,6 +994,7 @@ public class HoodieTableMetadataUtil {
           Collections.emptyList(),
           datasetMetaClient.getTableConfig().getRecordMergeStrategyId());
 
+      // CRITICAL: Ensure allowInflightInstants is set to true while replacing the scanner with *LogRecordReader or HoodieFileGroupReader
       HoodieMergedLogRecordScanner mergedLogRecordScanner = HoodieMergedLogRecordScanner.newBuilder()
           .withStorage(datasetMetaClient.getStorage())
           .withBasePath(datasetMetaClient.getBasePath())

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -317,34 +317,16 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     }
     if (shouldValidatePartialRead(fileSlice, avroSchema)) {
       assertThrows(IllegalArgumentException.class, () -> new HoodieFileGroupReader<>(
-          getHoodieReaderContext(tablePath, avroSchema, storageConf),
-          metaClient.getStorage(),
-          tablePath,
-          metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
-          fileSlice,
-          avroSchema,
-          avroSchema,
-          Option.empty(),
-          metaClient,
-          props,
-          1,
-          fileSlice.getTotalFileSize(),
-          false));
+          getHoodieReaderContext(tablePath, avroSchema, storageConf), metaClient.getStorage(),
+          tablePath, metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
+          fileSlice, avroSchema, avroSchema, Option.empty(), metaClient, props, 1,
+          fileSlice.getTotalFileSize(), false, false));
     }
     HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
-        getHoodieReaderContext(tablePath, avroSchema, storageConf),
-        metaClient.getStorage(),
-        tablePath,
-        metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
-        fileSlice,
-        avroSchema,
-        avroSchema,
-        Option.empty(),
-        metaClient,
-        props,
-        0,
-        fileSlice.getTotalFileSize(),
-        false);
+        getHoodieReaderContext(tablePath, avroSchema, storageConf), metaClient.getStorage(),
+        tablePath, metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
+        fileSlice, avroSchema, avroSchema, Option.empty(), metaClient, props, 0,
+        fileSlice.getTotalFileSize(), false, false);
     fileGroupReader.initRecordIterators();
     while (fileGroupReader.hasNext()) {
       actualRecordList.add(fileGroupReader.next());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -181,7 +182,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       Schema avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
       FileSlice fileSlice = getFileSliceToRead(getStorageConf(), getBasePath(), metaClient, dataGen.getPartitionPaths(), true, 0);
       List<T> records = readRecordsFromFileGroup(getStorageConf(), getBasePath(), metaClient,  fileSlice,
-          avroSchema, RecordMergeMode.COMMIT_TIME_ORDERING, false);
+          avroSchema, RecordMergeMode.COMMIT_TIME_ORDERING, false, false);
       HoodieReaderContext<T> readerContext = getHoodieReaderContext(getBasePath(), avroSchema, getStorageConf());
       Comparable orderingFieldValue = "100";
       for (Boolean isCompressionEnabled : new boolean[] {true, false}) {
@@ -230,7 +231,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     }
   }
 
-  private Map<String, String> getCommonConfigs(RecordMergeMode recordMergeMode) {
+  Map<String, String> getCommonConfigs(RecordMergeMode recordMergeMode) {
     Map<String, String> configMapping = new HashMap<>();
     configMapping.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
     configMapping.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
@@ -250,7 +251,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     return configMapping;
   }
 
-  private void validateOutputFromFileGroupReader(StorageConfiguration<?> storageConf,
+  void validateOutputFromFileGroupReader(StorageConfiguration<?> storageConf,
                                                  String tablePath,
                                                  String[] partitionPaths,
                                                  boolean containsBaseFile,
@@ -259,9 +260,21 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storageConf, tablePath);
     Schema avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
     FileSlice fileSlice = getFileSliceToRead(storageConf, tablePath, metaClient, partitionPaths, containsBaseFile, expectedLogFileNum);
-    List<T> actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, false);
+    List<T> actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, false, false);
     validateRecordsInFileGroup(tablePath, actualRecordList, avroSchema, fileSlice);
-    actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, true);
+    actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, true, false);
+    validateRecordsInFileGroup(tablePath, actualRecordList, avroSchema, fileSlice, true);
+  }
+
+  void validateOutputFromFileGroupReaderIncludingInflight(StorageConfiguration<?> storageConf, String tablePath, String[] partitionPaths,
+                                                          boolean containsBaseFile, int expectedLogFileNum, RecordMergeMode recordMergeMode,
+                                                          boolean allowInflightInstants) throws Exception {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storageConf, tablePath);
+    Schema avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    FileSlice fileSlice = getFileSliceToReadIncludingInflight(storageConf, tablePath, metaClient, partitionPaths, containsBaseFile, expectedLogFileNum);
+    List<T> actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, false, allowInflightInstants);
+    validateRecordsInFileGroup(tablePath, actualRecordList, avroSchema, fileSlice);
+    actualRecordList = readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlice, avroSchema, recordMergeMode, true, allowInflightInstants);
     validateRecordsInFileGroup(tablePath, actualRecordList, avroSchema, fileSlice, true);
   }
 
@@ -288,13 +301,21 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     return fileSlice;
   }
 
-  private List<T> readRecordsFromFileGroup(StorageConfiguration<?> storageConf,
-                                           String tablePath,
-                                           HoodieTableMetaClient metaClient,
-                                           FileSlice fileSlice,
-                                           Schema avroSchema,
-                                           RecordMergeMode recordMergeMode,
-                                           boolean isSkipMerge) throws Exception {
+  private FileSlice getFileSliceToReadIncludingInflight(StorageConfiguration<?> storageConf, String tablePath,
+                                                        HoodieTableMetaClient metaClient, String[] partitionPaths,
+                                                        boolean containsBaseFile, int expectedLogFileNum) {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(storageConf);
+    HoodieTableFileSystemView fsView = HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, metaClient.getActiveTimeline(), false);
+    FileSlice fileSlice = fsView.getLatestFileSlicesIncludingInflight(partitionPaths[0]).findFirst().get();
+    List<String> logFilePathList = getLogFileListFromFileSlice(fileSlice);
+    assertEquals(expectedLogFileNum, logFilePathList.size());
+    assertEquals(containsBaseFile, fileSlice.getBaseFile().isPresent());
+    return fileSlice;
+  }
+
+  private List<T> readRecordsFromFileGroup(StorageConfiguration<?> storageConf, String tablePath, HoodieTableMetaClient metaClient,
+                                           FileSlice fileSlice, Schema avroSchema, RecordMergeMode recordMergeMode, boolean isSkipMerge,
+                                           boolean allowInflightInstants) throws Exception {
 
     List<T> actualRecordList = new ArrayList<>();
     TypedProperties props = new TypedProperties();
@@ -320,13 +341,13 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
           getHoodieReaderContext(tablePath, avroSchema, storageConf), metaClient.getStorage(),
           tablePath, metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
           fileSlice, avroSchema, avroSchema, Option.empty(), metaClient, props, 1,
-          fileSlice.getTotalFileSize(), false, false));
+          fileSlice.getTotalFileSize(), false, allowInflightInstants));
     }
     HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
         getHoodieReaderContext(tablePath, avroSchema, storageConf), metaClient.getStorage(),
         tablePath, metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
         fileSlice, avroSchema, avroSchema, Option.empty(), metaClient, props, 0,
-        fileSlice.getTotalFileSize(), false, false);
+        fileSlice.getTotalFileSize(), false, allowInflightInstants);
     fileGroupReader.initRecordIterators();
     while (fileGroupReader.hasNext()) {
       actualRecordList.add(fileGroupReader.next());

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -45,8 +45,8 @@ public class HoodieFileGroupReaderTestUtils {
       TypedProperties properties,
       HoodieStorage storage,
       HoodieReaderContext<IndexedRecord> readerContext,
-      HoodieTableMetaClient metaClient
-  ) {
+      HoodieTableMetaClient metaClient,
+      boolean allowInflightCommits) {
     assert (fileSliceOpt.isPresent());
     return new HoodieFileGroupReaderBuilder()
         .withReaderContext(readerContext)
@@ -55,6 +55,7 @@ public class HoodieFileGroupReaderTestUtils {
         .withStart(start)
         .withLength(length)
         .withProperties(properties)
+        .withAllowInflightCommits(allowInflightCommits)
         .build(basePath, latestCommitTime, schema, shouldUseRecordPosition, metaClient);
   }
 
@@ -65,6 +66,7 @@ public class HoodieFileGroupReaderTestUtils {
     private TypedProperties props;
     private long start;
     private long length;
+    private boolean allowInflightCommits = false;
 
     public HoodieFileGroupReaderBuilder withReaderContext(
         HoodieReaderContext<IndexedRecord> context) {
@@ -97,6 +99,11 @@ public class HoodieFileGroupReaderTestUtils {
       return this;
     }
 
+    public HoodieFileGroupReaderBuilder withAllowInflightCommits(boolean allowInflightCommits) {
+      this.allowInflightCommits = allowInflightCommits;
+      return this;
+    }
+
     public HoodieFileGroupReader<IndexedRecord> build(
         String basePath,
         String latestCommitTime,
@@ -108,20 +115,8 @@ public class HoodieFileGroupReaderTestUtils {
       props.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(),  basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME);
       props.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
       props.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
-      return new HoodieFileGroupReader<>(
-          readerContext,
-          storage,
-          basePath,
-          latestCommitTime,
-          fileSlice,
-          schema,
-          schema,
-          Option.empty(),
-          metaClient,
-          props,
-          start,
-          length,
-          shouldUseRecordPosition);
+      return new HoodieFileGroupReader<>(readerContext, storage, basePath, latestCommitTime, fileSlice,
+          schema, schema, Option.empty(), metaClient, props, start, length, shouldUseRecordPosition, allowInflightCommits);
     }
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
@@ -92,6 +92,7 @@ public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupRead
 
   @Test
   public void testInflightDataRead() throws IOException, InterruptedException {
+    // delete the completed instant to convert last update commit to inflight commit
     testTable.moveCompleteCommitToInflight(instantTimes.get(1));
     metaClient = HoodieTableMetaClient.reload(metaClient);
     // The FileSlice contains a base file and a log file.

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
@@ -19,9 +19,7 @@
 
 package org.apache.hudi.common.table.read;
 
-import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.HoodieAvroRecordMerger;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.reader.HoodieAvroRecordTestMerger;
@@ -36,20 +34,13 @@ import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
-import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
-import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.UPDATE;
 import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.ROW_KEY;
@@ -59,8 +50,6 @@ public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupRead
 
   @BeforeAll
   public static void setUp() throws IOException {
-    // Create dedicated merger to avoid current delete logic holes.
-    // TODO: Unify delete logic (HUDI-7240).
     HoodieAvroRecordMerger merger = new HoodieAvroRecordTestMerger();
     readerContext = new HoodieTestReaderContext(
         Option.of(merger),
@@ -69,33 +58,16 @@ public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupRead
     // -------------------------------------------------------------
     // The test logic is as follows:
     // 1. Base file contains 10 records,
-    //    whose key values are from 1 to 10,
+    //    whose key values are from 1 to 5,
     //    whose instant time is "001" and ordering value is 2.
-    // 2. After adding the first log file,
-    //    we delete the records with keys from 1 to 5
+    // 2. After adding the first base file,
+    //    we update the records with keys from 1 to 3
     //    with ordering value 3.
-    //    Current existing keys: [6, 7, 8, 9, 10]
-    // 3. After adding the second log file,
-    //    we tried to add the records with keys from 1 to 3 back,
-    //    but we cannot since their ordering value is 1 < 3.
-    //    Current existing keys: [6, 7, 8, 9, 10]
-    // 4. After adding the third log file,
-    //    we tried to delete records with keys from 6 to 8,
-    //    but we cannot since their ordering value is 1 < 2.
-    //    Current existing keys: [6, 7, 8, 9, 10]
-    // 5. After adding the fourth log file,
-    //    we tried to add the records with keys from 1 to 2 back,
-    //    and it worked since their ordering value is 4 > 3.
-    //    Current existing keys: [1, 2, 6, 7, 8, 9, 10]
-    // -------------------------------------------------------------
 
     // Specify the key column values for each file.
     keyRanges = Arrays.asList(
         new HoodieFileSliceTestUtils.KeyRange(1, 5),
-        new HoodieFileSliceTestUtils.KeyRange(1, 3),
-        new HoodieFileSliceTestUtils.KeyRange(1, 3),
-        new HoodieFileSliceTestUtils.KeyRange(6, 8),
-        new HoodieFileSliceTestUtils.KeyRange(1, 2));
+        new HoodieFileSliceTestUtils.KeyRange(1, 3));
     // Specify the value of `timestamp` column for each file.
     timestamps = Arrays.asList(
         2L, 3L);
@@ -125,7 +97,7 @@ public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupRead
     // The FileSlice contains a base file and a log file.
     ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(2, false, true);
     List<String> leftKeysExpected = Arrays.asList("1", "2", "3", "4", "5");
-    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 1L, 1L);
+    List<Long> leftTimestampsExpected = Arrays.asList(3L, 3L, 3L, 2L, 2L);
     List<String> leftKeysActual = new ArrayList<>();
     List<Long> leftTimestampsActual = new ArrayList<>();
     while (iterator.hasNext()) {
@@ -135,89 +107,5 @@ public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupRead
     }
     assertEquals(leftKeysExpected, leftKeysActual);
     assertEquals(leftTimestampsExpected, leftTimestampsActual);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testWithTwoLogFiles(boolean useRecordPositions) throws IOException, InterruptedException {
-    shouldWritePositions = Arrays.asList(useRecordPositions, useRecordPositions, useRecordPositions);
-    // The FileSlice contains a base file and two log files.
-    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(3, useRecordPositions);
-    List<String> leftKeysExpected = Arrays.asList("6", "7", "8", "9", "10");
-    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 2L, 2L);
-    List<String> leftKeysActual = new ArrayList<>();
-    List<Long> leftTimestampsActual = new ArrayList<>();
-    while (iterator.hasNext()) {
-      IndexedRecord record = iterator.next();
-      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
-      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
-    }
-    assertEquals(leftKeysExpected, leftKeysActual);
-    assertEquals(leftTimestampsExpected, leftTimestampsActual);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testWithThreeLogFiles(boolean useRecordPositions) throws IOException, InterruptedException {
-    shouldWritePositions = Arrays.asList(useRecordPositions, useRecordPositions, useRecordPositions, useRecordPositions);
-    // The FileSlice contains a base file and three log files.
-    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(4, useRecordPositions);
-    List<String> leftKeysExpected = Arrays.asList("6", "7", "8", "9", "10");
-    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 2L, 2L);
-    List<String> leftKeysActual = new ArrayList<>();
-    List<Long> leftTimestampsActual = new ArrayList<>();
-    while (iterator.hasNext()) {
-      IndexedRecord record = iterator.next();
-      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
-      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
-    }
-    assertEquals(leftKeysExpected, leftKeysActual);
-    assertEquals(leftTimestampsExpected, leftTimestampsActual);
-  }
-
-  @Test
-  public void testWithFourLogFiles() throws IOException, InterruptedException {
-    // The FileSlice contains a base file and three log files.
-    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(5);
-    List<String> leftKeysExpected = Arrays.asList("1", "2", "6", "7", "8", "9", "10");
-    List<Long> leftTimestampsExpected = Arrays.asList(4L, 4L, 2L, 2L, 2L, 2L, 2L);
-    List<String> leftKeysActual = new ArrayList<>();
-    List<Long> leftTimestampsActual = new ArrayList<>();
-    while (iterator.hasNext()) {
-      IndexedRecord record = iterator.next();
-      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
-      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
-    }
-    assertEquals(leftKeysExpected, leftKeysActual);
-    assertEquals(leftTimestampsExpected, leftTimestampsActual);
-  }
-
-  @ParameterizedTest
-  @MethodSource("testArgs")
-  public void testPositionMergeFallback(boolean log1haspositions, boolean log2haspositions,
-                                        boolean log3haspositions, boolean log4haspositions) throws IOException, InterruptedException {
-    shouldWritePositions = Arrays.asList(true, log1haspositions, log2haspositions, log3haspositions, log4haspositions);
-    // The FileSlice contains a base file and three log files.
-    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(5, true);
-    List<String> leftKeysExpected = Arrays.asList("1", "2", "6", "7", "8", "9", "10");
-    List<Long> leftTimestampsExpected = Arrays.asList(4L, 4L, 2L, 2L, 2L, 2L, 2L);
-    List<String> leftKeysActual = new ArrayList<>();
-    List<Long> leftTimestampsActual = new ArrayList<>();
-    while (iterator.hasNext()) {
-      IndexedRecord record = iterator.next();
-      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
-      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
-    }
-    assertEquals(leftKeysExpected, leftKeysActual);
-    assertEquals(leftTimestampsExpected, leftTimestampsActual);
-  }
-
-  //generate all possible combos of 4 booleans
-  private static Stream<Arguments> testArgs() {
-    Stream.Builder<Arguments> b = Stream.builder();
-    for (int i = 0; i < 16; i++) {
-      b.add(Arguments.of(i % 2 == 0, (i / 2) % 2 == 0,  (i / 4) % 2 == 0, (i / 8) % 2 == 0));
-    }
-    return b.build();
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderInflightCommit.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.model.HoodieAvroRecordMerger;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.testutils.reader.HoodieAvroRecordTestMerger;
+import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
+import org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils;
+import org.apache.hudi.common.testutils.reader.HoodieRecordTestPayload;
+import org.apache.hudi.common.testutils.reader.HoodieTestReaderContext;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
+import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
+import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.UPDATE;
+import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.ROW_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestHoodieFileGroupReaderInflightCommit extends HoodieFileGroupReaderTestHarness {
+
+  @BeforeAll
+  public static void setUp() throws IOException {
+    // Create dedicated merger to avoid current delete logic holes.
+    // TODO: Unify delete logic (HUDI-7240).
+    HoodieAvroRecordMerger merger = new HoodieAvroRecordTestMerger();
+    readerContext = new HoodieTestReaderContext(
+        Option.of(merger),
+        Option.of(HoodieRecordTestPayload.class.getName()));
+
+    // -------------------------------------------------------------
+    // The test logic is as follows:
+    // 1. Base file contains 10 records,
+    //    whose key values are from 1 to 10,
+    //    whose instant time is "001" and ordering value is 2.
+    // 2. After adding the first log file,
+    //    we delete the records with keys from 1 to 5
+    //    with ordering value 3.
+    //    Current existing keys: [6, 7, 8, 9, 10]
+    // 3. After adding the second log file,
+    //    we tried to add the records with keys from 1 to 3 back,
+    //    but we cannot since their ordering value is 1 < 3.
+    //    Current existing keys: [6, 7, 8, 9, 10]
+    // 4. After adding the third log file,
+    //    we tried to delete records with keys from 6 to 8,
+    //    but we cannot since their ordering value is 1 < 2.
+    //    Current existing keys: [6, 7, 8, 9, 10]
+    // 5. After adding the fourth log file,
+    //    we tried to add the records with keys from 1 to 2 back,
+    //    and it worked since their ordering value is 4 > 3.
+    //    Current existing keys: [1, 2, 6, 7, 8, 9, 10]
+    // -------------------------------------------------------------
+
+    // Specify the key column values for each file.
+    keyRanges = Arrays.asList(
+        new HoodieFileSliceTestUtils.KeyRange(1, 5),
+        new HoodieFileSliceTestUtils.KeyRange(1, 3),
+        new HoodieFileSliceTestUtils.KeyRange(1, 3),
+        new HoodieFileSliceTestUtils.KeyRange(6, 8),
+        new HoodieFileSliceTestUtils.KeyRange(1, 2));
+    // Specify the value of `timestamp` column for each file.
+    timestamps = Arrays.asList(
+        2L, 3L);
+    // Specify the operation type for each file.
+    operationTypes = Arrays.asList(
+        INSERT, UPDATE);
+    // Specify the instant time for each file.
+    instantTimes = Arrays.asList(
+        "001", "002");
+    shouldWritePositions = Arrays.asList(false, false);
+  }
+
+  @BeforeEach
+  public void initialize() throws Exception {
+    setTableName(TestEventTimeMerging.class.getName());
+    initPath(tableName);
+    initMetaClient();
+    initTestDataGenerator(new String[]{PARTITION_PATH});
+    testTable = HoodieTestTable.of(metaClient);
+    setUpMockCommits();
+  }
+
+  @Test
+  public void testInflightDataRead() throws IOException, InterruptedException {
+    testTable.moveCompleteCommitToInflight(instantTimes.get(1));
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    // The FileSlice contains a base file and a log file.
+    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(2, false, true);
+    List<String> leftKeysExpected = Arrays.asList("1", "2", "3", "4", "5");
+    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 1L, 1L);
+    List<String> leftKeysActual = new ArrayList<>();
+    List<Long> leftTimestampsActual = new ArrayList<>();
+    while (iterator.hasNext()) {
+      IndexedRecord record = iterator.next();
+      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
+      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
+    }
+    assertEquals(leftKeysExpected, leftKeysActual);
+    assertEquals(leftTimestampsExpected, leftTimestampsActual);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testWithTwoLogFiles(boolean useRecordPositions) throws IOException, InterruptedException {
+    shouldWritePositions = Arrays.asList(useRecordPositions, useRecordPositions, useRecordPositions);
+    // The FileSlice contains a base file and two log files.
+    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(3, useRecordPositions);
+    List<String> leftKeysExpected = Arrays.asList("6", "7", "8", "9", "10");
+    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 2L, 2L);
+    List<String> leftKeysActual = new ArrayList<>();
+    List<Long> leftTimestampsActual = new ArrayList<>();
+    while (iterator.hasNext()) {
+      IndexedRecord record = iterator.next();
+      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
+      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
+    }
+    assertEquals(leftKeysExpected, leftKeysActual);
+    assertEquals(leftTimestampsExpected, leftTimestampsActual);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testWithThreeLogFiles(boolean useRecordPositions) throws IOException, InterruptedException {
+    shouldWritePositions = Arrays.asList(useRecordPositions, useRecordPositions, useRecordPositions, useRecordPositions);
+    // The FileSlice contains a base file and three log files.
+    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(4, useRecordPositions);
+    List<String> leftKeysExpected = Arrays.asList("6", "7", "8", "9", "10");
+    List<Long> leftTimestampsExpected = Arrays.asList(2L, 2L, 2L, 2L, 2L);
+    List<String> leftKeysActual = new ArrayList<>();
+    List<Long> leftTimestampsActual = new ArrayList<>();
+    while (iterator.hasNext()) {
+      IndexedRecord record = iterator.next();
+      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
+      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
+    }
+    assertEquals(leftKeysExpected, leftKeysActual);
+    assertEquals(leftTimestampsExpected, leftTimestampsActual);
+  }
+
+  @Test
+  public void testWithFourLogFiles() throws IOException, InterruptedException {
+    // The FileSlice contains a base file and three log files.
+    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(5);
+    List<String> leftKeysExpected = Arrays.asList("1", "2", "6", "7", "8", "9", "10");
+    List<Long> leftTimestampsExpected = Arrays.asList(4L, 4L, 2L, 2L, 2L, 2L, 2L);
+    List<String> leftKeysActual = new ArrayList<>();
+    List<Long> leftTimestampsActual = new ArrayList<>();
+    while (iterator.hasNext()) {
+      IndexedRecord record = iterator.next();
+      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
+      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
+    }
+    assertEquals(leftKeysExpected, leftKeysActual);
+    assertEquals(leftTimestampsExpected, leftTimestampsActual);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  public void testPositionMergeFallback(boolean log1haspositions, boolean log2haspositions,
+                                        boolean log3haspositions, boolean log4haspositions) throws IOException, InterruptedException {
+    shouldWritePositions = Arrays.asList(true, log1haspositions, log2haspositions, log3haspositions, log4haspositions);
+    // The FileSlice contains a base file and three log files.
+    ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(5, true);
+    List<String> leftKeysExpected = Arrays.asList("1", "2", "6", "7", "8", "9", "10");
+    List<Long> leftTimestampsExpected = Arrays.asList(4L, 4L, 2L, 2L, 2L, 2L, 2L);
+    List<String> leftKeysActual = new ArrayList<>();
+    List<Long> leftTimestampsActual = new ArrayList<>();
+    while (iterator.hasNext()) {
+      IndexedRecord record = iterator.next();
+      leftKeysActual.add(record.get(AVRO_SCHEMA.getField(ROW_KEY).pos()).toString());
+      leftTimestampsActual.add((Long) record.get(AVRO_SCHEMA.getField("timestamp").pos()));
+    }
+    assertEquals(leftKeysExpected, leftKeysActual);
+    assertEquals(leftTimestampsExpected, leftTimestampsActual);
+  }
+
+  //generate all possible combos of 4 booleans
+  private static Stream<Arguments> testArgs() {
+    Stream.Builder<Arguments> b = Stream.builder();
+    for (int i = 0; i < 16; i++) {
+      b.add(Arguments.of(i % 2 == 0, (i / 2) % 2 == 0,  (i / 4) % 2 == 0, (i / 8) % 2 == 0));
+    }
+    return b.build();
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
@@ -114,6 +114,11 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
 
   protected ClosableIterator<IndexedRecord> getFileGroupIterator(int numFiles, boolean shouldReadPositions)
       throws IOException, InterruptedException {
+    return getFileGroupIterator(numFiles, shouldReadPositions, false);
+  }
+
+  protected ClosableIterator<IndexedRecord> getFileGroupIterator(int numFiles, boolean shouldReadPositions, boolean allowInflightCommits)
+      throws IOException, InterruptedException {
     assert (numFiles >= 1 && numFiles <= keyRanges.size());
 
     HoodieStorage hoodieStorage = new HoodieHadoopStorage(basePath, storageConf);
@@ -143,8 +148,8 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
             properties,
             hoodieStorage,
             readerContext,
-            metaClient
-        );
+            metaClient,
+            allowInflightCommits);
 
     fileGroupReader.initRecordIterators();
     return fileGroupReader.getClosableIterator();

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
@@ -144,7 +144,7 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
     this.fileGroupReader = new HoodieFileGroupReader<>(readerContext, metaClient.getStorage(), tableBasePath,
         latestCommitTime, getFileSliceFromSplit(fileSplit, getFs(tableBasePath, jobConfCopy), tableBasePath),
         tableSchema, requestedSchema, Option.empty(), metaClient, props, fileSplit.getStart(),
-        fileSplit.getLength(), false);
+        fileSplit.getLength(), false, false);
     this.fileGroupReader.initRecordIterators();
     // it expects the partition columns to be at the end
     Schema outputSchema = HoodieAvroUtils.generateProjectionSchema(tableSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -167,20 +167,8 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
                 .builder().setConf(storageConf).setBasePath(tablePath).build
               val props = metaClient.getTableConfig.getProps
               options.foreach(kv => props.setProperty(kv._1, kv._2))
-              val reader = new HoodieFileGroupReader[InternalRow](
-                readerContext,
-                new HoodieHadoopStorage(metaClient.getBasePath, storageConf),
-                tablePath,
-                queryTimestamp,
-                fileSlice,
-                dataAvroSchema,
-                requestedAvroSchema,
-                internalSchemaOpt,
-                metaClient,
-                props,
-                file.start,
-                file.length,
-                shouldUseRecordPosition)
+              val reader = new HoodieFileGroupReader[InternalRow](readerContext, new HoodieHadoopStorage(metaClient.getBasePath, storageConf), tablePath, queryTimestamp,
+                fileSlice, dataAvroSchema, requestedAvroSchema, internalSchemaOpt, metaClient, props, file.start, file.length, shouldUseRecordPosition, false)
               reader.initRecordIterators()
               // Append partition values to rows and project to output schema
               appendPartitionAndProject(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -30,15 +30,14 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload.{DELETE_KEY, DELE
 import org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderOnSpark.getFileCount
-import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils, RawTripTestPayload}
+import org.apache.hudi.common.testutils.{HoodieTestUtils, RawTripTestPayload}
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
-import org.apache.hudi.storage.{StorageConfiguration, StoragePath, StoragePathInfo}
+import org.apache.hudi.storage.{StorageConfiguration, StoragePath}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
-import org.apache.hudi.common.model.WriteOperationType.{INSERT, UPSERT}
-import org.apache.hudi.common.table.timeline.versioning.DefaultInstantFileNameGenerator
 import org.apache.spark.{HoodieSparkKryoRegistrar, SparkConf}
 import org.apache.spark.sql.{Dataset, HoodieInternalRowUtils, HoodieUnsafeUtils, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -49,10 +48,11 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource}
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 import org.mockito.Mockito
 
 import java.util
+
 import scala.collection.JavaConverters._
 
 /**
@@ -106,16 +106,11 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     val recs = RawTripTestPayload.recordsToStrings(recordList)
     val inputDF: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(recs.asScala.toList, 2))
 
-    val tableType = if (options.containsKey(DataSourceWriteOptions.TABLE_TYPE.key())) {
-      options.get(DataSourceWriteOptions.TABLE_TYPE.key())
-    } else {
-      DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL
-    }
     inputDF.write.format("hudi")
       .options(options)
       .option("hoodie.compact.inline", "false") // else fails due to compaction & deltacommit instant times being same
       .option("hoodie.datasource.write.operation", operation)
-      .option("hoodie.datasource.write.table.type", tableType)
+      .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
       .mode(if (operation.equalsIgnoreCase(WriteOperationType.INSERT.value())) SaveMode.Overwrite
       else SaveMode.Append)
       .save(getBasePath)
@@ -136,8 +131,8 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
       assertEquals(expectedDf.count, actualRecordList.size)
       val actualDf = HoodieUnsafeUtils.createDataFrameFromInternalRows(
         spark, actualRecordList.asScala.toSeq, HoodieInternalRowUtils.getCachedSchema(schema))
-      assertEquals(0, expectedDf.except(actualDf.selectExpr(expectedDf.columns: _*)).count())
-      assertEquals(0, actualDf.except(expectedDf.selectExpr(actualDf.columns: _*)).count())
+      assertEquals(0, expectedDf.except(actualDf).count())
+      assertEquals(0, actualDf.except(expectedDf).count())
     }
   }
 
@@ -294,27 +289,6 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
       HOption.of(row), metadataMap, avroSchema, HOption.of(orderingColumn)))
     assertEquals(expectedOrderingValue,
       metadataMap.get(HoodieReaderContext.INTERNAL_META_ORDERING_FIELD))
-  }
-
-  @ParameterizedTest
-  @EnumSource(classOf[RecordMergeMode])
-  @throws[Exception]
-  def testReadFileGroupInflightData(recordMergeMode: RecordMergeMode): Unit = {
-    val writeConfigs = new util.HashMap[String, String](getCommonConfigs(recordMergeMode))
-    writeConfigs.put(DataSourceWriteOptions.TABLE_TYPE.key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
-    try {
-      val dataGen = new HoodieTestDataGenerator(0xDEEF)
-      try {
-        // One commit; reading one file group containing a base file only
-        commitToTable(dataGen.generateInserts("001", 100), INSERT.value, writeConfigs)
-        validateOutputFromFileGroupReader(getStorageConf, getBasePath, dataGen.getPartitionPaths, true, 0, recordMergeMode)
-
-        commitToTable(dataGen.generateUniqueUpdates("003", 100), UPSERT.value, writeConfigs)
-        val metaClient = HoodieTestUtils.createMetaClient(getStorageConf, getBasePath)
-        metaClient.getStorage.deleteFile(new StoragePath(metaClient.getTimelinePath, new DefaultInstantFileNameGenerator().getFileName(metaClient.getActiveTimeline.lastInstant().get())))
-        validateOutputFromFileGroupReaderIncludingInflight(getStorageConf, getBasePath, dataGen.getPartitionPaths, true, 1, recordMergeMode, true)
-      } finally if (dataGen != null) dataGen.close()
-    }
   }
 }
 


### PR DESCRIPTION
### Change Logs

The PR adds capability to read inflight instants with HoodieLogRecordReader by adding `allowInflightInstants` flag. The capability is required for updating RLI since RLI reads the log records and finds deleted keys.
While replacing `HoodieMergedLogRecordScanner` with new reader class, we need to use the allowInflightInstants flag.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
