### PR TITLE
[HUDI-9347] Handle archived clean instants in meta-sync for droppedPartitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
@@ -133,6 +134,12 @@ public class TimelineUtils {
                 partitionToLatestDeleteTimestamp.put(partition, instant.requestedTime());
               }
             });
+          } catch (HoodieIOException e) {
+            if (e.getCause() instanceof FileNotFoundException) {
+              LOG.warn("Instant {} not found in storage and has been archived", instant);
+            } else {
+              throw e;
+            }
           } catch (IOException e) {
             throw new HoodieIOException("Failed to get partitions cleaned at " + instant, e);
           }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -616,5 +616,10 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     // older partition is in the list dropped partitions
     assertEquals(1, droppedPartitions.size());
     assertEquals(olderPartition, droppedPartitions.get(0));
+
+    // Archive clean instant.
+    activeTimeline.deleteInstantFileIfExists(metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants().lastInstant().get());
+    droppedPartitions = TimelineUtils.getDroppedPartitions(metaClient, Option.empty(), Option.empty());
+    assertTrue(droppedPartitions.isEmpty());
   }
 }


### PR DESCRIPTION
### Change Logs

When cleaner and meta-sync are running concurrently, the activeTimeline for meta-sync can contain clean instants that are archived.

### Impact

Avoids failures which will succeed on retry but can create a lot of noise.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
