### PR TITLE
[HUDI-8680] Update doc description for metadata index partition enable

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -381,10 +381,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.enable")
-      .defaultValue(true)
+      // The defaultValue(false) here is the initial default, but it's overridden later based on
+      // column stats setting.
+      .defaultValue(false)
       .sinceVersion("1.0.0")
       .withDocumentation("Enable aggregating stats for each column at the storage partition level. "
-          + "The default value of this configuration depends on column stats index is enabled.");
+          + "Enabling this can improve query performance by leveraging partition and column stats "
+          + "for (partition) filtering. "
+          + "Important: The default value for this configuration is dynamically set based on the "
+          + "effective value of " + ENABLE_METADATA_INDEX_COLUMN_STATS.key() + ". If column stats "
+          + "index is enabled (default for Spark engine), partition stats indexing will also be "
+          + "enabled by default. Conversely, if column stats indexing is disabled (default for "
+          + "Flink and Java engines), partition stats indexing will also be disabled by default.");
 
   public static final ConfigProperty<Integer> METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.file.group.count")

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -381,9 +381,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("1.0.0")
-      .withDocumentation("Enable aggregating stats for each column at the storage partition level.");
+      .withDocumentation("Enable aggregating stats for each column at the storage partition level. "
+          + "The default value of this configuration depends on column stats index is enabled.");
 
   public static final ConfigProperty<Integer> METADATA_INDEX_PARTITION_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.partition.stats.file.group.count")


### PR DESCRIPTION
### Change Logs

`ENABLE_METADATA_INDEX_PARTITION_STATS` is enabled by default, a change that was introduce in the PR below that sets its default value to the value of `ENABLE_METADATA_INDEX_COLUMN_STATS` here:

https://github.com/apache/hudi/pull/12707/files#diff-11e9ef6bd53ef1001b669a1dc68dde2aba9b33c9eb72cc1e4198750336d79772R893

However, the config value is false. This PR changes the config value to remove this discrepancy. Automated config docs will also be updated as a result to reduce confusion.

In this PR, we are updating the doc description to better reflect the default value of this config.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

Default value of `ENABLE_METADATA_INDEX_PARTITION_STATS` / `hoodie.metadata.index.partition.enable` will be changed in the config docs.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
