### PR TITLE
[HUDI-9239]Fix the bug of Spark Cache not releasing cleanly

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieData.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.function.SerializablePairFunction;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.storage.StoragePath;
 
 import java.io.Serializable;
 import java.util.Iterator;
@@ -227,7 +228,7 @@ public interface HoodieData<T> extends Serializable {
   class HoodieDataCacheKey implements Serializable {
 
     public static HoodieDataCacheKey of(String basePath, String instantTime) {
-      return new HoodieDataCacheKey(basePath, instantTime);
+      return new HoodieDataCacheKey(new StoragePath(basePath).toString(), instantTime);
     }
 
     private final String basePath;


### PR DESCRIPTION
### Change Logs

For now using basePath String as Cache Key

for the extra `\` ( DFS consider the paths to be the same), the cache is released strictly according to the string comparison and is considered to be different paths, resulting in unclean release.

For Example

Put in Cache
<img width="1431" alt="截屏2025-03-23 22 52 27" src="https://github.com/user-attachments/assets/7c5f4187-0daf-4d60-82d6-468b8de31fbe" />

Check cache key during release cache stage
<img width="1446" alt="截屏2025-03-23 22 48 33" src="https://github.com/user-attachments/assets/512f6488-9c1f-4163-9780-cc64cb4aba3e" />




### Impact

Spark Cache release

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
