### PR TITLE
[HUDI-9263] Archived timeline downgrade fails with EightToSevenDowngradeHandler

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -776,6 +776,11 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTimeline downgradedArchivedTimeline = metaClient.getArchivedTimeline();
     metaClient.getArchivedTimeline().loadCompletedInstantDetailsInMemory();
+    // verify that commits till 11th instant are all archived
+    for (int i = 1; i < 13; i += 2) {
+      assertTrue(downgradedArchivedTimeline.containsInstant(String.format("%08d", i)));
+    }
+    // verify the contents of older archived timeline and downgraded archived timeline
     for (HoodieInstant instant : archivedTimeLine.getInstants()) {
       assertTrue(Arrays.equals(archivedTimeLine.getInstantReader().getInstantDetails(instant).get(),
           downgradedArchivedTimeline.getInstantReader().getInstantDetails(instant).get()));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -758,7 +758,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         testTable.doCluster(String.format("%08d", i), Collections.emptyMap(), Arrays.asList("p1", "p2"), 20);
       } else {
         testTable.doWriteOperation(String.format("%08d", i), WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
-        testTable.doClean(String.format("%08d", i+1), cleanStats, Collections.emptyMap());
+        testTable.doClean(String.format("%08d", i + 1), cleanStats, Collections.emptyMap());
       }
     }
     archiveAndGetCommitsList(writeConfig);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.LSMTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
@@ -113,6 +114,11 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.HoodieTestCommitGenerator.getBaseFilename;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.table.timeline.MetadataConversionUtils.convertCommitMetadataToAvro;
@@ -569,7 +575,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000005"));
     expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
     expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
-    expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), HoodieTimeline.CLEAN_ACTION));
+    expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008"), CLEAN_ACTION));
     verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
         expectedActiveInstants, commitsAfterArchival, false);
 
@@ -584,7 +590,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       // retains the 2 commits - C3 and C7. Since minInstantsToKeep is 2, c3 is retained. Archival is now blocked at
       // c7 since that is the replace commit after earliest savepoint c7 in cleaner
       expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000003", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
-      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), CLEAN_ACTION));
       expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
       List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
       archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000004", "00000006"), HoodieTimeline.REPLACE_COMMIT_ACTION));
@@ -594,7 +600,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000005"));
       expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
       expectedActiveInstants.addAll(getActiveSavepointedCommitInstants(Arrays.asList("00000003")));
-      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), CLEAN_ACTION));
       verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
           expectedActiveInstants, commitsAfterArchival, false);
     }
@@ -609,7 +615,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     if (archiveBeyondSavepoint) {
       // change from last state - Removal of savepoint instant from the active timeline since it is deleted
       expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000003", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
-      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), CLEAN_ACTION));
       List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
       archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000004", "00000006"), HoodieTimeline.REPLACE_COMMIT_ACTION));
       verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, true);
@@ -619,7 +625,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       // archival is triggered since clean also does not block it
       // c6 and c7 are retained since min instants to keep is 2
       expectedActiveInstants = getActiveCommitInstants(Arrays.asList("00000006", "00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION);
-      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), HoodieTimeline.CLEAN_ACTION));
+      expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009"), CLEAN_ACTION));
       List<HoodieInstant> archivedCommitInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000005"));
       archivedCommitInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000003", "00000004"), HoodieTimeline.REPLACE_COMMIT_ACTION));
       verifyArchival(archivedCommitInstants, expectedActiveInstants, commitsAfterArchival, false);
@@ -747,25 +753,62 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
   @Test
   public void testDowngradeArchivedTimeline() throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 1, 2, 5, HoodieTableType.COPY_ON_WRITE);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(false, 1, 2, 5, HoodieTableType.MERGE_ON_READ);
 
     // do ingestion and trigger archive actions here.
     Map<String, Integer> cleanStats = new HashMap<>();
     cleanStats.put("p1", 1);
     cleanStats.put("p2", 2);
