### PR TITLE
[HUDI-9208] Add file system view storage configs to MDT

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieArchivalConfig;
@@ -120,6 +121,11 @@ public class HoodieMetadataWriteUtils {
             .withMaxConsistencyChecks(writeConfig.getConsistencyGuardConfig().getMaxConsistencyChecks())
             .build())
         .withWriteConcurrencyMode(WriteConcurrencyMode.SINGLE_WRITER)
+        .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+            .withStorageType(writeConfig.getMetadataConfig().getMetadataViewType())
+            .withBaseStoreDir(writeConfig.getViewStorageConfig().getSpillableDir())
+            .withMaxMemoryForView(writeConfig.getMetadataConfig().getMetadataViewSpillableMemory())
+            .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).withFileListingParallelism(writeConfig.getFileListingParallelism()).build())
         .withAutoCommit(true)
         .withAvroSchemaValidate(false)


### PR DESCRIPTION
### Change Logs

This PR adds the configs to change the file system view used by the metadata table writer.

### Impact

Allows metadata table writer to use `SPILLABLE_DISK` view type to reduce memory footprint.

### Risk level

none

### Documentation Update

Config documentation will be automatically updated upon a new Hudi release.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
