### PR TITLE
[HUDI-9211] Fix bug with config in DataHubSyncTool

### DIFF
--- a/hudi-sync/hudi-datahub-sync/pom.xml
+++ b/hudi-sync/hudi-datahub-sync/pom.xml
@@ -129,6 +129,21 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Hive - Test -->
+    <dependency>
+      <groupId>${hive.groupid}</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <scope>test</scope>
+      <classifier>${hive.exec.classifier}</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubTableProperties.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubTableProperties.java
@@ -86,8 +86,8 @@ public class DataHubTableProperties {
   private static void addSparkRelatedProperties(Map<String, String> properties, DataHubSyncConfig config, HoodieTableMetadata tableMetadata) {
     Map<String, String> sparkProperties = SparkDataSourceTableUtils.getSparkTableProperties(
         config.getSplitStrings(META_SYNC_PARTITION_FIELDS),
-        config.getString(META_SYNC_SPARK_VERSION),
-        config.getInt(HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD),
+        config.getStringOrDefault(META_SYNC_SPARK_VERSION),
+        config.getIntOrDefault(HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD),
         tableMetadata.getSchema()
     );
     properties.putAll(sparkProperties);

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubTableProperties.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubTableProperties.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.sync.datahub;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
+import org.apache.hudi.sync.datahub.config.DataHubSyncConfig;
+
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.datahub.DataHubTableProperties.HUDI_BASE_PATH;
+import static org.apache.hudi.sync.datahub.DataHubTableProperties.HUDI_TABLE_TYPE;
+import static org.apache.hudi.sync.datahub.DataHubTableProperties.HUDI_TABLE_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestDataHubTableProperties {
+  @Test
+  void testGetTableProperties() {
+    String path = "file:///tmp/path";
+    Map<String, String> expected = new HashMap<>();
+    expected.put(HUDI_TABLE_TYPE, "MERGE_ON_READ");
+    expected.put(HUDI_TABLE_VERSION, "SIX");
+    expected.put(HUDI_BASE_PATH, path);
+    expected.put("spark.path", path);
+    expected.put("serdeClass", ParquetHiveSerDe.class.getName());
+    expected.put("spark.sql.sources.schema.numParts", "1");
+    expected.put("spark.sql.sources.provider", "hudi");
+    expected.put("spark.hoodie.query.as.ro.table", "false");
+    expected.put("spark.sql.sources.schema.part.0", "{\"type\":\"struct\",\"fields\":[{\"name\":\"int_field\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}}]}");
+    expected.put("inputFormat", HoodieParquetInputFormat.class.getName());
+    expected.put("outputFormat", MapredParquetOutputFormat.class.getName());
+
+    TypedProperties properties = new TypedProperties();
+    properties.put(META_SYNC_BASE_PATH.key(), path);
+    DataHubSyncConfig config = new DataHubSyncConfig(properties);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(metaClient.getTableType().name()).thenReturn(HoodieTableType.MERGE_ON_READ.name());
+    when(metaClient.getTableConfig().getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    MessageType messageType = new MessageType("record", new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.INT32, "int_field"));
+    DataHubTableProperties.HoodieTableMetadata tableMetadata = new DataHubTableProperties.HoodieTableMetadata(metaClient, messageType);
+    Map<String, String> actual = DataHubTableProperties.getTableProperties(config, tableMetadata);
+
+    assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
### Change Logs

- Updates the `getInt` and `getString` calls to return the default if not set to avoid NullPointerExceptions

### Impact

- Fixes runtime issue if the config is not set for `HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD`

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
