### PR TITLE
[HUDI-9213] Handle record index field position while create RLI payload

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -192,6 +192,14 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
             HoodieTableConfig.RECORD_MERGE_MODE,
             RecordMergeMode.EVENT_TIME_ORDERING.name());
       }
+    } else if (tableConfig.getPayloadClass() != null
+        && tableConfig.getPayloadClass().equals(DefaultHoodieRecordPayload.class.getName())) {
+      tablePropsToAdd.put(
+          HoodieTableConfig.PAYLOAD_CLASS_NAME,
+          DefaultHoodieRecordPayload.class.getName());
+      tablePropsToAdd.put(
+          HoodieTableConfig.RECORD_MERGE_MODE,
+          RecordMergeMode.EVENT_TIME_ORDERING.name());
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -173,7 +173,10 @@ public enum MetadataPartitionType {
     @Override
     public void constructMetadataPayload(HoodieMetadataPayload payload, GenericRecord record) {
       GenericRecord recordIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_RECORD_INDEX);
-      Object recordIndexPosition = recordIndexRecord.get(RECORD_INDEX_FIELD_POSITION);
+      Object recordIndexPosition = null;
+      if (recordIndexRecord.hasField(RECORD_INDEX_FIELD_POSITION)) {
+        recordIndexPosition = recordIndexRecord.get(RECORD_INDEX_FIELD_POSITION);
+      }
       payload.recordIndexMetadata = new HoodieRecordIndexInfo(recordIndexRecord.get(RECORD_INDEX_FIELD_PARTITION).toString(),
           Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_HIGH_BITS).toString()),
           Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_LOW_BITS).toString()),


### PR DESCRIPTION
### Change Logs

In RLI payload, the field `position` was added in 1.0 and its parsing fails when running compaction while downgrading or upgrading (with table version 6). This PR parses only when the field is present.
 
### Impact

Smooth upgrade/downgrade with RLI

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