-    for (int i = 1; i < 15; i += 2) {
+    for (int i = 1; i < 17; i += 2) {
       if (i == 3) {
         testTable.doRollback(String.format("%08d", 1), String.format("%08d", 3));
       } else if (i == 5) {
         testTable.doCluster(String.format("%08d", i), Collections.emptyMap(), Arrays.asList("p1", "p2"), 20);
-      } else if (i == 7) {
+      } else if (i == 7 || i == 13) {
         testTable.doCompaction(String.format("%08d", i), Arrays.asList("p1", "p2"));
       } else {
         testTable.doWriteOperation(String.format("%08d", i), WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
         testTable.doClean(String.format("%08d", i + 1), cleanStats, Collections.emptyMap());
       }
     }
-    archiveAndGetCommitsList(writeConfig);
+    testTable.doCompaction(String.format("%08d", 17), Arrays.asList("p1", "p2"));
+
+    // 1 - dc, 2- clean, 3 - rollback, 5 -> clustering, 7 -> compaction, 9 -> dc, 10 -> clean. 11 -> dc,
+    // 12 -> clean. 13 -> compaction, 15 -> dc, 16 -> clean, 17 -> compaction
+    Pair<List<HoodieInstant>, List<HoodieInstant>> result = archiveAndGetCommitsList(writeConfig);
+    // after archival, only instants 16 and 17 are in active timeline.
+    List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
+    //List<String> expectedArchivedInstants = Arrays.asList(new String[]{String.format("%08d",1), String.format("%08d",2), String.format("%08d",12)})
+    expectedActiveInstants.add(getHoodieInstant(CLEAN_ACTION, String.format("%08d",16)));
+    expectedActiveInstants.add(getHoodieInstant(COMMIT_ACTION, String.format("%08d",17)));
+
+    // validate active instants
+    List<HoodieInstant> actualActiveInstants = new ArrayList<>(result.getRight());
+    Collections.sort(actualActiveInstants);
+    Collections.sort(expectedActiveInstants);
+    assertEquals(expectedActiveInstants, actualActiveInstants);
+
+    List<HoodieInstant> actualArchivedCommits = new ArrayList<>(result.getKey());
+    actualArchivedCommits.removeAll(result.getValue());
+
+    List<HoodieInstant> expectedArchivedInstants = new ArrayList<>();
+    expectedArchivedInstants.add(getHoodieInstant(DELTA_COMMIT_ACTION, String.format("%08d",1)));
+    expectedArchivedInstants.add(getHoodieInstant(CLEAN_ACTION, String.format("%08d",2)));
+    expectedArchivedInstants.add(getHoodieInstant(ROLLBACK_ACTION, String.format("%08d",3)));
+    expectedArchivedInstants.add(getHoodieInstant(REPLACE_COMMIT_ACTION, String.format("%08d",5)));
+    expectedArchivedInstants.add(getHoodieInstant(COMMIT_ACTION, String.format("%08d",7)));
+    expectedArchivedInstants.add(getHoodieInstant(DELTA_COMMIT_ACTION, String.format("%08d",9)));
+    expectedArchivedInstants.add(getHoodieInstant(CLEAN_ACTION, String.format("%08d",10)));
+    expectedArchivedInstants.add(getHoodieInstant(DELTA_COMMIT_ACTION, String.format("%08d",11)));
+    expectedArchivedInstants.add(getHoodieInstant(CLEAN_ACTION, String.format("%08d",12)));
+    expectedArchivedInstants.add(getHoodieInstant(COMMIT_ACTION, String.format("%08d",13)));
+    expectedArchivedInstants.add(getHoodieInstant(DELTA_COMMIT_ACTION, String.format("%08d",15)));
+
+    // validate archived instants
+    Collections.sort(actualArchivedCommits);
+    Collections.sort(expectedArchivedInstants);
+    assertEquals(expectedArchivedInstants, actualArchivedCommits);
+
     // loading archived timeline instants
     HoodieArchivedTimeline archivedTimeLine = metaClient.getArchivedTimeline();
     archivedTimeLine.loadCompletedInstantDetailsInMemory();
@@ -774,17 +817,19 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     new UpgradeDowngrade(metaClient, writeConfig, context, SparkUpgradeDowngradeHelper.getInstance())
         .run(HoodieTableVersion.SIX, null);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    HoodieTimeline downgradedArchivedTimeline = metaClient.getArchivedTimeline();
     metaClient.getArchivedTimeline().loadCompletedInstantDetailsInMemory();
-    // verify that commits till 11th instant are all archived
-    for (int i = 1; i < 13; i += 2) {
-      assertTrue(downgradedArchivedTimeline.containsInstant(String.format("%08d", i)));
-    }
+    HoodieTimeline downgradedArchivedTimeline = metaClient.getArchivedTimeline();
+    // verify expected archived instants
+    expectedArchivedInstants.forEach(instant -> assertTrue(downgradedArchivedTimeline.containsInstant(instant)));
     // verify the contents of older archived timeline and downgraded archived timeline
     for (HoodieInstant instant : archivedTimeLine.getInstants()) {
       assertTrue(Arrays.equals(archivedTimeLine.getInstantReader().getInstantDetails(instant).get(),
           downgradedArchivedTimeline.getInstantReader().getInstantDetails(instant).get()));
     }
+  }
+
+  private HoodieInstant getHoodieInstant(String action, String instantTime) {
+    return new HoodieInstant(State.COMPLETED, action, instantTime, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
   }
 
   @ParameterizedTest
@@ -1174,7 +1219,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
   private void verifyInflightInstants(HoodieTableMetaClient metaClient, int expectedTotalInstants) {
     HoodieTimeline timeline = metaClient.getActiveTimeline().reload()
-        .getTimelineOfActions(Collections.singleton(HoodieTimeline.CLEAN_ACTION)).filterInflights();
+        .getTimelineOfActions(Collections.singleton(CLEAN_ACTION)).filterInflights();
     assertEquals(expectedTotalInstants, timeline.countInstants(),
         "Loaded inflight clean actions and the count should match");
   }
@@ -1223,7 +1268,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         List<HoodieInstant> expectedActiveInstants = new ArrayList<>(getActiveCommitInstants(Arrays.asList("00000007", "00000008")));
         List<HoodieInstant> expectedArchiveInstants = new ArrayList<>();
         expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000004", "00000006")));
-        expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000005"), HoodieTimeline.CLEAN_ACTION));
+        expectedArchiveInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000005"), CLEAN_ACTION));
 
         verifyArchival(expectedArchiveInstants, expectedActiveInstants, commitsAfterArchival, false);
       }
@@ -1284,11 +1329,11 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
         expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000009", "00000010", "00000011", "00000012")));
         expectedActiveInstants.addAll(
-            getActiveCommitInstants(Arrays.asList("00000013", "00000014", "00000015", "00000016"), HoodieTimeline.CLEAN_ACTION));
+            getActiveCommitInstants(Arrays.asList("00000013", "00000014", "00000015", "00000016"), CLEAN_ACTION));
         List<HoodieInstant> expectedArchivedInstants = new ArrayList<>();
         expectedArchivedInstants.addAll(getAllArchivedCommitInstants(
             Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000008"), HoodieTimeline.COMMIT_ACTION));
-        expectedArchivedInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000006"), HoodieTimeline.CLEAN_ACTION));
+        expectedArchivedInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000006"), CLEAN_ACTION));
         expectedArchivedInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000007"), HoodieTimeline.REPLACE_COMMIT_ACTION));
         verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival, false);
       }
