### PR TITLE
[HUDI-9256] Fix table version used while inferring merge behaviour

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.LocalAvroSchemaCache;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -216,7 +215,7 @@ public class FileGroupReaderSchemaHandler<T> {
         cfg.getPayloadClass(),
         cfg.getRecordMergeStrategyId(),
         cfg.getPreCombineField(),
-        HoodieTableVersion.current());
+        cfg.getTableVersion());
 
     if (mergingConfigs.getLeft() == RecordMergeMode.CUSTOM) {
       return recordMerger.get().getMandatoryFieldsForMerging(tableSchema, cfg, props);


### PR DESCRIPTION
### Change Logs

Currently in some places we are directly using current table version in HoodieTableConfig#inferCorrectMergingBehavior. The Jira aims to fix the callers and ensure the correct table version is passed to the API.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
