### PR TITLE
[HUDI-9227] Fix bulk insert overwrite after a failed insert

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -80,6 +80,7 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
   }
 
   private HoodieWriteMetadata<JavaRDD<WriteStatus>> buildHoodieWriteMetadata(Option<HoodieData<WriteStatus>> writeStatuses) {
+    table.getMetaClient().reloadActiveTimeline();
     return writeStatuses.map(statuses -> {
       // cache writeStatusRDD, so that all actions before this are not triggered again for future
       statuses.persist(writeConfig.getString(WRITE_STATUS_STORAGE_LEVEL_VALUE), writeClient.getEngineContext(), HoodieData.HoodieDataCacheKey.of(writeConfig.getBasePath(), instantTime));

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -23,7 +23,9 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
-import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.common.table.timeline.HoodieInstant.State
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.{HoodieDuplicateKeyException, HoodieException}
@@ -1281,6 +1283,46 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
               checkAnswer(s"select id, name, price, dt from $target order by id")(Seq.empty: _*)
             }
           }
+        }
+      }
+    }
+  }
+
+  test("Test bulk insert overwrite with rollback") {
+    withSQLConf("hoodie.spark.sql.insert.into.operation" -> "bulk_insert") {
+      withTempDir { tmp =>
+        withTable(generateTableName) { tableName =>
+          val tableLocation = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  dt int
+               |) using hudi
+               | tblproperties (
+               |  type = 'cow',
+               |  primaryKey = 'id'
+               | ) partitioned by (dt)
+               | location '$tableLocation'
+               | """.stripMargin)
+
+          spark.sql(s"insert overwrite table $tableName partition (dt) values(1, 'a1', 10)")
+          checkAnswer(s"select id, name, dt from $tableName order by id")(
+            Seq(1, "a1", 10)
+          )
+
+          // Simulate a insert overwrite failure
+          val metaClient = createMetaClient(spark, tableLocation)
+          val instant = metaClient.createNewInstantTime()
+          val timeline = HoodieTestUtils.TIMELINE_FACTORY.createActiveTimeline(metaClient)
+          timeline.createNewInstant(metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
+          timeline.createNewInstant(metaClient.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
+
+          spark.sql(s"insert overwrite table $tableName partition (dt) values(1, 'a1', 10)")
+          checkAnswer(s"select id, name, dt from $tableName order by id")(
+            Seq(1, "a1", 10)
+          )
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/TestInsertTable.scala
@@ -23,7 +23,6 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
-import org.apache.hudi.common.table.timeline.HoodieInstant.State
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.{Option => HOption}
@@ -1316,8 +1315,10 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
           val metaClient = createMetaClient(spark, tableLocation)
           val instant = metaClient.createNewInstantTime()
           val timeline = HoodieTestUtils.TIMELINE_FACTORY.createActiveTimeline(metaClient)
-          timeline.createNewInstant(metaClient.createNewInstant(State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
-          timeline.createNewInstant(metaClient.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
+          timeline.createNewInstant(metaClient.createNewInstant(
+            HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
+          timeline.createNewInstant(metaClient.createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))
 
           spark.sql(s"insert overwrite table $tableName partition (dt) values(1, 'a1', 10)")
           checkAnswer(s"select id, name, dt from $tableName order by id")(


### PR DESCRIPTION
### Change Logs

Fix bulk insert overwrite after a failed insert

```sql
set hoodie.spark.sql.insert.into.operation=bulk_insert;

create table t(
  id int,
  name string,
  dt int
) using hudi
 tblproperties (
  type = 'cow',
  primaryKey = 'id'
 ) partitioned by (dt);

-- kill this
insert overwrite table t partition (dt) values(1, 'a1', 10);

-- rerun will raise exception
insert overwrite table t partition (dt) values(1, 'a1', 10);
```


```
Caused by: org.apache.hudi.exception.HoodieIOException: Failed to check emptiness of instant [==>20250327073905540__replacecommit__REQUESTED]
	at org.apache.hudi.common.table.timeline.TimelineUtils.isEmpty(TimelineUtils.java:616)
	at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.isEmpty(ActiveTimelineV2.java:755)
	at org.apache.hudi.common.util.ClusteringUtils.isEmptyReplaceOrClusteringInstant(ClusteringUtils.java:226)
	at org.apache.hudi.common.util.ClusteringUtils.getRequestedReplaceMetadata(ClusteringUtils.java:198)
	at org.apache.hudi.common.util.ClusteringUtils.getClusteringPlan(ClusteringUtils.java:259)
	at org.apache.hudi.common.util.ClusteringUtils.getClusteringPlan(ClusteringUtils.java:248)
	at org.apache.hudi.common.util.ClusteringUtils.lambda$getAllPendingClusteringPlans$0(ClusteringUtils.java:87)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at org.apache.hudi.common.util.ClusteringUtils.getAllFileGroupsInPendingClusteringPlans(ClusteringUtils.java:282)
	... 45 more
Caused by: java.io.FileNotFoundException: File file:/private/var/folders/px/y3gybll50ggctcjp2t4r2b500000gp/T/spark-c259d9c8-c882-46c6-b52b-722c77922855/h1/.hoodie/timeline/20250327073905540.replacecommit.requested does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:779)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1100)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:769)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
	at org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem.lambda$getFileStatus$17(HoodieWrapperFileSystem.java:415)
	at org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem.executeFuncWithTimeMetrics(HoodieWrapperFileSystem.java:118)
	at org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem.getFileStatus(HoodieWrapperFileSystem.java:409)
	at org.apache.hudi.storage.hadoop.HoodieHadoopStorage.getPathInfo(HoodieHadoopStorage.java:170)
	at org.apache.hudi.common.table.timeline.TimelineUtils.isEmpty(TimelineUtils.java:613)
	... 59 more
```

### Impact

Fix this

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
