### PR TITLE
[MINOR] Update bundle validation README.md

### DIFF
--- a/packaging/bundle-validation/README.md
+++ b/packaging/bundle-validation/README.md
@@ -61,7 +61,7 @@ to `base/` and the image should only be used for development only and not be pus
 ## Running Bundle Validation on a Release Candidate
 
 The bundle validation on a release candidate is specified in the GitHub Action job `validate-release-candidate-bundles`
-in `.github/workflows/bot.yml`. By default, this is disabled.
+in `.github/workflows/release_candidate_validation.yml`. By default, this is disabled.
 
 To enable the bundle validation on a particular release candidate, makes the following changes to the job by flipping the
 flag and adding the release candidate version and staging repo number:


### PR DESCRIPTION
### Change Logs

The `validate-release-candidate-bundles` was moved to a new file in this PR: https://github.com/apache/hudi/pull/10729, however the readme wasn't updated, this PR cleans it up.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