@@ -1313,7 +1358,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
 
     for (int i = 2; i < 5; i++) {
       String cleanInstant = metaClient.createNewInstantTime();
-      instants.add(Pair.of(cleanInstant, HoodieTimeline.CLEAN_ACTION));
+      instants.add(Pair.of(cleanInstant, CLEAN_ACTION));
       testTable.doClean(cleanInstant, partitionToFileDeleteCount);
     }
 
@@ -1369,7 +1414,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     List<HoodieInstant> expectedArchivedInstants = new ArrayList<>();
     for (int i = 0; i < maxInstantsToKeep + 1; i++, startInstant++) {
       createCleanMetadata(String.format("%02d", startInstant), false, false, isEmpty || i % 2 == 0);
-      expectedArchivedInstants.add(INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, String.format("%02d", startInstant)));
+      expectedArchivedInstants.add(INSTANT_GENERATOR.createNewInstant(State.COMPLETED, CLEAN_ACTION, String.format("%02d", startInstant)));
     }
 
     for (int i = 0; i < maxInstantsToKeep + 1; i++, startInstant += 2) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -23,6 +23,8 @@ import org.apache.hudi.avro.model.HoodieArchivedMetaEntry;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieLSMTimelineInstant;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
@@ -178,7 +180,6 @@ public class MetadataConversionUtils {
     archivedMetaWrapper.setStateTransitionTime(completionTime);
     String actionType = lsmTimelineRecord.get(ArchivedTimelineV2.ACTION_ARCHIVED_META_FIELD).toString();
     HoodieInstant hoodieInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, actionType, instantTime, completionTime);
