### PR TITLE
[HUDI-9355] Avoid calling FileSystem#close in HoodieHadoopStorage

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -299,6 +299,8 @@ public class HoodieHadoopStorage extends HoodieStorage {
 
   @Override
   public void close() throws IOException {
-    fs.close();
+    // Don't close the wrapped `FileSystem` object.
+    // This will end up closing it for every thread since it
+    // could be cached across JVM. We don't own that object anyway.
   }
 }


### PR DESCRIPTION
### Change Logs

This PR removes `FileSystem#close` in `HoodieHadoopStorage#close`.  If the underlying `FileSystem` object is closed, the cache of the object based on the path is closed and removed, which causes problems if the object is reused elsewhere.

### Impact

Fixes `FileSystem` object usage.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
