### PR TITLE
[HUDI-9336] Extract common logic of getting reader for secondary index

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieFileSliceReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieFileSliceReader.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.HoodieFileReader;
@@ -32,13 +33,12 @@ import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
 public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
   private final Option<HoodieFileReader> baseFileReader;
-  private final Option<Iterator<HoodieRecord>> baseFileIterator;
+  private final Option<ClosableIterator<HoodieRecord>> baseFileIterator;
   private final Schema schema;
   private final Properties props;
 
@@ -49,7 +49,7 @@ public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
   HoodieRecordMerger merger;
 
   public HoodieFileSliceReader(Option<HoodieFileReader> baseFileReader,
-                                   HoodieMergedLogRecordScanner scanner, Schema schema, String preCombineField, HoodieRecordMerger merger,
+                               HoodieMergedLogRecordScanner scanner, Schema schema, String preCombineField, HoodieRecordMerger merger,
                                Properties props, Option<Pair<String, String>> simpleKeyGenFieldsOpt, Option<BaseKeyGenerator> keyGeneratorOpt) throws IOException {
     super(scanner);
     this.baseFileReader = baseFileReader;
@@ -102,6 +102,9 @@ public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
   @Override
   public void close() {
     super.close();
+    if (baseFileIterator.isPresent()) {
+      baseFileIterator.get().close();
+    }
     if (baseFileReader.isPresent()) {
       baseFileReader.get().close();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieFileSliceReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieFileSliceReader.java
@@ -37,14 +37,14 @@ import java.util.Map;
 import java.util.Properties;
 
 public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
-  private Option<Iterator<HoodieRecord>> baseFileIterator;
-  private HoodieMergedLogRecordScanner scanner;
-  private Schema schema;
-  private Properties props;
+  private final Option<HoodieFileReader> baseFileReader;
+  private final Option<Iterator<HoodieRecord>> baseFileIterator;
+  private final Schema schema;
+  private final Properties props;
 
-  private TypedProperties payloadProps = new TypedProperties();
-  private Option<Pair<String, String>> simpleKeyGenFieldsOpt;
-  private Option<BaseKeyGenerator> keyGeneratorOpt;
+  private final TypedProperties payloadProps = new TypedProperties();
+  private final Option<Pair<String, String>> simpleKeyGenFieldsOpt;
+  private final Option<BaseKeyGenerator> keyGeneratorOpt;
   Map<String, HoodieRecord> records;
   HoodieRecordMerger merger;
 
@@ -52,12 +52,12 @@ public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
                                    HoodieMergedLogRecordScanner scanner, Schema schema, String preCombineField, HoodieRecordMerger merger,
                                Properties props, Option<Pair<String, String>> simpleKeyGenFieldsOpt, Option<BaseKeyGenerator> keyGeneratorOpt) throws IOException {
     super(scanner);
+    this.baseFileReader = baseFileReader;
     if (baseFileReader.isPresent()) {
       this.baseFileIterator = Option.of(baseFileReader.get().getRecordIterator(schema));
     } else {
       this.baseFileIterator = Option.empty();
     }
-    this.scanner = scanner;
     this.schema = schema;
     this.merger = merger;
     if (preCombineField != null) {
@@ -66,7 +66,7 @@ public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
     this.props = props;
     this.simpleKeyGenFieldsOpt = simpleKeyGenFieldsOpt;
     this.keyGeneratorOpt = keyGeneratorOpt;
-    this.records = scanner.getRecords();
+    this.records = this.scanner.getRecords();
   }
 
   private boolean hasNextInternal() {
@@ -99,4 +99,11 @@ public class HoodieFileSliceReader<T> extends LogFileIterator<T> {
     return hasNextInternal();
   }
 
+  @Override
+  public void close() {
+    super.close();
+    if (baseFileReader.isPresent()) {
+      baseFileReader.get().close();
+    }
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -276,7 +276,6 @@ public class SecondaryIndexRecordGenerationUtils {
       } else {
         readerSchema = tableSchema;
       }
-      // TODO: add task completion listener to close the file readers
       return createSecondaryIndexGenerator(metaClient, engineType, logFilePaths, readerSchema, partition, dataFilePath, indexDefinition,
           metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::requestedTime).orElse(""));
     });

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -190,7 +190,6 @@ public class SecondaryIndexRecordGenerationUtils {
       }
     }
     return recordKeyToSecondaryKey;
-
   }
 
   private static HoodieFileSliceReader getFileSliceReader(

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -176,6 +176,25 @@ public class SecondaryIndexRecordGenerationUtils {
                                                                 Option<StoragePath> dataFilePath,
                                                                 HoodieIndexDefinition indexDefinition,
                                                                 String instantTime) throws Exception {
+    HoodieFileSliceReader fileSliceReader =
+        getFileSliceReader(metaClient, engineType, logFilePaths, tableSchema, partition, dataFilePath, instantTime);
+    // Collect the records from the iterator in a map by record key to secondary key
+    Map<String, String> recordKeyToSecondaryKey = new HashMap<>();
+    while (fileSliceReader.hasNext()) {
+      HoodieRecord record = (HoodieRecord) fileSliceReader.next();
+      String secondaryKey = getSecondaryKey(record, tableSchema, indexDefinition);
+      if (secondaryKey != null) {
+        // no delete records here
+        recordKeyToSecondaryKey.put(record.getRecordKey(tableSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD), secondaryKey);
+      }
+    }
+    return recordKeyToSecondaryKey;
+  }
+
+  private static HoodieFileSliceReader getFileSliceReader(
+      HoodieTableMetaClient metaClient, EngineType engineType,
+      List<String> logFilePaths, Schema tableSchema, String partition,
+      Option<StoragePath> dataFilePath, String instantTime) throws IOException {
     final String basePath = metaClient.getBasePath().toString();
     final StorageConfiguration<?> storageConf = metaClient.getStorageConf();
 
@@ -207,19 +226,8 @@ public class SecondaryIndexRecordGenerationUtils {
     if (dataFilePath.isPresent()) {
       baseFileReader = Option.of(HoodieIOFactory.getIOFactory(metaClient.getStorage()).getReaderFactory(recordMerger.getRecordType()).getFileReader(getReaderConfigs(storageConf), dataFilePath.get()));
     }
-    HoodieFileSliceReader fileSliceReader = new HoodieFileSliceReader(baseFileReader, mergedLogRecordScanner, tableSchema, metaClient.getTableConfig().getPreCombineField(), recordMerger,
+    return new HoodieFileSliceReader(baseFileReader, mergedLogRecordScanner, tableSchema, metaClient.getTableConfig().getPreCombineField(), recordMerger,
         metaClient.getTableConfig().getProps(), Option.empty(), Option.empty());
-    // Collect the records from the iterator in a map by record key to secondary key
-    Map<String, String> recordKeyToSecondaryKey = new HashMap<>();
-    while (fileSliceReader.hasNext()) {
-      HoodieRecord record = (HoodieRecord) fileSliceReader.next();
-      String secondaryKey = getSecondaryKey(record, tableSchema, indexDefinition);
-      if (secondaryKey != null) {
-        // no delete records here
-        recordKeyToSecondaryKey.put(record.getRecordKey(tableSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD), secondaryKey);
-      }
-    }
-    return recordKeyToSecondaryKey;
   }
 
   private static String getSecondaryKey(HoodieRecord record, Schema tableSchema, HoodieIndexDefinition indexDefinition) {
@@ -277,41 +285,8 @@ public class SecondaryIndexRecordGenerationUtils {
                                                                               Option<StoragePath> dataFilePath,
                                                                               HoodieIndexDefinition indexDefinition,
                                                                               String instantTime) throws Exception {
-    final String basePath = metaClient.getBasePath().toString();
-    final StorageConfiguration<?> storageConf = metaClient.getStorageConf();
-
-    HoodieRecordMerger recordMerger = HoodieRecordUtils.createRecordMerger(
-        basePath,
-        engineType,
-        Collections.emptyList(),
-        metaClient.getTableConfig().getRecordMergeStrategyId());
-
-    HoodieMergedLogRecordScanner mergedLogRecordScanner = HoodieMergedLogRecordScanner.newBuilder()
-        .withStorage(metaClient.getStorage())
-        .withBasePath(metaClient.getBasePath())
-        .withLogFilePaths(logFilePaths)
-        .withReaderSchema(tableSchema)
-        .withLatestInstantTime(instantTime)
-        .withReverseReader(false)
-        .withMaxMemorySizeInBytes(storageConf.getLong(MAX_MEMORY_FOR_COMPACTION.key(), DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES))
-        .withBufferSize(HoodieMetadataConfig.MAX_READER_BUFFER_SIZE_PROP.defaultValue())
-        .withSpillableMapBasePath(FileIOUtils.getDefaultSpillableMapBasePath())
-        .withPartition(partition)
-        .withOptimizedLogBlocksScan(storageConf.getBoolean("hoodie" + HoodieMetadataConfig.OPTIMIZED_LOG_BLOCKS_SCAN, false))
-        .withDiskMapType(storageConf.getEnum(SPILLABLE_DISK_MAP_TYPE.key(), SPILLABLE_DISK_MAP_TYPE.defaultValue()))
-        .withBitCaskDiskMapCompressionEnabled(storageConf.getBoolean(DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue()))
-        .withRecordMerger(recordMerger)
-        .withTableMetaClient(metaClient)
-        .build();
-
-    Option<HoodieFileReader> baseFileReader = Option.empty();
-    if (dataFilePath.isPresent()) {
-      baseFileReader = Option.of(HoodieIOFactory.getIOFactory(metaClient.getStorage()).getReaderFactory(recordMerger.getRecordType()).getFileReader(getReaderConfigs(storageConf), dataFilePath.get()));
-    }
-    HoodieFileSliceReader fileSliceReader = new HoodieFileSliceReader(baseFileReader, mergedLogRecordScanner, tableSchema, metaClient.getTableConfig().getPreCombineField(), recordMerger,
-        metaClient.getTableConfig().getProps(),
-        Option.empty(), Option.empty());
-    ClosableIterator<HoodieRecord> fileSliceIterator = ClosableIterator.wrap(fileSliceReader);
+    ClosableIterator<HoodieRecord> fileSliceIterator = ClosableIterator.wrap(
+        getFileSliceReader(metaClient, engineType, logFilePaths, tableSchema, partition, dataFilePath, instantTime));
     return new ClosableIterator<HoodieRecord>() {
       private HoodieRecord nextValidRecord;
 


### PR DESCRIPTION
### Change Logs

This PR extracts common logic of getting the file slice reader for secondary index to reduce code duplication.  It also makes changes to close resources in the file slice reader and the iterator for the secondary index properly.

### Impact

Improves code maintainability and resource management

### Risk level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