-    metaClient.getArchivedTimeline().loadCompletedInstantDetailsInMemory();
     switch (actionType) {
       case HoodieTimeline.CLEAN_ACTION: {
         archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, new ByteArrayInputStream(instantDetails.get())));
@@ -187,8 +188,9 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.COMMIT_ACTION: {
-        getArchivedCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class)
-            .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata)));
+        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieCommitMetadata.class);
+        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata));
         archivedMetaWrapper.setActionType(ActionType.commit.name());
 
         if (planBytes.isPresent()) {
@@ -199,8 +201,9 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.DELTA_COMMIT_ACTION: {
-        getArchivedCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class)
-            .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata)));
+        HoodieCommitMetadata deltaCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieCommitMetadata.class);
+        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(deltaCommitMetadata));
         archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
 
         if (planBytes.isPresent()) {
@@ -212,13 +215,14 @@ public class MetadataConversionUtils {
       }
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
       case HoodieTimeline.CLUSTERING_ACTION: {
-        getArchivedCommitMetadata(metaClient, hoodieInstant, HoodieReplaceCommitMetadata.class)
-            .ifPresent(replaceCommitMetadata -> archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertCommitMetadataToAvro(replaceCommitMetadata)));
+        HoodieCommitMetadata replaceCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieReplaceCommitMetadata.class);
+        archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertCommitMetadataToAvro(replaceCommitMetadata));
 
         // inflight replacecommit files have the same metadata body as HoodieCommitMetadata
         // so we could re-use it without further creating an inflight extension.
         // Or inflight replacecommit files are empty under clustering circumstance
-        Option<HoodieCommitMetadata> inflightCommitMetadata = getArchivedCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class);
+        Option<HoodieCommitMetadata> inflightCommitMetadata = getInflightCommitMetadata(metaClient, hoodieInstant, instantDetails);
         if (inflightCommitMetadata.isPresent()) {
           archivedMetaWrapper.setHoodieInflightReplaceMetadata(convertCommitMetadataToAvro(inflightCommitMetadata.get()));
         }
@@ -227,13 +231,13 @@ public class MetadataConversionUtils {
       }
       case HoodieTimeline.ROLLBACK_ACTION: {
         archivedMetaWrapper.setHoodieRollbackMetadata(
-            metaClient.getArchivedTimeline().readRollbackMetadata(hoodieInstant));
+            TimelineMetadataUtils.deserializeAvroMetadata(new ByteArrayInputStream(instantDetails.get()), HoodieRollbackMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.rollback.name());
         break;
       }
       case HoodieTimeline.SAVEPOINT_ACTION: {
         archivedMetaWrapper.setHoodieSavePointMetadata(
-            metaClient.getArchivedTimeline().readSavepointMetadata(hoodieInstant));
+            TimelineMetadataUtils.deserializeAvroMetadata(new ByteArrayInputStream(instantDetails.get()), HoodieSavepointMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.savepoint.name());
         break;
       }
@@ -255,6 +259,16 @@ public class MetadataConversionUtils {
       }
     }
     return archivedMetaWrapper;
+  }
+
+  private static Option<HoodieCommitMetadata> getInflightCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant,
+                                                                        Option<byte[]> inflightContent) throws IOException {
+    if (!inflightContent.isPresent() || inflightContent.get().length == 0) {
+      // inflight files can be empty in some certain cases, e.g. when users opt in clustering
+      return Option.empty();
+    }
+    return Option.of(metaClient.getCommitMetadataSerDe().deserialize(instant, new ByteArrayInputStream(inflightContent.get()),
+        () -> inflightContent.get().length == 0, HoodieCommitMetadata.class));
   }
 
   public static HoodieLSMTimelineInstant createLSMTimelineInstant(ActiveAction activeAction, HoodieTableMetaClient metaClient) {
@@ -337,15 +351,6 @@ public class MetadataConversionUtils {
       }
     }
     return archivedMetaWrapper;
-  }
-
-  private static <T extends HoodieCommitMetadata> Option<T> getArchivedCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant, Class<T> clazz) throws IOException {
-    T commitMetadata = metaClient.getArchivedTimeline().readInstantContent(instant, clazz);
-    // an empty file will return the default instance with an UNKNOWN operation type and in that case we return an empty option
-    if (commitMetadata.getOperationType() == WriteOperationType.UNKNOWN) {
-      return Option.empty();
-    }
-    return Option.of(commitMetadata);
   }
 
   private static <T extends HoodieCommitMetadata> Option<T> getCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant, Class<T> clazz) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -23,6 +23,8 @@ import org.apache.hudi.avro.model.HoodieArchivedMetaEntry;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieLSMTimelineInstant;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
@@ -186,8 +188,9 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.COMMIT_ACTION: {
-        getCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class)
-            .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata)));
+        HoodieCommitMetadata commitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieCommitMetadata.class);
+        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata));
         archivedMetaWrapper.setActionType(ActionType.commit.name());
 
         if (planBytes.isPresent()) {
@@ -198,8 +201,9 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.DELTA_COMMIT_ACTION: {
-        getCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class)
-            .ifPresent(commitMetadata -> archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(commitMetadata)));
+        HoodieCommitMetadata deltaCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieCommitMetadata.class);
+        archivedMetaWrapper.setHoodieCommitMetadata(convertCommitMetadataToAvro(deltaCommitMetadata));
         archivedMetaWrapper.setActionType(ActionType.deltacommit.name());
 
         if (planBytes.isPresent()) {
@@ -211,13 +215,14 @@ public class MetadataConversionUtils {
       }
       case HoodieTimeline.REPLACE_COMMIT_ACTION:
       case HoodieTimeline.CLUSTERING_ACTION: {
-        getCommitMetadata(metaClient, hoodieInstant, HoodieReplaceCommitMetadata.class)
-            .ifPresent(replaceCommitMetadata -> archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertCommitMetadataToAvro(replaceCommitMetadata)));
+        HoodieCommitMetadata replaceCommitMetadata = metaClient.getCommitMetadataSerDe().deserialize(hoodieInstant, new ByteArrayInputStream(instantDetails.get()),
+            () -> instantDetails.get().length == 0, HoodieReplaceCommitMetadata.class);
+        archivedMetaWrapper.setHoodieReplaceCommitMetadata(convertCommitMetadataToAvro(replaceCommitMetadata));
 
         // inflight replacecommit files have the same metadata body as HoodieCommitMetadata
         // so we could re-use it without further creating an inflight extension.
         // Or inflight replacecommit files are empty under clustering circumstance
-        Option<HoodieCommitMetadata> inflightCommitMetadata = getCommitMetadata(metaClient, hoodieInstant, HoodieCommitMetadata.class);
+        Option<HoodieCommitMetadata> inflightCommitMetadata = getInflightCommitMetadata(metaClient, hoodieInstant, instantDetails);
         if (inflightCommitMetadata.isPresent()) {
           archivedMetaWrapper.setHoodieInflightReplaceMetadata(convertCommitMetadataToAvro(inflightCommitMetadata.get()));
         }
@@ -225,26 +230,24 @@ public class MetadataConversionUtils {
         break;
       }
       case HoodieTimeline.ROLLBACK_ACTION: {
-        archivedMetaWrapper.setHoodieRollbackMetadata(
-            metaClient.getActiveTimeline().readRollbackMetadata(hoodieInstant));
+        archivedMetaWrapper.setHoodieRollbackMetadata(TimelineMetadataUtils.deserializeAvroMetadata(new ByteArrayInputStream(instantDetails.get()), HoodieRollbackMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.rollback.name());
         break;
       }
       case HoodieTimeline.SAVEPOINT_ACTION: {
-        archivedMetaWrapper.setHoodieSavePointMetadata(
-            metaClient.getActiveTimeline().readSavepointMetadata(hoodieInstant));
+        archivedMetaWrapper.setHoodieSavePointMetadata(TimelineMetadataUtils.deserializeAvroMetadata(new ByteArrayInputStream(instantDetails.get()), HoodieSavepointMetadata.class));
         archivedMetaWrapper.setActionType(ActionType.savepoint.name());
         break;
       }
       case HoodieTimeline.COMPACTION_ACTION: {
         // should be handled by commit_action branch though, this logic is redundant.
-        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, hoodieInstant);
+        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, new ByteArrayInputStream(planBytes.get()));
         archivedMetaWrapper.setHoodieCompactionPlan(plan);
         archivedMetaWrapper.setActionType(ActionType.compaction.name());
         break;
       }
       case HoodieTimeline.LOG_COMPACTION_ACTION: {
-        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, hoodieInstant);
+        HoodieCompactionPlan plan = CompactionUtils.getCompactionPlan(metaClient, new ByteArrayInputStream(planBytes.get()));
         archivedMetaWrapper.setHoodieCompactionPlan(plan);
         archivedMetaWrapper.setActionType(ActionType.logcompaction.name());
         break;
