### PR TITLE
[MINOR] Avoid edge case where spillable map estimator is repeatedly called

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -221,7 +221,7 @@ public class ExternalSpillableMap<T extends Serializable, R> implements Map<T, R
       // At first, use the sizeEstimate of a record being inserted into the spillable map.
       // Note, the converter may over-estimate the size of a record in the JVM
       this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
-    } else if (this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
+    } else if (this.currentInMemoryMapSize < this.maxInMemorySizeInBytes && this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
       this.estimatedPayloadSize = (long) (this.estimatedPayloadSize * 0.9 + (keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value)) * 0.1);
       this.currentInMemoryMapSize = this.inMemoryMap.size() * this.estimatedPayloadSize;
       if (this.inMemoryMap.size() / NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 1) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -221,17 +221,18 @@ public class ExternalSpillableMap<T extends Serializable, R> implements Map<T, R
       // At first, use the sizeEstimate of a record being inserted into the spillable map.
       // Note, the converter may over-estimate the size of a record in the JVM
       this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
-    } else if (this.currentInMemoryMapSize < this.maxInMemorySizeInBytes && this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
-      this.estimatedPayloadSize = (long) (this.estimatedPayloadSize * 0.9 + (keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value)) * 0.1);
-      this.currentInMemoryMapSize = this.inMemoryMap.size() * this.estimatedPayloadSize;
-      if (this.inMemoryMap.size() / NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 1) {
-        LOG.info("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
-      }
     }
 
     if (this.inMemoryMap.containsKey(key)) {
       this.inMemoryMap.put(key, value);
     } else if (this.currentInMemoryMapSize < this.maxInMemorySizeInBytes) {
+      if (this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
+        this.estimatedPayloadSize = (long) (this.estimatedPayloadSize * 0.9 + (keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value)) * 0.1);
+        this.currentInMemoryMapSize = this.inMemoryMap.size() * this.estimatedPayloadSize;
+        if (this.inMemoryMap.size() / NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 1) {
+          LOG.info("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
+        }
+      }
       this.currentInMemoryMapSize += this.estimatedPayloadSize;
       // Remove the old version of the record from disk first to avoid data duplication.
       if (inDiskContainsKey(key)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -227,7 +227,9 @@ public class ExternalSpillableMap<T extends Serializable, R> implements Map<T, R
       } else if (this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
         this.estimatedPayloadSize = (long) (this.estimatedPayloadSize * 0.9 + (keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value)) * 0.1);
         this.currentInMemoryMapSize = this.inMemoryMap.size() * this.estimatedPayloadSize;
-        LOG.debug("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
+        if (this.inMemoryMap.size() / NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 1) {
+          LOG.info("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
+        }
       }
       this.currentInMemoryMapSize += this.estimatedPayloadSize;
       // Remove the old version of the record from disk first to avoid data duplication.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -217,21 +217,17 @@ public class ExternalSpillableMap<T extends Serializable, R> implements Map<T, R
 
   @Override
   public R put(T key, R value) {
-    if (this.estimatedPayloadSize == 0) {
-      // At first, use the sizeEstimate of a record being inserted into the spillable map.
-      // Note, the converter may over-estimate the size of a record in the JVM
-      this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
-    }
-
     if (this.inMemoryMap.containsKey(key)) {
       this.inMemoryMap.put(key, value);
     } else if (this.currentInMemoryMapSize < this.maxInMemorySizeInBytes) {
-      if (this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
+      if (this.estimatedPayloadSize == 0) {
+        // At first, use the sizeEstimate of a record being inserted into the spillable map.
+        // Note, the converter may over-estimate the size of a record in the JVM
+        this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
+      } else if (this.inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
         this.estimatedPayloadSize = (long) (this.estimatedPayloadSize * 0.9 + (keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value)) * 0.1);
         this.currentInMemoryMapSize = this.inMemoryMap.size() * this.estimatedPayloadSize;
-        if (this.inMemoryMap.size() / NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 1) {
-          LOG.info("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
-        }
+        LOG.debug("{} : Updated Estimated Payload size {}", loggingContext, this.estimatedPayloadSize);
       }
       this.currentInMemoryMapSize += this.estimatedPayloadSize;
       // Remove the old version of the record from disk first to avoid data duplication.


### PR DESCRIPTION
### Change Logs

- There is an edge case where the spillable map's in-memory size limit is reached and the number of records in that map are a multiple of 100. This would cause the estimator to be called on every insert and impact performance as a result.

### Impact

- Fixes edge case that causes performance regression

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
