### PR TITLE
[MINOR] Force UT FT common & other modules Azure CI to use ubuntu 24

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -513,6 +513,9 @@ stages:
               ImageName: $(Build.BuildId)
           - task: Docker@2
             displayName: "UT FT common & other modules"
+            # trying with ubuntu 24
+            pool:
+              vmImage: 'ubuntu-24.04'
             inputs:
               containerRegistry: 'apachehudi-docker-hub'
               repository: 'apachehudi/hudi-ci-bundle-validation-base'


### PR DESCRIPTION
### Change Logs

There's some issue with the latest linux kernel version in the ubuntu 22.04 version, so using ubuntu 24.04 which still refers to `6.8.0-1021-azure` linux version is a temporary workaround to get `UT FT common & other modules` passing in Azure CI.


Related PR:
https://github.com/apache/hudi/pull/13124

Related JIRA:
https://issues.apache.org/jira/browse/HUDI-9284 

### Impact

Test fix

### Risk level (write none, low medium or high below)

None

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed

