### PR TITLE
[HUDI-9270]Support displaying complete dag for update statement in spark web ui

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -432,8 +432,8 @@ case class ResolveImplementations(sparkSession: SparkSession) extends Rule[Logic
 
         // Convert to UpdateHoodieTableCommand
         case ut@UpdateTable(plan@ResolvesToHudiTable(_), _, _) if ut.resolved =>
-          val plan = UpdateHoodieTableCommand.inputPlan(sparkSession, ut)
-          UpdateHoodieTableCommand(ut, plan)
+          val inputPlan = UpdateHoodieTableCommand.inputPlan(sparkSession, ut)
+          UpdateHoodieTableCommand(ut, inputPlan)
 
 
         // Convert to DeleteHoodieTableCommand


### PR DESCRIPTION
### Change Logs
Support displaying complete dag for update statement in spark web ui

#### Implement steps
- resolve input plan while analyzing `UpdateTable`  and  then convert `UpdateTable` to `UpdateHoodieTableCommand`.
- make `UpdateHoodieTableCommand` extends `DataWritingCommand`

Before：
![image](https://github.com/user-attachments/assets/ea510368-8fe3-4338-84aa-c4ea97d13ed7)

After：
![image](https://github.com/user-attachments/assets/e78464cf-74b3-4e23-9233-f4298d9ee7d9)


### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
