### PR TITLE
[HUDI-9255] Fix inferring correct merge behavior for few scenarios 

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -210,7 +210,7 @@ public interface HoodieRecordMerger extends Serializable {
       }
       return null;
     } else {
-      // For table version 8, we give preference to payload based strategy over input recordMergeStrategyId
+      // For table version 6, we give preference to payload based strategy over input recordMergeStrategyId
       if (nonEmpty(payloadClassName)) {
         return PAYLOAD_BASED_MERGE_STRATEGY_UUID;
       } else if (nonEmpty(recordMergeStrategyId)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -827,7 +827,7 @@ public class HoodieTableConfig extends HoodieConfig {
         inferredRecordMergeMode, payloadClassName);
     // Inferring record merge strategy ID
     inferredRecordMergeStrategyId = HoodieRecordMerger.getRecordMergeStrategyId(
-        inferredRecordMergeMode, inferredPayloadClassName, recordMergeStrategyId);
+        inferredRecordMergeMode, inferredPayloadClassName, recordMergeStrategyId, tableVersion);
 
     // For custom merge mode, either payload class name or record merge strategy ID must be configured
     if (inferredRecordMergeMode == CUSTOM) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -801,7 +801,7 @@ public class HoodieTableConfig extends HoodieConfig {
         inferredRecordMergeMode = modeBasedOnPayload != null ? modeBasedOnPayload : modeBasedOnStrategyId;
       }
     }
