### PR TITLE
[MINOR]Follow up HUDI-8803, optimize vectorized reader by cache 'batchIdxField'

### DIFF
--- a/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/spark/sql/execution/datasources/parquet/Spark3HoodieVectorizedParquetRecordReader.java
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/spark/sql/execution/datasources/parquet/Spark3HoodieVectorizedParquetRecordReader.java
@@ -56,6 +56,8 @@ public class Spark3HoodieVectorizedParquetRecordReader extends VectorizedParquet
   // The memory mode of the columnarBatch.
   private final MemoryMode memoryMode;
 
+  private Field batchIdxField;
+
   public Spark3HoodieVectorizedParquetRecordReader(
       ZoneId convertTz,
       String datetimeRebaseMode,
@@ -161,8 +163,10 @@ public class Spark3HoodieVectorizedParquetRecordReader extends VectorizedParquet
 
   private int batchIdxFromSuper() {
     try {
-      Field batchIdxField = VectorizedParquetRecordReader.class.getDeclaredField("batchIdx");
-      batchIdxField.setAccessible(true);
+      if (batchIdxField == null) {
+        batchIdxField = VectorizedParquetRecordReader.class.getDeclaredField("batchIdx");
+        batchIdxField.setAccessible(true);
+      }
       return (Integer) batchIdxField.get(this);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
### Change Logs

Follow up HUDI-8803, optimize vectorized reader by cache 'batchIdxField'

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update
none


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
