### PR TITLE
[HUDI-9304] support configurable RowDataParquetWriteSupport for Flink

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
@@ -115,8 +116,12 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
         writeConfig.getBloomFilterFPP(),
         writeConfig.getDynamicBloomFilterMaxNumEntries(),
         writeConfig.getBloomFilterType());
-    HoodieRowDataParquetWriteSupport writeSupport =
-        new HoodieRowDataParquetWriteSupport((Configuration) table.getStorageConf().unwrap(), rowType, filter);
+
+    HoodieRowDataParquetWriteSupport writeSupport = (HoodieRowDataParquetWriteSupport) ReflectionUtils.loadClass(
+        writeConfig.getStringOrDefault(HoodieStorageConfig.HOODIE_PARQUET_FLINK_ROW_DATA_WRITE_SUPPORT_CLASS),
+        new Class<?>[] {Configuration.class, RowType.class, BloomFilter.class},
+        (Configuration) table.getStorageConf().unwrap(), rowType, filter);
+
     return new HoodieRowDataParquetWriter(
         convertToStoragePath(path),
         new HoodieParquetConfig<>(

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -245,6 +245,14 @@ public class HoodieStorageConfig extends HoodieConfig {
           + "and it is loaded at runtime. This is only required when trying to "
           + "override the existing write context when `hoodie.datasource.write.row.writer.enable=true`.");
 
+  public static final ConfigProperty<String> HOODIE_PARQUET_FLINK_ROW_DATA_WRITE_SUPPORT_CLASS = ConfigProperty
+      .key("hoodie.parquet.flink.rowdata.write.support.class")
+      .defaultValue("org.apache.hudi.io.storage.row.HoodieRowDataParquetWriteSupport")
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Provided write support class should extend HoodieRowDataParquetWriteSupport class "
+          + "and it is loaded at runtime. This is only required when trying to override the existing write support.");
+
   public static final ConfigProperty<String> HOODIE_STORAGE_CLASS = ConfigProperty
       .key("hoodie.storage.class")
       .defaultValue("org.apache.hudi.storage.hadoop.HoodieHadoopStorage")
@@ -498,6 +506,11 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder withAvroWriteSupport(String avroWriteSupportClassName) {
       storageConfig.setValue(HOODIE_AVRO_WRITE_SUPPORT_CLASS, avroWriteSupportClassName);
+      return this;
+    }
+
+    public Builder withRowDataWriteSupport(String rowDataWriteSupportClassName) {
+      storageConfig.setValue(HOODIE_PARQUET_FLINK_ROW_DATA_WRITE_SUPPORT_CLASS, rowDataWriteSupportClassName);
       return this;
     }
 


### PR DESCRIPTION
### Change Logs

1.  Add a new storage config to hoodie.parquet.flink.rowdata.write.support.class
2. Use reflection to load the class with default constructor


### Impact
none

### Risk level (write none, low medium or high below)
none

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
