### PR TITLE
[HUDI-9216] Fallback to spark.catalog.currentDatabase if tableConfig.databaseName is null or empty

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -538,7 +538,7 @@ object HoodieFileIndex extends Logging {
       properties.setProperty(PARTITIONPATH_FIELD.key, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(tableConfig).orElse(""))
 
       // for simple bucket index, we need to set the INDEX_TYPE, BUCKET_INDEX_HASH_FIELD, BUCKET_INDEX_NUM_BUCKETS
-      val database = getDatabaseName(tableConfig)
+      val database = getDatabaseName(tableConfig, spark.catalog.currentDatabase)
       val tableName = tableConfig.getTableName
 
       if (spark.catalog.tableExists(database, tableName)) {
@@ -615,9 +615,11 @@ object HoodieFileIndex extends Logging {
   }
 
   // if database name is not set, fall back to use 'default' instead of failing
-  def getDatabaseName(tableConfig: HoodieTableConfig)  = {
-    if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName)) {
+  def getDatabaseName(tableConfig: HoodieTableConfig, defaultDatabase: String)  = {
+    if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName) && StringUtils.isNullOrEmpty(defaultDatabase)) {
       "default"
+    } else if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName)) {
+      defaultDatabase
     } else {
       tableConfig.getDatabaseName
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import javax.annotation.concurrent.NotThreadSafe
+
 import java.text.SimpleDateFormat
 import java.util.stream.Collectors
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -44,7 +44,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import javax.annotation.concurrent.NotThreadSafe
-
 import java.text.SimpleDateFormat
 import java.util.stream.Collectors
 
@@ -616,10 +615,12 @@ object HoodieFileIndex extends Logging {
 
   // if database name is not set, fall back to use 'default' instead of failing
   def getDatabaseName(tableConfig: HoodieTableConfig, defaultDatabase: String)  = {
-    if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName) && StringUtils.isNullOrEmpty(defaultDatabase)) {
-      "default"
-    } else if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName)) {
-      defaultDatabase
+    if (StringUtils.isNullOrEmpty(tableConfig.getDatabaseName)) {
+      if (StringUtils.isNullOrEmpty(defaultDatabase)) {
+        "default"
+      } else {
+        defaultDatabase
+      }
     } else {
       tableConfig.getDatabaseName
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
@@ -22,14 +22,13 @@ package org.apache.spark.sql.hudi
 import org.apache.hudi.HoodieFileIndex
 import org.apache.hudi.common.table.HoodieTableConfig
 
-import org.apache.spark.sql.hive.test.TestHive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class TestHoodieFileIndex {
   @Test
   def testDefaultDatabaseName(): Unit = {
-    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), null), "default")
-    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), TestHive.sparkSession.catalog.currentDatabase), "default")
+    assertEquals("default", HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), null))
+    assertEquals("default_db", HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), "default_db"))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestHoodieFileIndex.scala
@@ -22,12 +22,14 @@ package org.apache.spark.sql.hudi
 import org.apache.hudi.HoodieFileIndex
 import org.apache.hudi.common.table.HoodieTableConfig
 
+import org.apache.spark.sql.hive.test.TestHive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class TestHoodieFileIndex {
   @Test
   def testDefaultDatabaseName(): Unit = {
-    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig()), "default")
+    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), null), "default")
+    assertEquals(HoodieFileIndex.getDatabaseName(new HoodieTableConfig(), TestHive.sparkSession.catalog.currentDatabase), "default")
   }
 }


### PR DESCRIPTION
### Change Logs

1.x spark reader tries to return the database as "default" instead of the database found in the sparkSession causing validation failures. 

### Impact

A user can take a hudi basePath, register it their own catalog with the database name of their choice and do spark SQL queries on it. 

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed