### PR TITLE
[MINOR] Force each functional test runner into its own JVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2049,7 +2049,7 @@
             <configuration combine.self="append">
               <skip>${skipFTs}</skip>
               <forkCount>1</forkCount>
-              <reuseForks>true</reuseForks>
+              <reuseForks>false</reuseForks>
               <includes>
                 <include>**/*FunctionalTestSuite.java</include>
                 <include>**/*FunctionalTestSuiteA.java</include>
@@ -2106,7 +2106,7 @@
             <configuration combine.self="append">
               <skip>${skipFTs}</skip>
               <forkCount>1</forkCount>
-              <reuseForks>true</reuseForks>
+              <reuseForks>false</reuseForks>
               <includes>
                 <include>**/*FunctionalTestSuiteB.java</include>
               </includes>


### PR DESCRIPTION
### Change Logs

Configure the test plugin to fork a new JVM for each test set or each module. This ensures each test run has a fresh JVM, so no conflict arises from repeated agent attachment as seen in https://dev.azure.com/apachehudi/hudi-oss-ci/_build/results?buildId=4742&view=logs&j=d8698f62-59df-5d60-659e-8e4b90e4e5ba&t=7e6a176b-fa3b-5e2b-bced-8d295e83a4a8&l=12623

### Impact

Fix azure ci

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
