### PR TITLE
[HUDI-9377] feat(datahub-sync): adds DataPlatformInstance aspect

### DIFF
--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -33,6 +33,8 @@ import org.apache.hudi.sync.datahub.util.SchemaFieldsUtil;
 import com.linkedin.common.BrowsePathEntry;
 import com.linkedin.common.BrowsePathEntryArray;
 import com.linkedin.common.BrowsePathsV2;
+import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.Status;
 import com.linkedin.common.SubTypes;
 import com.linkedin.common.UrnArray;
@@ -72,6 +74,9 @@ public class DataHubSyncClient extends HoodieSyncClient {
   private static final Logger LOG = LoggerFactory.getLogger(DataHubSyncClient.class);
 
   protected final DataHubSyncConfig config;
+  private final DataPlatformUrn dataPlatformUrn;
+  private final Option<String> dataPlatformInstance;
+  private final Option<Urn> dataPlatformInstanceUrn;
   private final DatasetUrn datasetUrn;
   private final Urn databaseUrn;
   private final String tableName;
@@ -83,6 +88,9 @@ public class DataHubSyncClient extends HoodieSyncClient {
     this.config = config;
     HoodieDataHubDatasetIdentifier datasetIdentifier =
             config.getDatasetIdentifier();
+    this.dataPlatformUrn = datasetIdentifier.getDataPlatformUrn();
+    this.dataPlatformInstance = datasetIdentifier.getDataPlatformInstance();
+    this.dataPlatformInstanceUrn = datasetIdentifier.getDataPlatformInstanceUrn();
     this.datasetUrn = datasetIdentifier.getDatasetUrn();
     this.databaseUrn = datasetIdentifier.getDatabaseUrn();
     this.tableName = datasetIdentifier.getTableName();
@@ -211,8 +219,8 @@ public class DataHubSyncClient extends HoodieSyncClient {
     return containerProposal;
   }
 
-  private MetadataChangeProposalWrapper createBrowsePathsAspect(Urn entityUrn, List<BrowsePathEntry> path) {
-    BrowsePathEntryArray browsePathEntryArray = new BrowsePathEntryArray(path);
+  private MetadataChangeProposalWrapper createBrowsePathsAspect(Urn entityUrn, List<BrowsePathEntry> paths) {
+    BrowsePathEntryArray browsePathEntryArray = new BrowsePathEntryArray(paths);
     MetadataChangeProposalWrapper browsePathsProposal = MetadataChangeProposalWrapper.builder()
             .entityType(entityUrn.getEntityType())
             .entityUrn(entityUrn)
@@ -220,6 +228,21 @@ public class DataHubSyncClient extends HoodieSyncClient {
             .aspect(new BrowsePathsV2().setPath(browsePathEntryArray))
             .build();
     return browsePathsProposal;
+  }
+
+  private MetadataChangeProposalWrapper createDataPlatformInstanceAspect(Urn entityUrn) {
+    DataPlatformInstance dataPlatformInstanceAspect = new DataPlatformInstance().setPlatform(this.dataPlatformUrn);
+    if (this.dataPlatformInstanceUrn.isPresent()) {
+      dataPlatformInstanceAspect.setInstance(dataPlatformInstanceUrn.get());
+    }
+
+    MetadataChangeProposalWrapper dataPlatformInstanceProposal = MetadataChangeProposalWrapper.builder()
+            .entityType(entityUrn.getEntityType())
+            .entityUrn(entityUrn)
+            .upsert()
+            .aspect(dataPlatformInstanceAspect)
+            .build();
+    return dataPlatformInstanceProposal;
   }
 
   private MetadataChangeProposalWrapper createDomainAspect(Urn entityUrn) {
@@ -246,10 +269,16 @@ public class DataHubSyncClient extends HoodieSyncClient {
             .aspect(new ContainerProperties().setName(databaseName))
             .build();
 
+    List<BrowsePathEntry> paths = dataPlatformInstanceUrn.map(dpiUrn -> Collections.singletonList(
+        new BrowsePathEntry().setUrn(dpiUrn).setId(dpiUrn.toString()))
+    ).orElse(Collections.emptyList());
+
     Stream<MetadataChangeProposalWrapper> resultStream = Stream.of(
             containerEntityProposal,
             createSubTypeAspect(databaseUrn, "Database"),
-            createBrowsePathsAspect(databaseUrn, Collections.emptyList()), createStatusAspect(databaseUrn),
+            createDataPlatformInstanceAspect(databaseUrn),
+            createBrowsePathsAspect(databaseUrn, paths),
+            createStatusAspect(databaseUrn),
             config.attachDomain() ? createDomainAspect(databaseUrn) : null
         ).filter(Objects::nonNull);
     return resultStream;
@@ -308,10 +337,20 @@ public class DataHubSyncClient extends HoodieSyncClient {
   }
 
   private Stream<MetadataChangeProposalWrapper> createDatasetEntity() {
+    BrowsePathEntry databasePath = new BrowsePathEntry().setUrn(databaseUrn).setId(databaseName);
+    List<BrowsePathEntry> paths = dataPlatformInstanceUrn.map(dpiUrn -> {
+      List<BrowsePathEntry> list = new ArrayList<BrowsePathEntry>();
+      list.add(new BrowsePathEntry().setUrn(dpiUrn).setId(dpiUrn.toString()));
+      list.add(databasePath);
+      return list;
+    }
+    ).orElse(Collections.singletonList(databasePath));
+
     Stream<MetadataChangeProposalWrapper> result = Stream.of(
             createStatusAspect(datasetUrn),
             createSubTypeAspect(datasetUrn, "Table"),
-            createBrowsePathsAspect(datasetUrn, Collections.singletonList(new BrowsePathEntry().setUrn(databaseUrn).setId(databaseName))),
+            createDataPlatformInstanceAspect(datasetUrn),
+            createBrowsePathsAspect(datasetUrn, paths),
             createContainerAspect(datasetUrn, databaseUrn),
             createSchemaMetadataAspect(tableName),
             config.attachDomain() ? createDomainAspect(datasetUrn) : null

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -78,6 +78,13 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       .withDocumentation("String used to represent Hudi when creating its corresponding DataPlatform entity "
           + "within Datahub");
 
+  public static final ConfigProperty<String> META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME = ConfigProperty
+      .key("hoodie.meta.sync.datahub.dataplatform_instance.name")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("String used to represent Hudi instance when emitting Container and Dataset entities "
+          + "with the corresponding DataPlatformInstance, only if given.");
+
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATASET_ENV = ConfigProperty
       .key("hoodie.meta.sync.datahub.dataset.env")
       .defaultValue(DEFAULT_DATAHUB_ENV.name())
@@ -174,6 +181,10 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
         + "corresponding DataPlatform entity within Datahub")
     public String dataPlatformName;
 
+    @Parameter(names = {"--data-platform-instance-name"}, description = "String used to represent Hudi instance when emitting Container and Dataset entities "
+        + "with the corresponding DataPlatformInstance, only if given.")
+    public String dataPlatformInstanceName;
+
     @Parameter(names = {"--dataset-env"}, description = "Which Datahub Environment to use when pushing entities")
     public String datasetEnv;
 
@@ -196,6 +207,7 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_EMITTER_TOKEN.key(), emitterToken);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_EMITTER_SUPPLIER_CLASS.key(), emitterSupplierClass);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATAPLATFORM_NAME.key(), dataPlatformName);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME.key(), dataPlatformInstanceName);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATASET_ENV.key(), datasetEnv);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_DOMAIN_IDENTIFIER.key(), domainIdentifier);
       // We want the default behavior of DataHubSync Tool when run as command line to NOT suppress exceptions

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.sync.datahub.config;
 
+import org.apache.hudi.common.util.Option;
+
 import com.linkedin.common.FabricType;
 import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.DatasetUrn;
@@ -29,6 +31,7 @@ import java.util.Properties;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATASET_ENV;
 
@@ -43,6 +46,10 @@ public class HoodieDataHubDatasetIdentifier {
   public static final FabricType DEFAULT_DATAHUB_ENV = FabricType.DEV;
 
   protected final Properties props;
+  private final String dataPlatform;
+  private final DataPlatformUrn dataPlatformUrn;
+  private final Option<String> dataPlatformInstance;
+  private final Option<Urn> dataPlatformInstanceUrn;
   private final DatasetUrn datasetUrn;
   private final Urn databaseUrn;
   private final String tableName;
@@ -55,18 +62,26 @@ public class HoodieDataHubDatasetIdentifier {
     }
     DataHubSyncConfig config = new DataHubSyncConfig(props);
 
+    this.dataPlatform = config.getStringOrDefault(META_SYNC_DATAHUB_DATAPLATFORM_NAME);
+    this.dataPlatformUrn = createDataPlatformUrn(this.dataPlatform);
+    this.dataPlatformInstance = Option.ofNullable(config.getString(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME));
+    this.dataPlatformInstanceUrn = createDataPlatformInstanceUrn(
+        this.dataPlatformUrn,
+        Option.ofNullable(config.getString(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME))
+    );
     this.datasetUrn = new DatasetUrn(
-            createDataPlatformUrn(config.getStringOrDefault(META_SYNC_DATAHUB_DATAPLATFORM_NAME)),
-            createDatasetName(config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)),
+            this.dataPlatformUrn,
+            createDatasetName(this.dataPlatformInstance, config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)),
             FabricType.valueOf(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV))
     );
 
     this.tableName = config.getString(META_SYNC_TABLE_NAME);
     this.databaseName = config.getString(META_SYNC_DATABASE_NAME);
 
