### PR TITLE
[MINOR] Use native file reader by default

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 public class HoodieReaderConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> USE_NATIVE_HFILE_READER = ConfigProperty
       .key("_hoodie.hfile.use.native.reader")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("When enabled, the native HFile reader is used to read HFiles.  This is an internal config.");


### PR DESCRIPTION
### Change Logs

In https://github.com/apache/hudi/commit/7cf6dc1832a902392b31fd0f3ee03d5895b4f680 we reverted the default to false and went back to using legacy hbase hfile reader. We also fixed an issue. However, that means other engines now need to have hbase dependencies in the classpath to read the metadata table. This defeats the purpose of native hfile reader.

The reason we went back to leagacy hfile reader in the above commit was that the native hfile reader does not work for large hfiles (> 200mb) with multiple branching of leaf index. This will be fixed in HUDI-8601. But, going back to legacy is a backward step and will not work for engines like Trino. In production, very few users will have large hfiles. We are going to call out this limitation and fix HUDI-8601 immediately in the next release.

### Impact

Use native file reader by default

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
