### PR TITLE
[MINOR] Upgrade jetty version to 9.4.57.v20241219 to fix CVE-2024-8184

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <surefire-log4j.file>log4j2-surefire.properties</surefire-log4j.file>
     <thrift.version>0.13.0</thrift.version>
     <javalin.version>4.6.7</javalin.version>
-    <jetty.version>9.4.53.v20231009</jetty.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <hbase.version>2.4.13</hbase.version>
     <h2.version>1.4.199</h2.version>


### PR DESCRIPTION
### Change Logs

This code change is made to update jetty version to fix CVE-2024-8184
### Impact

No impact. Fixes the vulnerability

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
