### PR TITLE
[HUDI-9246] Confine protobuf shading to the hudi-io package

### DIFF
--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -47,6 +47,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -59,6 +59,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
 
     <dependency>

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -83,7 +83,7 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
         kryo.addDefaultSerializer(classOf[Message], new ProtobufSerializer())
       }
     } catch {
-      case ClassNotFoundException => log.warn("Protobuf classes not found on the classpath, skipping Protobuf serializer registration.")
+      case _: ClassNotFoundException => log.warn("Protobuf classes not found on the classpath, skipping Protobuf serializer registration.")
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -18,7 +18,6 @@
 
 package org.apache.spark
 
-import org.apache.hudi.IncrementalRelationV1
 import org.apache.hudi.client.model.HoodieInternalRow
 import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -83,7 +83,7 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
         kryo.addDefaultSerializer(classOf[Message], new ProtobufSerializer())
       }
     } catch {
-      case _: ClassNotFoundException => log.warn("Protobuf classes not found on the classpath, skipping Protobuf serializer registration.")
+      case _: ClassNotFoundException | _: NoClassDefFoundError => log.warn("Protobuf classes not found on the classpath, skipping Protobuf serializer registration.")
     }
   }
 

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -107,6 +107,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
 
     <dependency>

--- a/hudi-hadoop-common/pom.xml
+++ b/hudi-hadoop-common/pom.xml
@@ -77,6 +77,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
 
     <!-- Hadoop -->

--- a/hudi-io/pom.xml
+++ b/hudi-io/pom.xml
@@ -96,6 +96,36 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <!-- native HFile reader uses protobuf -->
+                  <include>com.google.protobuf:protobuf-java</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf.</pattern>
+                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -205,6 +205,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-sync/hudi-hive-sync/pom.xml
+++ b/hudi-sync/hudi-hive-sync/pom.xml
@@ -53,6 +53,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -172,6 +172,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -121,6 +121,7 @@
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>com.twitter:parquet-avro</include>
                   <include>com.twitter.common:objectsize</include>
+                  <include>com.google.protobuf:protobuf-java</include>
 
                   <include>io.confluent:kafka-avro-serializer</include>
                   <include>io.confluent:common-config</include>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -234,10 +234,6 @@
                   <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.protobuf.</pattern>
-                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.uber.m3.</pattern>
                   <shadedPattern>org.apache.hudi.com.uber.m3.</shadedPattern>
                 </relocation>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -163,10 +163,6 @@
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.protobuf.</pattern>
-                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.uber.m3.</pattern>
                   <shadedPattern>org.apache.hudi.com.uber.m3.</shadedPattern>
                 </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -464,8 +464,6 @@
               <!-- afterburner module for jackson performance -->
               <include>com.fasterxml.jackson.module:jackson-module-afterburner</include>
               <include>com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}</include>
-              <!-- native HFile reader uses protobuf -->
-              <include>com.google.protobuf:protobuf-java</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -482,10 +480,6 @@
               <pattern>com.fasterxml.jackson.module</pattern>
               <shadedPattern>org.apache.hudi.com.fasterxml.jackson.module
               </shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>com.google.protobuf.</pattern>
-              <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
### Change Logs

- Moves the protobuf relocation to only exist in the hudi-io module
- Modules that depend on hudi-io now depend on the shaded jar with the relocated protobuf libraries

### Impact

- Fixes runtime issues when reading protobuf encoded topics in the Streamer

### Risk level (write none, low medium or high below)

Medium, packaging related changes may have side effects. I have run some tests with this change and have not found any packaging related issues though.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