-    if (recordMergeMode != null) {
+    if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT) && recordMergeMode != null) {
       checkArgument(inferredRecordMergeMode == recordMergeMode,
           String.format("Configured record merge mode (%s) is inconsistent with payload class (%s) "
                   + "or record merge strategy ID (%s) configured. Please revisit the configs.",

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -801,7 +801,7 @@ public class HoodieTableConfig extends HoodieConfig {
         inferredRecordMergeMode = modeBasedOnPayload != null ? modeBasedOnPayload : modeBasedOnStrategyId;
       }
     }
-    if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT) && recordMergeMode != null) {
+    if (recordMergeMode != null) {
       checkArgument(inferredRecordMergeMode == recordMergeMode,
           String.format("Configured record merge mode (%s) is inconsistent with payload class (%s) "
                   + "or record merge strategy ID (%s) configured. Please revisit the configs.",

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.LocalAvroSchemaCache;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -216,7 +215,7 @@ public class FileGroupReaderSchemaHandler<T> {
         cfg.getPayloadClass(),
         cfg.getRecordMergeStrategyId(),
         cfg.getPreCombineField(),
-        HoodieTableVersion.current());
+        cfg.getTableVersion());
 
     if (mergingConfigs.getLeft() == RecordMergeMode.CUSTOM) {
       return recordMerger.get().getMandatoryFieldsForMerging(tableSchema, cfg, props);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupRecordBuffer.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -110,33 +111,53 @@ class TestFileGroupRecordBuffer {
 
   @ParameterizedTest
   @CsvSource({
-      "true, true, true, EVENT_TIME_ORDERING",
-      "true, false, false, EVENT_TIME_ORDERING",
-      "false, true, false, EVENT_TIME_ORDERING",
-      "false, false, true, EVENT_TIME_ORDERING",
-      "true, true, true, COMMIT_TIME_ORDERING",
-      "true, false, false, COMMIT_TIME_ORDERING",
-      "false, true, false, COMMIT_TIME_ORDERING",
-      "false, false, true, COMMIT_TIME_ORDERING",
-      "true, true, true, CUSTOM",
-      "true, false, false, CUSTOM",
-      "false, true, false, CUSTOM",
-      "false, false, true, CUSTOM",
-      "true, true, true,",
-      "true, false, false,",
-      "false, true, false,",
-      "false, false, true,"
+      "true, true, true, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "true, false, false, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "false, true, false, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "false, false, true, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "true, true, true, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "true, false, false, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "false, true, false, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "false, false, true, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "true, true, true, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "true, false, false, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "false, true, false, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "false, false, true, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "true, true, true, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "true, false, false, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "false, true, false, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "false, false, true, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
+      "true, true, true, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "true, false, false, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "false, true, false, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "false, false, true, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
+      "true, true, true, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "true, false, false, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "false, true, false, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "false, false, true, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
+      "true, true, true, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
+      "true, false, false, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
+      "false, true, false, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
+      "false, false, true, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
+      "true, true, true, , false, SIX, 00000000-0000-0000-0000-000000000000",
+      "true, false, false, , false, SIX, 00000000-0000-0000-0000-000000000000",
+      "false, true, false, , false, SIX, 00000000-0000-0000-0000-000000000000",
+      "false, false, true, , false, SIX, 00000000-0000-0000-0000-000000000000",
+      "true, true, true, CUSTOM, true, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5", /// with table version 6, commit time based merge mode can have event time based merge strategy id.
   })
   public void testSchemaForMandatoryFields(boolean setPrecombine,
                                            boolean addHoodieIsDeleted,
                                            boolean addCustomDeleteMarker,
-                                           RecordMergeMode mergeMode) {
+                                           RecordMergeMode mergeMode,
+                                           boolean isProjectionCompatible,
+                                           HoodieTableVersion tableVersion,
+                                           String mergeStrategyId) {
     HoodieReaderContext readerContext = mock(HoodieReaderContext.class);
     when(readerContext.getHasBootstrapBaseFile()).thenReturn(false);
     when(readerContext.getHasLogFiles()).thenReturn(true);
     HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
     when(readerContext.getRecordMerger()).thenReturn(Option.of(recordMerger));
-    when(recordMerger.isProjectionCompatible()).thenReturn(false);
+    when(recordMerger.isProjectionCompatible()).thenReturn(isProjectionCompatible);
 
     String preCombineField = "ts";
     String customDeleteKey = "colC";
@@ -156,6 +177,10 @@ class TestFileGroupRecordBuffer {
     when(tableConfig.getRecordMergeMode()).thenReturn(mergeMode);
     when(tableConfig.populateMetaFields()).thenReturn(true);
     when(tableConfig.getPreCombineField()).thenReturn(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING);
+    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    if (mergeMode != null) {
+      when(tableConfig.getRecordMergeStrategyId()).thenReturn(mergeStrategyId);
+    }
 
     TypedProperties props = new TypedProperties();
     if (addCustomDeleteMarker) {
@@ -176,7 +201,7 @@ class TestFileGroupRecordBuffer {
     if (addHoodieIsDeleted) {
       expectedFields.add(HoodieRecord.HOODIE_IS_DELETED_FIELD);
     }
-    Schema expectedSchema = mergeMode == RecordMergeMode.CUSTOM ? dataSchema : getSchema(expectedFields);
+    Schema expectedSchema = ((mergeMode == RecordMergeMode.CUSTOM) && !isProjectionCompatible) ? dataSchema : getSchema(expectedFields);
     Schema actualSchema = fileGroupReaderSchemaHandler.generateRequiredSchema();
     assertEquals(expectedSchema, actualSchema);
     assertEquals(addHoodieIsDeleted, fileGroupReaderSchemaHandler.hasBuiltInDelete());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -377,7 +377,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
         arguments(CUSTOM, null, customStrategy, null,
             "false", CUSTOM, defaultPayload, customStrategy),
         arguments(CUSTOM, customPayload, customStrategy, null,
-            "false", CUSTOM, customPayload, customStrategy),
+            "false", CUSTOM, customPayload, null),
 
         //test legal configs that work but should not be used usually
         arguments(CUSTOM, defaultPayload, customStrategy, null,
@@ -455,12 +455,10 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
               : Boolean.parseBoolean(shouldThrowString);
           RecordMergeMode expectedMergeMode = outputMergeMode;
           String expectedMergeStrategy = outputMergeStrategy;
-          if (!shouldThrow && outputMergeMode == null) {
+          if (!shouldThrow && (outputMergeMode == null || outputMergeStrategy == null)) {
             expectedMergeMode = tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
                 ? CUSTOM : inferRecordMergeModeFromPayloadClass(outputPayloadClass);
-            expectedMergeStrategy = tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
-                ? PAYLOAD_BASED_MERGE_STRATEGY_UUID
-                : getRecordMergeStrategyId(expectedMergeMode, outputPayloadClass, null);
+            expectedMergeStrategy = getRecordMergeStrategyId(expectedMergeMode, outputPayloadClass, inputMergeStrategy, tableVersion);
           }
           if (shouldThrow) {
             assertThrows(IllegalArgumentException.class,


### PR DESCRIPTION
### Change Logs

- We are inferring merge mode by inferring it using merge strategy id when table version is 8 and using payload when table version is 6. The Jira aims to use a similar rule when inferring merge strategy id.
If table version is 8, we use table config merge strategy id otherwise we determine strategy id using payload. This handling is required only for custom merge mode.

- Also, fixed the table version argument that we pass in to infer merge mode configs. 

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
