### PR TITLE
[HUDI-9302] Enable vectorized reading for file slice without log file

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedParquetFileFormat.scala
@@ -75,17 +75,31 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
   private val sanitizedTableName = AvroSchemaUtils.getAvroRecordQualifiedName(tableName)
 
   /**
-   * Support batch needs to remain consistent, even if one side of a bootstrap merge can support
-   * while the other side can't
+   * Support vectorized reading
    */
   private var supportBatchCalled = false
+
+  /**
+   * Support return result as batch
+   */
   private var supportBatchResult = false
 
+  /**
+   * Check if the file format supports vectorized reading, please refer to SPARK-40918
+   *
+   * NOTE: for mor read, even for file-slice with only base file, we can read parquet file with vectorized, but the return result of the whole data-source-scan phase cannot be batch,
+   * because when there are any log file in a file slice, it needs to be read by the file group reader.
+   * Since we are currently performing merges based on rows, the result returned at this time is also based on rows,
+   * we cannot assume that all file slices have only base files.
+   * So we need to set the batch result back to false
+   *
+   */
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
-    if (!supportBatchCalled || supportBatchResult) {
-      supportBatchCalled = true
-      supportBatchResult = !isMOR && !isIncremental && !isBootstrap && super.supportBatch(sparkSession, schema)
-    }
+    val superSupportBatch = super.supportBatch(sparkSession, schema)
+    supportBatchCalled = !isIncremental && !isBootstrap && superSupportBatch
+    supportBatchResult = !isMOR && supportBatchCalled
+    logInfo(s"supportBatchResult: $supportBatchResult, supportBatchCalled: $supportBatchCalled, isIncremental: $isIncremental, " +
+      s"isBootstrap: $isBootstrap, superSupportBatch: $superSupportBatch")
     supportBatchResult
   }
 
@@ -148,8 +162,16 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
     val requestedSchema = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
     val requestedAvroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(requestedSchema, sanitizedTableName)
     val dataAvroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(dataSchema, sanitizedTableName)