@@ -336,6 +339,16 @@ public class MetadataConversionUtils {
       }
     }
     return archivedMetaWrapper;
+  }
+
+  private static Option<HoodieCommitMetadata> getInflightCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant,
+                                                                        Option<byte[]> inflightContent) throws IOException {
+    if (!inflightContent.isPresent() || inflightContent.get().length == 0) {
+      // inflight files can be empty in some certain cases, e.g. when users opt in clustering
+      return Option.empty();
+    }
+    return Option.of(metaClient.getCommitMetadataSerDe().deserialize(instant, new ByteArrayInputStream(inflightContent.get()),
+        () -> inflightContent.get().length == 0, HoodieCommitMetadata.class));
   }
 
   private static <T extends HoodieCommitMetadata> Option<T> getCommitMetadata(HoodieTableMetaClient metaClient, HoodieInstant instant, Class<T> clazz) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -178,6 +178,7 @@ public class MetadataConversionUtils {
     archivedMetaWrapper.setStateTransitionTime(completionTime);
     String actionType = lsmTimelineRecord.get(ArchivedTimelineV2.ACTION_ARCHIVED_META_FIELD).toString();
     HoodieInstant hoodieInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, actionType, instantTime, completionTime);
+    metaClient.getArchivedTimeline().loadCompletedInstantDetailsInMemory();
     switch (actionType) {
       case HoodieTimeline.CLEAN_ACTION: {
         archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, new ByteArrayInputStream(instantDetails.get())));


### PR DESCRIPTION
### Change Logs

While downgrading archived timeline, EightToSevenDowngradeHandler hits an error where it is trying to get instant details from active timeline instead of archive timeline.

