### PR TITLE
[MINOR] Force UT hudi-hadoop-common & Hudi Utilities others Azure CI to use ubuntu 24

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -400,6 +400,9 @@ stages:
       - job: UT_FT_8
         displayName: UT hudi-hadoop-common & Hudi Utilities others
         timeoutInMinutes: '75'
+        # trying with specific container image
+        container:
+          image: '20250323.1.0'
         steps:
           - task: Docker@2
             displayName: "login to docker hub"

--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -400,9 +400,9 @@ stages:
       - job: UT_FT_8
         displayName: UT hudi-hadoop-common & Hudi Utilities others
         timeoutInMinutes: '75'
-        # trying with specific container image
-        container:
-          image: '20250323.1.0'
+        # trying with ubuntu 24
+        pool:
+          vmImage: 'ubuntu-24.04'
         steps:
           - task: Docker@2
             displayName: "login to docker hub"


### PR DESCRIPTION
### Change Logs

There's some issue with the latest linux kernel version in the ubuntu 22.04 version, so using ubuntu 24.04 which still refers to `6.8.0-1021-azure` linux version is a temporary workaround to get `UT hudi-hadoop-common & Hudi Utilities others` passing in Azure CI.

### Impact

Test fix

### Risk level (write none, low medium or high below)

None

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
