### PR TITLE
[DOCS] Data quality docs update

### DIFF
--- a/website/docs/precommit_validator.md
+++ b/website/docs/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/docs/precommit_validator.md
+++ b/website/docs/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/docs/precommit_validator.md
+++ b/website/docs/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.14.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.0/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/versioned_docs/version-0.14.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.0/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.14.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.0/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.14.1/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.1/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/versioned_docs/version-0.14.1/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.1/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.14.1/precommit_validator.md
+++ b/website/versioned_docs/version-0.14.1/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.15.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.15.0/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/versioned_docs/version-0.15.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.15.0/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-0.15.0/precommit_validator.md
+++ b/website/versioned_docs/version-0.15.0/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-1.0.0/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.0/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/versioned_docs/version-1.0.0/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.0/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-1.0.0/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.0/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-1.0.1/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.1/precommit_validator.md
@@ -8,7 +8,7 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
 :::note
-Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_operations#bulk_insert) write operation type.
 :::
 
 Multiple class names can be separated by `,` delimiter.

--- a/website/versioned_docs/version-1.0.1/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.1/precommit_validator.md
@@ -7,7 +7,13 @@ Data quality refers to the overall accuracy, completeness, consistency, and vali
 
 Hudi offers **Pre-Commit Validators** that allow you to ensure that your data meets certain data quality expectations as you are writing with Hudi Streamer or Spark Datasource writers.
 
-To configure pre-commit validators, use this setting `hoodie.precommit.validators=<comma separated list of validator class names>`.
+:::note
+Pre-commit validators are skipped when using the [BULK_INSERT](docs/write_operations#bulk_insert) write operation type.
+:::
+
+Multiple class names can be separated by `,` delimiter.
+
+Syntax: `class_name1,class_name2`
 
 Example:
 ```scala
@@ -49,6 +55,10 @@ This validator is useful when you want to verify that your query does not change
 - Validate that there are no duplicate records after your query runs
 - Validate that you are only updating the data, and no inserts slip through
 
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
+
 Example:
 ```scala
 // In this example, we set up a validator that expects no change of null rows with the new commit
@@ -66,6 +76,10 @@ df.write.format("hudi").mode(Overwrite).
 [org.apache.hudi.client.validator.SqlQueryInequalityPreCommitValidator](https://github.com/apache/hudi/blob/bf5a52e51bbeaa089995335a0a4c55884792e505/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java)
 
 The SQL Query Inquality validator runs a query before ingesting the data, then runs the same query after ingesting the data and confirms that both outputs DO NOT match. This allows you to confirm changes in the rows before and after the commit.
+
+Multiple queries can be separated by `;` delimiter.
+
+Syntax: `query1;query2`
 
 Example:
 ```scala

--- a/website/versioned_docs/version-1.0.1/precommit_validator.md
+++ b/website/versioned_docs/version-1.0.1/precommit_validator.md
@@ -13,7 +13,7 @@ Pre-commit validators are skipped when using the [BULK_INSERT](/docs/write_opera
 
 Multiple class names can be separated by `,` delimiter.
 
-Syntax: `class_name1,class_name2`
+Syntax: `hoodie.precommit.validators=class_name1,class_name2`
 
 Example:
 ```scala


### PR DESCRIPTION
### Change Logs

Context is missing about the fact that pre-commit validation is skipped when write mode is set to BULK_INSERT so I propose to add it because it is not obvious.
Also I tried to use the same syntax for information about separator and syntax usage for existing validator classes.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
