### PR TITLE
[HUDI-9324]Support displaying complete dag for delete statement in spark web ui

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -437,8 +437,10 @@ case class ResolveImplementations(sparkSession: SparkSession) extends Rule[Logic
 
 
         // Convert to DeleteHoodieTableCommand
-        case dft@DeleteFromTable(plan@ResolvesToHudiTable(_), _) if dft.resolved =>
-          DeleteHoodieTableCommand(dft)
+        case dft@DeleteFromTable(ResolvesToHudiTable(table), _) if dft.resolved =>
+          val catalogTable = new HoodieCatalogTable(sparkSession, table)
+          val (plan, config) = DeleteHoodieTableCommand.inputPlan(sparkSession, dft, catalogTable)
+          DeleteHoodieTableCommand(catalogTable, plan, config)
 
         // Convert to CompactionHoodieTableCommand
         case ct @ CompactionTable(plan @ ResolvesToHudiTable(table), operation, options) if ct.resolved =>


### PR DESCRIPTION
Support displaying complete dag for delete statement in spark web ui

### implement steps
- resolve input plan while analyzing `DeleteTable` and then convert to `DeleteHoodieTableCommand`
- make `DeleteHoodieTableCommand` extends `DataWritingCommand`

Before:
![image](https://github.com/user-attachments/assets/9236c1ac-3d9a-4621-972d-c3d9a1d53f02)

After:
![image](https://github.com/user-attachments/assets/53cb55c3-5461-4e3e-9ab5-cb9083529509)



### Change Logs
None

### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
