### PR TITLE
[HUDI-8902] Fix the incorrect data read after changing the column type from float to double

### DIFF
--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
@@ -63,7 +63,7 @@ class Spark3ParquetSchemaEvolutionUtils(sharedConf: Configuration,
     val layout = TimelineLayout.fromVersion(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
     InternalSchemaCache.getInternalSchemaByVersionId(commitInstantTime, tablePath,
       new HoodieHadoopStorage(tablePath, sharedConf), if (validCommits == null) "" else validCommits,
-      layout.getInstantFileNameParser, layout.getCommitMetadataSerDe, layout.getInstantGenerator)
+      layout)
   } else {
     null
   }

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark33LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark33LegacyHoodieParquetFileFormat.scala
@@ -168,7 +168,7 @@ class Spark33LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
         val storage = new HoodieHadoopStorage(tablePath, sharedConf)
         InternalSchemaCache.getInternalSchemaByVersionId(
           commitInstantTime, tablePath, storage, if (validCommits == null) "" else validCommits,
-          layout.getInstantFileNameParser, layout.getCommitMetadataSerDe, layout.getInstantGenerator)
+          layout)
       } else {
         null
       }

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark34LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark34LegacyHoodieParquetFileFormat.scala
@@ -179,7 +179,7 @@ class Spark34LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
         val storage = new HoodieHadoopStorage(tablePath, sharedConf)
         InternalSchemaCache.getInternalSchemaByVersionId(commitInstantTime, tablePath, storage,
           if (validCommits == null) "" else validCommits,
-          layout.getInstantFileNameParser, layout.getCommitMetadataSerDe, layout.getInstantGenerator)
+          layout)
       } else {
         null
       }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark35LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark35LegacyHoodieParquetFileFormat.scala
@@ -180,7 +180,7 @@ class Spark35LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
         val layout = TimelineLayout.fromVersion(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
         InternalSchemaCache.getInternalSchemaByVersionId(
           commitInstantTime, tablePath, storage, if (validCommits == null) "" else validCommits,
-          layout.getInstantFileNameParser, layout.getCommitMetadataSerDe, layout.getInstantGenerator)
+          layout)
       } else {
         null
       }


### PR DESCRIPTION
Fix the incorrect data read after changing the column type from float to double

There are two reasons for the above problems：
1. `InternalSchemaCache` cannot obtain the path of the commit file correctly. Because after version 1.x, we placed the commit file separately in the `timeline` directory. However, `InternalSchemaCache` still retrievals files from `basePath/.hoodie`, thus failing to obtain the correct schema.
2. When we read parquet file without `enableVectorizedReader`, we use spark 's `CAST` for type conversion when we need to do scheme evolution, but spark has a loss of precision when dealing with `CAST` that converts `float` to `double`.

Change logs:
1. pass the correct timeline path for `InternalSchemaCache`
2. for schema evolution without `enableVectorizedReader`, for the case `CAST(FLOAT as DOUBLE)` we turn it to `CAST(CAST(FLOAT as STRING) as DOUBLE)`.

### Change Logs

1. pass the correct timeline path for `InternalSchemaCache`
2. for schema evolution without `enableVectorizedReader`, for the case `CAST(FLOAT as DOUBLE)` we turn it to `CAST(CAST(FLOAT as STRING) as DOUBLE)`.

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

fix the incorrectness after change data type from float to double

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
