### PR TITLE
[HUDI-9329] Avoid obtaining an incorrect partition id due to int type overflow in `BucketIndexUtil`

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/BucketIndexUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/BucketIndexUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.util.hash;
 
 import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.ValidationUtils;
 
 /**
  * Utility class for bucket index.
@@ -37,9 +38,12 @@ public class BucketIndexUtil {
    */
   public static Functions.Function3<Integer, String, Integer, Integer> getPartitionIndexFunc(int parallelism) {
     return (bucketNum, partition, curBucket) -> {
-      int partitionIndex = (partition.hashCode() & Integer.MAX_VALUE) % parallelism * bucketNum;
-      int globalIndex = partitionIndex + curBucket;
-      return globalIndex % parallelism;
+      long partitionIndex = (partition.hashCode() & Integer.MAX_VALUE) % parallelism * (long) bucketNum;
+      long globalIndex = partitionIndex + curBucket;
+      int partitionId = (int) (globalIndex % parallelism);
+      ValidationUtils.checkArgument(partitionId >= 0 && partitionId < parallelism,
+          () -> "Partition id should be in range [0, " + parallelism + "), but got " + partitionId);
+      return partitionId;
     };
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/hash/TestBucketIndexUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/hash/TestBucketIndexUtil.java
@@ -55,6 +55,7 @@ public class TestBucketIndexUtil {
     argsList.add(Arguments.of(201, 100, true));
     argsList.add(Arguments.of(400, 1000, true));
     argsList.add(Arguments.of(401, 1000, true));
+    argsList.add(Arguments.of(65536, 65536, true));
 
     return argsList.stream();
   }
@@ -144,6 +145,7 @@ public class TestBucketIndexUtil {
 
   private void checkResult(Map<Integer, Integer> parallelism2TaskCount, int parallelism, int bucketNumber, boolean partitioned, boolean needExpand) {
     int sum = 0;
+    assertTrue(parallelism2TaskCount.keySet().stream().allMatch(id -> id >= 0 && id < parallelism));
     for (int v : parallelism2TaskCount.values()) {
       sum = sum + v;
     }


### PR DESCRIPTION
We execute a sql with:
1. `bulk insert` operation
2. `92160 ` buckets per partition
3. `set hoodie.bulkinsert.shuffle.parallelism=92160`

And then there a error occurs:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/5fa5f11e-06fb-467e-8c60-527b486f95e9" />

The reason for this error is that when our partitioner calculates the partition id, it returns a number that is not within the parallelism range.

As for why an illegal id was returned, is it because there is an overflow of int type during the process of calculating the id.

<img width="937" alt="image" src="https://github.com/user-attachments/assets/8084a4f2-0ffe-401a-8ea3-c1cfe3c7fab9" />


### Change Logs

1. avoid obtaining an incorrect partition id due to int type overflow in `BucketIndexUtil`

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

fix the error when we set a large buckets num and large `hoodie.bulkinsert.shuffle.parallelism`

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
