### PR TITLE
[MINOR] Fix NumberFormatException while updating metrics for MDT in table version 6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -57,6 +57,12 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I> extends 
   /**
    * Hudi backed table metadata writer.
    *
+   * Timestamps are generated in format {@link org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator#MILLIS_INSTANT_TIMESTAMP_FORMAT}.
+   * For operations like compaction, log compaction, clean, index and rollback - suffix are used which are appended to the timestamp. In some cases
+   * it is possible for suffix to be added twice. For instance, there is an index commit in metadata table leading to an instant with 010 suffix in
+   * the timeline. If compaction triggers now, the compaction would use the index instant timestamp and add 001 suffix to it, creating a timestamp
+   * value with suffix 010001. Both indexing and compaction suffix would be present in the compaction timestamp in such a case.
+   *
    * @param storageConf                Storage configuration to use for the metadata writer
    * @param writeConfig                Writer config
    * @param failedWritesCleaningPolicy Cleaning policy on failed writes

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -457,9 +457,9 @@ public class HoodieMetrics {
     Option<HoodieInstant> hoodieInstantOption = filteredInstants.lastInstant();
     if (hoodieInstantOption.isPresent()) {
       String requestedTime = hoodieInstantOption.get().requestedTime();
-      if (hoodieInstantOption.get().requestedTime().length() > MILLIS_INSTANT_TIMESTAMP_FORMAT_LENGTH) {
+      if (requestedTime.length() > MILLIS_INSTANT_TIMESTAMP_FORMAT_LENGTH) {
         // If requested instant is in MDT with table version six, it can contain suffix
-        requestedTime = requestedTime.substring(0, requestedTime.length() - 3);
+        requestedTime = requestedTime.substring(0, MILLIS_INSTANT_TIMESTAMP_FORMAT_LENGTH);
       }
       updateMetric(action, metricName, Long.parseLong(requestedTime));
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
@@ -295,8 +295,11 @@ public class TestHoodieMetrics {
     HoodieInstant instant008 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "1008");
     HoodieInstant instant0012 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "10012");
     HoodieInstant instant0014 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "10014");
+    HoodieInstant longInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "20250329154030600010001");
 
-    HoodieActiveTimeline activeTimeline3 = new MockHoodieActiveTimeline(instant002, instant003, instant006, instant008, instant0012, instant0014);
+    HoodieActiveTimeline activeTimeline3 = new MockHoodieActiveTimeline(instant002, instant003, instant006, instant008, instant0012, instant0014, longInstant);
+    // verify longer instant times can also be updated in the metrics. These are required for table version six
+    // where suffix is added at the end of older instants for compaction in the metadata timeline
     hoodieMetrics.updateTableServiceInstantMetrics(activeTimeline3);
 
     metricName = hoodieMetrics.getMetricsName(HoodieTimeline.COMPACTION_ACTION, HoodieMetrics.EARLIEST_PENDING_COMPACTION_INSTANT_STR);
@@ -306,7 +309,7 @@ public class TestHoodieMetrics {
     assertEquals((long)metrics.getRegistry().getGauges().get(metricName).getValue(), Long.valueOf("1006"));
 
     metricName = hoodieMetrics.getMetricsName(HoodieTimeline.COMPACTION_ACTION, HoodieMetrics.PENDING_COMPACTION_INSTANT_COUNT_STR);
-    assertEquals((long)metrics.getRegistry().getGauges().get(metricName).getValue(), 5L);
+    assertEquals((long)metrics.getRegistry().getGauges().get(metricName).getValue(), 6L);
   }
 
   private static class MockHoodieActiveTimeline extends ActiveTimelineV2 {


### PR DESCRIPTION
### Change Logs

With table version 6, MDT uses suffix `001` for compaction instants. This causes NumberFormatException while updating metrics while parsing the instant as Long. The PR fixes the issue to use only the timestamp while updating the metrics.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
