### PR TITLE
[HUDI-9231]Show complete DAG for one single query in spark web ui while inserting into hudi table

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -207,15 +207,7 @@ class HoodieSparkSqlWriterInternal {
       }
       toReturn
     }
-
-    val executionId = getExecutionId(sqlContext.sparkContext, sourceDf.queryExecution)
-    if (executionId.isEmpty) {
-      sparkAdapter.sqlExecutionWithNewExecutionId(sourceDf.sparkSession, sourceDf.queryExecution, Option("Hudi Command"))(
-        retryWrite.apply()
-      )
-    } else {
-      retryWrite.apply()
-    }
+    retryWrite()
   }
 
   private def writeInternal(sqlContext: SQLContext,


### PR DESCRIPTION
### Change Logs

While inserting into hudi table，the DAG in the Spark web ui is not fully displayed，missing the DAG for subquery of insert into statement。Although [HUDI-5956](https://issues.apache.org/jira/browse/HUDI-5956) has enabled subquery DAG display in sub-execution, it remains insufficiently user-friendly.

### Fix steps：
- Moving `alignedQuery` to analysis phase
- Adjusting parent class  of `InsertIntoHudiTableCommand` and `CreateHoodieTableAsSelectCommand` to `DataWritingCommand`
- use `sparkPlan` of `DataWritingCommand` to generate the DataFrame

Before:
![image](https://github.com/user-attachments/assets/d01c9f30-07be-4e69-a03a-4d48f5741231)
![image](https://github.com/user-attachments/assets/4cb134ad-39e7-42c7-89c1-4811b6766083)
![image](https://github.com/user-attachments/assets/b3bcc8ab-21e5-4f93-b725-cf80fe18c2ae)


After:
![image](https://github.com/user-attachments/assets/d07e6051-b530-490c-9a4b-dc2001d34604)

![image](https://github.com/user-attachments/assets/3611a8ce-2beb-49c8-a80b-42e7ea0d5e88)


### Related Issues and Pull Requests
https://github.com/apache/hudi/issues/9944
https://github.com/apache/hudi/pull/11376

### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
