### PR TITLE
[HUDI-9386] Deprecate startCommitWithTime(instantTime, actionType) 

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -965,6 +965,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     startCommitWithTime(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
   }
 
+  @Deprecated
+  public void startCommitWithTime(String instantTime, String actionType) {
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    startCommitWithTime(instantTime, actionType, metaClient);
+  }
+
   /**
    * Starts a new commit time for a write operation against the metadata table with the provided instant and action type.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -941,6 +941,11 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     return startCommit(metaClient.getCommitActionType(), metaClient);
   }
 
+  public String startCommit(String actionType) {
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    return startCommit(actionType, metaClient);
+  }
+
   /**
    * Provides a new commit time for a write operation (insert/update/delete/insert_overwrite/insert_overwrite_table) with specified action.
    */
@@ -958,10 +963,11 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   }
 
   /**
-   * Completes a new commit time for a write operation (insert/update/delete/insert_overwrite/insert_overwrite_table) with specified action.
+   * Starts a new commit time for a write operation against the metadata table with the provided instant and action type.
    */
-  public void startCommitWithTime(String instantTime, String actionType) {
+  public void startCommitForMetadataTable(String instantTime, String actionType) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
+    ValidationUtils.checkArgument(metaClient.isMetadataTable(), "Attempting to create an instant with a predetermined time on a non-metadata table.");
     startCommitWithTime(Option.of(instantTime), actionType, metaClient);
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -974,7 +974,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   @VisibleForTesting
   void startCommitWithTime(String instantTime, String actionType) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
-    startCommitWithTime(instantTime, actionType, metaClient);
+    startCommitWithTime(Option.of(instantTime), actionType, metaClient);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -965,8 +965,14 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     startCommitWithTime(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
   }
 
-  @Deprecated
-  public void startCommitWithTime(String instantTime, String actionType) {
+  /**
+   * Provides a new commit at the specified time with the provided action type.
+   * This is only for testing purposes to setup particular sequences of commits.
+   * @param instantTime the commit start time
+   * @param actionType the type of commit
+   */
+  @VisibleForTesting
+  void startCommitWithTime(String instantTime, String actionType) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
     startCommitWithTime(instantTime, actionType, metaClient);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -941,6 +941,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     return startCommit(metaClient.getCommitActionType(), metaClient);
   }
 
+  /**
+   * Provides a new commit time for the provided action.
+   */
   public String startCommit(String actionType) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
     return startCommit(actionType, metaClient);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -980,10 +980,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   /**
    * Starts a new commit time for a write operation against the metadata table with the provided instant and action type.
    */
-  public void startCommitForMetadataTable(String instantTime, String actionType) {
-    HoodieTableMetaClient metaClient = createMetaClient(true);
-    ValidationUtils.checkArgument(metaClient.isMetadataTable(), "Attempting to create an instant with a predetermined time on a non-metadata table.");
-    startCommitWithTime(Option.of(instantTime), actionType, metaClient);
+  public void startCommitForMetadataTable(HoodieTableMetaClient metadataMetaClient, String instantTime, String actionType) {
+    ValidationUtils.checkArgument(metadataMetaClient.isMetadataTable(), "Attempting to create an instant with a predetermined time on a non-metadata table.");
+    startCommitWithTime(Option.of(instantTime), actionType, metadataMetaClient);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -953,7 +953,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * Provides a new commit time for a write operation (insert/update/delete/insert_overwrite/insert_overwrite_table) with specified action.
    */
   public String startCommit(String actionType, HoodieTableMetaClient metaClient) {
-    return startCommitWithTime(Option.empty(), actionType, metaClient);
+    return startCommit(Option.empty(), actionType, metaClient);
   }
 
   /**
@@ -962,19 +962,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   public void startCommitWithTime(String instantTime) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
-    startCommitWithTime(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
-  }
-
-  /**
-   * Provides a new commit at the specified time with the provided action type.
-   * This is only for testing purposes to setup particular sequences of commits.
-   * @param instantTime the commit start time
-   * @param actionType the type of commit
-   */
-  @VisibleForTesting
-  void startCommitWithTime(String instantTime, String actionType) {
-    HoodieTableMetaClient metaClient = createMetaClient(true);
-    startCommitWithTime(Option.of(instantTime), actionType, metaClient);
+    startCommit(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
   }
 
   /**
@@ -982,13 +970,20 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   public void startCommitForMetadataTable(HoodieTableMetaClient metadataMetaClient, String instantTime, String actionType) {
     ValidationUtils.checkArgument(metadataMetaClient.isMetadataTable(), "Attempting to create an instant with a predetermined time on a non-metadata table.");
-    startCommitWithTime(Option.of(instantTime), actionType, metadataMetaClient);
+    startCommit(Option.of(instantTime), actionType, metadataMetaClient);
   }
 
   /**
    * Starts a new commit time for a write operation (insert/update/delete) with specified action.
+   *
+   * @param providedInstantTime an optional argument that should only be provided for writes to the metadata table or for testing purposes.
+   *                            If not provided, a new instant time will be generated and returned to the caller.
+   * @param actionType the type of commit
+   * @param metaClient a meta client for the table
+   * @return the requested instant time for the commit that was started
    */
-  private String startCommitWithTime(Option<String> providedInstantTime, String actionType, HoodieTableMetaClient metaClient) {
+  @VisibleForTesting
+  String startCommit(Option<String> providedInstantTime, String actionType, HoodieTableMetaClient metaClient) {
     if (needsUpgrade(metaClient)) {
       // unclear what instant to use, since upgrade does have a given instant.
       executeUsingTxnManager(Option.empty(), () -> tryUpgrade(metaClient, Option.empty()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1403,7 +1403,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       metadataMetaClient.reloadActiveTimeline();
     }
 
-    writeClient.startCommitForMetadataTable(instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
+    writeClient.startCommitForMetadataTable(metadataMetaClient, instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
     preWrite(instantTime);
     if (isInitializing) {
       engineContext.setJobStatus(this.getClass().getSimpleName(), String.format("Bulk inserting at %s into metadata table %s", instantTime, metadataWriteConfig.getTableName()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1403,7 +1403,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       metadataMetaClient.reloadActiveTimeline();
     }
 
-    writeClient.startCommitWithTime(instantTime);
+    writeClient.startCommitForMetadataTable(instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
     preWrite(instantTime);
     if (isInitializing) {
       engineContext.setJobStatus(this.getClass().getSimpleName(), String.format("Bulk inserting at %s into metadata table %s", instantTime, metadataWriteConfig.getTableName()));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -135,14 +135,13 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     BaseHoodieTableServiceClient<String, String, String> tableServiceClient = mock(BaseHoodieTableServiceClient.class);
     TestWriteClient writeClient = new TestWriteClient(writeConfig, table, Option.empty(), tableServiceClient, transactionManager, timeGenerator);
 
-    writeClient.startCommit();
+    String instantTime = writeClient.startCommit("commit");
 
     HoodieTimeline writeTimeline = metaClient.getActiveTimeline().getWriteTimeline();
     assertTrue(writeTimeline.lastInstant().isPresent());
     assertEquals("commit", writeTimeline.lastInstant().get().getAction());
-    String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(now.getEpochSecond());
-    assertEquals(commitTime, writeTimeline.lastInstant().get().requestedTime());
-    HoodieInstant expectedInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieActiveTimeline.COMMIT_ACTION, commitTime, InstantComparatorV2.COMPLETION_TIME_BASED_COMPARATOR);
+    assertEquals(instantTime, writeTimeline.lastInstant().get().requestedTime());
+    HoodieInstant expectedInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieActiveTimeline.COMMIT_ACTION, instantTime, InstantComparatorV2.COMPLETION_TIME_BASED_COMPARATOR);
 
     InOrder inOrder = Mockito.inOrder(transactionManager, timeGenerator);
     inOrder.verify(transactionManager).beginTransaction(Option.empty(), Option.empty());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -36,7 +36,6 @@ import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
-import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -18,11 +18,13 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.common.util.Option;
+
 public class WriteClientTestUtils {
   private WriteClientTestUtils() {
   }
 
   public static void startCommitWithTime(BaseHoodieWriteClient<?, ?, ?, ?> writeClient, String instantTime, String actionType) {
-    writeClient.startCommitWithTime(instantTime, actionType);
+    writeClient.startCommit(Option.of(instantTime), actionType, writeClient.createMetaClient(false));
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+public class WriteClientTestUtils {
+  private WriteClientTestUtils() {
+  }
+
+  public static void startCommitWithTime(BaseHoodieWriteClient<?, ?, ?, ?> writeClient, String instantTime, String actionType) {
+    writeClient.startCommitWithTime(instantTime, actionType);
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -159,7 +159,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       metadataMetaClient.reloadActiveTimeline();
     }
 
-    writeClient.startCommitForMetadataTable(instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
+    writeClient.startCommitForMetadataTable(metadataMetaClient, instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
     preWrite(instantTime);
 
     List<WriteStatus> statuses = isInitializing

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -159,7 +159,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       metadataMetaClient.reloadActiveTimeline();
     }
 
-    writeClient.startCommitWithTime(instantTime);
+    writeClient.startCommitForMetadataTable(instantTime, HoodieActiveTimeline.DELTA_COMMIT_ACTION);
     preWrite(instantTime);
 
     List<WriteStatus> statuses = isInitializing

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
-import org.apache.hudi.common.model.PartitionBucketIndexHashingConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
@@ -40,18 +39,16 @@ public class BucketIndexBulkInsertPartitionerWithRows implements BulkInsertParti
   private FileSystemViewStorageConfig viewConfig;
 
   public BucketIndexBulkInsertPartitionerWithRows(String indexKeyFields, HoodieWriteConfig writeConfig) {
-    this.indexKeyFields = indexKeyFields;
-    this.numBucketsFunction = NumBucketsFunction.fromWriteConfig(writeConfig);
-    this.writeConfig = writeConfig;
-    if (writeConfig.isUsingRemotePartitioner()) {
-      this.viewConfig = writeConfig.getViewStorageConfig();
-    }
+    this(writeConfig, NumBucketsFunction.fromWriteConfig(writeConfig), indexKeyFields);
   }
 
-  public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig, PartitionBucketIndexHashingConfig hashingConfig) {
-    this.indexKeyFields = writeConfig.getBucketIndexHashFieldWithDefault();
-    this.numBucketsFunction = new NumBucketsFunction(hashingConfig.getExpressions(),
-        hashingConfig.getRule(), hashingConfig.getDefaultBucketNumber());
+  public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig, String expressions, String rule, int bucketNumber) {
+    this(writeConfig, new NumBucketsFunction(expressions, rule, bucketNumber), writeConfig.getBucketIndexHashFieldWithDefault());
+  }
+
+  private BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig, NumBucketsFunction numBucketsFunction, String indexKeyFields) {
+    this.indexKeyFields = indexKeyFields;
+    this.numBucketsFunction = numBucketsFunction;
     this.writeConfig = writeConfig;
     if (writeConfig.isUsingRemotePartitioner()) {
       this.viewConfig = writeConfig.getViewStorageConfig();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -156,7 +156,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     SparkRDDWriteClient writeClient = (SparkRDDWriteClient) getWriteClient();
     String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);
-    writeClient.startCommitForMetadataTable(instantTime, actionType);
+    writeClient.startCommitForMetadataTable(metadataMetaClient, instantTime, actionType);
     writeClient.deletePartitions(partitionsToDrop, instantTime);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -156,7 +156,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     SparkRDDWriteClient writeClient = (SparkRDDWriteClient) getWriteClient();
     String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);
-    writeClient.startCommitWithTime(instantTime, actionType);
+    writeClient.startCommitForMetadataTable(instantTime, actionType);
     writeClient.deletePartitions(partitionsToDrop, instantTime);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -132,7 +132,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
 
     SparkRDDWriteClient writeClient = (SparkRDDWriteClient) getWriteClient();
     String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);
-    writeClient.startCommitForMetadataTable(instantTime, actionType);
+    writeClient.startCommitForMetadataTable(metadataMetaClient, instantTime, actionType);
     writeClient.deletePartitions(partitionsToDrop, instantTime);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -132,7 +132,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
 
     SparkRDDWriteClient writeClient = (SparkRDDWriteClient) getWriteClient();
     String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);
-    writeClient.startCommitWithTime(instantTime, actionType);
+    writeClient.startCommitForMetadataTable(instantTime, actionType);
     writeClient.deletePartitions(partitionsToDrop, instantTime);
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieWriteResult;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.SparkTaskContextSupplier;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.clustering.plan.strategy.SparkSingleFileSortPlanStrategy;
 import org.apache.hudi.client.clustering.run.strategy.SparkSingleFileSortExecutionStrategy;
@@ -1264,7 +1265,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     // Do Insert Overwrite
     String commitTime2 = "002";
-    client.startCommitWithTime(commitTime2, REPLACE_COMMIT_ACTION);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime2, REPLACE_COMMIT_ACTION);
     List<HoodieRecord> inserts2 = dataGen.generateInserts(commitTime2, batch2RecordsCount);
     List<HoodieRecord> insertsAndUpdates2 = new ArrayList<>(inserts2);
     JavaRDD<HoodieRecord> insertAndUpdatesRDD2 = jsc.parallelize(insertsAndUpdates2, 2);
@@ -1319,7 +1320,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   }
 
   private Set<String> deletePartitionWithCommit(SparkRDDWriteClient client, String commitTime, List<String> deletePartitionPath) {
-    client.startCommitWithTime(commitTime, REPLACE_COMMIT_ACTION);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime, REPLACE_COMMIT_ACTION);
     HoodieWriteResult writeResult = client.deletePartitions(deletePartitionPath, commitTime);
     Set<String> deletePartitionReplaceFileIds =
         writeResult.getPartitionToReplaceFileIds().entrySet()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1264,7 +1264,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     // Do Insert Overwrite
     String commitTime2 = "002";
-    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(commit1, REPLACE_COMMIT_ACTION);
+    client.startCommitWithTime(commitTime2, REPLACE_COMMIT_ACTION);
     List<HoodieRecord> inserts2 = dataGen.generateInserts(commitTime2, batch2RecordsCount);
     List<HoodieRecord> insertsAndUpdates2 = new ArrayList<>(inserts2);
     JavaRDD<HoodieRecord> insertAndUpdatesRDD2 = jsc.parallelize(insertsAndUpdates2, 2);
@@ -1319,7 +1319,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   }
 
   private Set<String> deletePartitionWithCommit(SparkRDDWriteClient client, String commitTime, List<String> deletePartitionPath) {
-    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(commitTime, REPLACE_COMMIT_ACTION);
+    client.startCommitWithTime(commitTime, REPLACE_COMMIT_ACTION);
     HoodieWriteResult writeResult = client.deletePartitions(deletePartitionPath, commitTime);
     Set<String> deletePartitionReplaceFileIds =
         writeResult.getPartitionToReplaceFileIds().entrySet()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1264,7 +1264,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     // Do Insert Overwrite
     String commitTime2 = "002";
-    client.startCommitWithTime(commitTime2, REPLACE_COMMIT_ACTION);
+    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(commit1, REPLACE_COMMIT_ACTION);
     List<HoodieRecord> inserts2 = dataGen.generateInserts(commitTime2, batch2RecordsCount);
     List<HoodieRecord> insertsAndUpdates2 = new ArrayList<>(inserts2);
     JavaRDD<HoodieRecord> insertAndUpdatesRDD2 = jsc.parallelize(insertsAndUpdates2, 2);
@@ -1319,7 +1319,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   }
 
   private Set<String> deletePartitionWithCommit(SparkRDDWriteClient client, String commitTime, List<String> deletePartitionPath) {
-    client.startCommitWithTime(commitTime, REPLACE_COMMIT_ACTION);
+    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(commitTime, REPLACE_COMMIT_ACTION);
     HoodieWriteResult writeResult = client.deletePartitions(deletePartitionPath, commitTime);
     Set<String> deletePartitionReplaceFileIds =
         writeResult.getPartitionToReplaceFileIds().entrySet()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -143,7 +144,7 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
     newCommitTime = "002";
     records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     writeRecords = jsc.parallelize(records, 1);
-    client.startCommitWithTime(newCommitTime, commitActionType);
+    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(newCommitTime, REPLACE_COMMIT_ACTION);
     HoodieWriteResult result = client.insertOverwrite(writeRecords, newCommitTime);
     statuses = result.getWriteStatuses();
     Assertions.assertNoWriteErrors(statuses.collect());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
@@ -20,6 +20,7 @@ package org.apache.hudi.table.action.rollback;
 
 import org.apache.hudi.client.HoodieWriteResult;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
@@ -41,7 +42,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -144,7 +144,7 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
     newCommitTime = "002";
     records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     writeRecords = jsc.parallelize(records, 1);
-    metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(newCommitTime, REPLACE_COMMIT_ACTION);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime, commitActionType);
     HoodieWriteResult result = client.insertOverwrite(writeRecords, newCommitTime);
     statuses = result.getWriteStatuses();
     Assertions.assertNoWriteErrors(statuses.collect());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
@@ -77,8 +77,7 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
       assertEquals(21, countRecordsOptionallySince(jsc(), basePath(), sqlContext(), timeline1, Option.empty()));
 
       // delete the 1st and the 2nd partition; 1 replace commit
-      final String instantTime4 = client.createNewInstantTime();
-      client.startCommitWithTime(instantTime4, HoodieActiveTimeline.REPLACE_COMMIT_ACTION);
+      final String instantTime4 = client.startCommit(HoodieActiveTimeline.REPLACE_COMMIT_ACTION);
       client.deletePartitions(Arrays.asList(DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH), instantTime4);
 
       // 2nd write batch; 6 commits for the 4th partition; the 6th commit to trigger archiving the replace commit

--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
@@ -129,8 +129,7 @@ public class HoodieWriteClientExample {
         client.delete(deleteRecords, newCommitTime);
 
         // Delete by partition
-        newCommitTime = client.startCommit();
-        client.startCommitWithTime(newCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION);
+        newCommitTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
         LOG.info("Starting commit " + newCommitTime);
         // The partition where the data needs to be deleted
         List<String> partitionList = toBeDeleted.stream().map(s -> s.getPartitionPath()).distinct().collect(Collectors.toList());

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
-import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer;
 import org.apache.hudi.utilities.schema.SchemaProvider;

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -86,8 +86,7 @@ public class HoodieDeltaStreamerWrapper extends HoodieDeltaStreamer {
         .setConf(service.getStorage().getConf().newInstance())
         .setBasePath(service.getCfg().targetBasePath)
         .build();
-    String instantTime = InProcessTimeGenerator.createNewInstantTime();
-    InputBatch inputBatch = service.readFromSource(instantTime, metaClient).getLeft();
+    InputBatch inputBatch = service.readFromSource(metaClient).getLeft();
     return Pair.of(inputBatch.getSchemaProvider(), Pair.of(inputBatch.getCheckpointForNextBatch(), (JavaRDD<HoodieRecord>) inputBatch.getBatch().get()));
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -67,6 +67,7 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
   protected void preExecute() {
     table.validateInsertSchema();
+    table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
     instantTime = writeClient.startCommit(getCommitActionType());
     writeClient.preWrite(instantTime, getWriteOperationType(), table.getMetaClient());
   }
@@ -96,7 +97,6 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
     boolean populateMetaFields = writeConfig.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS);
     preExecute();
-    table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
 
     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);
     Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, bulkInsertPartitionerRows, instantTime);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -95,13 +95,12 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
     }
 
     boolean populateMetaFields = writeConfig.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS);
-
+    preExecute();
     table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
 
     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);
     Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, bulkInsertPartitionerRows, instantTime);
 
-    preExecute();
     HoodieWriteMetadata<JavaRDD<WriteStatus>> result = buildHoodieWriteMetadata(doExecute(hoodieDF, bulkInsertPartitionerRows.arePartitionRecordsSorted()));
     afterExecute(result);
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -96,6 +96,10 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
     boolean populateMetaFields = writeConfig.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS);
     preExecute();
+    if (instantTime == null) {
+      // ensure that the commit is started
+      instantTime = writeClient.startCommit(getCommitActionType());
+    }
     table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
 
     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -96,10 +96,6 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
     boolean populateMetaFields = writeConfig.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS);
     preExecute();
-    if (instantTime == null) {
-      // ensure that the commit is started
-      instantTime = writeClient.startCommit(getCommitActionType());
-    }
     table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
 
     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -56,20 +56,18 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
   protected final transient HoodieWriteConfig writeConfig;
   protected final transient SparkRDDWriteClient writeClient;
-  protected final String instantTime;
+  protected String instantTime;
   protected HoodieTable table;
 
   public BaseDatasetBulkInsertCommitActionExecutor(HoodieWriteConfig config,
-                                                   SparkRDDWriteClient writeClient,
-                                                   String instantTime) {
+                                                   SparkRDDWriteClient writeClient) {
     this.writeConfig = config;
     this.writeClient = writeClient;
-    this.instantTime = instantTime;
   }
 
   protected void preExecute() {
     table.validateInsertSchema();
-    writeClient.startCommitWithTime(instantTime, getCommitActionType());
+    instantTime = writeClient.startCommit(getCommitActionType());
     writeClient.preWrite(instantTime, getWriteOperationType(), table.getMetaClient());
   }
 
@@ -137,5 +135,9 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
 
   protected Map<String, List<String>> getPartitionToReplacedFileIds(HoodieData<WriteStatus> writeStatuses) {
     return Collections.emptyMap();
+  }
+
+  public String getInstantTime() {
+    return instantTime;
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -66,9 +66,9 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
   }
 
   protected void preExecute() {
-    table.validateInsertSchema();
-    table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
     instantTime = writeClient.startCommit(getCommitActionType());
+    table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
+    table.validateInsertSchema();
     writeClient.preWrite(instantTime, getWriteOperationType(), table.getMetaClient());
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
@@ -44,9 +44,8 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
   private final PartitionBucketIndexHashingConfig hashingConfig;
 
   public DatasetBucketRescaleCommitActionExecutor(HoodieWriteConfig config,
-                                                  SparkRDDWriteClient writeClient,
-                                                  String instantTime) {
-    super(config, writeClient, instantTime);
+                                                  SparkRDDWriteClient writeClient) {
+    super(config, writeClient);
     String expression = config.getBucketIndexPartitionExpression();
     String rule = config.getBucketIndexPartitionRuleType();
     int bucketNumber = config.getBucketIndexNumBuckets();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
@@ -41,16 +41,17 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
   private static final long serialVersionUID = 1L;
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetBucketRescaleCommitActionExecutor.class);
-  private final PartitionBucketIndexHashingConfig hashingConfig;
+  private final String expression;
+  private final String rule;
+  private final int bucketNumber;
+  private PartitionBucketIndexHashingConfig hashingConfig;
 
   public DatasetBucketRescaleCommitActionExecutor(HoodieWriteConfig config,
                                                   SparkRDDWriteClient writeClient) {
     super(config, writeClient);
-    String expression = config.getBucketIndexPartitionExpression();
-    String rule = config.getBucketIndexPartitionRuleType();
-    int bucketNumber = config.getBucketIndexNumBuckets();
-    this.hashingConfig = new PartitionBucketIndexHashingConfig(expression,
-        bucketNumber, rule, PartitionBucketIndexHashingConfig.CURRENT_VERSION, instantTime);
+    expression = config.getBucketIndexPartitionExpression();
+    rule = config.getBucketIndexPartitionRuleType();
+    bucketNumber = config.getBucketIndexNumBuckets();
   }
 
   /**
@@ -63,14 +64,15 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
 
   /**
    * create new hashing_config during afterExecute and before commit finished.
-   * @param result
    */
   @Override
   protected void preExecute() {
     super.preExecute();
+    hashingConfig = new PartitionBucketIndexHashingConfig(expression,
+        bucketNumber, rule, PartitionBucketIndexHashingConfig.CURRENT_VERSION, instantTime);
     boolean res = PartitionBucketIndexHashingConfig.saveHashingConfig(hashingConfig, table.getMetaClient());
     ValidationUtils.checkArgument(res);
-    LOG.info("Finish to save hashing config " + hashingConfig);
+    LOG.info("Finish to save hashing config {}", hashingConfig);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
@@ -44,7 +44,6 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
   private final String expression;
   private final String rule;
   private final int bucketNumber;
-  private PartitionBucketIndexHashingConfig hashingConfig;
 
   public DatasetBucketRescaleCommitActionExecutor(HoodieWriteConfig config,
                                                   SparkRDDWriteClient writeClient) {
@@ -59,7 +58,7 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
    */
   @Override
   protected BulkInsertPartitioner<Dataset<Row>> getPartitioner(boolean populateMetaFields, boolean isTablePartitioned) {
-    return new BucketIndexBulkInsertPartitionerWithRows(writeClient.getConfig(), hashingConfig);
+    return new BucketIndexBulkInsertPartitionerWithRows(writeClient.getConfig(), expression, rule, bucketNumber);
   }
 
   /**
@@ -68,7 +67,7 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
   @Override
   protected void preExecute() {
     super.preExecute();
-    hashingConfig = new PartitionBucketIndexHashingConfig(expression,
+    PartitionBucketIndexHashingConfig hashingConfig = new PartitionBucketIndexHashingConfig(expression,
         bucketNumber, rule, PartitionBucketIndexHashingConfig.CURRENT_VERSION, instantTime);
     boolean res = PartitionBucketIndexHashingConfig.saveHashingConfig(hashingConfig, table.getMetaClient());
     ValidationUtils.checkArgument(res);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -49,7 +49,7 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
 
   @Override
   protected void preExecute() {
-    instantTime = writeClient.startCommit(getCommitActionType());
+    instantTime = writeClient.startCommit();
     table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -49,7 +49,7 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
 
   @Override
   protected void preExecute() {
-    // no op
+    instantTime = writeClient.startCommit();
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieInternalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.internal.DataSourceInternalWriterHelper;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -43,9 +42,8 @@ import java.util.stream.Collectors;
 public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsertCommitActionExecutor {
 
   public DatasetBulkInsertCommitActionExecutor(HoodieWriteConfig config,
-                                               SparkRDDWriteClient writeClient,
-                                               String instantTime) {
-    super(config, writeClient, instantTime);
+                                               SparkRDDWriteClient writeClient) {
+    super(config, writeClient);
   }
 
   @Override
@@ -72,7 +70,6 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
     }
 
     records.write().format(targetFormat)
-        .option(DataSourceInternalWriterHelper.INSTANT_TIME_OPT_KEY, instantTime)
         .options(opts)
         .options(customOpts)
         .options(optsOverrides)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -50,6 +50,7 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
   @Override
   protected void preExecute() {
     instantTime = writeClient.startCommit();
+    table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieInternalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.internal.DataSourceInternalWriterHelper;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -70,6 +71,7 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
     }
 
     records.write().format(targetFormat)
+        .option(DataSourceInternalWriterHelper.INSTANT_TIME_OPT_KEY, instantTime)
         .options(opts)
         .options(customOpts)
         .options(optsOverrides)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertCommitActionExecutor.java
@@ -49,7 +49,7 @@ public class DatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsert
 
   @Override
   protected void preExecute() {
-    instantTime = writeClient.startCommit();
+    instantTime = writeClient.startCommit(getCommitActionType());
     table = writeClient.initTable(getWriteOperationType(), Option.ofNullable(instantTime));
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteCommitActionExecutor.java
@@ -43,9 +43,8 @@ import java.util.stream.Collectors;
 public class DatasetBulkInsertOverwriteCommitActionExecutor extends BaseDatasetBulkInsertCommitActionExecutor {
 
   public DatasetBulkInsertOverwriteCommitActionExecutor(HoodieWriteConfig config,
-                                                        SparkRDDWriteClient writeClient,
-                                                        String instantTime) {
-    super(config, writeClient, instantTime);
+                                                        SparkRDDWriteClient writeClient) {
+    super(config, writeClient);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteTableCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBulkInsertOverwriteTableCommitActionExecutor.java
@@ -35,9 +35,8 @@ import java.util.Map;
 public class DatasetBulkInsertOverwriteTableCommitActionExecutor extends DatasetBulkInsertOverwriteCommitActionExecutor {
 
   public DatasetBulkInsertOverwriteTableCommitActionExecutor(HoodieWriteConfig config,
-                                                             SparkRDDWriteClient writeClient,
-                                                             String instantTime) {
-    super(config, writeClient, instantTime);
+                                                             SparkRDDWriteClient writeClient) {
+    super(config, writeClient);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/HoodieStreamerDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/HoodieStreamerDatasetBulkInsertCommitActionExecutor.java
@@ -36,14 +36,8 @@ import org.apache.spark.sql.Row;
  */
 public class HoodieStreamerDatasetBulkInsertCommitActionExecutor extends BaseDatasetBulkInsertCommitActionExecutor {
 
-  public HoodieStreamerDatasetBulkInsertCommitActionExecutor(HoodieWriteConfig config, SparkRDDWriteClient writeClient, String instantTime) {
-    super(config, writeClient, instantTime);
-  }
-
-  @Override
-  protected void preExecute() {
-    table.validateInsertSchema();
-    writeClient.preWrite(instantTime, getWriteOperationType(), table.getMetaClient());
+  public HoodieStreamerDatasetBulkInsertCommitActionExecutor(HoodieWriteConfig config, SparkRDDWriteClient writeClient) {
+    super(config, writeClient);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 public class DataSourceInternalWriterHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataSourceInternalWriterHelper.class);
-  public static final String INSTANT_TIME_OPT_KEY = "hoodie.instant.time";
 
   private final String instantTime;
   private final HoodieTableMetaClient metaClient;
@@ -57,14 +56,13 @@ public class DataSourceInternalWriterHelper {
   private final WriteOperationType operationType;
   private final Map<String, String> extraMetadata;
 
-  public DataSourceInternalWriterHelper(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
+  public DataSourceInternalWriterHelper(HoodieWriteConfig writeConfig, StructType structType,
                                         SparkSession sparkSession, StorageConfiguration<?> storageConf, Map<String, String> extraMetadata) {
-    this.instantTime = instantTime;
     this.operationType = WriteOperationType.BULK_INSERT;
     this.extraMetadata = extraMetadata;
     this.writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(new JavaSparkContext(sparkSession.sparkContext())), writeConfig);
     this.writeClient.setOperationType(operationType);
-    this.writeClient.startCommitWithTime(instantTime);
+    this.instantTime = this.writeClient.startCommit();
     this.hoodieTable = this.writeClient.initTable(operationType, Option.of(instantTime));
 
     this.metaClient = HoodieTableMetaClient.builder()
@@ -98,10 +96,11 @@ public class DataSourceInternalWriterHelper {
     writeClient.close();
   }
 
-  public void createInflightCommit() {
+  public String createInflightCommit() {
     metaClient.getActiveTimeline().transitionRequestedToInflight(
         metaClient.createNewInstant(State.REQUESTED,
             CommitUtils.getCommitActionType(operationType, metaClient.getTableType()), instantTime), Option.empty());
+    return instantTime;
   }
 
   public HoodieTable getHoodieTable() {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 public class DataSourceInternalWriterHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataSourceInternalWriterHelper.class);
+  public static final String INSTANT_TIME_OPT_KEY = "hoodie.instant.time";
 
   private final String instantTime;
   private final HoodieTableMetaClient metaClient;
@@ -56,13 +57,13 @@ public class DataSourceInternalWriterHelper {
   private final WriteOperationType operationType;
   private final Map<String, String> extraMetadata;
 
-  public DataSourceInternalWriterHelper(HoodieWriteConfig writeConfig, StructType structType,
+  public DataSourceInternalWriterHelper(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
                                         SparkSession sparkSession, StorageConfiguration<?> storageConf, Map<String, String> extraMetadata) {
+    this.instantTime = instantTime;
     this.operationType = WriteOperationType.BULK_INSERT;
     this.extraMetadata = extraMetadata;
     this.writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(new JavaSparkContext(sparkSession.sparkContext())), writeConfig);
     this.writeClient.setOperationType(operationType);
-    this.instantTime = this.writeClient.startCommit();
     this.hoodieTable = this.writeClient.initTable(operationType, Option.of(instantTime));
 
     this.metaClient = HoodieTableMetaClient.builder()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/DefaultSource.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/DefaultSource.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.config.HoodieInternalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.internal.BaseDefaultSource;
-import org.apache.hudi.internal.DataSourceInternalWriterHelper;
 
 import org.apache.spark.sql.HoodieDataTypeUtils;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -49,7 +48,6 @@ public class DefaultSource extends BaseDefaultSource implements TableProvider {
 
   @Override
   public Table getTable(StructType schema, Transform[] partitioning, Map<String, String> properties) {
-    String instantTime = properties.get(DataSourceInternalWriterHelper.INSTANT_TIME_OPT_KEY);
     String path = properties.get("path");
     String tblName = properties.get(HoodieWriteConfig.TBL_NAME.key());
     boolean populateMetaFields = Boolean.parseBoolean(properties.getOrDefault(HoodieTableConfig.POPULATE_META_FIELDS.key(),
@@ -62,7 +60,7 @@ public class DefaultSource extends BaseDefaultSource implements TableProvider {
     HoodieDataTypeUtils.tryOverrideParquetWriteLegacyFormatProperty(newProps, schema);
     // 1st arg to createHoodieConfig is not really required to be set. but passing it anyways.
     HoodieWriteConfig config = DataSourceUtils.createHoodieConfig(newProps.get(HoodieWriteConfig.AVRO_SCHEMA_STRING.key()), path, tblName, newProps);
-    return new HoodieDataSourceInternalTable(instantTime, config, schema, getSparkSession(),
+    return new HoodieDataSourceInternalTable(config, schema, getSparkSession(),
         getConfiguration(), newProps, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/DefaultSource.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/DefaultSource.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.config.HoodieInternalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.internal.BaseDefaultSource;
+import org.apache.hudi.internal.DataSourceInternalWriterHelper;
 
 import org.apache.spark.sql.HoodieDataTypeUtils;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -48,6 +49,7 @@ public class DefaultSource extends BaseDefaultSource implements TableProvider {
 
   @Override
   public Table getTable(StructType schema, Transform[] partitioning, Map<String, String> properties) {
+    String instantTime = properties.get(DataSourceInternalWriterHelper.INSTANT_TIME_OPT_KEY);
     String path = properties.get("path");
     String tblName = properties.get(HoodieWriteConfig.TBL_NAME.key());
     boolean populateMetaFields = Boolean.parseBoolean(properties.getOrDefault(HoodieTableConfig.POPULATE_META_FIELDS.key(),
@@ -60,7 +62,7 @@ public class DefaultSource extends BaseDefaultSource implements TableProvider {
     HoodieDataTypeUtils.tryOverrideParquetWriteLegacyFormatProperty(newProps, schema);
     // 1st arg to createHoodieConfig is not really required to be set. but passing it anyways.
     HoodieWriteConfig config = DataSourceUtils.createHoodieConfig(newProps.get(HoodieWriteConfig.AVRO_SCHEMA_STRING.key()), path, tblName, newProps);
-    return new HoodieDataSourceInternalTable(config, schema, getSparkSession(),
+    return new HoodieDataSourceInternalTable(instantTime, config, schema, getSparkSession(),
         getConfiguration(), newProps, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWrite.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWrite.java
@@ -44,7 +44,6 @@ import java.util.stream.Collectors;
  */
 public class HoodieDataSourceInternalBatchWrite implements BatchWrite {
 
-  private final String instantTime;
   private final HoodieWriteConfig writeConfig;
   private final StructType structType;
   private final boolean arePartitionRecordsSorted;
@@ -52,21 +51,20 @@ public class HoodieDataSourceInternalBatchWrite implements BatchWrite {
   private final DataSourceInternalWriterHelper dataSourceInternalWriterHelper;
   private Map<String, String> extraMetadata = new HashMap<>();
 
-  public HoodieDataSourceInternalBatchWrite(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
+  public HoodieDataSourceInternalBatchWrite(HoodieWriteConfig writeConfig, StructType structType,
                                             SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties, boolean populateMetaFields, boolean arePartitionRecordsSorted) {
-    this.instantTime = instantTime;
     this.writeConfig = writeConfig;
     this.structType = structType;
     this.populateMetaFields = populateMetaFields;
     this.arePartitionRecordsSorted = arePartitionRecordsSorted;
     this.extraMetadata = DataSourceUtils.getExtraMetadata(properties);
-    this.dataSourceInternalWriterHelper = new DataSourceInternalWriterHelper(instantTime, writeConfig, structType,
+    this.dataSourceInternalWriterHelper = new DataSourceInternalWriterHelper(writeConfig, structType,
         jss, storageConf, extraMetadata);
   }
 
   @Override
   public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
-    dataSourceInternalWriterHelper.createInflightCommit();
+    String instantTime = dataSourceInternalWriterHelper.createInflightCommit();
     if (WriteOperationType.BULK_INSERT == dataSourceInternalWriterHelper.getWriteOperationType()) {
       return new HoodieBulkInsertDataInternalWriterFactory(dataSourceInternalWriterHelper.getHoodieTable(),
           writeConfig, instantTime, structType, populateMetaFields, arePartitionRecordsSorted);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWrite.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWrite.java
@@ -51,14 +51,14 @@ public class HoodieDataSourceInternalBatchWrite implements BatchWrite {
   private final DataSourceInternalWriterHelper dataSourceInternalWriterHelper;
   private Map<String, String> extraMetadata = new HashMap<>();
 
-  public HoodieDataSourceInternalBatchWrite(HoodieWriteConfig writeConfig, StructType structType,
+  public HoodieDataSourceInternalBatchWrite(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
                                             SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties, boolean populateMetaFields, boolean arePartitionRecordsSorted) {
     this.writeConfig = writeConfig;
     this.structType = structType;
     this.populateMetaFields = populateMetaFields;
     this.arePartitionRecordsSorted = arePartitionRecordsSorted;
     this.extraMetadata = DataSourceUtils.getExtraMetadata(properties);
-    this.dataSourceInternalWriterHelper = new DataSourceInternalWriterHelper(writeConfig, structType,
+    this.dataSourceInternalWriterHelper = new DataSourceInternalWriterHelper(instantTime, writeConfig, structType,
         jss, storageConf, extraMetadata);
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWriteBuilder.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWriteBuilder.java
@@ -34,7 +34,6 @@ import java.util.Map;
  */
 public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
 
-  private final String instantTime;
   private final HoodieWriteConfig writeConfig;
   private final StructType structType;
   private final SparkSession jss;
@@ -43,10 +42,9 @@ public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
   private final boolean populateMetaFields;
   private final boolean arePartitionRecordsSorted;
 
-  public HoodieDataSourceInternalBatchWriteBuilder(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
+  public HoodieDataSourceInternalBatchWriteBuilder(HoodieWriteConfig writeConfig, StructType structType,
                                                    SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties, boolean populateMetaFields,
                                                    boolean arePartitionRecordsSorted) {
-    this.instantTime = instantTime;
     this.writeConfig = writeConfig;
     this.structType = structType;
     this.jss = jss;
@@ -58,7 +56,7 @@ public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
 
   @Override
   public BatchWrite buildForBatch() {
-    return new HoodieDataSourceInternalBatchWrite(instantTime, writeConfig, structType, jss,
+    return new HoodieDataSourceInternalBatchWrite(writeConfig, structType, jss,
         storageConf, properties, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWriteBuilder.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalBatchWriteBuilder.java
@@ -34,6 +34,7 @@ import java.util.Map;
  */
 public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
 
+  private final String instantTime;
   private final HoodieWriteConfig writeConfig;
   private final StructType structType;
   private final SparkSession jss;
@@ -42,9 +43,10 @@ public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
   private final boolean populateMetaFields;
   private final boolean arePartitionRecordsSorted;
 
-  public HoodieDataSourceInternalBatchWriteBuilder(HoodieWriteConfig writeConfig, StructType structType,
+  public HoodieDataSourceInternalBatchWriteBuilder(String instantTime, HoodieWriteConfig writeConfig, StructType structType,
                                                    SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties, boolean populateMetaFields,
                                                    boolean arePartitionRecordsSorted) {
+    this.instantTime = instantTime;
     this.writeConfig = writeConfig;
     this.structType = structType;
     this.jss = jss;
@@ -56,7 +58,7 @@ public class HoodieDataSourceInternalBatchWriteBuilder implements WriteBuilder {
 
   @Override
   public BatchWrite buildForBatch() {
-    return new HoodieDataSourceInternalBatchWrite(writeConfig, structType, jss,
+    return new HoodieDataSourceInternalBatchWrite(instantTime, writeConfig, structType, jss,
         storageConf, properties, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalTable.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalTable.java
@@ -37,6 +37,7 @@ import java.util.Set;
  */
 class HoodieDataSourceInternalTable implements SupportsWrite {
 
+  private final String instantTime;
   private final HoodieWriteConfig writeConfig;
   private final StructType structType;
   private final SparkSession jss;
@@ -45,9 +46,10 @@ class HoodieDataSourceInternalTable implements SupportsWrite {
   private final Map<String, String> properties;
   private final boolean populateMetaFields;
 
-  public HoodieDataSourceInternalTable(HoodieWriteConfig config,
+  public HoodieDataSourceInternalTable(String instantTime, HoodieWriteConfig config,
                                        StructType schema, SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties,
                                        boolean populateMetaFields, boolean arePartitionRecordsSorted) {
+    this.instantTime = instantTime;
     this.writeConfig = config;
     this.structType = schema;
     this.jss = jss;
@@ -79,7 +81,7 @@ class HoodieDataSourceInternalTable implements SupportsWrite {
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
-    return new HoodieDataSourceInternalBatchWriteBuilder(writeConfig, structType, jss,
+    return new HoodieDataSourceInternalBatchWriteBuilder(instantTime, writeConfig, structType, jss,
         storageConf, properties, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalTable.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/spark/internal/HoodieDataSourceInternalTable.java
@@ -37,7 +37,6 @@ import java.util.Set;
  */
 class HoodieDataSourceInternalTable implements SupportsWrite {
 
-  private final String instantTime;
   private final HoodieWriteConfig writeConfig;
   private final StructType structType;
   private final SparkSession jss;
@@ -46,10 +45,9 @@ class HoodieDataSourceInternalTable implements SupportsWrite {
   private final Map<String, String> properties;
   private final boolean populateMetaFields;
 
-  public HoodieDataSourceInternalTable(String instantTime, HoodieWriteConfig config,
+  public HoodieDataSourceInternalTable(HoodieWriteConfig config,
                                        StructType schema, SparkSession jss, StorageConfiguration<?> storageConf, Map<String, String> properties,
                                        boolean populateMetaFields, boolean arePartitionRecordsSorted) {
-    this.instantTime = instantTime;
     this.writeConfig = config;
     this.structType = schema;
     this.jss = jss;
@@ -81,7 +79,7 @@ class HoodieDataSourceInternalTable implements SupportsWrite {
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
-    return new HoodieDataSourceInternalBatchWriteBuilder(instantTime, writeConfig, structType, jss,
+    return new HoodieDataSourceInternalBatchWriteBuilder(writeConfig, structType, jss,
         storageConf, properties, populateMetaFields, arePartitionRecordsSorted);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -836,9 +836,9 @@ class HoodieSparkSqlWriterInternal {
       case _ =>
         throw new HoodieException(s"$mode with bulk_insert in row writer path is not supported yet");
     }
-    val instantTime = executor.getInstantTime
 
     val writeResult = executor.execute(df, tableConfig.isTablePartitioned)
+    val instantTime = executor.getInstantTime
 
     try {
       val (writeSuccessful, compactionInstant, clusteringInstant) = mode match {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -413,9 +413,8 @@ class HoodieSparkSqlWriterInternal {
               streamingWritesParamsOpt.map(_.asyncClusteringTriggerFn.get.apply(client))
             }
 
-            instantTime = client.createNewInstantTime()
             // Issue deletes
-            client.startCommitWithTime(instantTime, commitActionType)
+            instantTime = client.startCommit(commitActionType)
             val writeStatuses = DataSourceUtils.doDeleteOperation(client, hoodieKeysAndLocationsToDelete, instantTime, preppedSparkSqlWrites || preppedWriteOperation)
             (writeStatuses, client)
 
@@ -445,8 +444,7 @@ class HoodieSparkSqlWriterInternal {
                 (parameters - HoodieWriteConfig.AUTO_COMMIT_ENABLE.key).asJava))
               .asInstanceOf[SparkRDDWriteClient[_]]
             // Issue delete partitions
-            instantTime = client.createNewInstantTime()
-            client.startCommitWithTime(instantTime, commitActionType)
+            instantTime = client.startCommit(commitActionType)
             val writeStatuses = DataSourceUtils.doDeletePartitionsOperation(client, partitionsToDelete, instantTime)
             (writeStatuses, client)
 
@@ -508,7 +506,7 @@ class HoodieSparkSqlWriterInternal {
             if (writeConfig.getRecordMerger.getRecordType == HoodieRecordType.SPARK && tableType == MERGE_ON_READ && writeConfig.getLogDataBlockFormat.orElse(HoodieLogBlockType.AVRO_DATA_BLOCK) != HoodieLogBlockType.PARQUET_DATA_BLOCK) {
               throw new UnsupportedOperationException(s"${writeConfig.getRecordMerger.getClass.getName} only support parquet log.")
             }
-            instantTime = client.createNewInstantTime()
+            instantTime = client.startCommit(commitActionType)
             // Convert to RDD[HoodieRecord]
             val hoodieRecords = Try(HoodieCreateRecordUtils.createHoodieRecordRdd(
               HoodieCreateRecordUtils.createHoodieRecordRddArgs(df, writeConfig, parameters, avroRecordName,
@@ -520,7 +518,6 @@ class HoodieSparkSqlWriterInternal {
 
             // Remove duplicates from incoming records based on existing keys from storage.
             val dedupedHoodieRecords = handleInsertDuplicates(hoodieRecords, hoodieConfig, operation, jsc, parameters)
-            client.startCommitWithTime(instantTime, commitActionType)
             try {
               val writeResult = DataSourceUtils.doWriteOperation(client, dedupedHoodieRecords, instantTime, operation,
                 preppedSparkSqlWrites || preppedWriteOperation)
@@ -825,21 +822,21 @@ class HoodieSparkSqlWriterInternal {
     val overwriteOperationType = Option(hoodieConfig.getString(HoodieInternalConfig.BULKINSERT_OVERWRITE_OPERATION_TYPE))
       .map(WriteOperationType.fromValue)
       .orNull
-    val instantTime = writeClient.createNewInstantTime()
     val executor = mode match {
       case _ if overwriteOperationType == null =>
         // Don't need to overwrite
-        new DatasetBulkInsertCommitActionExecutor(writeConfig, writeClient, instantTime)
+        new DatasetBulkInsertCommitActionExecutor(writeConfig, writeClient)
       case SaveMode.Append if overwriteOperationType == WriteOperationType.INSERT_OVERWRITE =>
         // INSERT OVERWRITE PARTITION uses Append mode
-        new DatasetBulkInsertOverwriteCommitActionExecutor(writeConfig, writeClient, instantTime)
+        new DatasetBulkInsertOverwriteCommitActionExecutor(writeConfig, writeClient)
       case SaveMode.Append if overwriteOperationType == WriteOperationType.BUCKET_RESCALE =>
-        new DatasetBucketRescaleCommitActionExecutor(writeConfig, writeClient, instantTime)
+        new DatasetBucketRescaleCommitActionExecutor(writeConfig, writeClient)
       case SaveMode.Overwrite if overwriteOperationType == WriteOperationType.INSERT_OVERWRITE_TABLE =>
-        new DatasetBulkInsertOverwriteTableCommitActionExecutor(writeConfig, writeClient, instantTime)
+        new DatasetBulkInsertOverwriteTableCommitActionExecutor(writeConfig, writeClient)
       case _ =>
         throw new HoodieException(s"$mode with bulk_insert in row writer path is not supported yet");
     }
+    val instantTime = executor.getInstantTime
 
     val writeResult = executor.execute(df, tableConfig.isTablePartitioned)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
@@ -108,9 +108,7 @@ object AlterHoodieTableAddColumnsCommand extends SparkAdapterSupport with Loggin
     )
 
     val commitActionType = CommitUtils.getCommitActionType(WriteOperationType.ALTER_SCHEMA, hoodieCatalogTable.tableType)
-    val instantTime = client.createNewInstantTime()
-
-    client.startCommitWithTime(instantTime, commitActionType)
+    val instantTime = client.startCommit(commitActionType)
     client.preWrite(instantTime, WriteOperationType.ALTER_SCHEMA, hoodieCatalogTable.metaClient)
 
     val hoodieTable = HoodieSparkTable.create(client.getConfig, client.getEngineContext)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
@@ -273,8 +273,7 @@ object AlterTableCommand extends Logging {
       .build()
 
     val commitActionType = CommitUtils.getCommitActionType(WriteOperationType.ALTER_SCHEMA, metaClient.getTableType)
-    val instantTime = client.createNewInstantTime()
-    client.startCommitWithTime(instantTime, commitActionType)
+    val instantTime = client.startCommit(commitActionType)
     client.setOperationType(WriteOperationType.ALTER_SCHEMA)
 
     val hoodieTable = HoodieSparkTable.create(client.getConfig, client.getEngineContext)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
@@ -94,11 +94,10 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
       assertEquals(timestamp0, instants.get(4).requestedTime());
 
       // Insert second batch.
-      String timestamp1 = "20241015000000001";
+      String timestamp1 = writeClient.startCommit(REPLACE_COMMIT_ACTION);
       List<HoodieRecord> records1 = dataGen.generateInserts(timestamp1, 50);
       JavaRDD<HoodieRecord> dataset1 = jsc.parallelize(records1, 2);
 
-      writeClient.startCommitWithTime(timestamp1, REPLACE_COMMIT_ACTION);
       writeClient.insertOverwriteTable(dataset1, timestamp1);
 
       // Validate.

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -1332,7 +1332,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
 
   private static void startSchemaEvolutionTransaction(HoodieTableMetaClient metaClient, SparkRDDWriteClient client, String nextCommitTime2, HoodieTableType tableType) throws IOException {
     String commitActionType = CommitUtils.getCommitActionType(WriteOperationType.UPSERT, tableType);
-    client.startCommitWithTime(nextCommitTime2, commitActionType);
+    metaClient.getActiveTimeline().createNewInstant(metaClient.createNewInstant(HoodieInstant.State.REQUESTED, metaClient.getCommitActionType(), nextCommitTime2));
     client.preWrite(nextCommitTime2, WriteOperationType.UPSERT, client.createMetaClient(true));
     HoodieInstant requested = metaClient.createNewInstant(HoodieInstant.State.REQUESTED, commitActionType, nextCommitTime2);
     HoodieCommitMetadata metadata = new HoodieCommitMetadata();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -324,15 +324,13 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     HoodieWriteConfig writeConfig2 = HoodieWriteConfig.newBuilder().withProperties(writeConfig.getProps()).build();
     writeConfig2.setSchema(writerSchema1);
     final SparkRDDWriteClient client2 = getHoodieWriteClient(writeConfig2);
-    final String nextCommitTime21 = "0021";
-    startSchemaEvolutionTransaction(metaClient, client2, nextCommitTime21, tableType);
+    final String nextCommitTime21 = startSchemaEvolutionTransaction(metaClient, client2, tableType);
 
     // Start concurrent txn 003 alter table schema
     HoodieWriteConfig writeConfig3 = HoodieWriteConfig.newBuilder().withProperties(writeConfig.getProps()).build();
     writeConfig3.setSchema(writerSchema2);
     final SparkRDDWriteClient client3 = getHoodieWriteClient(writeConfig3);
-    final String nextCommitTime31 = "0031";
-    startSchemaEvolutionTransaction(metaClient, client3, nextCommitTime31, tableType);
+    final String nextCommitTime31 = startSchemaEvolutionTransaction(metaClient, client3, tableType);
 
     Properties props = new TypedProperties();
     HoodieWriteConfig tableServiceWriteCfg = tableType.equals(MERGE_ON_READ)
@@ -1330,14 +1328,15 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     return result;
   }
 
-  private static void startSchemaEvolutionTransaction(HoodieTableMetaClient metaClient, SparkRDDWriteClient client, String nextCommitTime2, HoodieTableType tableType) throws IOException {
+  private static String startSchemaEvolutionTransaction(HoodieTableMetaClient metaClient, SparkRDDWriteClient client, HoodieTableType tableType) throws IOException {
     String commitActionType = CommitUtils.getCommitActionType(WriteOperationType.UPSERT, tableType);
-    metaClient.getActiveTimeline().createNewInstant(metaClient.createNewInstant(HoodieInstant.State.REQUESTED, metaClient.getCommitActionType(), nextCommitTime2));
-    client.preWrite(nextCommitTime2, WriteOperationType.UPSERT, client.createMetaClient(true));
-    HoodieInstant requested = metaClient.createNewInstant(HoodieInstant.State.REQUESTED, commitActionType, nextCommitTime2);
+    String instant = client.startCommit(commitActionType);
+    client.preWrite(instant, WriteOperationType.UPSERT, client.createMetaClient(true));
+    HoodieInstant requested = metaClient.createNewInstant(HoodieInstant.State.REQUESTED, commitActionType, instant);
     HoodieCommitMetadata metadata = new HoodieCommitMetadata();
     metadata.setOperationType(WriteOperationType.UPSERT);
     client.createMetaClient(true).getActiveTimeline().transitionRequestedToInflight(requested, Option.of(metadata));
+    return instant;
   }
 
   private void createCommitWithUpserts(HoodieWriteConfig cfg, SparkRDDWriteClient client, String prevCommit,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/spark/internal/TestHoodieDataSourceInternalBatchWrite.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/spark/internal/TestHoodieDataSourceInternalBatchWrite.java
@@ -151,7 +151,7 @@ class TestHoodieDataSourceInternalBatchWrite extends
     extraMeta.put("keyB", "valB");
     extraMeta.put("commit_extra_c", "valC");
     // none of the keys has commit metadata key prefix.
-    testDataSourceWriterInternal(extraMeta, Collections.EMPTY_MAP, true);
+    testDataSourceWriterInternal(extraMeta, Collections.emptyMap(), true);
   }
 
   @ParameterizedTest
@@ -210,7 +210,7 @@ class TestHoodieDataSourceInternalBatchWrite extends
     for (int i = 0; i < 3; i++) {
       // init writer
       HoodieDataSourceInternalBatchWrite dataSourceInternalBatchWrite =
-          new HoodieDataSourceInternalBatchWrite(cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, Collections.EMPTY_MAP, populateMetaFields, false);
+          new HoodieDataSourceInternalBatchWrite(cfg, STRUCT_TYPE, sqlContext.sparkSession(), storageConf, Collections.emptyMap(), populateMetaFields, false);
       List<HoodieWriterCommitMessage> commitMessages = new ArrayList<>();
       Dataset<Row> totalInputRows = null;
       DataWriter<InternalRow> writer = dataSourceInternalBatchWrite.createBatchWriterFactory(null).createWriter(partitionCounter++, RANDOM.nextLong());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/spark/internal/TestHoodieDataSourceInternalBatchWrite.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/spark/internal/TestHoodieDataSourceInternalBatchWrite.java
@@ -336,7 +336,6 @@ class TestHoodieDataSourceInternalBatchWrite extends
     }
   }
 
-
   private String createInstant(HoodieWriteConfig cfg) {
     String instantTime;
     try (SparkRDDWriteClient<?> writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(new JavaSparkContext(sparkSession.sparkContext())), cfg)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -439,7 +439,7 @@ public class TestAsyncCompaction extends CompactionTestBase {
       Set<HoodieFileGroupId> fileGroupsBeforeReplace = getAllFileGroups(hoodieTable, dataGen.getPartitionPaths());
       // replace by using insertOverwrite
       JavaRDD<HoodieRecord> replaceRecords = jsc.parallelize(dataGen.generateInserts(replaceInstantTime, numRecs), 1);
-      client.startCommitWithTime(replaceInstantTime, HoodieTimeline.REPLACE_COMMIT_ACTION);
+      metaClient.getActiveTimeline().createRequestedCommitWithReplaceMetadata(replaceInstantTime, HoodieTimeline.REPLACE_COMMIT_ACTION);
       client.insertOverwrite(replaceRecords, replaceInstantTime);
 
       metaClient.reloadActiveTimeline();

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -309,8 +309,7 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase {
       saveMode = SaveMode.Overwrite)
 
     Using(getHoodieWriteClient(getWriteConfig(hudiOpts))) { client =>
-      val commitTime = client.startCommit
-      client.startCommitWithTime(commitTime, HoodieTimeline.REPLACE_COMMIT_ACTION)
+      val commitTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION)
       val deletingPartition = dataGen.getPartitionPaths.last
       val partitionList = Collections.singletonList(deletingPartition)
       client.deletePartitions(partitionList, commitTime)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTable.scala
@@ -248,8 +248,7 @@ class TestAlterTable extends HoodieSparkSqlTestBase {
         // Create an inflight commit
         val client = HoodieCLIUtils.createHoodieWriteClient(spark, tablePath, Map.empty, Option(tableName))
         val metaClient = createMetaClient(spark, tablePath)
-        val firstInstant = client.createNewInstantTime()
-        client.startCommitWithTime(firstInstant, HoodieTimeline.COMMIT_ACTION)
+        val firstInstant = client.startCommit(HoodieTimeline.COMMIT_ACTION)
         val hoodieTable = HoodieSparkTable.create(client.getConfig, client.getEngineContext)
         val timeLine = hoodieTable.getActiveTimeline
         val requested = hoodieTable.getInstantGenerator.createNewInstant(State.REQUESTED, HoodieTimeline.COMMIT_ACTION, firstInstant)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -3295,7 +3295,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     HoodieStreamer deltaStreamer = new HoodieStreamer(cfg, jsc);
     HoodieStreamer.StreamSyncService streamSyncService = (HoodieStreamer.StreamSyncService) deltaStreamer.getIngestionService();
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(HoodieTestUtils.getDefaultStorageConf()).setBasePath(tableBasePath).build();
-    InputBatch inputBatch = streamSyncService.getStreamSync().readFromSource("00000", metaClient).getLeft();
+    InputBatch inputBatch = streamSyncService.getStreamSync().readFromSource(metaClient).getLeft();
     // Read from source and validate persistRdd call.
     JavaRDD<GenericRecord> sourceRdd = (JavaRDD<GenericRecord>) inputBatch.getBatch().get();
     assertEquals(1000, sourceRdd.count());


### PR DESCRIPTION
### Change Logs
This is the beginning of an epic to standardize creating requested instants on the timeline within the same transaction as where the instant time is generated to ensure consistency across writers.

- Removes non-test usage of `startCommitWithTime(instantTime, actionType)`
- Add new method for use with metadata table writers that still takes in the instant time and action type since the metadata table's instant is aligned to the data table's instant
- Updates the StreamSync to generate the instant time and persist it before using it in the HoodieRecords for the auto-keygen case
- Updates bulk insert flows to generate the timestamp instead of simply providing one

### Impact

- First step towards standardizing how the writer starts its commit

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
