### PR TITLE
[HUDI-9117] Replace usage of *LogScanner with FileGroupReader

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
@@ -129,6 +129,9 @@ public class HoodieMergedReadHandle<T, I, K, O> extends HoodieReadHandle<T, I, K
   private HoodieMergedLogRecordScanner getLogRecordScanner(FileSlice fileSlice) {
     List<String> logFilePaths = fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
         .map(l -> l.getPath().toString()).collect(toList());
+
+    //FIXME-vc: replace using file group reader
+
     return HoodieMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
         .withBasePath(hoodieTable.getMetaClient().getBasePath())

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/HoodieSparkFileGroupReaderBasedMergeHandle.java
@@ -185,20 +185,21 @@ public class HoodieSparkFileGroupReaderBasedMergeHandle<T, I, K, O> extends Hood
     hoodieTable.getMetaClient().getTableConfig().getProps().forEach(props::putIfAbsent);
     config.getProps().forEach(props::putIfAbsent);
     // Initializes file group reader
-    try (HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
-        readerContext,
-        storage.newInstance(hoodieTable.getMetaClient().getBasePath(), new HadoopStorageConfiguration(conf)),
-        hoodieTable.getMetaClient().getBasePath().toString(),
-        instantTime,
-        fileSlice,
-        writeSchemaWithMetaFields,
-        writeSchemaWithMetaFields,
-        internalSchemaOption,
-        hoodieTable.getMetaClient(),
-        props,
-        0,
-        Long.MAX_VALUE,
-        usePosition)) {
+    try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.newBuilder()
+        .withReaderContext(readerContext)
+        .withStorage(storage.newInstance(hoodieTable.getMetaClient().getBasePath(), new HadoopStorageConfiguration(conf)))
+        .withTablePath(hoodieTable.getMetaClient().getBasePath().toString())
+        .withLatestCommitTime(instantTime)
+        .withFileSlice(fileSlice)
+        .withDataSchema(writeSchemaWithMetaFields)
+        .withRequestedSchema(writeSchemaWithMetaFields)
+        .withInternalSchema(internalSchemaOption)
+        .withHoodieTableMetaClient(hoodieTable.getMetaClient())
+        .withProps(props)
+        .withStart(0)
+        .withLength(Long.MAX_VALUE)
+        .withShouldUseRecordPosition(usePosition)
+        .build()) {
       fileGroupReader.initRecordIterators();
       // Reads the records from the file slice
       try (HoodieFileGroupReaderIterator<InternalRow> recordIterator

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroReaderContext.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.common.testutils.reader;
+package org.apache.hudi.avro;
 
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
@@ -50,17 +50,19 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.ROW_KEY;
-
-public class HoodieTestReaderContext extends HoodieReaderContext<IndexedRecord> {
+// FIXME-vc: Need to reimplement this class properly.
+public class HoodieAvroReaderContext extends HoodieReaderContext<IndexedRecord> {
   private Option<HoodieRecordMerger> customMerger;
   private Option<String> payloadClass;
+  private final String keyFieldName;
 
-  public HoodieTestReaderContext(
+  public HoodieAvroReaderContext(
       Option<HoodieRecordMerger> customMerger,
-      Option<String> payloadClass) {
+      Option<String> payloadClass,
+      String keyFieldName) {
     this.customMerger = customMerger;
     this.payloadClass = payloadClass;
+    this.keyFieldName = keyFieldName;
   }
 
   @Override
@@ -103,7 +105,7 @@ public class HoodieTestReaderContext extends HoodieReaderContext<IndexedRecord> 
 
   @Override
   public String getRecordKey(IndexedRecord record, Schema schema) {
-    return getFieldValueFromIndexedRecord(record, schema, ROW_KEY).toString();
+    return getFieldValueFromIndexedRecord(record, schema, keyFieldName).toString();
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -91,7 +91,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
 
   public abstract String getBasePath();
 
-  public abstract HoodieReaderContext<T> getHoodieReaderContext(String tablePath, Schema avroSchema, StorageConfiguration<?> storageConf);
+  public abstract HoodieReaderContext getHoodieReaderContext(String tablePath, Schema avroSchema, StorageConfiguration<?> storageConf);
 
   public abstract String getCustomPayload();
 
@@ -316,35 +316,35 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       props.setProperty(HoodieReaderConfig.MERGE_TYPE.key(), HoodieReaderConfig.REALTIME_SKIP_MERGE);
     }
     if (shouldValidatePartialRead(fileSlice, avroSchema)) {
-      assertThrows(IllegalArgumentException.class, () -> new HoodieFileGroupReader<>(
-          getHoodieReaderContext(tablePath, avroSchema, storageConf),
-          metaClient.getStorage(),
-          tablePath,
-          metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
-          fileSlice,
-          avroSchema,
-          avroSchema,
-          Option.empty(),
-          metaClient,
-          props,
-          1,
-          fileSlice.getTotalFileSize(),
-          false));
+      assertThrows(IllegalArgumentException.class, () -> HoodieFileGroupReader.newBuilder()
+          .withReaderContext(getHoodieReaderContext(tablePath, avroSchema, storageConf))
+          .withStorage(metaClient.getStorage())
+          .withTablePath(tablePath)
+          .withLatestCommitTime(metaClient.getActiveTimeline().lastInstant().get().requestedTime())
+          .withFileSlice(fileSlice)
+          .withDataSchema(avroSchema)
+          .withRequestedSchema(avroSchema)
+          .withHoodieTableMetaClient(metaClient)
+          .withProps(props)
+          .withStart(1)
+          .withLength(fileSlice.getTotalFileSize())
+          .withShouldUseRecordPosition(false)
+          .build());
     }
-    HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
-        getHoodieReaderContext(tablePath, avroSchema, storageConf),
-        metaClient.getStorage(),
-        tablePath,
-        metaClient.getActiveTimeline().lastInstant().get().requestedTime(),
-        fileSlice,
-        avroSchema,
-        avroSchema,
-        Option.empty(),
-        metaClient,
-        props,
-        0,
-        fileSlice.getTotalFileSize(),
-        false);
+    HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.newBuilder()
+        .withReaderContext(getHoodieReaderContext(tablePath, avroSchema, storageConf))
+        .withStorage(metaClient.getStorage())
+        .withTablePath(tablePath)
+        .withLatestCommitTime(metaClient.getActiveTimeline().lastInstant().get().requestedTime())
+        .withFileSlice(fileSlice)
+        .withDataSchema(avroSchema)
+        .withRequestedSchema(avroSchema)
+        .withHoodieTableMetaClient(metaClient)
+        .withProps(props)
+        .withStart(0)
+        .withLength(fileSlice.getTotalFileSize())
+        .withShouldUseRecordPosition(false)
+        .build();
     fileGroupReader.initRecordIterators();
     while (fileGroupReader.hasNext()) {
       actualRecordList.add(fileGroupReader.next());

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestUtils.java
@@ -48,14 +48,21 @@ public class HoodieFileGroupReaderTestUtils {
       HoodieTableMetaClient metaClient
   ) {
     assert (fileSliceOpt.isPresent());
-    return new HoodieFileGroupReaderBuilder()
+    return HoodieFileGroupReader.<IndexedRecord>newBuilder()
         .withReaderContext(readerContext)
         .withStorage(storage)
+        .withTablePath(basePath)
+        .withLatestCommitTime(latestCommitTime)
         .withFileSlice(fileSliceOpt.get())
+        .withDataSchema(schema)
+        .withRequestedSchema(schema)
+        .withInternalSchema(Option.empty())
+        .withHoodieTableMetaClient(metaClient)
+        .withProps(properties)
         .withStart(start)
         .withLength(length)
-        .withProperties(properties)
-        .build(basePath, latestCommitTime, schema, shouldUseRecordPosition, metaClient);
+        .withShouldUseRecordPosition(shouldUseRecordPosition)
+        .build();
   }
 
   public static class HoodieFileGroupReaderBuilder {
@@ -108,20 +115,22 @@ public class HoodieFileGroupReaderTestUtils {
       props.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(),  basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME);
       props.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
       props.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
-      return new HoodieFileGroupReader<>(
-          readerContext,
-          storage,
-          basePath,
-          latestCommitTime,
-          fileSlice,
-          schema,
-          schema,
-          Option.empty(),
-          metaClient,
-          props,
-          start,
-          length,
-          shouldUseRecordPosition);
+
+      // Create a new HoodieFileGroupReader with the provided parameters
+      return HoodieFileGroupReader.<IndexedRecord>newBuilder()
+          .withReaderContext(readerContext)
+          .withStorage(storage)
+          .withTablePath(basePath)
+          .withLatestCommitTime(latestCommitTime)
+          .withFileSlice(fileSlice)
+          .withDataSchema(schema)
+          .withRequestedSchema(schema)
+          .withHoodieTableMetaClient(metaClient)
+          .withProps(props)
+          .withStart(start)
+          .withLength(length)
+          .withShouldUseRecordPosition(shouldUseRecordPosition)
+          .build();
     }
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomMerger.java
@@ -29,7 +29,7 @@ import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
 import org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils;
 import org.apache.hudi.common.testutils.reader.HoodieRecordTestPayload;
-import org.apache.hudi.common.testutils.reader.HoodieTestReaderContext;
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -72,9 +72,10 @@ public class TestCustomMerger extends HoodieFileGroupReaderTestHarness {
   @BeforeAll
   public static void setUp() throws IOException {
     // Enable our custom merger.
-    readerContext = new HoodieTestReaderContext(
+    readerContext = new HoodieAvroReaderContext(
         Option.of(new CustomAvroMerger()),
-        Option.of(HoodieRecordTestPayload.class.getName()));
+        Option.of(HoodieRecordTestPayload.class.getName()),
+        HoodieFileSliceTestUtils.ROW_KEY);
     properties.setProperty(
         "hoodie.write.record.merge.mode", RecordMergeMode.CUSTOM.name());
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.testutils.reader.HoodieAvroRecordTestMerger;
 import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
 import org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils;
 import org.apache.hudi.common.testutils.reader.HoodieRecordTestPayload;
-import org.apache.hudi.common.testutils.reader.HoodieTestReaderContext;
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 
@@ -68,9 +68,10 @@ public class TestEventTimeMerging extends HoodieFileGroupReaderTestHarness {
     // Create dedicated merger to avoid current delete logic holes.
     // TODO: Unify delete logic (HUDI-7240).
     HoodieAvroRecordMerger merger = new HoodieAvroRecordTestMerger();
-    readerContext = new HoodieTestReaderContext(
+    readerContext = new HoodieAvroReaderContext(
         Option.of(merger),
-        Option.of(HoodieRecordTestPayload.class.getName()));
+        Option.of(HoodieRecordTestPayload.class.getName()),
+        ROW_KEY);
     properties.setProperty(
         "hoodie.write.record.merge.mode", RecordMergeMode.EVENT_TIME_ORDERING.name());
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestOverwriteWithLatestMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestOverwriteWithLatestMerger.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.common.table.read;
 
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
@@ -27,7 +28,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
 import org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils;
-import org.apache.hudi.common.testutils.reader.HoodieTestReaderContext;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 
@@ -66,9 +66,10 @@ public class TestOverwriteWithLatestMerger extends HoodieFileGroupReaderTestHarn
   @BeforeAll
   public static void setUp() throws IOException {
     HoodieRecordMerger merger = new OverwriteWithLatestMerger();
-    readerContext = new HoodieTestReaderContext(
+    readerContext = new HoodieAvroReaderContext(
         Option.of(merger),
-        Option.of(OverwriteWithLatestAvroPayload.class.getName()));
+        Option.of(OverwriteWithLatestAvroPayload.class.getName()),
+        HoodieFileSliceTestUtils.ROW_KEY);
     properties.setProperty("hoodie.write.record.merge.mode", RecordMergeMode.COMMIT_TIME_ORDERING.name());
 
     // -------------------------------------------------------------

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.common.testutils.reader;
 
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.FileSlice;
@@ -70,8 +71,8 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
     properties.setProperty(
         "hoodie.datasource.write.precombine.field", "timestamp");
     storageConf = getDefaultStorageConf();
-    readerContext = new HoodieTestReaderContext(
-        Option.empty(), Option.empty());
+    readerContext = new HoodieAvroReaderContext(
+        Option.empty(), Option.empty(), HoodieFileSliceTestUtils.ROW_KEY);
   }
 
   @AfterAll

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
@@ -141,10 +141,20 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
       }
     }
     LOG.debug("Creating HoodieFileGroupReaderRecordReader with tableBasePath={}, latestCommitTime={}, fileSplit={}", tableBasePath, latestCommitTime, fileSplit.getPath());
-    this.fileGroupReader = new HoodieFileGroupReader<>(readerContext, metaClient.getStorage(), tableBasePath,
-        latestCommitTime, getFileSliceFromSplit(fileSplit, getFs(tableBasePath, jobConfCopy), tableBasePath),
-        tableSchema, requestedSchema, Option.empty(), metaClient, props, fileSplit.getStart(),
-        fileSplit.getLength(), false);
+    this.fileGroupReader = HoodieFileGroupReader.<ArrayWritable>newBuilder()
+        .withReaderContext(readerContext)
+        .withStorage(metaClient.getStorage())
+        .withTablePath(tableBasePath)
+        .withLatestCommitTime(latestCommitTime)
+        .withFileSlice(getFileSliceFromSplit(fileSplit, getFs(tableBasePath, jobConfCopy), tableBasePath))
+        .withDataSchema(tableSchema)
+        .withRequestedSchema(requestedSchema)
+        .withHoodieTableMetaClient(metaClient)
+        .withProps(props)
+        .withStart(fileSplit.getStart())
+        .withLength(fileSplit.getLength())
+        .withShouldUseRecordPosition(false)
+        .build();
     this.fileGroupReader.initRecordIterators();
     // it expects the partition columns to be at the end
     Schema outputSchema = HoodieAvroUtils.generateProjectionSchema(tableSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -167,20 +167,22 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
                 .builder().setConf(storageConf).setBasePath(tablePath).build
               val props = metaClient.getTableConfig.getProps
               options.foreach(kv => props.setProperty(kv._1, kv._2))
-              val reader = new HoodieFileGroupReader[InternalRow](
-                readerContext,
-                new HoodieHadoopStorage(metaClient.getBasePath, storageConf),
-                tablePath,
-                queryTimestamp,
-                fileSlice,
-                dataAvroSchema,
-                requestedAvroSchema,
-                internalSchemaOpt,
-                metaClient,
-                props,
-                file.start,
-                file.length,
-                shouldUseRecordPosition)
+              val reader = HoodieFileGroupReader.newBuilder()
+                .withReaderContext(readerContext)
+                .withStorage(new HoodieHadoopStorage(metaClient.getBasePath, storageConf))
+                .withTablePath(tablePath)
+                .withLatestCommitTime(queryTimestamp)
+                .withFileSlice(fileSlice)
+                .withDataSchema(dataAvroSchema)
+                .withRequestedSchema(requestedAvroSchema)
+                .withInternalSchema(internalSchemaOpt)
+                .withHoodieTableMetaClient(metaClient)
+                .withProps(props)
+                .withStart(file.start)
+                .withLength(file.length)
+                .withShouldUseRecordPosition(shouldUseRecordPosition)
+                .build()
+
               reader.initRecordIterators()
               // Append partition values to rows and project to output schema
               appendPartitionAndProject(


### PR DESCRIPTION

### Change Logs

 - Introduced builder pattern for constructing the file group reader.

### Impact

 - Should not cause any behavior change by intent 

### Risk level (write none, low medium or high below)

medium; touches a bunch core read/write paths. 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