+    // https://github.com/datahub-project/datahub/blob/0b105395e913cc47a59bdeed0c56d7c0d4b71b63/metadata-ingestion/src/datahub/emitter/mcp_builder.py#L69-L72
     DatabaseKey databaseKey = DatabaseKey.builder()
             .platform(config.getStringOrDefault(META_SYNC_DATAHUB_DATAPLATFORM_NAME))
-            .instance(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV))
+            .instance(this.dataPlatformInstance.orElse(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV)))
             .database(this.databaseName)
             .build();
 
@@ -75,6 +90,22 @@ public class HoodieDataHubDatasetIdentifier {
 
   public DatasetUrn getDatasetUrn() {
     return this.datasetUrn;
+  }
+
+  public String getDataPlatform() {
+    return this.dataPlatform;
+  }
+
+  public DataPlatformUrn getDataPlatformUrn() {
+    return this.dataPlatformUrn;
+  }
+
+  public Option<String> getDataPlatformInstance() {
+    return this.dataPlatformInstance;
+  }
+
+  public Option<Urn> getDataPlatformInstanceUrn() {
+    return this.dataPlatformInstanceUrn;
   }
 
   public Urn getDatabaseUrn() {
@@ -93,7 +124,22 @@ public class HoodieDataHubDatasetIdentifier {
     return new DataPlatformUrn(platformUrn);
   }
 
-  private static String createDatasetName(String databaseName, String tableName) {
+  private static Option<Urn> createDataPlatformInstanceUrn(DataPlatformUrn dataPlatformUrn, Option<String> dataPlatformInstance) {
+    if (dataPlatformInstance.isEmpty()) {
+      return Option.empty();
+    }
+    String dataPlatformInstanceStr = String.format("urn:li:dataPlatformInstance:(%s,%s)", dataPlatformUrn.toString(), dataPlatformInstance.get());
+    try {
+      return Option.of(Urn.createFromString(dataPlatformInstanceStr));
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Failed to create DataPlatformInstance URN from string: %s", dataPlatformInstanceStr), e);
+    }
+  }
+
+  private static String createDatasetName(Option<String> dataPlatformInstance, String databaseName, String tableName) {
+    if (dataPlatformInstance.isPresent()) {
+      return String.format("%s.%s.%s", dataPlatformInstance.get(), databaseName, tableName);
+    }
     return String.format("%s.%s", databaseName, tableName);
   }
 }


### PR DESCRIPTION
### Change Logs

This update introduces the ability to set `DataPlatformInstance` via configuration.

**Before this PR:**

* `DataPlatformInstance` was not emitted for either `Dataset` or `Container` entities.
* It was automatically injected by the DataHub backend, only for `Dataset`, and included only the `platform` field.

**With this PR:**

* If no platform instance is configured:
  * `DataPlatformInstance` is consistently emitted for both `Dataset` and `Container` entities, including only the `platform` field.

* If a platform instance is configured:
  * `DataPlatformInstance` is consistently emitted for both `Dataset` and `Container` entities, including both the `platform` and `instance` fields.
  * The platform instance is included in the browse paths.
  * The platform instance is also included in the identity (URN) for both `Dataset` and `Container`.

Consistent and correct management of `DataPlatformInstance` aspect is relevant for the platform instance filtering in the DataHub UI as well as the browsing experience.

### Impact

Low

### Risk level (write none, low medium or high below)

None

### Documentation Update

- The new optional config feature needs to be documented

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
