### PR TITLE
[HUDI-9216] Ignore validation of empty databaseName in HoodieTableMetaClient

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1375,7 +1375,7 @@ public class HoodieTableMetaClient implements Serializable {
 
       tableConfig.setAll(others);
 
-      if (databaseName != null) {
+      if (!StringUtils.isNullOrEmpty(databaseName)) {
         tableConfig.setValue(HoodieTableConfig.DATABASE_NAME, databaseName);
       }
       tableConfig.setValue(HoodieTableConfig.NAME, tableName);

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieHFileInputFormat.java
@@ -299,8 +299,8 @@ public class TestHoodieHFileInputFormat {
 
     metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, "");
-    assertEquals("", metaClient.getTableConfig().getDatabaseName(),
-        "The hoodie.database.name should be empty");
+    assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
+        "The hoodie.database.name will be null if set to empty");
 
     files = inputFormat.listStatus(jobConf);
     assertEquals(10, files.length,

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -396,8 +396,8 @@ public class TestHoodieParquetInputFormat {
 
     metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultStorageConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
         baseFileFormat, "");
-    assertEquals("", metaClient.getTableConfig().getDatabaseName(),
-        "The hoodie.database.name should be empty");
+    assertEquals(null, metaClient.getTableConfig().getDatabaseName(),
+        "The hoodie.database.name will be null if set to empty");
 
     files = inputFormat.listStatus(jobConf);
     assertEquals(10, files.length,

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
@@ -1,0 +1,29 @@
+package org.apache.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+import org.apache.hudi.util.JavaScalaConverters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getMetaClientBuilder;
+
+class TestHoodieWriterUtils extends HoodieClientTestBase {
+
+  @Test
+  void validateTableConfig() throws IOException {
+    HoodieTableMetaClient tableMetaClient = getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, new Properties(), "")
+        .initTable(storageConf, tempDir.resolve("table1").toString());
+    HoodieTableConfig tableConfig = tableMetaClient.getTableConfig();
+    TypedProperties properties = new TypedProperties(tableConfig.getProps());
+    properties.put(HoodieTableConfig.DATABASE_NAME.key(), "databaseFromCatalog");
+    Assertions.assertDoesNotThrow(() -> HoodieWriterUtils.validateTableConfig(sparkSession, JavaScalaConverters.convertJavaPropertiesToScalaMap(properties), tableConfig));
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi;
 
 import org.apache.hudi.common.config.TypedProperties;


### PR DESCRIPTION
### Change Logs

If user passes a different value of `hoodie.database.name` in properties, the validation can be ignored if tableConfig (content in hoodie.properties) contains null/empty string in it. This is primarily for use-cases, where there's an external table created with 0.x, initializing the table using 1.x adds `hoodie.database.name` in hoodie.properties as empty string and the validation keeps failing after that.

In the current PR we are removing both - the validation for empty `hoodie.database.name` and not setting `hoodie.database.name` in tableConfig if it's null or empty.

### Impact

Low

### Risk level (write none, low medium or high below)

Medium 

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
