### PR TITLE
Correction in Hudi CLI public documentation

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -10,7 +10,7 @@ Once hudi has been built, the shell can be fired by via  `cd packaging/hudi-cli-
 ### Hudi CLI setup
 In release `0.13.0` we have now added new way of launching the `hudi cli`, which is using the `hudi-cli-bundle` script.
 
-#### Note: The traditional `hudi-cli.sh` script has been deprecated and replaced with `hudi-cli-with-bundle.sh` from `1.1.0` release onwards. Users should migrate to the new bundled CLI script `hudi-cli-with-bundle.sh` for better compatibility and ease of use.
+#### Note: The traditional `hudi-cli.sh` script has been deprecated and replaced with `hudi-cli-with-bundle.sh` from `1.0.2` release onwards. Users should migrate to the new bundled CLI script `hudi-cli-with-bundle.sh` for better compatibility and ease of use.
 
 There are a couple of requirements such as having `spark` installed locally on your machine. 
 It is required to use a spark distribution with hadoop dependencies packaged such as `spark-3.5.4-bin-hadoop3.tgz` from https://archive.apache.org/dist/spark/.

--- a/website/versioned_docs/version-1.0.2/cli.md
+++ b/website/versioned_docs/version-1.0.2/cli.md
@@ -10,7 +10,7 @@ Once hudi has been built, the shell can be fired by via  `cd packaging/hudi-cli-
 ### Hudi CLI setup
 In release `0.13.0` we have now added new way of launching the `hudi cli`, which is using the `hudi-cli-bundle` script.
 
-#### Note: The traditional `hudi-cli.sh` script has been deprecated and replaced with `hudi-cli-with-bundle.sh` from `1.1.0` release onwards. Users should migrate to the new bundled CLI script `hudi-cli-with-bundle.sh` for better compatibility and ease of use.
+#### Note: The traditional `hudi-cli.sh` script has been deprecated and replaced with `hudi-cli-with-bundle.sh` from `1.0.2` release onwards. Users should migrate to the new bundled CLI script `hudi-cli-with-bundle.sh` for better compatibility and ease of use.
 
 There are a couple of requirements such as having `spark` installed locally on your machine. 
 It is required to use a spark distribution with hadoop dependencies packaged such as `spark-3.5.4-bin-hadoop3.tgz` from https://archive.apache.org/dist/spark/.
@@ -85,7 +85,7 @@ Once these are set, you are good to launch hudi-cli and access S3 dataset.
 Apache Flink, Presto and many other frameworks, including Hudi. If you want to run the Hudi CLI on a Dataproc node 
 which has not been launched with Hudi support enabled, you can use the steps below:  
 
-These steps use Hudi version 1.1.0. If you want to use a different version you will have to edit the below commands 
+These steps use Hudi version 1.0.2. If you want to use a different version you will have to edit the below commands 
 appropriately:  
 1. Once you've started the Dataproc cluster, you can ssh into it as follows:
 ```
@@ -94,22 +94,22 @@ $ gcloud compute ssh --zone "YOUR_ZONE" "HOSTNAME_OF_MASTER_NODE"  --project "YO
 
 2. Download the Hudi CLI bundle
 ```
-wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-cli-bundle_2.12/1.1.0/hudi-cli-bundle_2.12-1.1.0.jar  
+wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-cli-bundle_2.12/1.0.2/hudi-cli-bundle_2.12-1.0.2.jar  
 ```
 
 3. Download the Hudi Spark bundle
 ```
-wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.1.0/hudi-spark3.5-bundle_2.12-1.1.0.jar
+wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.0.2/hudi-spark3.5-bundle_2.12-1.0.2.jar
 ```     
 
 4. Download the shell script that launches Hudi CLI bundle
 ```
-wget https://raw.githubusercontent.com/apache/hudi/release-1.1.0/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+wget https://raw.githubusercontent.com/apache/hudi/release-1.0.2/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
 ```    
 
 5. Launch Hudi CLI bundle with appropriate environment variables as follows:
 ``` 
-CLIENT_JAR=$DATAPROC_DIR/lib/gcs-connector.jar CLI_BUNDLE_JAR=hudi-cli-bundle_2.12-1.1.0.jar SPARK_BUNDLE_JAR=hudi-spark3.5-bundle_2.12-1.1.0.jar ./hudi-cli-with-bundle.sh  
+CLIENT_JAR=$DATAPROC_DIR/lib/gcs-connector.jar CLI_BUNDLE_JAR=hudi-cli-bundle_2.12-1.0.2.jar SPARK_BUNDLE_JAR=hudi-spark3.5-bundle_2.12-1.0.2.jar ./hudi-cli-with-bundle.sh  
 ```
 
 6. hudi->connect --path gs://path_to_some_table  


### PR DESCRIPTION
### Change Logs

Update the Apache Hudi public documentation to reflect the CLI deprecation changes.  Although these changes were initially targeted for release 1.1.0, they have been included in the recent 1.0.2 release.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

- Update the Apache Hudi public documentation to reflect the CLI deprecation changes that were merged in version 1.0.2. 

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
