### PR TITLE
[HUDI-9331] Fix Incorrect memory estimation for CDC block flushing can lead to OOM

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCDCLogger.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCDCLogger.java
@@ -177,6 +177,8 @@ public class HoodieCDCLogger implements Closeable {
     HoodieAvroPayload payload = new HoodieAvroPayload(Option.of(cdcRecord));
     if (cdcData.isEmpty()) {
       averageCDCRecordSize = sizeEstimator.sizeEstimate(payload);
+    } else if (numOfCDCRecordsInMemory.get() % 100 == 0) {
+      averageCDCRecordSize = (long) (averageCDCRecordSize * 0.8 + sizeEstimator.sizeEstimate(payload) * 0.2);
     }
     cdcData.put(recordKey, payload);
     numOfCDCRecordsInMemory.incrementAndGet();


### PR DESCRIPTION
### Change Logs

Updated the logic for estimating averageCDCRecordSize during CDC block accumulation.
Instead of estimating the size only once based on the first record, the estimation is now refreshed every 100 records using an exponential moving average

### Impact

Reduces the risk of OOM caused by underestimating memory usage due to anomalously small initial CDC records.

Enables more accurate triggering of CDC block flushes, improving memory stability during write operations.

The change maintains minimal overhead by updating the estimation infrequently (every 100 records) and smoothing transitions using a weighted average.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
