### PR TITLE
[HUDI-9371] Fix conflict resolution handling of inflight clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 
@@ -55,9 +56,9 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
     HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
     // To find which instants are conflicting, we apply the following logic
     // 1. Get completed instants timeline only for commits that have happened since the last successful write.
-    // 2. Get any scheduled or completed compaction or clustering operations that have started and/or finished
-    // after the current instant. We need to check for write conflicts since they may have mutated the same files
-    // that are being newly created by the current write.
+    // 2. Get any scheduled or completed compaction that have started and/or finished after the current instant.
+    // 3. Get any completed replace commit that happened since the last successful write and any pending replace commit.
+    // We need to check for write conflicts since they may have mutated the same files that are being newly created by the current write.
     Stream<HoodieInstant> completedCommitsInstantStream = activeTimeline
         .getCommitsTimeline()
         .filterCompletedInstants()
@@ -67,8 +68,7 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
     Stream<HoodieInstant> compactionAndClusteringPendingTimeline = activeTimeline
         .filterPendingReplaceClusteringAndCompactionTimeline()
         .filter(instant -> ClusteringUtils.isClusteringInstant(activeTimeline, instant, metaClient.getInstantGenerator())
-            || HoodieTimeline.COMPACTION_ACTION.equals(instant.getAction()))
-        .findInstantsAfter(currentInstant.requestedTime())
+            || (HoodieTimeline.COMPACTION_ACTION.equals(instant.getAction()) && compareTimestamps(instant.requestedTime(), GREATER_THAN, currentInstant.requestedTime())))
         .getInstantsAsStream();
     return Stream.concat(completedCommitsInstantStream, compactionAndClusteringPendingTimeline);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -68,7 +68,7 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
     Stream<HoodieInstant> compactionAndClusteringPendingTimeline = activeTimeline
         .filterPendingReplaceClusteringAndCompactionTimeline()
         .filter(instant -> ClusteringUtils.isClusteringInstant(activeTimeline, instant, metaClient.getInstantGenerator())
-            || (HoodieTimeline.COMPACTION_ACTION.equals(instant.getAction()) && compareTimestamps(instant.requestedTime(), GREATER_THAN, currentInstant.requestedTime())))
+            || (!HoodieTimeline.CLUSTERING_ACTION.equals(instant.getAction()) && compareTimestamps(instant.requestedTime(), GREATER_THAN, currentInstant.requestedTime())))
         .getInstantsAsStream();
     return Stream.concat(completedCommitsInstantStream, compactionAndClusteringPendingTimeline);
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -41,8 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
-
 public class TestConflictResolutionStrategyUtil {
 
   public static void createCommit(String instantTime, HoodieTableMetaClient metaClient) throws Exception {
@@ -117,15 +115,15 @@ public class TestConflictResolutionStrategyUtil {
     String fileId2 = "file-2";
 
     // create replace instant to mark fileId1 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildRequestedReplaceMetadata(fileId1, WriteOperationType.CLUSTER);
     HoodieTestTable.of(metaClient)
         .addRequestedCluster(instantTime, requestedReplaceMetadata)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
   }
 
-  static HoodieRequestedReplaceMetadata buildClusteringPlan(String fileId1) {
+  static HoodieRequestedReplaceMetadata buildRequestedReplaceMetadata(String fileId1, WriteOperationType writeOperationType) {
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
-    requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.name());
+    requestedReplaceMetadata.setOperationType(writeOperationType.name());
     HoodieClusteringPlan clusteringPlan = new HoodieClusteringPlan();
     HoodieClusteringGroup clusteringGroup = new HoodieClusteringGroup();
     HoodieSliceInfo sliceInfo = new HoodieSliceInfo();
@@ -194,7 +192,7 @@ public class TestConflictResolutionStrategyUtil {
     replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
     replaceMetadata.setOperationType(writeOperationType);
     // create replace instant to mark fileId1 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildRequestedReplaceMetadata(fileId1, WriteOperationType.INSERT_OVERWRITE);
     HoodieTestTable.of(metaClient)
         .addReplaceCommit(instantTime, Option.of(requestedReplaceMetadata), Option.empty(), replaceMetadata)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
@@ -214,7 +212,7 @@ public class TestConflictResolutionStrategyUtil {
     replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
     replaceMetadata.setOperationType(writeOperationType);
     // create replace instant to mark fileId1 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildRequestedReplaceMetadata(fileId1, writeOperationType);
     HoodieTestTable.of(metaClient)
         .addCluster(instantTime, requestedReplaceMetadata, Option.empty(), replaceMetadata)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
@@ -224,26 +222,10 @@ public class TestConflictResolutionStrategyUtil {
     String fileId1 = "file-1";
     String fileId2 = "file-2";
     // create replace instant to mark fileId2 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId2);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildRequestedReplaceMetadata(fileId2, writeOperationType);
     HoodieTestTable.of(metaClient)
         .addPendingCluster(instantTime, requestedReplaceMetadata, Option.empty())
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
-  }
-
-  public static void createCompleteReplace(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {
-    String fileId1 = "file-1";
-    String fileId2 = "file-2";
-
-    // create replace instant to mark fileId2 as deleted
-    HoodieReplaceCommitMetadata replaceMetadata = new HoodieReplaceCommitMetadata();
-    Map<String, List<String>> partitionFileIds = new HashMap<>();
-    partitionFileIds.put(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, Arrays.asList(fileId2));
-    replaceMetadata.setPartitionToReplaceFileIds(partitionFileIds);
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId("file-2");
-    replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
-    replaceMetadata.setOperationType(writeOperationType);
-    FileCreateUtilsLegacy.createReplaceCommit(COMMIT_METADATA_SER_DE, metaClient.getBasePath().toString(), instantTime, replaceMetadata);
   }
 
   public static void createPendingCompaction(String instantTime, HoodieTableMetaClient metaClient) throws Exception {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -140,9 +140,8 @@ public class TestConflictResolutionStrategyUtil {
     String fileId1 = "file-1";
     String fileId2 = "file-2";
 
-    HoodieReplaceCommitMetadata inflightReplaceMetadata = buildReplaceCommitMetadata(WriteOperationType.CLUSTER);
     HoodieTestTable.of(metaClient)
-        .addInflightCluster(instantTime, Option.of(inflightReplaceMetadata))
+        .addInflightCluster(instantTime)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
   }
 
@@ -277,15 +276,6 @@ public class TestConflictResolutionStrategyUtil {
     HoodieTestTable.of(metaClient)
         .addCommit(instantTime, Option.of(commitMetadata))
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
-  }
-
-  public static void createClusterInflight(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {
-    Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata = Option.empty();
-    if (WriteOperationType.INSERT_OVERWRITE.equals(writeOperationType)) {
-      inflightReplaceMetadata = Option.of(createReplaceCommitMetadata(WriteOperationType.INSERT_OVERWRITE));
-    }
-    HoodieTestTable.of(metaClient)
-        .addInflightCluster(instantTime, inflightReplaceMetadata);
   }
 
   private static HoodieReplaceCommitMetadata createReplaceCommitMetadata(WriteOperationType writeOperationType) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -136,14 +136,29 @@ public class TestConflictResolutionStrategyUtil {
     String fileId1 = "file-1";
     String fileId2 = "file-2";
 
-    HoodieReplaceCommitMetadata inflightReplaceMetadata = new HoodieReplaceCommitMetadata();
-    inflightReplaceMetadata.setOperationType(WriteOperationType.INSERT_OVERWRITE);
-    HoodieWriteStat writeStat = new HoodieWriteStat();
-    writeStat.setFileId("file-1");
-    inflightReplaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
+    HoodieReplaceCommitMetadata inflightReplaceMetadata = buildReplaceCommitMetadata(WriteOperationType.CLUSTER);
     HoodieTestTable.of(metaClient)
         .addInflightCluster(instantTime, Option.of(inflightReplaceMetadata))
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+  }
+
+  public static void createReplaceInflight(String instantTime, HoodieTableMetaClient metaClient) throws Exception {
+    String fileId1 = "file-1";
+    String fileId2 = "file-2";
+
+    HoodieReplaceCommitMetadata inflightReplaceMetadata = buildReplaceCommitMetadata(WriteOperationType.INSERT_OVERWRITE);
+    HoodieTestTable.of(metaClient)
+        .addInflightReplace(instantTime, Option.of(inflightReplaceMetadata))
+        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+  }
+
+  private static HoodieReplaceCommitMetadata buildReplaceCommitMetadata(WriteOperationType insertOverwrite) {
+    HoodieReplaceCommitMetadata inflightReplaceMetadata = new HoodieReplaceCommitMetadata();
+    inflightReplaceMetadata.setOperationType(insertOverwrite);
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId("file-1");
+    inflightReplaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
+    return inflightReplaceMetadata;
   }
 
   public static void createPendingInsertOverwrite(String instantTime, WriteOperationType writeOperationType, HoodieTableMetaClient metaClient) throws Exception {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +117,13 @@ public class TestConflictResolutionStrategyUtil {
     String fileId2 = "file-2";
 
     // create replace instant to mark fileId1 as deleted
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
+    HoodieTestTable.of(metaClient)
+        .addRequestedCluster(instantTime, requestedReplaceMetadata)
+        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+  }
+
+  static HoodieRequestedReplaceMetadata buildClusteringPlan(String fileId1) {
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
     requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.name());
     HoodieClusteringPlan clusteringPlan = new HoodieClusteringPlan();
@@ -123,13 +131,11 @@ public class TestConflictResolutionStrategyUtil {
     HoodieSliceInfo sliceInfo = new HoodieSliceInfo();
     sliceInfo.setFileId(fileId1);
     sliceInfo.setPartitionPath(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
-    clusteringGroup.setSlices(Arrays.asList(sliceInfo));
-    clusteringPlan.setInputGroups(Arrays.asList(clusteringGroup));
+    clusteringGroup.setSlices(Collections.singletonList(sliceInfo));
+    clusteringPlan.setInputGroups(Collections.singletonList(clusteringGroup));
     requestedReplaceMetadata.setClusteringPlan(clusteringPlan);
     requestedReplaceMetadata.setVersion(TimelineLayoutVersion.CURR_VERSION);
-    HoodieTestTable.of(metaClient)
-        .addRequestedCluster(instantTime, requestedReplaceMetadata)
-        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+    return requestedReplaceMetadata;
   }
 
   public static void createClusterInflight(String instantTime, HoodieTableMetaClient metaClient) throws Exception {
@@ -188,17 +194,7 @@ public class TestConflictResolutionStrategyUtil {
     replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
     replaceMetadata.setOperationType(writeOperationType);
     // create replace instant to mark fileId1 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
-    requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.name());
-    HoodieClusteringPlan clusteringPlan = new HoodieClusteringPlan();
-    HoodieClusteringGroup clusteringGroup = new HoodieClusteringGroup();
-    HoodieSliceInfo sliceInfo = new HoodieSliceInfo();
-    sliceInfo.setFileId(fileId1);
-    sliceInfo.setPartitionPath(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
-    clusteringGroup.setSlices(Arrays.asList(sliceInfo));
-    clusteringPlan.setInputGroups(Arrays.asList(clusteringGroup));
-    requestedReplaceMetadata.setClusteringPlan(clusteringPlan);
-    requestedReplaceMetadata.setVersion(TimelineLayoutVersion.CURR_VERSION);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
     HoodieTestTable.of(metaClient)
         .addReplaceCommit(instantTime, Option.of(requestedReplaceMetadata), Option.empty(), replaceMetadata)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
@@ -218,17 +214,7 @@ public class TestConflictResolutionStrategyUtil {
     replaceMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
     replaceMetadata.setOperationType(writeOperationType);
     // create replace instant to mark fileId1 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
-    requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.name());
-    HoodieClusteringPlan clusteringPlan = new HoodieClusteringPlan();
-    HoodieClusteringGroup clusteringGroup = new HoodieClusteringGroup();
-    HoodieSliceInfo sliceInfo = new HoodieSliceInfo();
-    sliceInfo.setFileId(fileId1);
-    sliceInfo.setPartitionPath(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
-    clusteringGroup.setSlices(Arrays.asList(sliceInfo));
-    clusteringPlan.setInputGroups(Arrays.asList(clusteringGroup));
-    requestedReplaceMetadata.setClusteringPlan(clusteringPlan);
-    requestedReplaceMetadata.setVersion(TimelineLayoutVersion.CURR_VERSION);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId1);
     HoodieTestTable.of(metaClient)
         .addCluster(instantTime, requestedReplaceMetadata, Option.empty(), replaceMetadata)
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
@@ -238,17 +224,7 @@ public class TestConflictResolutionStrategyUtil {
     String fileId1 = "file-1";
     String fileId2 = "file-2";
     // create replace instant to mark fileId2 as deleted
-    HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
-    requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.name());
-    HoodieClusteringPlan clusteringPlan = new HoodieClusteringPlan();
-    HoodieClusteringGroup clusteringGroup = new HoodieClusteringGroup();
-    HoodieSliceInfo sliceInfo = new HoodieSliceInfo();
-    sliceInfo.setFileId(fileId2);
-    sliceInfo.setPartitionPath(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
-    clusteringGroup.setSlices(Arrays.asList(sliceInfo));
-    clusteringPlan.setInputGroups(Arrays.asList(clusteringGroup));
-    requestedReplaceMetadata.setClusteringPlan(clusteringPlan);
-    requestedReplaceMetadata.setVersion(TimelineLayoutVersion.CURR_VERSION);
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = buildClusteringPlan(fileId2);
     HoodieTestTable.of(metaClient)
         .addPendingCluster(instantTime, requestedReplaceMetadata, Option.empty())
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConflictResolutionStrategyUtil.java
@@ -137,12 +137,7 @@ public class TestConflictResolutionStrategyUtil {
   }
 
   public static void createClusterInflight(String instantTime, HoodieTableMetaClient metaClient) throws Exception {
-    String fileId1 = "file-1";
-    String fileId2 = "file-2";
-
-    HoodieTestTable.of(metaClient)
-        .addInflightCluster(instantTime)
-        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+    HoodieTestTable.of(metaClient).addInflightCluster(instantTime);
   }
 
   public static void createReplaceInflight(String instantTime, HoodieTableMetaClient metaClient) throws Exception {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestPreferWriterConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestPreferWriterConflictResolutionStrategy.java
@@ -174,7 +174,7 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
     // clustering 1 gets scheduled
     String newInstantTime = metaClient.createNewInstantTime();
     createClusterRequested(newInstantTime, metaClient);
-    createClusterInflight(newInstantTime, WriteOperationType.CLUSTER, metaClient);
+    createClusterInflight(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
     PreferWriterConflictResolutionStrategy strategy = new PreferWriterConflictResolutionStrategy();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -40,7 +40,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.buildClusteringPlan;
+import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.buildRequestedReplaceMetadata;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createCluster;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createClusterRequested;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createCommit;
@@ -180,7 +180,7 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   public void testConcurrentWritesWithLegacyClusteringInflightCommit() throws Exception {
     String clusteringInstantTime = metaClient.createNewInstantTime();
     // create a replace commit with a clustering operation to mimic a commit written by a v6 writer
-    HoodieTestTable.of(metaClient).addRequestedReplace(clusteringInstantTime, Option.of(buildClusteringPlan("file-1")));
+    HoodieTestTable.of(metaClient).addRequestedReplace(clusteringInstantTime, Option.of(buildRequestedReplaceMetadata("file-1", WriteOperationType.CLUSTER)));
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
     HoodieTestTable.of(metaClient).addInflightReplace(clusteringInstantTime, Option.empty());
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.buildRequestedReplaceMetadata;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createCluster;
+import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createClusterInflight;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createClusterRequested;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createCommit;
 import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyUtil.createCommitMetadata;
@@ -159,7 +160,7 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
     String clusteringInstantTime = metaClient.createNewInstantTime();
     createClusterRequested(clusteringInstantTime, metaClient);
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
-    HoodieTestTable.of(metaClient).addInflightCluster(clusteringInstantTime, Option.empty());
+    createClusterInflight(clusteringInstantTime, metaClient);
 
     SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
     HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -129,14 +129,14 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
 
   @Test
   public void testConcurrentWritesWithReplaceInflightCommit() throws Exception {
-    String replaceInstant = metaClient.createNewInstantTime();
-    HoodieTestTable.of(metaClient).addRequestedReplace(replaceInstant, Option.empty());
-    TestConflictResolutionStrategyUtil.createClusterInflight(replaceInstant, metaClient);
-    Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
-
     String currentWriterInstant = metaClient.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+
+    String replaceInstant = metaClient.createNewInstantTime();
+    HoodieTestTable.of(metaClient).addRequestedReplace(replaceInstant, Option.empty());
+    TestConflictResolutionStrategyUtil.createReplaceInflight(replaceInstant, metaClient);
+    Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
 
     SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
     HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
@@ -168,7 +168,7 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
     String clusteringInstantTime = metaClient.createNewInstantTime();
     createClusterRequested(clusteringInstantTime, metaClient);
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
-    HoodieTestTable.of(metaClient).addInflightReplace(clusteringInstantTime, Option.empty());
+    HoodieTestTable.of(metaClient).addInflightCluster(clusteringInstantTime, Option.empty());
 
     SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
     HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
@@ -372,7 +372,7 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   }
 
   @Test
-  public void tstConcurrentWritesWithPendingInsertOverwriteReplace() throws Exception {
+  public void testConcurrentWritesWithPendingInsertOverwriteReplace() throws Exception {
     createCommit(metaClient.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -376,8 +376,8 @@ public class HoodieTestTable implements AutoCloseable {
     return this;
   }
 
-  public HoodieTestTable addInflightCluster(String instantTime, Option<HoodieReplaceCommitMetadata> inflightReplaceMetadata) throws Exception {
-    createInflightClusterCommit(metaClient, metaClient.getCommitMetadataSerDe(), instantTime, inflightReplaceMetadata);
+  public HoodieTestTable addInflightCluster(String instantTime) throws Exception {
+    createInflightClusterCommit(metaClient, metaClient.getCommitMetadataSerDe(), instantTime, Option.empty());
     currentInstantTime = instantTime;
     return this;
   }


### PR DESCRIPTION
### Change Logs

- Fixes conflict detection when there is an in-flight clustering. Previously an in-flight clustering would inspect the in-flight commit which is empty. This would mean that the code would always return that there was no conflict and potentially result in a false negative. Now the code will check the requested commit when it is a clustering.
- Fixes conflict detection with replace commits for non-clustering actions. Previously these were filtered out. Now they are included.
- Updates tests to be consistent with action type to ensure we're testing real world scenarios

### Impact

- Fixes conflict detection to avoid data consistency issues

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
