### PR TITLE
[HUDI-9365] Reduce overhead of Hive and AWS Glue sync tools

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -23,7 +23,6 @@ import org.apache.hudi.aws.sync.util.GluePartitionFilterGenerator;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -143,11 +142,12 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   private static final String ENABLE_MDT_LISTING = "hudi.metadata-listing-enabled";
   private final String databaseName;
 
-  private final Boolean skipTableArchive;
+  private final boolean skipTableArchive;
   private final String enableMetadataTable;
   private final int allPartitionsReadParallelism;
   private final int changedPartitionsReadParallelism;
   private final int changeParallelism;
+  private final Map<String, Table> initialTableByName = new HashMap<>();
 
   public AWSGlueCatalogSyncClient(HiveSyncConfig config, HoodieTableMetaClient metaClient) {
     this(buildAsyncClient(config), config, metaClient);
@@ -199,6 +199,10 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Failed to get all partitions for table " + tableId(databaseName, tableName), e);
     }
+  }
+
+  private Table getInitialTable(String tableName) {
+    return initialTableByName.computeIfAbsent(tableName, t -> getTable(awsGlue, databaseName, t));
   }
 
   @Override
@@ -447,7 +451,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   private String getTableDoc() {
     try {
-      return new TableSchemaResolver(metaClient).getTableAvroSchema(true).getDoc();
+      return tableSchemaResolver.getTableAvroSchema(true).getDoc();
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Failed to get schema's doc from storage : ", e);
     }
@@ -456,7 +460,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public List<FieldSchema> getStorageFieldSchemas() {
     try {
-      return new TableSchemaResolver(metaClient).getTableAvroSchema(true)
+      return tableSchemaResolver.getTableAvroSchema(true)
           .getFields()
           .stream()
           .map(f -> new FieldSchema(f.name(), f.schema().getType().getName(), f.doc()))
@@ -790,7 +794,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     try {
       // GlueMetastoreClient returns partition keys separate from Columns, hence get both and merge to
       // get the Schema of the table.
-      Table table = getTable(awsGlue, databaseName, tableName);
+      Table table = getInitialTable(tableName);
       Map<String, String> partitionKeysMap =
           table.partitionKeys().stream().collect(Collectors.toMap(Column::name, f -> f.type().toUpperCase()));
 
@@ -813,7 +817,11 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         .name(tableName)
         .build();
     try {
-      return Objects.nonNull(awsGlue.getTable(request).get().table());
+      Table table = awsGlue.getTable(request).get().table();
+      if (table != null) {
+        initialTableByName.put(tableName, table);
+      }
+      return Objects.nonNull(table);
     } catch (ExecutionException e) {
       if (e.getCause() instanceof EntityNotFoundException) {
         LOG.warn("Table not found: " + tableId(databaseName, tableName), e);
@@ -869,8 +877,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public Option<String> getLastCommitTimeSynced(String tableName) {
     try {
-      Table table = getTable(awsGlue, databaseName, tableName);
-      return Option.ofNullable(table.parameters().getOrDefault(HOODIE_LAST_COMMIT_TIME_SYNC, null));
+      return Option.ofNullable(getInitialTable(tableName).parameters().getOrDefault(HOODIE_LAST_COMMIT_TIME_SYNC, null));
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to get last sync commit time for " + tableId(databaseName, tableName), e);
     }
@@ -880,8 +887,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   public Option<String> getLastCommitCompletionTimeSynced(String tableName) {
     // Get the last commit completion time from the TBLproperties
     try {
-      Table table = getTable(awsGlue, databaseName, tableName);
-      return Option.ofNullable(table.parameters().getOrDefault(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, null));
+      return Option.ofNullable(getInitialTable(tableName).parameters().getOrDefault(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, null));
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Failed to get the last commit completion time synced from the table " + tableName, e);
     }
@@ -1045,8 +1051,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public String getTableLocation(String tableName) {
     try {
-      Table table = getTable(awsGlue, databaseName, tableName);
-      return table.storageDescriptor().location();
+      return getInitialTable(tableName).storageDescriptor().location();
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to get base path for the table " + tableId(databaseName, tableName), e);
     }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -46,9 +46,8 @@ import org.apache.hudi.hive.ddl.HMSDDLExecutor;
 import org.apache.hudi.hive.ddl.HiveSyncMode;
 import org.apache.hudi.hive.testutils.HiveTestUtil;
 import org.apache.hudi.hive.util.IMetaStoreClientUtil;
-import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.metrics.MetricsReporterType;
-import org.apache.hudi.sync.common.HoodieSyncConfig;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
 import org.apache.hudi.sync.common.model.PartitionEvent;
@@ -114,6 +113,7 @@ import static org.apache.hudi.hive.testutils.HiveTestUtil.hiveSyncProps;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL_SYNC;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_INCREMENTAL;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -275,7 +275,7 @@ public class TestHiveSyncTool {
     assertEquals(3, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "Table partitions should match the number of partitions we wrote");
     // Use META_SYNC_PARTITION_FIXMODE, sync all partition metadata
-    hiveSyncProps.setProperty(HoodieSyncConfig.META_SYNC_INCREMENTAL.key(), "false");
+    hiveSyncProps.setProperty(META_SYNC_INCREMENTAL.key(), "false");
     reInitHiveSyncClient();
     reSyncHiveTable();
     assertEquals(4, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
@@ -994,6 +994,7 @@ public class TestHiveSyncTool {
     assertEquals(0, commentCnt, "hive schema field comment numbers should match the avro schema field doc numbers");
 
     hiveSyncProps.setProperty(HIVE_SYNC_COMMENT.key(), "true");
+    hiveSyncProps.setProperty(META_SYNC_INCREMENTAL.key(), "false");
     reInitHiveSyncClient();
     reSyncHiveTable();
     fieldSchemas = hiveClient.getMetastoreFieldSchemas(HiveTestUtil.TABLE_NAME);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -58,12 +58,14 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
   protected final HoodieSyncConfig config;
   protected final PartitionValueExtractor partitionValueExtractor;
   protected final HoodieTableMetaClient metaClient;
+  protected final ParquetTableSchemaResolver tableSchemaResolver;
   private static final String TEMP_SUFFIX = "_temp";
 
   public HoodieSyncClient(HoodieSyncConfig config, HoodieTableMetaClient metaClient) {
     this.config = config;
     this.partitionValueExtractor = ReflectionUtils.loadClass(config.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS));
     this.metaClient = Objects.requireNonNull(metaClient, "metaClient is null");
+    this.tableSchemaResolver = new ParquetTableSchemaResolver(metaClient);
   }
 
   public HoodieTimeline getActiveTimeline() {
@@ -98,7 +100,7 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
   @Override
   public MessageType getStorageSchema() {
     try {
-      return new ParquetTableSchemaResolver(metaClient).getTableParquetSchema();
+      return tableSchemaResolver.getTableParquetSchema();
     } catch (Exception e) {
       throw new HoodieSyncException("Failed to read schema from storage.", e);
     }
@@ -107,7 +109,7 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
   @Override
   public MessageType getStorageSchema(boolean includeMetadataField) {
     try {
-      return new ParquetTableSchemaResolver(metaClient).getTableParquetSchema(includeMetadataField);
+      return tableSchemaResolver.getTableParquetSchema(includeMetadataField);
     } catch (Exception e) {
       throw new HoodieSyncException("Failed to read schema from storage.", e);
     }


### PR DESCRIPTION
### Change Logs

- Reduce overhead of fetching schema in sync
- Reduce number of calls to remote system
- Avoid sync if already up to date

### Impact

- Lowers overhead of running the sync tool 

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