-    val parquetFileReader = spark.sparkContext.broadcast(sparkAdapter.createParquetFileReader(supportBatchResult,
+    val parquetFileReaderForBaseOnly = spark.sparkContext.broadcast(sparkAdapter.createParquetFileReader(supportBatchCalled,
       spark.sessionState.conf, options, augmentedStorageConf.unwrap()))
+    val parquetFileReaderForFileGroupReader = if (isMOR && supportBatchCalled) {
+      // for file group reader to perform read, we always need to read the record without vectorized reader because our merging is based on row level
+      // TODO: please consider to support vectorized reader in file group reader
+      spark.sparkContext.broadcast(sparkAdapter.createParquetFileReader(false,
+        spark.sessionState.conf, options, augmentedStorageConf.unwrap()))
+    } else {
+      parquetFileReaderForBaseOnly
+    }
     val broadcastedStorageConf = spark.sparkContext.broadcast(new SerializableConfiguration(augmentedStorageConf.unwrap()))
     val fileIndexProps: TypedProperties = HoodieFileIndex.getConfigProperties(spark, options, null)
 
@@ -162,7 +184,7 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
             .getSparkPartitionedFileUtils.getPathFromPartitionedFile(file))
           fileSliceMapping.getSlice(filegroupName) match {
             case Some(fileSlice) if !isCount && (requiredSchema.nonEmpty || fileSlice.getLogFiles.findAny().isPresent) =>
-              val readerContext = new SparkFileFormatInternalRowReaderContext(parquetFileReader.value, filters, requiredFilters)
+              val readerContext = new SparkFileFormatInternalRowReaderContext(parquetFileReaderForFileGroupReader.value, filters, requiredFilters)
               val metaClient: HoodieTableMetaClient = HoodieTableMetaClient
                 .builder().setConf(storageConf).setBasePath(tablePath).build
               val props = metaClient.getTableConfig.getProps
@@ -180,15 +202,15 @@ class HoodieFileGroupReaderBasedParquetFileFormat(tablePath: String,
                 fixedPartitionIndexes)
 
             case _ =>
-              readBaseFile(file, parquetFileReader.value, requestedSchema, remainingPartitionSchema, fixedPartitionIndexes,
+              readBaseFile(file, parquetFileReaderForBaseOnly.value, requestedSchema, remainingPartitionSchema, fixedPartitionIndexes,
                 requiredSchema, partitionSchema, outputSchema, filters, storageConf)
           }
         // CDC queries.
         case hoodiePartitionCDCFileGroupSliceMapping: HoodiePartitionCDCFileGroupMapping =>
-          buildCDCRecordIterator(hoodiePartitionCDCFileGroupSliceMapping, parquetFileReader.value, storageConf, fileIndexProps, requiredSchema)
+          buildCDCRecordIterator(hoodiePartitionCDCFileGroupSliceMapping, parquetFileReaderForFileGroupReader.value, storageConf, fileIndexProps, requiredSchema)
 
         case _ =>
-          readBaseFile(file, parquetFileReader.value, requestedSchema, remainingPartitionSchema, fixedPartitionIndexes,
+          readBaseFile(file, parquetFileReaderForBaseOnly.value, requestedSchema, remainingPartitionSchema, fixedPartitionIndexes,
             requiredSchema, partitionSchema, outputSchema, filters, storageConf)
       }
     }

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark33ParquetReader.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark33ParquetReader.scala
@@ -252,6 +252,17 @@ object Spark33ParquetReader extends SparkParquetReaderBuilder {
       sqlConf.getConfString("spark.sql.legacy.parquet.nanosAsLong", "false").toBoolean
     )
 
+    // Should always be set by FileSourceScanExec creating this.
+    // Check conf before checking option, to allow working around an issue by changing conf.
+    val returningBatch = sqlConf.parquetVectorizedReaderEnabled &&
+      options.get(FileFormat.OPTION_RETURNING_BATCH)
+        .getOrElse {
+          throw new IllegalArgumentException(
+            "OPTION_RETURNING_BATCH should always be set for ParquetFileFormat. " +
+              "To workaround this issue, set spark.sql.parquet.enableVectorizedReader=false.")
+        }
+        .equals("true")
+
     val parquetOptions = new ParquetOptions(options, sqlConf)
     new Spark33ParquetReader(enableVectorizedReader = vectorized,
       datetimeRebaseModeInRead = parquetOptions.datetimeRebaseModeInRead,
@@ -266,7 +277,7 @@ object Spark33ParquetReader extends SparkParquetReaderBuilder {
       timestampConversion = sqlConf.isParquetINT96TimestampConversion,
       enableOffHeapColumnVector = sqlConf.offHeapColumnVectorEnabled,
       capacity = sqlConf.parquetVectorizedReaderBatchSize,
-      returningBatch = sqlConf.parquetVectorizedReaderEnabled,
+      returningBatch = returningBatch,
       enableRecordFilter = sqlConf.parquetRecordFilterEnabled,
       timeZoneId = Some(sqlConf.sessionLocalTimeZone))
   }


### PR DESCRIPTION
Current `snapshot` reading performance of file slice with base file only has greater rollback than `read_optimized` read performance.
The main reason is that `read_optimized` is a chance to turn on vectorized reading parquet, but `snapshot` reads never do vectorized reading. Refer to spark's code: https://github.com/apache/spark/pull/38397 , this behavior seems a little too strict. Because we can separate whether  parquet is read as vectorized or not and whether batch is returned. 
So I modified the code, even if `snapshot` read occurs, but if the slice to read is only the base file, It uses vectorization to read parquet. However, when using `snapshot` to read, the batch result is always set to false, because we can't be sure if there is a file slice that needs to be merged on read time, which is row-based, so the batch result cannot be returned.

> Our test case

1. all file slices are base file only
2. 3G per partition

> Read with operation: read_optimized

<img width="256" alt="image" src="https://github.com/user-attachments/assets/776a0c88-6d63-48ee-a4e3-056970c12368" />


> Before optimization: snapshot_read

<img width="277" alt="image" src="https://github.com/user-attachments/assets/a09d84a9-91fc-4e80-a970-a7ad600134d9" />

> After optimization: snapshot_read

<img width="248" alt="image" src="https://github.com/user-attachments/assets/529b4410-d643-4f84-9a1b-d18cee23168e" />



### Change Logs

1. enable vectorized reading for file slice without log file


### Impact

improve snapshot read performance when there are some file slices which are base-file-only.

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
