### PR TITLE
[HUDI-9262] Skip building stats for decimal field with very high precision

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -204,6 +204,11 @@ public class HoodieTableMetadataUtil {
       HoodieRecord.HoodieMetadataField.PARTITION_PATH_METADATA_FIELD.getFieldName(),
       HoodieRecord.HoodieMetadataField.COMMIT_TIME_METADATA_FIELD.getFieldName()));
 
+  // The maximum allowed precision and scale as per the payload schema. See DecimalWrapper in HoodieMetadata.avsc:
+  // https://github.com/apache/hudi/blob/45dedd819e56e521148bde51a3dfa4e472ea70cd/hudi-common/src/main/avro/HoodieMetadata.avsc#L247
+  private static final int DECIMAL_MAX_PRECISION = 30;
+  private static final int DECIMAL_MAX_SCALE = 15;
+
   private HoodieTableMetadataUtil() {
   }
 
@@ -1913,11 +1918,7 @@ public class HoodieTableMetadataUtil {
     LogicalType logicalType = schemaToCheck.getLogicalType();
     if (logicalType != null && logicalType instanceof LogicalTypes.Decimal) {
       LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) logicalType;
-      // The maximum allowed precision and scale as per the payload schema. See DecimalWrapper in HoodieMetadata.avsc:
-      // https://github.com/apache/hudi/blob/45dedd819e56e521148bde51a3dfa4e472ea70cd/hudi-common/src/main/avro/HoodieMetadata.avsc#L247
-      final int maxPrecision = 30;
-      final int maxScale = 15;
-      if (decimalType.getPrecision() > maxPrecision || decimalType.getScale() > maxScale) {
+      if (decimalType.getPrecision() + (DECIMAL_MAX_SCALE - decimalType.getScale()) > DECIMAL_MAX_PRECISION || decimalType.getScale() > DECIMAL_MAX_SCALE) {
         return false;
       }
     }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -666,6 +666,13 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     decimalType.addToSchema(schema);
     // Expect the column to be unsupported.
     assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(schema, Option.of(HoodieRecord.HoodieRecordType.AVRO)));
+
+    // Test for logical decimal type with precision exceeding limit after upscaling
+    schema = Schema.create(Schema.Type.BYTES);
+    decimalType = LogicalTypes.decimal(28, 10);
+    decimalType.addToSchema(schema);
+    // Expect the column to be unsupported.
+    assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(schema, Option.of(HoodieRecord.HoodieRecordType.AVRO)));
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -652,6 +652,20 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         .name("dateField").type(dateFieldSchema).noDefault()
         .endRecord();
     assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(schema.getField("dateField").schema(), Option.empty()));
+
+    // Test for logical decimal type with allowed precision and scale
+    schema = Schema.create(Schema.Type.BYTES);
+    LogicalTypes.Decimal decimalType = LogicalTypes.decimal(30, 15);
+    decimalType.addToSchema(schema);
+    // Expect the column to be supported.
+    assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(schema, Option.of(HoodieRecord.HoodieRecordType.AVRO)));
+
+    // Test for logical decimal type with precision and scale exceeding the limit
+    schema = Schema.create(Schema.Type.BYTES);
+    decimalType = LogicalTypes.decimal(35, 20);
+    decimalType.addToSchema(schema);
+    // Expect the column to be unsupported.
+    assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(schema, Option.of(HoodieRecord.HoodieRecordType.AVRO)));
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

Column stats creation fails when a decimal field with precision exceeds the max limit.

```
 org.apache.avro.AvroTypeException: Cannot encode decimal with precision 35 as max precision 30. This is after safely adjusting scale from 0 to required 15
	at org.apache.hudi.metadata.HoodieTableMetadataUtil.tryUpcastDecimal(HoodieTableMetadataUtil.java:1833)
	at org.apache.hudi.avro.HoodieAvroUtils.wrapValueIntoAvro(HoodieAvroUtils.java:1464)
	at org.apache.hudi.metadata.HoodieMetadataPayload.createColumnStatsRecord(HoodieMetadataPayload.java:523)
	at org.apache.hudi.metadata.HoodieMetadataPayload.lambda$createColumnStatsRecords$5(HoodieMetadataPayload.java:497)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
```

This patch simply skip building stats for such fields instead of blocking ingestion.

### Impact

Skip building stats for decimal field with very high precision instead of blocking ingestion.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
