### PR TITLE
[HUDI-9228] Support rowdata writing for MOR table with consistent buc…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
@@ -57,7 +57,7 @@ public class HoodieFlinkRecord extends HoodieRecord<RowData> {
 
   @Override
   public HoodieRecord<RowData> newInstance() {
-    return new HoodieFlinkRecord(this.data);
+    return new HoodieFlinkRecord(key, operation, orderingValue, data);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -42,7 +42,6 @@ import org.apache.hudi.table.format.FilePathUtils;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.types.logical.RowType;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -79,7 +78,7 @@ public class OptionsResolver {
    * <p> support RowData append for COW, see HUDI-9149
    * <p> support RowData append for operation besides UPSERT/DELETE, see HUDI-9149
    */
-  public static boolean supportRowDataAppend(Configuration conf, RowType rowType) {
+  public static boolean supportRowDataAppend(Configuration conf) {
     return conf.get(FlinkOptions.INSERT_ROWDATA_MODE_ENABLED)
         && HoodieTableType.valueOf(conf.get(FlinkOptions.TABLE_TYPE)) == HoodieTableType.MERGE_ON_READ
         && (WriteOperationType.valueOf(conf.get(FlinkOptions.OPERATION).toUpperCase()) == WriteOperationType.UPSERT

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/RowDataStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/RowDataStreamWriteFunction.java
@@ -496,7 +496,7 @@ public class RowDataStreamWriteFunction extends AbstractStreamWriteFunction<Hood
     return ret;
   }
 
-  private interface WriteFunction {
+  protected interface WriteFunction {
     List<WriteStatus> write(Iterator<HoodieRecord> records, BucketInfo bucketInfo, String instant);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.types.logical.RowType;
 public class StreamWriteOperator extends AbstractWriteOperator<HoodieFlinkInternalRow> {
 
   public StreamWriteOperator(Configuration conf, RowType rowType) {
-    super(OptionsResolver.supportRowDataAppend(conf, rowType)
+    super(OptionsResolver.supportRowDataAppend(conf)
         ? new RowDataStreamWriteFunction(conf, rowType) : new StreamWriteFunction(conf, rowType));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/RowDataConsistentBucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/RowDataConsistentBucketStreamWriteFunction.java
@@ -27,7 +27,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.sink.RowDataStreamWriteFunction;
 import org.apache.hudi.sink.buffer.RowDataBucket;
 import org.apache.hudi.sink.clustering.update.strategy.RowDataConsistentBucketUpdateStrategy;
-import org.apache.hudi.sink.clustering.update.strategy.RowDataConsistentBucketUpdateStrategy.RichRecords;
+import org.apache.hudi.sink.clustering.update.strategy.RowDataConsistentBucketUpdateStrategy.BucketRecords;
 import org.apache.hudi.util.MutableIteratorWrapperIterator;
 
 import org.apache.flink.configuration.Configuration;
@@ -89,11 +89,11 @@ public class RowDataConsistentBucketStreamWriteFunction extends RowDataStreamWri
     Iterator<HoodieRecord> recordItr = deduplicateRecordsIfNeeded(
         new MappingIterator<>(rowItr, rowData -> convertToRecord(rowData, rowDataBucket.getBucketInfo())));
 
-    Pair<List<RichRecords>, Set<HoodieFileGroupId>> recordListFgPair =
-        updateStrategy.handleUpdate(Collections.singletonList(RichRecords.of(recordItr, rowDataBucket.getBucketInfo(), instant)));
+    Pair<List<BucketRecords>, Set<HoodieFileGroupId>> recordListFgPair =
+        updateStrategy.handleUpdate(Collections.singletonList(BucketRecords.of(recordItr, rowDataBucket.getBucketInfo(), instant)));
 
     return recordListFgPair.getKey().stream()
-        .flatMap(richRecords -> writeFunction.write(richRecords.getRecordItr(), richRecords.getBucketInfo(), richRecords.getInstant()).stream())
+        .flatMap(bucketRecords -> writeFunction.write(bucketRecords.getRecordItr(), bucketRecords.getBucketInfo(), bucketRecords.getInstant()).stream())
         .collect(Collectors.toList());
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/RowDataConsistentBucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/RowDataConsistentBucketStreamWriteFunction.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.MappingIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.sink.RowDataStreamWriteFunction;
+import org.apache.hudi.sink.buffer.RowDataBucket;
+import org.apache.hudi.sink.clustering.update.strategy.FlinkConsistentBucketUpdateStrategy;
+import org.apache.hudi.table.action.commit.BucketInfo;
+import org.apache.hudi.table.action.commit.BucketType;
+import org.apache.hudi.util.MutableIteratorWrapperIterator;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A stream write function with consistent bucket hash index, and it writes flink RowData without Avro conversion.
+ * The function tags each incoming record with a location of a file based on consistent bucket index.
+ */
+public class RowDataConsistentBucketStreamWriteFunction extends RowDataStreamWriteFunction {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RowDataConsistentBucketStreamWriteFunction.class);
+
+  private transient FlinkConsistentBucketUpdateStrategy updateStrategy;
+
+  /**
+   * Constructs a RowDataConsistentBucketStreamWriteFunction.
+   *
+   * @param config  The config options
+   * @param rowType LogicalType of record
+   */
+  public RowDataConsistentBucketStreamWriteFunction(Configuration config, RowType rowType) {
+    super(config, rowType);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws IOException {
+    super.open(parameters);
+
+    List<String> indexKeyFields = Arrays.asList(config.getString(FlinkOptions.INDEX_KEY_FIELD).split(","));
+    this.updateStrategy = new FlinkConsistentBucketUpdateStrategy(this.writeClient, indexKeyFields);
+    LOG.info("Create update strategy with index key fields: {}", indexKeyFields);
+  }
+
+  @Override
+  public void snapshotState() {
+    super.snapshotState();
+    updateStrategy.reset();
+  }
+
+  @Override
+  protected List<WriteStatus> writeRecords(String instant, RowDataBucket rowDataBucket) {
+    writeMetrics.startFileFlush();
+    updateStrategy.initialize(this.writeClient);
+
+    Iterator<BinaryRowData> rowItr =
+        new MutableIteratorWrapperIterator<>(
+            rowDataBucket.getDataIterator(), () -> new BinaryRowData(rowType.getFieldCount()));
+    Iterator<HoodieRecord> recordItr = new MappingIterator<>(
+        rowItr, rowData -> convertToRecord(rowData, rowDataBucket.getBucketInfo()));
+    List<HoodieRecord> recordList = new ArrayList<>();
+    deduplicateRecordsIfNeeded(recordItr).forEachRemaining(recordList::add);
+
+    // save bucket info into the first record, which will be used in update strategy
+    String instantTime = rowDataBucket.getBucketInfo().getBucketType() == BucketType.INSERT ? "I" : "U";
+    HoodieRecordLocation recordLocation = new HoodieRecordLocation(instantTime, rowDataBucket.getBucketInfo().getFileIdPrefix());
+    recordList.get(0).setCurrentLocation(recordLocation);
+
+    Pair<List<Pair<List<HoodieRecord>, String>>, Set<HoodieFileGroupId>> recordListFgPair =
+        updateStrategy.handleUpdate(Collections.singletonList(Pair.of(recordList, instant)));
+
+    return recordListFgPair.getKey().stream().flatMap(
+        recordsInstantPair -> {
+          List<HoodieRecord> records = recordsInstantPair.getLeft();
+          BucketInfo bucketInfo = getBucketInfo(records.get(0));
+          return writeFunction.write(records.iterator(), bucketInfo, recordsInstantPair.getRight()).stream();
+        }).collect(Collectors.toList());
+  }
+
+  private static BucketInfo getBucketInfo(HoodieRecord hoodieRecord) {
+    BucketType bucketType;
+    ValidationUtils.checkArgument(hoodieRecord.getCurrentLocation() != null,
+        "The HoodieRecordLocation field should not be null for the first HoodieRecord.");
+    switch (hoodieRecord.getCurrentLocation().getInstantTime()) {
+      case "I":
+        bucketType = BucketType.INSERT;
+        break;
+      case "U":
+        bucketType = BucketType.UPDATE;
+        break;
+      default:
+        throw new HoodieException("Unexpected bucket type: " + hoodieRecord.getCurrentLocation().getInstantTime());
+    }
+    return new BucketInfo(bucketType, hoodieRecord.getCurrentLocation().getFileId(), hoodieRecord.getPartitionPath());
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/update/strategy/RowDataConsistentBucketUpdateStrategy.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/update/strategy/RowDataConsistentBucketUpdateStrategy.java
@@ -20,11 +20,8 @@ package org.apache.hudi.sink.clustering.update.strategy;
 
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.HoodieRecordLocation;
-import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ClusteringUtils;
@@ -34,6 +31,9 @@ import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.table.action.cluster.strategy.UpdateStrategy;
 import org.apache.hudi.table.action.cluster.util.ConsistentHashingUpdateStrategyUtils;
+import org.apache.hudi.table.action.commit.BucketInfo;
+import org.apache.hudi.sink.clustering.update.strategy.RowDataConsistentBucketUpdateStrategy.RichRecords;
+import org.apache.hudi.table.action.commit.BucketType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,22 +50,21 @@ import java.util.stream.Collectors;
 
 /**
  * Update strategy for consistent hashing bucket index. If updates to file groups that are under clustering are identified,
- * then the current batch of records will route to both old and new file groups
- * (i.e., dual write).
- *
- * TODO: remove this class when RowData mode writing is supported for COW.
+ * then the current batch of records will route to both old and new file groups, i.e., dual write.
  */
-public class FlinkConsistentBucketUpdateStrategy<T extends HoodieRecordPayload> extends UpdateStrategy<T, List<Pair<List<HoodieRecord>, String>>> {
+public class RowDataConsistentBucketUpdateStrategy<T> extends UpdateStrategy<T, List<RichRecords>> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FlinkConsistentBucketUpdateStrategy.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RowDataConsistentBucketUpdateStrategy.class);
 
   private boolean initialized = false;
   private final List<String> indexKeyFields;
   private final Map<String, Pair<String, ConsistentBucketIdentifier>> partitionToIdentifier;
   private String lastRefreshInstant = HoodieTimeline.INIT_INSTANT_TS;
 
-  public FlinkConsistentBucketUpdateStrategy(HoodieFlinkWriteClient writeClient, List<String> indexKeyFields) {
+  public RowDataConsistentBucketUpdateStrategy(
+      HoodieFlinkWriteClient writeClient, List<String> indexKeyFields) {
     super(writeClient.getEngineContext(), writeClient.getHoodieTable(), Collections.emptySet());
+
     this.indexKeyFields = indexKeyFields;
     this.partitionToIdentifier = new HashMap<>();
   }
@@ -95,47 +95,49 @@ public class FlinkConsistentBucketUpdateStrategy<T extends HoodieRecordPayload> 
   }
 
   @Override
-  public Pair<List<Pair<List<HoodieRecord>, String>>, Set<HoodieFileGroupId>> handleUpdate(List<Pair<List<HoodieRecord>, String>> recordsList) {
+  public Pair<List<RichRecords>, Set<HoodieFileGroupId>> handleUpdate(List<RichRecords> richRecordsList) {
     ValidationUtils.checkArgument(initialized, "Strategy has not been initialized");
-    ValidationUtils.checkArgument(recordsList.size() == 1);
+    ValidationUtils.checkArgument(richRecordsList.size() == 1);
 
-    Pair<List<HoodieRecord>, String> recordsInstantPair = recordsList.get(0);
-    HoodieRecord sampleRecord = recordsInstantPair.getLeft().get(0);
-    HoodieFileGroupId fileId = new HoodieFileGroupId(sampleRecord.getPartitionPath(), sampleRecord.getCurrentLocation().getFileId());
+    RichRecords richRecords = richRecordsList.get(0);
+    BucketInfo bucketInfo = richRecords.getBucketInfo();
+    HoodieFileGroupId fileId = new HoodieFileGroupId(bucketInfo.getPartitionPath(), bucketInfo.getFileIdPrefix());
     if (!needDualWrite(fileId)) {
-      return Pair.of(recordsList, Collections.singleton(fileId));
+      return Pair.of(richRecordsList, Collections.singleton(fileId));
     }
-
-    return doHandleUpdate(fileId, recordsInstantPair);
+    return doHandleUpdate(fileId, richRecords);
   }
 
   public boolean needDualWrite(HoodieFileGroupId fileId) {
     return !fileGroupsInPendingClustering.isEmpty() && fileGroupsInPendingClustering.contains(fileId);
   }
 
-  private Pair<List<Pair<List<HoodieRecord>, String>>, Set<HoodieFileGroupId>> doHandleUpdate(HoodieFileGroupId fileId, Pair<List<HoodieRecord>, String> recordsInstantPair) {
+  private Pair<List<RichRecords>, Set<HoodieFileGroupId>> doHandleUpdate(HoodieFileGroupId fileId, RichRecords richRecords) {
     Pair<String, ConsistentBucketIdentifier> bucketIdentifierPair = getBucketIdentifierOfPartition(fileId.getPartitionPath());
     String clusteringInstant = bucketIdentifierPair.getLeft();
     ConsistentBucketIdentifier identifier = bucketIdentifierPair.getRight();
 
+    List<HoodieRecord> records = new ArrayList<>();
+    richRecords.getRecordItr().forEachRemaining(records::add);
     // Construct records list routing to new file groups according the new bucket identifier
-    Map<String, List<HoodieRecord>> fileIdToRecords = recordsInstantPair.getLeft().stream().map(HoodieRecord::newInstance)
+    Map<String, List<HoodieRecord>> fileIdToRecords = records.stream().map(HoodieRecord::newInstance)
         .collect(Collectors.groupingBy(r -> identifier.getBucket(r.getKey(), indexKeyFields).getFileIdPrefix()));
 
     // Tag first record with the corresponding fileId & clusteringInstantTime
-    List<Pair<List<HoodieRecord>, String>> recordsList = new ArrayList<>();
+    List<RichRecords> richRecordsList = new ArrayList<>();
     Set<HoodieFileGroupId> fgs = new LinkedHashSet<>();
     for (Map.Entry<String, List<HoodieRecord>> e : fileIdToRecords.entrySet()) {
       String newFileId = FSUtils.createNewFileId(e.getKey(), 0);
-      patchFileIdToRecords(e.getValue(), newFileId);
-      recordsList.add(Pair.of(e.getValue(), clusteringInstant));
+      BucketInfo bucketInfo = new BucketInfo(BucketType.UPDATE, newFileId, richRecords.getBucketInfo().getPartitionPath());
+      richRecordsList.add(RichRecords.of(e.getValue().iterator(), bucketInfo, clusteringInstant));
       fgs.add(new HoodieFileGroupId(fileId.getPartitionPath(), newFileId));
     }
     LOG.info("Apply duplicate update for FileGroup {}, routing records to: {}.", fileId, String.join(",", fileIdToRecords.keySet()));
     // TODO add option to skip dual update, i.e., write updates only to the new file group
-    recordsList.add(recordsInstantPair);
+    // `recordItr` inside `richRecords` is based on MutableObjectIterator, which is one-time iterator and cannot be reused.
+    richRecordsList.add(RichRecords.of(records.iterator(), richRecords.getBucketInfo(), richRecords.getInstant()));
     fgs.add(fileId);
-    return Pair.of(recordsList, fgs);
+    return Pair.of(richRecordsList, fgs);
   }
 
   private Pair<String, ConsistentBucketIdentifier> getBucketIdentifierOfPartition(String partition) {
@@ -143,14 +145,31 @@ public class FlinkConsistentBucketUpdateStrategy<T extends HoodieRecordPayload> 
     );
   }
 
-  /**
-   * Rewrite the first record with given fileID
-   */
-  private void patchFileIdToRecords(List<HoodieRecord> records, String fileId) {
-    HoodieRecord first = records.get(0);
-    HoodieRecord record = new HoodieAvroRecord<>(first.getKey(), (HoodieRecordPayload) first.getData(), first.getOperation());
-    HoodieRecordLocation newLoc = new HoodieRecordLocation("U", fileId);
-    record.setCurrentLocation(newLoc);
-    records.set(0, record);
+  public static class RichRecords {
+    private final Iterator<HoodieRecord> recordItr;
+    private final BucketInfo bucketInfo;
+    private final String instant;
+
+    private RichRecords(Iterator<HoodieRecord> recordItr, BucketInfo bucketInfo, String instant) {
+      this.recordItr = recordItr;
+      this.bucketInfo = bucketInfo;
+      this.instant = instant;
+    }
+
+    public static RichRecords of(Iterator<HoodieRecord> recordItr, BucketInfo bucketInfo, String instant) {
+      return new RichRecords(recordItr, bucketInfo, instant);
+    }
+
+    public Iterator<HoodieRecord> getRecordItr() {
+      return this.recordItr;
+    }
+
+    public BucketInfo getBucketInfo() {
+      return this.bucketInfo;
+    }
+
+    public String getInstant() {
+      return this.instant;
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
@@ -149,7 +149,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   }
 
   public Map<String, List<HoodieRecord>> getDataBuffer() {
-    if (OptionsResolver.supportRowDataAppend(conf, rowType)) {
+    if (OptionsResolver.supportRowDataAppend(conf)) {
       return ((RowDataStreamWriteFunction) writeFunction).getDataBuffer();
     } else {
       return ((StreamWriteFunction) writeFunction).getDataBuffer();
@@ -232,7 +232,7 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   }
 
   protected AbstractStreamWriteFunction createWriteFunction() {
-    if (OptionsResolver.supportRowDataAppend(conf, rowType)) {
+    if (OptionsResolver.supportRowDataAppend(conf)) {
       return new RowDataBucketStreamWriteFunction(conf, rowType);
     } else {
       return new BucketStreamWriteFunction(conf, rowType);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
@@ -19,9 +19,11 @@
 package org.apache.hudi.sink.utils;
 
 import org.apache.hudi.client.model.HoodieFlinkInternalRow;
-import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.sink.bucket.ConsistentBucketAssignFunction;
 import org.apache.hudi.sink.bucket.ConsistentBucketStreamWriteFunction;
+import org.apache.hudi.sink.bucket.RowDataConsistentBucketStreamWriteFunction;
+import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -60,8 +62,12 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
   }
 
   @Override
-  protected StreamWriteFunction createWriteFunction() {
-    return new ConsistentBucketStreamWriteFunction(conf, rowType);
+  protected AbstractStreamWriteFunction createWriteFunction() {
+    if (OptionsResolver.supportRowDataAppend(conf)) {
+      return new RowDataConsistentBucketStreamWriteFunction(conf, rowType);
+    } else {
+      return new ConsistentBucketStreamWriteFunction(conf, rowType);
+    }
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -191,7 +191,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public Map<String, List<HoodieRecord>> getDataBuffer() {
-    if (OptionsResolver.supportRowDataAppend(conf, rowType)) {
+    if (OptionsResolver.supportRowDataAppend(conf)) {
       return ((RowDataStreamWriteFunction) writeFunction).getDataBuffer();
     } else {
       return ((StreamWriteFunction) writeFunction).getDataBuffer();
@@ -307,7 +307,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   // -------------------------------------------------------------------------
 
   private void setupWriteFunction() throws Exception {
-    if (OptionsResolver.supportRowDataAppend(conf, rowType)) {
+    if (OptionsResolver.supportRowDataAppend(conf)) {
       this.writeFunction = new RowDataStreamWriteFunction(conf, rowType);
     } else {
       this.writeFunction = new StreamWriteFunction(conf, rowType);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -638,7 +638,7 @@ public class TestWriteBase {
 
   protected boolean supportRowDataAppend(Configuration conf) {
     RowType rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
-    return OptionsResolver.supportRowDataAppend(conf, rowType);
+    return OptionsResolver.supportRowDataAppend(conf);
   }
 
   protected TestHarness preparePipeline(Configuration conf) throws Exception {


### PR DESCRIPTION
…ket index

### Change Logs

Support rowdata mode writing for MOR table with consistent bucket index.

### Impact

Enhance write performance for consistent bucket index by eliminating AVRO SerDe.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
