### PR TITLE
[HUDI-9364] Improve FileSystemView loading performance with large partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/SerializationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/SerializationUtils.java
@@ -19,6 +19,10 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.avro.GenericAvroSerializer;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieLogFile;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
@@ -32,6 +36,7 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.TreeSet;
 
 /**
  * {@link SerializationUtils} class internally uses {@link Kryo} serializer for serializing / deserializing objects.
@@ -129,6 +134,11 @@ public class SerializationUtils {
       kryo.register(GenericData.Fixed.class, new GenericAvroSerializer<>());
       kryo.register(IndexedRecord.class, new GenericAvroSerializer<>());
       kryo.register(GenericData.Record.class, new GenericAvroSerializer<>());
+      kryo.register(HoodieFileGroupId.class);
+      kryo.register(FileSlice.class);
+      kryo.register(HoodieBaseFile.class);
+      kryo.register(HoodieLogFile.class);
+      kryo.register(TreeSet.class);
 
       return kryo;
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.util.ObjectSizeCalculator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
@@ -47,15 +50,37 @@ class TestHoodieFileGroupSizeEstimator {
     // setup mocks
     HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
     List<FileSlice> fileSlices = Collections.singletonList(new FileSlice(fileGroupId, "001",
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList()));
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId())), Collections.emptyList()));
     when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
-    when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream());
+    when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());
 
     when(fileGroup2.getFileGroupId()).thenReturn(new HoodieFileGroupId("path2", UUID.randomUUID().toString()));
-    when(fileGroup2.getAllFileSlices()).thenReturn(Stream.empty());
+    when(fileGroup2.getAllFileSlices()).thenReturn(Stream.empty()).thenReturn(Stream.empty());
 
     long result = new HoodieFileGroupSizeEstimator().sizeEstimate(Arrays.asList(fileGroup1, fileGroup2));
     Assertions.assertTrue(result > 0);
+    verify(fileGroup1, never()).getTimeline();
+    verify(fileGroup2, never()).getTimeline();
+  }
+
+  @Test
+  void estimatorWithManyFileSlices() {
+    HoodieFileGroup fileGroup1 = mock(HoodieFileGroup.class);
+    HoodieFileGroup fileGroup2 = mock(HoodieFileGroup.class);
+
+    // setup mocks
+    HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
+    List<FileSlice> fileSlices = IntStream.range(1, 100).mapToObj(i -> new FileSlice(fileGroupId, "001",
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("00" + i, "1-0-1", fileGroupId.getFileId())), Collections.emptyList())).collect(Collectors.toList());
+    when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
+    when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());
+
+    when(fileGroup2.getFileGroupId()).thenReturn(new HoodieFileGroupId("path2", UUID.randomUUID().toString()));
+    when(fileGroup2.getAllFileSlices()).thenReturn(Stream.empty()).thenReturn(Stream.empty());
+
+    long result = new HoodieFileGroupSizeEstimator().sizeEstimate(Arrays.asList(fileGroup1, fileGroup2));
+    long exactSize = ObjectSizeCalculator.getObjectSize(fileSlices) + ObjectSizeCalculator.getObjectSize(fileGroupId) * 2;
+    Assertions.assertTrue(Math.abs(result - exactSize) / (1.0 * exactSize) < 0.05); // ensure that sampling is accurate within 5%
     verify(fileGroup1, never()).getTimeline();
     verify(fileGroup2, never()).getTimeline();
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
@@ -50,7 +50,7 @@ class TestHoodieFileGroupSizeEstimator {
     // setup mocks
     HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
     List<FileSlice> fileSlices = Collections.singletonList(new FileSlice(fileGroupId, "001",
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId())), Collections.emptyList()));
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList()));
     when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
     when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());
 
@@ -71,7 +71,8 @@ class TestHoodieFileGroupSizeEstimator {
     // setup mocks
     HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
     List<FileSlice> fileSlices = IntStream.range(1, 100).mapToObj(i -> new FileSlice(fileGroupId, "001",
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("00" + i, "1-0-1", fileGroupId.getFileId())), Collections.emptyList())).collect(Collectors.toList());
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("00" + i, "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList()))
+        .collect(Collectors.toList());
     when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
     when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());
 
@@ -80,7 +81,7 @@ class TestHoodieFileGroupSizeEstimator {
 
     long result = new HoodieFileGroupSizeEstimator().sizeEstimate(Arrays.asList(fileGroup1, fileGroup2));
     long exactSize = ObjectSizeCalculator.getObjectSize(fileSlices) + ObjectSizeCalculator.getObjectSize(fileGroupId) * 2;
-    Assertions.assertTrue(Math.abs(result - exactSize) / (1.0 * exactSize) < 0.05); // ensure that sampling is accurate within 5%
+    Assertions.assertTrue(Math.abs(result - exactSize) / (1.0 * exactSize) < 0.1); // ensure that sampling is accurate within 10%
     verify(fileGroup1, never()).getTimeline();
     verify(fileGroup2, never()).getTimeline();
   }


### PR DESCRIPTION
### Change Logs

- Reduce size of serialized File Group in FSView 
- Register the required classes for Kryo to reduce the size 
- Only compute valid instants once for MDT reader instead of per scanner

### Impact

- Reduces overhead of loading the FSView from the metadata table

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
