### PR TITLE
[MINOR] Clean up RAT check errors

### DIFF
--- a/packaging/bundle-validation/cli/commands.txt
+++ b/packaging/bundle-validation/cli/commands.txt
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 create --path file:///tmp/hudi-bundles/tests/table --tableName trips --tableType COPY_ON_WRITE
 connect --path file:///tmp/hudi-bundles/tests/trips
 desc

--- a/packaging/bundle-validation/cli/commands.txt
+++ b/packaging/bundle-validation/cli/commands.txt
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 create --path file:///tmp/hudi-bundles/tests/table --tableName trips --tableType COPY_ON_WRITE
 connect --path file:///tmp/hudi-bundles/tests/trips
 desc

--- a/packaging/bundle-validation/validate.sh
+++ b/packaging/bundle-validation/validate.sh
@@ -293,7 +293,8 @@ test_cli_bundle() {
 
     # Execute with debug output
     echo "Executing Hudi CLI commands..."
-    $WORKDIR/docker-test/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh < $WORKDIR/cli/commands.txt 2>&1 | tee $CLI_TEST_DIR/output.txt
+    # This feeds CLI commands, stripping license lines to avoid parser errors
+    sed '/^#/d' "$WORKDIR/cli/commands.txt" | $WORKDIR/docker-test/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh 2>&1 | tee $CLI_TEST_DIR/output.txt
 
     # Verify CLI started successfully
     if ! grep -q "hudi->" $CLI_TEST_DIR/output.txt; then

--- a/rfc/rfc-65/rfc-65.md
+++ b/rfc/rfc-65/rfc-65.md
@@ -1,3 +1,19 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 ## Proposers
 
 - @stream2000

--- a/rfc/rfc-66/rfc-66.md
+++ b/rfc/rfc-66/rfc-66.md
@@ -1,3 +1,19 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 # RFC-66: Non-blocking Concurrency Control
 
 ## Proposers

--- a/rfc/rfc-93/rfc-93.md
+++ b/rfc/rfc-93/rfc-93.md
@@ -1,4 +1,19 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 # RFC-93: Pluggable Table Formats in Hudi
 
 ## Proposers


### PR DESCRIPTION
### Change Logs

Cleaning up RAT check errors when running:

```shell
 mvn apache-rat:check
```

The error below is thrown:

```shell
[INFO] --- apache-rat:0.16.1:check (default-cli) @ hudi ---
[WARNING]  Parameter 'licenseFamilies' is deprecated: No reason given
[WARNING]  Parameter 'licenses' is deprecated: No reason given
[WARNING] Configuration uses deprecated configuration.  Please upgrade to v0.17 configuration options
[INFO] Rat check: Summary over all files. Unapproved: 4, unknown: 4, generated: 0, approved: 4343 licenses.
[WARNING] Files with unapproved licenses:
  packaging/bundle-validation/cli/commands.txt
  rfc/rfc-65/rfc-65.md
  rfc/rfc-66/rfc-66.md
  rfc/rfc-93/rfc-93.md
```

Rat check is performed manually with the command below when verifying a staged release:
```shell
cd scripts && ./release/validate_staged_release.sh --release=${RELEASE_VERSION} --rc_num=${RC_NUM} --verbose
```

### Impact

None, changes here only affects CI run, so we need to monitor CI to ensure that are no behavioural changes.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
