### PR TITLE
[MINOR] Time generator defaults to sleeping for 200ms even with in-process lock provider

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -113,7 +113,7 @@ public class HoodieConfig implements Serializable {
     }
   }
 
-  public Boolean contains(String key) {
+  public boolean contains(String key) {
     return props.containsKey(key);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTimeGeneratorConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTimeGeneratorConfig.java
@@ -132,11 +132,10 @@ public class HoodieTimeGeneratorConfig extends HoodieConfig {
     }
 
     public HoodieTimeGeneratorConfig build() {
-      timeGeneratorConfig.setDefaults(HoodieTimeGeneratorConfig.class.getName());
-
       if (!timeGeneratorConfig.contains(LOCK_PROVIDER_KEY)) {
         timeGeneratorConfig.setValue(LOCK_PROVIDER_KEY, DEFAULT_LOCK_PROVIDER);
       }
+      timeGeneratorConfig.setDefaults(HoodieTimeGeneratorConfig.class.getName());
       return timeGeneratorConfig;
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTimeGeneratorConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTimeGeneratorConfig.java
@@ -19,7 +19,8 @@
 
 package org.apache.hudi.common.config;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.hudi.common.util.StringUtils;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -38,7 +39,7 @@ class TestHoodieTimeGeneratorConfig {
   void testMaxSkewDefaults(String lockProvider, long expected) {
     TypedProperties properties = new TypedProperties();
     properties.setProperty(BASE_PATH.key(), "/tmp/path");
-    if (StringUtils.isNotEmpty(lockProvider)) {
+    if (!StringUtils.isNullOrEmpty(lockProvider)) {
       properties.setProperty(HoodieTimeGeneratorConfig.LOCK_PROVIDER_KEY, lockProvider);
     }
     HoodieTimeGeneratorConfig config = HoodieTimeGeneratorConfig.newBuilder().fromProperties(properties).build();

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTimeGeneratorConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTimeGeneratorConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestHoodieTimeGeneratorConfig {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "org.apache.hudi.client.transaction.lock.InProcessLockProvider,1",
+      "org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider,200",
+      ",1",
+      "any_string,200"
+  })
+  void testMaxSkewDefaults(String lockProvider, long expected) {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(BASE_PATH.key(), "/tmp/path");
+    if (StringUtils.isNotEmpty(lockProvider)) {
+      properties.setProperty(HoodieTimeGeneratorConfig.LOCK_PROVIDER_KEY, lockProvider);
+    }
+    HoodieTimeGeneratorConfig config = HoodieTimeGeneratorConfig.newBuilder().fromProperties(properties).build();
+    assertEquals(expected, config.getMaxExpectedClockSkewMs());
+  }
+}


### PR DESCRIPTION
### Change Logs

- Fixes issue in the ordering of applying defaults so that the in process time generator will sleep for 1ms as intended

### Impact

- Lowers execution time by 199ms for a lot of our tests

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