```
25/04/07 15:26:47 WARN UpgradeDowngrade: Unable to upgrade or downgrade the metadata table to version SIX, ignoring the error and continue.
org.apache.hudi.exception.HoodieException: Failed to downgrade LSM timeline to old archived format
    at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler.downgradeFromLSMTimeline(EightToSevenDowngradeHandler.java:232)
    at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler.downgrade(EightToSevenDowngradeHandler.java:131)
    at org.apache.hudi.table.upgrade.UpgradeDowngrade.downgrade(UpgradeDowngrade.java:275)
    at org.apache.hudi.table.upgrade.UpgradeDowngrade.run(UpgradeDowngrade.java:181)
    at org.apache.hudi.table.upgrade.UpgradeDowngrade.run(UpgradeDowngrade.java:150)
    at $line30.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$DowngradeTable$.downgradeTable(../src/main/scala/com/hudi/spark/DowngradeTable.scala:60)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:46)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:50)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:52)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:54)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:56)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:58)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:60)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:62)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:64)
    at $line31.$read$$iw$$iw$$iw$$iw$$iw.<init>(<console>:66)
    at $line31.$read$$iw$$iw$$iw$$iw.<init>(<console>:68)
    at $line31.$read$$iw$$iw$$iw.<init>(<console>:70)
    at $line31.$read$$iw$$iw.<init>(<console>:72)
    at $line31.$read$$iw.<init>(<console>:74)
    at $line31.$read.<init>(<console>:76)
    at $line31.$read$.<init>(<console>:80)
    at $line31.$read$.<clinit>(<console>)
    at $line31.$eval$.$print$lzycompute(<console>:7)
    at $line31.$eval$.$print(<console>:6)
    at $line31.$eval.$print(<console>)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:747)
    at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1020)
    at scala.tools.nsc.interpreter.IMain.$anonfun$interpret$1(IMain.scala:568)
    at scala.reflect.internal.util.ScalaClassLoader.asContext(ScalaClassLoader.scala:36)
    at scala.reflect.internal.util.ScalaClassLoader.asContext$(ScalaClassLoader.scala:116)
    at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:41)
    at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:567)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:594)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:564)
    at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:865)
    at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:733)
    at scala.tools.nsc.interpreter.ILoop.processLine(ILoop.scala:435)
    at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:456)
    at org.apache.spark.repl.SparkILoop.process(SparkILoop.scala:239)
    at org.apache.spark.repl.Main$.doMain(Main.scala:78)
    at org.apache.spark.repl.Main$.main(Main.scala:58)
    at org.apache.spark.repl.Main.main(Main.scala)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
    at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1020)
    at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:192)
    at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:215)
    at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
    at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1111)
    at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1120)
    at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: org.apache.hudi.exception.HoodieIOException: Could not read commit details from /tmp/output/20250407/table_comp_test_0_14_1_1_1_0-SNAPSHOT_1744019628/.hoodie/metadata/.hoodie/timeline/00000000000000000_20250407152558742.deltacommit
    at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.readDataStreamFromPath(ActiveTimelineV2.java:728)
    at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.getContentStream(ActiveTimelineV2.java:271)
    at org.apache.hudi.common.table.timeline.BaseHoodieTimeline.getInstantContentStream(BaseHoodieTimeline.java:558)
    at org.apache.hudi.common.table.timeline.HoodieTimeline.readInstantContent(HoodieTimeline.java:138)
    at org.apache.hudi.common.table.timeline.MetadataConversionUtils.getCommitMetadata(MetadataConversionUtils.java:342)
    at org.apache.hudi.common.table.timeline.MetadataConversionUtils.createMetaWrapper(MetadataConversionUtils.java:201)
    at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler$ArchiveEntryFlusher.accept(EightToSevenDowngradeHandler.java:262)
    at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler$ArchiveEntryFlusher.accept(EightToSevenDowngradeHandler.java:240)
    at org.apache.hudi.common.table.timeline.versioning.v2.ArchivedTimelineLoaderV2.lambda$loadInstants$1(ArchivedTimelineLoaderV2.java:73)
    at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
    at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
    at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
    at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
    at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.io.FileNotFoundException: File file:/tmp/output/20250407/table_comp_test_0_14_1_1_1_0-SNAPSHOT_1744019628/.hoodie/metadata/.hoodie/timeline/00000000000000000_20250407152558742.deltacommit does not exist
    at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:779)
    at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1100)
    at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:769)
    at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
    at org.apache.hadoop.fs.ChecksumFileSystem$ChecksumFSInputChecker.<init>(ChecksumFileSystem.java:160)
    at org.apache.hadoop.fs.ChecksumFileSystem.open(ChecksumFileSystem.java:372)
    at org.apache.hadoop.fs.FileSystem.open(FileSystem.java:976)
    at org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem.open(HoodieWrapperFileSystem.java:481)
    at org.apache.hudi.storage.hadoop.HoodieHadoopStorage.open(HoodieHadoopStorage.java:149)
    at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.readDataStreamFromPath(ActiveTimelineV2.java:726)
    ... 19 more
25/04/07 15:26:48 WARN EightToSevenDowngradeHandler: Failed to downgrade LSM timeline to old archived format
org.apache.hudi.exception.HoodieException: Failed to downgrade LSM timeline to old archived format
  at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler.downgradeFromLSMTimeline(EightToSevenDowngradeHandler.java:232)
  at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler.downgrade(EightToSevenDowngradeHandler.java:131)
  at org.apache.hudi.table.upgrade.UpgradeDowngrade.downgrade(UpgradeDowngrade.java:275)
  at org.apache.hudi.table.upgrade.UpgradeDowngrade.run(UpgradeDowngrade.java:181)
  at DowngradeTable$.downgradeTable(../src/main/scala/com/hudi/spark/DowngradeTable.scala:60)
  ... 53 elided
Caused by: org.apache.hudi.exception.HoodieIOException: Could not read commit details from /tmp/output/20250407/table_comp_test_0_14_1_1_1_0-SNAPSHOT_1744019628/.hoodie/timeline/20250407152428412_20250407152459189.commit
  at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.readDataStreamFromPath(ActiveTimelineV2.java:728)
  at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.getContentStream(ActiveTimelineV2.java:271)
  at org.apache.hudi.common.table.timeline.BaseHoodieTimeline.getInstantContentStream(BaseHoodieTimeline.java:558)
  at org.apache.hudi.common.table.timeline.HoodieTimeline.readInstantContent(HoodieTimeline.java:138)
  at org.apache.hudi.common.table.timeline.MetadataConversionUtils.getCommitMetadata(MetadataConversionUtils.java:342)
  at org.apache.hudi.common.table.timeline.MetadataConversionUtils.createMetaWrapper(MetadataConversionUtils.java:189)
  at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler$ArchiveEntryFlusher.accept(EightToSevenDowngradeHandler.java:262)
  at org.apache.hudi.table.upgrade.EightToSevenDowngradeHandler$ArchiveEntryFlusher.accept(EightToSevenDowngradeHandler.java:240)
  at org.apache.hudi.common.table.timeline.versioning.v2.ArchivedTimelineLoaderV2.lambda$loadInstants$1(ArchivedTimelineLoaderV2.java:73)
  at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
  at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
  at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
  at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
  at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
  at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
  at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
  at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
  at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
  at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
  at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.io.FileNotFoundException: File file:/tmp/output/20250407/table_comp_test_0_14_1_1_1_0-SNAPSHOT_1744019628/.hoodie/timeline/20250407152428412_20250407152459189.commit does not exist
  at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:779)
  at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1100)
  at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:769)
  at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
  at org.apache.hadoop.fs.ChecksumFileSystem$ChecksumFSInputChecker.<init>(ChecksumFileSystem.java:160)
  at org.apache.hadoop.fs.ChecksumFileSystem.open(ChecksumFileSystem.java:372)
  at org.apache.hadoop.fs.FileSystem.open(FileSystem.java:976)
  at org.apache.hudi.hadoop.fs.HoodieWrapperFileSystem.open(HoodieWrapperFileSystem.java:481)
  at org.apache.hudi.storage.hadoop.HoodieHadoopStorage.open(HoodieHadoopStorage.java:149)
  at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.readDataStreamFromPath(ActiveTimelineV2.java:726)
  ... 19 more
 ```

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
