### PR TITLE
[HUDI-9345] Use hoodie.table.precombine.field parameter as fallback  when building HoodieWriteConfig

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -200,7 +200,7 @@ public class DataSourceUtils {
             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
             .withPayloadOrderingField(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
-                parameters.getOrDefault(HoodieTableConfig.PRECOMBINE_FIELD, HoodieTableConfig.PRECOMBINE_FIELD.defaultValue())))
+                parameters.getOrDefault(HoodieTableConfig.PRECOMBINE_FIELD, null)))
             .build())
         // override above with Hoodie configs specified as options.
         .withProps(parameters).build();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -200,7 +200,7 @@ public class DataSourceUtils {
             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
             .withPayloadOrderingField(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
-                parameters.getOrDefault(HoodieTableConfig.PRECOMBINE_FIELD, null)))
+                parameters.get(HoodieTableConfig.PRECOMBINE_FIELD)))
             .build())
         // override above with Hoodie configs specified as options.
         .withProps(parameters).build();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -199,7 +199,8 @@ public class DataSourceUtils {
             // to realize the SQL functionality, so the write config needs to be fetched first.
             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
-            .withPayloadOrderingField(parameters.get(DataSourceWriteOptions.PRECOMBINE_FIELD().key()))
+            .withPayloadOrderingField(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
+                parameters.getOrDefault(HoodieTableConfig.PRECOMBINE_FIELD, HoodieTableConfig.PRECOMBINE_FIELD.defaultValue())))
             .build())
         // override above with Hoodie configs specified as options.
         .withProps(parameters).build();


### PR DESCRIPTION

### Change Logs

Use hoodie.table.precombine.field parameter as fallback when building HoodieWriteConfig

### Impact



### Risk level (write none, low medium or high below)



### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
