### PR TITLE
[MINOR] Fix flaky test testDeletePartitionsV2

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
@@ -66,11 +66,12 @@ public class DataSourceTestUtils {
 
   public static List<Row> generateRandomRows(int count) {
     List<Row> toReturn = new ArrayList<>();
-    List<String> partitions = Arrays.asList(new String[] {DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH});
+    List<String> partitions = Arrays.asList(
+        DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH);
     for (int i = 0; i < count; i++) {
       Object[] values = new Object[4];
       values[0] = HoodieTestDataGenerator.genPseudoRandomUUID(RANDOM).toString();
-      values[1] = partitions.get(RANDOM.nextInt(3));
+      values[1] = partitions.get(i % 3);
       values[2] = new Date().getTime();
       values[3] = false;
       toReturn.add(RowFactory.create(values));

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -821,7 +821,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
  * @return dataframe to be used by testDeletePartitionsV2 and a map containing the table params
  */
   def deletePartitionSetup(): (DataFrame, Map[String,String]) = {
-    var fooTableModifier = getCommonParams(tempPath, hoodieFooTableName, HoodieTableType.COPY_ON_WRITE.name())
+    val fooTableModifier = getCommonParams(tempPath, hoodieFooTableName, HoodieTableType.COPY_ON_WRITE.name())
     val schema = DataSourceTestUtils.getStructTypeExampleSchema
     val structType = AvroConversionUtils.convertAvroSchemaToStructType(schema)
     val records = DataSourceTestUtils.generateRandomRows(10)


### PR DESCRIPTION
### Change Logs

This PR fixes the flaky test `testDeletePartitionsV2` as shown below.  The root cause is that the test expects 3 partitions to be written by `deletePartitionSetup` but the random record generator can generate records in fewer partitions due to how the partition path value is set.

https://github.com/apache/hudi/actions/runs/14589199410/job/40920578922
```
Error:  Tests run: 57, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 172.08 s <<< FAILURE! - in org.apache.hudi.TestHoodieSparkSqlWriter
Error:  testDeletePartitionsV2{boolean}[2]  Time elapsed: 3.315 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <6> but was: <4>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:527)
	at org.apache.hudi.TestHoodieSparkSqlWriter.validateDataAndPartitionStats(TestHoodieSparkSqlWriter.scala:902)
	at org.apache.hudi.TestHoodieSparkSqlWriter.testDeletePartitionsV2(TestHoodieSparkSqlWriter.scala:859)
```

### Impact

Fixes the test flakiness and makes CI stable

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
