### PR TITLE
[HUDI-9319] Fix inconsistency of ordering value type between reader &…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/SpillableMapUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/SpillableMapUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.fs.SizeAwareDataOutputStream;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -168,8 +169,9 @@ public class SpillableMapUtils {
     if (isNullOrEmpty(preCombineField)) {
       return DEFAULT_ORDERING_VALUE;
     }
-    Schema.Field field = rec.getSchema().getField(preCombineField);
-    return field == null ? DEFAULT_ORDERING_VALUE : (Comparable) rec.get(field.pos());
+    // keep consistent with writer side, using Java type for ordering value, see `DefaultHoodieRecordPayload`.
+    Object orderingValue = HoodieAvroUtils.getNestedFieldVal(rec, preCombineField, true, false);
+    return orderingValue == null ? DEFAULT_ORDERING_VALUE : (Comparable) orderingValue;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
@@ -56,7 +56,7 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
   @Override
   public void invoke(I record) throws Exception {
     HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
-    ScalaCollector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
+    RecordsCollector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance();
     assignFunction.processElement(hoodieRecord, null, collector);
     for (HoodieFlinkInternalRow row: collector.getVal()) {
       writeFunction.processElement(row, null, null);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ConsistentBucketStreamWriteFunctionWrapper.java
@@ -58,7 +58,9 @@ public class ConsistentBucketStreamWriteFunctionWrapper<I> extends BucketStreamW
     HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
     ScalaCollector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
     assignFunction.processElement(hoodieRecord, null, collector);
-    writeFunction.processElement(collector.getVal(), null, null);
+    for (HoodieFlinkInternalRow row: collector.getVal()) {
+      writeFunction.processElement(row, null, null);
+    }
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/RecordsCollector.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/RecordsCollector.java
@@ -26,15 +26,15 @@ import java.util.List;
 /**
  * A mock {@link Collector} that used in  {@link TestFunctionWrapper}.
  */
-class ScalaCollector<T> implements Collector<T> {
+class RecordsCollector<T> implements Collector<T> {
   private List<T> val;
 
-  public ScalaCollector() {
+  public RecordsCollector() {
     this.val = new ArrayList<>();
   }
 
-  public static <T> ScalaCollector<T> getInstance() {
-    return new ScalaCollector<>();
+  public static <T> RecordsCollector<T> getInstance() {
+    return new RecordsCollector<>();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ScalaCollector.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/ScalaCollector.java
@@ -20,11 +20,18 @@ package org.apache.hudi.sink.utils;
 
 import org.apache.flink.util.Collector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A mock {@link Collector} that used in  {@link TestFunctionWrapper}.
  */
 class ScalaCollector<T> implements Collector<T> {
-  private T val;
+  private List<T> val;
+
+  public ScalaCollector() {
+    this.val = new ArrayList<>();
+  }
 
   public static <T> ScalaCollector<T> getInstance() {
     return new ScalaCollector<>();
@@ -32,15 +39,16 @@ class ScalaCollector<T> implements Collector<T> {
 
   @Override
   public void collect(T t) {
-    this.val = t;
+    this.val.add(t);
   }
 
   @Override
   public void close() {
+    this.val.clear();
     this.val = null;
   }
 
-  public T getVal() {
+  public List<T> getVal() {
     return val;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -179,7 +179,9 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
     ScalaCollector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
     bucketAssignerFunction.processElement(hoodieRecord, null, collector);
     bucketAssignFunctionContext.setCurrentKey(hoodieRecord.getRecordKey());
-    writeFunction.processElement(collector.getVal(), null, null);
+    for (HoodieFlinkInternalRow row: collector.getVal()) {
+      writeFunction.processElement(row, null, null);
+    }
   }
 
   public WriteMetadataEvent[] getEventBuffer() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -156,7 +156,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
       bootstrapOperator.setup(streamTask, streamConfig, output);
       bootstrapOperator.initializeState(this.stateInitializationContext);
 
-      Collector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
+      Collector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance();
       for (HoodieFlinkInternalRow bootstrapRecord : output.getRecords()) {
         stateInitializationContext.getKeyedStateStore().setCurrentKey(bootstrapRecord.getRecordKey());
         bucketAssignerFunction.processElement(bootstrapRecord, null, collector);
@@ -176,7 +176,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   public void invoke(I record) throws Exception {
     HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
     stateInitializationContext.getKeyedStateStore().setCurrentKey(hoodieRecord.getRecordKey());
-    ScalaCollector<HoodieFlinkInternalRow> collector = ScalaCollector.getInstance();
+    RecordsCollector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance();
     bucketAssignerFunction.processElement(hoodieRecord, null, collector);
     bucketAssignFunctionContext.setCurrentKey(hoodieRecord.getRecordKey());
     for (HoodieFlinkInternalRow row: collector.getVal()) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -1156,10 +1156,12 @@ public class TestInputFormat {
 
   @Test
   void testOrderingValueWithDecimalType() throws Exception {
-    conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
-    conf.removeKey(FlinkOptions.SOURCE_AVRO_SCHEMA_PATH.key());
-    conf.setString(FlinkOptions.SOURCE_AVRO_SCHEMA.key(), AvroSchemaConverter.convertToSchema(TestConfigurations.ROW_TYPE_DECIMAL_ORDERING).toString());
+    conf = new Configuration();
+    conf.set(FlinkOptions.PATH, tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.TABLE_NAME, "TestHoodieTable");
     conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    conf.set(FlinkOptions.PARTITION_PATH_FIELD, "partition");
+    conf.setString(FlinkOptions.SOURCE_AVRO_SCHEMA.key(), AvroSchemaConverter.convertToSchema(TestConfigurations.ROW_TYPE_DECIMAL_ORDERING).toString());
     conf.set(FlinkOptions.COMPACTION_ASYNC_ENABLED, false); // by default close the async compaction
     StreamerUtil.initTableIfNotExists(conf);
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -57,8 +57,23 @@ public class TestConfigurations {
 
   public static final RowType ROW_TYPE = (RowType) ROW_DATA_TYPE.getLogicalType();
 
+  public static final DataType ROW_DATA_TYPE_DECIMAL_ORDERING = DataTypes.ROW(
+          DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),// record key
+          DataTypes.FIELD("name", DataTypes.VARCHAR(10)),
+          DataTypes.FIELD("age", DataTypes.INT()),
+          DataTypes.FIELD("ts", DataTypes.DECIMAL(10, 0)), // precombine field
+          DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
+      .notNull();
+
+  public static final RowType ROW_TYPE_DECIMAL_ORDERING =
+      (RowType) ROW_DATA_TYPE_DECIMAL_ORDERING.getLogicalType();
+
   public static final ResolvedSchema TABLE_SCHEMA = SchemaBuilder.instance()
       .fields(ROW_TYPE.getFieldNames(), ROW_DATA_TYPE.getChildren())
+      .build();
+
+  public static final ResolvedSchema TABLE_SCHEMA_DECIMAL_ORDERING = SchemaBuilder.instance()
+      .fields(ROW_TYPE_DECIMAL_ORDERING.getFieldNames(), ROW_DATA_TYPE_DECIMAL_ORDERING.getChildren())
       .build();
 
   private static final List<String> FIELDS = ROW_TYPE.getFields().stream()
@@ -305,6 +320,8 @@ public class TestConfigurations {
   }
 
   public static final RowDataSerializer SERIALIZER = new RowDataSerializer(ROW_TYPE);
+
+  public static final RowDataSerializer SERIALIZER_DECIMAL_ORDERING = new RowDataSerializer(ROW_TYPE_DECIMAL_ORDERING);
 
   public static Configuration getDefaultConf(String tablePath) {
     Configuration conf = new Configuration();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -58,6 +58,7 @@ import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
@@ -117,6 +118,13 @@ public class TestData {
           TimestampData.fromEpochMillis(7), StringData.fromString("par4")),
       insertRow(StringData.fromString("id8"), StringData.fromString("Han"), 56,
           TimestampData.fromEpochMillis(8), StringData.fromString("par4"))
+  );
+
+  public static List<RowData> DATA_SET_INSERT_DECIMAL_ORDERING = Arrays.asList(
+      insertRow(TestConfigurations.ROW_TYPE_DECIMAL_ORDERING, StringData.fromString("id1"), StringData.fromString("Danny"),
+          23, DecimalData.fromBigDecimal(BigDecimal.TEN, 10, 0), StringData.fromString("par1")),
+      insertRow(TestConfigurations.ROW_TYPE_DECIMAL_ORDERING, StringData.fromString("id1"), StringData.fromString("Bob"),
+          44, DecimalData.fromBigDecimal(BigDecimal.ONE, 10, 0), StringData.fromString("par2"))
   );
 
   public static List<RowData> DATA_SET_INSERT_PARTITION_IS_NULL = Arrays.asList(
@@ -499,8 +507,15 @@ public class TestData {
    * Returns string format of a list of RowData.
    */
   public static String rowDataToString(List<RowData> rows) {
+    return rowDataToString(rows, TestConfigurations.ROW_DATA_TYPE);
+  }
+
+  /**
+   * Returns string format of a list of RowData.
+   */
+  public static String rowDataToString(List<RowData> rows, DataType rowType) {
     DataStructureConverter<Object, Object> converter =
-        DataStructureConverters.getConverter(TestConfigurations.ROW_DATA_TYPE);
+        DataStructureConverters.getConverter(rowType);
     return rows.stream()
         .sorted(Comparator.comparing(o -> toIdSafely(o.getString(0))))
         .map(row -> converter.toExternal(row).toString())
@@ -671,8 +686,20 @@ public class TestData {
    * @param expected Expected row data list
    */
   public static void assertRowDataEquals(List<RowData> rows, List<RowData> expected) {
-    String rowsString = rowDataToString(rows);
-    assertThat(rowsString, is(rowDataToString(expected)));
+    assertRowDataEquals(rows, expected, TestConfigurations.ROW_DATA_TYPE);
+  }
+
+  /**
+   * Sort the {@code rows} using field at index 0 and asserts
+   * it equals with the expected row data list {@code expected}.
+   *
+   * @param rows     Actual result rows
+   * @param expected Expected row data list
+   * @param rowType DataType for record
+   */
+  public static void assertRowDataEquals(List<RowData> rows, List<RowData> expected, DataType rowType) {
+    String rowsString = rowDataToString(rows, rowType);
+    assertThat(rowsString, is(rowDataToString(expected, rowType)));
   }
 
   /**


### PR DESCRIPTION
… writers

### Change Logs

Fix inconsistency of ordering value type between reader & writers

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
