### PR TITLE
[HUDI-9203] Fix usability w/ upgrading from 0.x to 1.x and wish to stay in table version 6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -91,12 +91,6 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     HoodieTableConfig tableConfig = metaClient.getTableConfig();
     // If auto upgrade is disabled, set writer version to 6 and return
     if (!config.autoUpgrade()) {
-      /**
-       * At this point, metadata should already be disabled (see {@link UpgradeDowngrade#needsUpgradeOrDowngrade(HoodieTableVersion)}).
-       * So, check either this is a metadata table itself,  or metadata table is disabled.
-       */
-      ValidationUtils.checkState(table.isMetadataTable() || !config.isMetadataTableEnabled(),
-          "Metadata table should be disabled to write in table version SIX using 1.0.0+" + metaClient.getBasePath());
       config.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
       return tablePropsToAdd;
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -80,12 +80,6 @@ public class UpgradeDowngrade {
       throw new HoodieUpgradeDowngradeException(
           String.format("Please upgrade table from version %s to %s before upgrading to version %s.", fromTableVersion, HoodieTableVersion.SIX.versionCode(), toWriteVersion));
     }
-    // If autoUpgrade is disabled and metadata is enabled, and table version is SIX or SEVEN, while toWriteVersion is EIGHT or greater, then we should disable metadata first
-    if (!config.autoUpgrade() && metaClient.getTableConfig().isMetadataTableAvailable()
-        && (fromTableVersion == HoodieTableVersion.SIX || fromTableVersion == HoodieTableVersion.SEVEN) && toWriteVersion.versionCode() >= HoodieTableVersion.EIGHT.versionCode()) {
-      throw new HoodieUpgradeDowngradeException(
-          String.format("Please disable metadata table before upgrading from version %s to %s.", fromTableVersion, toWriteVersion));
-    }
 
     // allow upgrades otherwise.
     return toWriteVersion.versionCode() > fromTableVersion.versionCode();


### PR DESCRIPTION
### Change Logs

Currently master fails while upgrading from table version (6, 7) to 8 with `hoodie.write.auto.upgrade` set to false and metadata enabled. Since backward compatibility of metadata writer has been fixed with HUDI-9026, the PR aims to remove those checks. 

### Impact

Ensures that a version 6 or 7 table can be upgraded to version 8 with metadata enabled

### Risk level (write none, low medium or high below)

low

### Documentation Update

While upgrading to table version 8, we do not need to disable metadata  when `hoodie.write.auto.upgrade` is set to false.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
