### PR TITLE
[HUDI-9215] Set partitionColumnsWithKeyGenerator based on table version

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/SparkKeyGenUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/SparkKeyGenUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi.util
 
 import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.common.table.HoodieTableVersion
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
@@ -37,11 +38,12 @@ object SparkKeyGenUtils {
 
   /**
    * @param properties config properties
+   * @param writerTableVersion table version used by writer
    * @return partition columns
    */
-  def getPartitionColumnsForKeyGenerator(props: TypedProperties): String = {
+  def getPartitionColumnsForKeyGenerator(props: TypedProperties, writerTableVersion: HoodieTableVersion): String = {
     val keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(props)
-    getPartitionColumns(keyGenerator, props, true)
+    getPartitionColumns(keyGenerator, props, writerTableVersion.versionCode() > HoodieTableVersion.SIX.versionCode())
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -281,7 +282,8 @@ public class BootstrapExecutorUtils implements Serializable {
       keyGenClass = KeyGeneratorType.getKeyGeneratorClassName(new HoodieConfig(props));
     }
     props.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), keyGenClass);
-    String partitionColumnsForKeyGenerator = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props);
+    HoodieTableVersion tableVersion = HoodieTableVersion.fromVersionCode(props.getInteger(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), HoodieTableVersion.current().versionCode()));
+    String partitionColumnsForKeyGenerator = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props, tableVersion);
 
     if (StringUtils.isNullOrEmpty(partitionColumnsForKeyGenerator)) {
       partitionColumnsForKeyGenerator = null;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -233,7 +234,7 @@ public class BootstrapExecutor implements Serializable {
         .setPartitionMetafileUseBaseFormat(props.getBoolean(
             PARTITION_METAFILE_USE_BASE_FORMAT.key(),
             PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()));
-    String partitionColumnsForKeyGenerator = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props);
+    String partitionColumnsForKeyGenerator = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props, HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION)));
     if (!StringUtils.isNullOrEmpty(partitionColumnsForKeyGenerator)) {
       builder.setPartitionFields(partitionColumnsForKeyGenerator).setKeyGeneratorClassProp(
           props.getString(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), SimpleKeyGenerator.class.getName()));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -45,6 +45,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
@@ -419,7 +420,7 @@ public class StreamSync implements Serializable, Closeable {
 
   private HoodieTableMetaClient initializeEmptyTable() throws IOException {
     return initializeEmptyTable(HoodieTableMetaClient.newTableBuilder(),
-        SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props),
+        SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(props, HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION))),
         HadoopFSUtils.getStorageConfWithCopy(hoodieSparkContext.hadoopConfiguration()));
   }
 


### PR DESCRIPTION
### Change Logs

The tests were failing when hiveStylePartitioning && urlEncodePartitioning is true for 0.x spark reader and table version 6.
[https://github.com/onehouseinc/hudi-internal/blob/master/hudi-spark-datasource/hud[…]/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala](https://github.com/onehouseinc/hudi-internal/blob/master/hudi-spark-datasource/hud%5B%E2%80%A6%5D/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala)
```
 => org.sparkproject.guava.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Cannot find columns: 'country:simple' in the schema[StructField(_hoodie_commit_time,StringType,true),StructField(_hoodie_commit_seqno,StringType,true),StructField(_hoodie_record_key,StringType,true),StructField(_hoodie_partition_path,StringType,true),StructField(_hoodie_file_name,StringType,true),StructField(key,StringType,true),StructField(country,StringType,true),StructField(ts,LongType,true),StructField(nested_record,StructType(StructField(nested_int,IntegerType,true)),true),StructField(record_map,MapType(StringType,StructType(StructField(nested_int,IntegerType,true)),true),true),StructField(primitive_map,MapType(StringType,StringType,true),true),StructField(primitive_array,ArrayType(IntegerType,true),true),StructField(int_date,DateType,true),StructField(long_timestamp_millis,TimestampType,true),StructField(long_timestamp_micros,TimestampType,true),StructField(long_timestamp_millis_local,LongType,true),StructField(long_timestamp_micros_local,LongType,true),StructField(bytes_decimal,DecimalType(4,2),true)]
       org.sparkproject.guava.cache.LocalCache$Segment.get(LocalCache.java:2263)
       org.sparkproject.guava.cache.LocalCache.get(LocalCache.java:4000)
       org.sparkproject.guava.cache.LocalCache$LocalManualCache.get(LocalCache.java:4789)
       org.apache.spark.sql.catalyst.catalog.SessionCatalog.getCachedPlan(SessionCatalog.scala:174)
       org.apache.spark.sql.execution.datasources.FindDataSourceTable.org$apache$spark$sql$execution$datasources$FindDataSourceTable$$readDataSourceTable(DataSourceStrategy.scala:240)
       [...]
     Caused by: java.lang.IllegalArgumentException: Cannot find columns: 'country:simple' in the schema[StructField(_hoodie_commit_time,StringType,true),StructField(_hoodie_commit_seqno,StringType,true),StructField(_hoodie_record_key,StringType,true),StructField(_hoodie_partition_path,StringType,true),StructField(_hoodie_file_name,StringType,true),StructField(key,StringType,true),StructField(country,StringType,true),StructField(ts,LongType,true),StructField(nested_record,StructType(StructField(nested_int,IntegerType,true)),true),StructField(record_map,MapType(StringType,StructType(StructField(nested_int,IntegerType,true)),true),true),StructField(primitive_map,MapType(StringType,StringType,true),true),StructField(primitive_array,ArrayType(IntegerType,true),true),StructField(int_date,DateType,true),StructField(long_timestamp_millis,TimestampType,true),StructField(long_timestamp_micros,TimestampType,true),StructField(long_timestamp_millis_local,LongType,true),StructField(long_timestamp_micros_local,LongType,true),StructField(bytes_decimal,DecimalType(4,2),true)]
       org.apache.hudi.SparkHoodieTableFileIndex._partitionSchemaFromProperties$lzycompute(SparkHoodieTableFileIndex.scala:136)
       org.apache.hudi.SparkHoodieTableFileIndex._partitionSchemaFromProperties(SparkHoodieTableFileIndex.scala:110)
       org.apache.hudi.SparkHoodieTableFileIndex.partitionSchema(SparkHoodieTableFileIndex.scala:170)
       org.apache.hudi.BaseFileOnlyRelation.toHadoopFsRelation(BaseFileOnlyRelation.scala:156)
       org.apache.hudi.DefaultSource$.resolveBaseFileOnlyRelation(DefaultSource.scala:345)
       [...]
```


### Impact

Fix failures for backwards compatibility issues for 1.x binary + table version 6. 

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
