### PR TITLE
[HUDI-9309]Fix perf regression from supporting display dag of insert/update statment in spark ui

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -104,9 +104,7 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
     }
     val config = buildHoodieInsertConfig(catalogTable, sparkSession, isOverWritePartition, isOverWriteTable, partitionSpec, extraOptions, staticOverwritePartitionPathOpt)
 
-    val sparkRowSerDe = sparkAdapter.createSparkRowSerDe(query.schema)
-    val rows = query.execute().map(sparkRowSerDe.deserializeRow)
-    val df = sparkSession.createDataFrame(rows, query.schema)
+    val df = sparkSession.internalCreateDataFrame(query.execute(), query.schema)
     val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, mode, config, df)
 
     if (!success) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -57,9 +57,7 @@ case class UpdateHoodieTableCommand(ut: UpdateTable, query: LogicalPlan) extends
       buildHoodieConfig(catalogTable)
     }
 
-    val sparkRowSerDe = sparkAdapter.createSparkRowSerDe(plan.schema)
-    val rows = plan.execute().map(sparkRowSerDe.deserializeRow)
-    val df = sparkSession.createDataFrame(rows, plan.schema)
+    val df = sparkSession.internalCreateDataFrame(plan.execute(), plan.schema)
     HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, config, df)
 
     sparkSession.catalog.refreshTable(tableId)


### PR DESCRIPTION

### Change Logs
https://github.com/apache/hudi/pull/13044
https://github.com/apache/hudi/pull/13110

these two commit both use `sparkRowSerDe` to convert `RDD[InternalRow]` to `RDD[Row],` and then use `sparkSession.createDataFrame` to convert to `DataFrame`. this introduce perf regression for insert

### fix step

use `sparkSession.internalCreateDataFrame` instead

### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
