### PR TITLE
[HUDI-9352] Close CompletionTimeQueryView in fsView

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -300,16 +300,23 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   public void close() {
     try {
       writeLock.lock();
-      this.metaClient = null;
-      this.completionTimeQueryView = null;
-      this.visibleCommitsAndCompactionTimeline = null;
-      tableMetadata.close();
+      closeResources();
       clear();
     } catch (Exception ex) {
       throw new HoodieException("Unable to close file system view", ex);
     } finally {
       writeLock.unlock();
     }
+  }
+
+  protected void closeResources() throws Exception {
+    if (this.completionTimeQueryView != null) {
+      this.completionTimeQueryView.close();
+      this.completionTimeQueryView = null;
+    }
+    this.metaClient = null;
+    this.visibleCommitsAndCompactionTimeline = null;
+    tableMetadata.close();
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.util.RocksDBSchemaHelper;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.collection.RocksDBDAO;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.StoragePathInfo;
 
@@ -596,10 +597,15 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
   @Override
   public void close() {
-    LOG.info("Closing Rocksdb !!");
-    closed = true;
-    rocksDB.close();
-    LOG.info("Closed Rocksdb !!");
+    try {
+      LOG.info("Closing Rocksdb !!");
+      closed = true;
+      closeResources();
+      rocksDB.close();
+      LOG.info("Closed Rocksdb !!");
+    } catch (Exception e) {
+      throw new HoodieException("Unable to close file system view", e);
+    }
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -67,6 +67,7 @@ import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -231,6 +232,10 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     // confirm deleted
     assertTrue(deleteReplaceCommit && deleteClusterCommitInflight && deleteClusterCommitRequested);
     assertDoesNotThrow(() -> fsView.close());
+    if ((fsView.getClass().isAssignableFrom(AbstractTableFileSystemView.class))) {
+      // completionTimeQueryView will be set to null after close.
+      Assertions.assertThrows(NullPointerException.class, () -> ((AbstractTableFileSystemView) fsView).getCompletionTime(""));
+    }
   }
 
   protected void testViewForFileSlicesWithNoBaseFile(int expNumTotalFileSlices,


### PR DESCRIPTION
### Change Logs

completionTimeQueryView is a new resource that's initialized in 1.x fsView, but it's not closed properly in the close method. 

### Impact

Properly close resources in views which are created often. 

### Risk level (write none, low medium or high below)

Medium. 

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
