### PR TITLE
[HUDI-9308]Fix incorrect usage of mapreduce.input.fileinputformat.split.maxsize in HoodieCombineHiveInputFormat

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -975,16 +975,15 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
         }
         ArrayList<CombineFileSplit> combineFileSplits = new ArrayList<>();
         HoodieCombineRealtimeFileSplit.Builder builder = new HoodieCombineRealtimeFileSplit.Builder();
-        int counter = 0;
+        long counter = 0;
         for (int pos = 0; pos < splits.length; pos++) {
-          if (counter == maxSize - 1 || pos == splits.length - 1) {
-            builder.addSplit((FileSplit) splits[pos]);
+          InputSplit split = splits[pos];
+          counter += split.getLength();
+          builder.addSplit((FileSplit) split);
+          if (counter >= maxSize || pos == splits.length - 1) {
             combineFileSplits.add(builder.build(job));
             builder = new HoodieCombineRealtimeFileSplit.Builder();
             counter = 0;
-          } else if (counter < maxSize) {
-            counter++;
-            builder.addSplit((FileSplit) splits[pos]);
           }
         }
         return combineFileSplits.toArray(new CombineFileSplit[combineFileSplits.size()]);


### PR DESCRIPTION
### Change Logs

`mapreduce.input.fileinputformat.split.maxsize` is used to control the split size. When using CombineInputFormat, it is used to control the size of `CombineSplit`. But in `HoodieCombineHiveInputFormat`, it is used to control how many original splits are combined into one `CombineSplit`.

https://github.com/apache/hudi/blob/7c9a1ddc1b2b39b5a3a634691a83054b1b876f0b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java#L978-L989

### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
