### PR TITLE
[HUDI-9133] Fallback to legacy schema fetching in case of IllegalAccessError from schema registry client

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -172,7 +171,7 @@ class TestSchemaRegistryProvider {
     when(failingParsedSchema.canonicalString()).thenThrow(new IllegalAccessError("tried to access field org.apache.avro.Schema.FACTORY from class org.apache.avro.Schemas"));
     // Override the existing parseSchema behavior on the mock registry client so that it returns our failingParsedSchema
     when(mockRegistryClient.parseSchema("AVRO", RAW_SCHEMA, Collections.emptyList()))
-        .thenReturn(Optional.of(failingParsedSchema));
+        .thenReturn(java.util.Optional.of(failingParsedSchema));
     // Stub the legacy fallback method to return a known fallback schema string.
     SchemaRegistryProvider spyProvider = spy(provider);
     final String FALLBACK_SCHEMA = "{\"type\": \"record\", \"namespace\": \"example.fallback\", \"name\": \"Fallback\", \"fields\": []}";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -31,12 +31,16 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -156,5 +160,26 @@ class TestSchemaRegistryProvider {
     assertNotNull(actual);
     assertEquals(getExpectedSchema(), actual);
     verify(mockRestService, never()).setHttpHeaders(any());
+  }
+
+  @Test
+  public void testFallbackWhenIllegalAccessErrorThrown() throws Exception {
+    TypedProperties props = getProps();
+    // Create an instance with useConverter=false (so canonicalString() is used)
+    SchemaRegistryProvider provider = getUnderTest(props, -1, false);
+    // Simulate failure by making canonicalString() throw IllegalAccessError.
+    ParsedSchema failingParsedSchema = mock(ParsedSchema.class);
+    when(failingParsedSchema.canonicalString()).thenThrow(new IllegalAccessError("tried to access field org.apache.avro.Schema.FACTORY from class org.apache.avro.Schemas"));
+    // Override the existing parseSchema behavior on the mock registry client so that it returns our failingParsedSchema
+    when(mockRegistryClient.parseSchema("AVRO", RAW_SCHEMA, Collections.emptyList()))
+        .thenReturn(Optional.of(failingParsedSchema));
+    // Stub the legacy fallback method to return a known fallback schema string.
+    SchemaRegistryProvider spyProvider = spy(provider);
+    final String FALLBACK_SCHEMA = "{\"type\": \"record\", \"namespace\": \"example.fallback\", \"name\": \"Fallback\", \"fields\": []}";
+    doReturn(FALLBACK_SCHEMA).when(spyProvider).fetchSchemaUsingLegacyMethod(anyString());
+    // Invoke the method; the IllegalAccessError should be caught and fallback used.
+    Schema schema = spyProvider.getSourceSchema();
+    // Verify that the fallback schema is returned.
+    assertEquals(new Schema.Parser().parse(FALLBACK_SCHEMA), schema);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
     <pulsar.spark.scala12.version>3.1.1.4</pulsar.spark.scala12.version>
     <pulsar.spark.scala13.version>3.4.1.1</pulsar.spark.scala13.version>
-    <confluent.version>5.5.0</confluent.version>
+    <confluent.version>6.2.15</confluent.version>
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
     <pulsar.spark.scala12.version>3.1.1.4</pulsar.spark.scala12.version>
     <pulsar.spark.scala13.version>3.4.1.1</pulsar.spark.scala13.version>
-    <confluent.version>6.2.15</confluent.version>
+    <confluent.version>5.5.0</confluent.version>
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>


### PR DESCRIPTION
### Change Logs

Confluent 5.5.0 implementation of `ParsedSchema::canonicalString` accessed Avro's `Schema.FACTORY` in the incorrect way. See https://github.com/confluentinc/schema-registry/issues/1432
This was fixed later [here](https://github.com/confluentinc/schema-registry/pull/1742/files#diff-c050108d2e79a497d4150248a9fca3d516baf47c225155c543e44ca86039d85c). 

But, upgrading the version confluent version leads to dependency conflict with Guava. So, this patch adds a fallback to the previous way of fetching schema if the schema type is not Protobuf.

### Impact

Fix regression with fetching Avro/Json schema.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
