### PR TITLE
[HUDI-9220] Cannot find write operation type if run inline log compaction

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -100,6 +100,8 @@ public enum WriteOperationType {
         return INDEX;
       case "alter_schema":
         return ALTER_SCHEMA;
+      case "logcompact":
+        return LOG_COMPACT;
       case "unknown":
         return UNKNOWN;
       default:

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -55,7 +55,7 @@ public enum WriteOperationType {
   // alter schema
   ALTER_SCHEMA("alter_schema"),
   // log compact
-  LOG_COMPACT("logcompact"),
+  LOG_COMPACT("log_compact"),
   // used for old version
   UNKNOWN("unknown");
 
@@ -100,7 +100,7 @@ public enum WriteOperationType {
         return INDEX;
       case "alter_schema":
         return ALTER_SCHEMA;
-      case "logcompact":
+      case "log_compact":
         return LOG_COMPACT;
       case "unknown":
         return UNKNOWN;


### PR DESCRIPTION
### Change Logs
Fix that cannot find write operation type during inline log-compaction.

### Impact

recognizes operation type for writes

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
