### PR TITLE
[HUDI-9149] Follow up: do not use ExternalSpillableMap in merge handl…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -276,12 +276,14 @@ public class HoodieMergeHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O>
       // NOTE: Once Records are added to map (spillable-map), DO NOT change it as they won't persist
       keyToNewRecords.put(record.getRecordKey(), record);
     }
-    LOG.info("Number of entries in MemoryBasedMap => "
-        + ((ExternalSpillableMap) keyToNewRecords).getInMemoryMapNumEntries()
-        + ", Total size in bytes of MemoryBasedMap => "
-        + ((ExternalSpillableMap) keyToNewRecords).getCurrentInMemoryMapSize() + ", Number of entries in BitCaskDiskMap => "
-        + ((ExternalSpillableMap) keyToNewRecords).getDiskBasedMapNumEntries() + ", Size of file spilled to disk => "
-        + ((ExternalSpillableMap) keyToNewRecords).getSizeOfFileOnDiskInBytes());
+    if (keyToNewRecords instanceof ExternalSpillableMap) {
+      LOG.info("Number of entries in MemoryBasedMap => "
+          + ((ExternalSpillableMap) keyToNewRecords).getInMemoryMapNumEntries()
+          + ", Total size in bytes of MemoryBasedMap => "
+          + ((ExternalSpillableMap) keyToNewRecords).getCurrentInMemoryMapSize() + ", Number of entries in BitCaskDiskMap => "
+          + ((ExternalSpillableMap) keyToNewRecords).getDiskBasedMapNumEntries() + ", Size of file spilled to disk => "
+          + ((ExternalSpillableMap) keyToNewRecords).getSizeOfFileOnDiskInBytes());
+    }
   }
 
   public boolean isEmptyNewRecords() {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandle.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -139,6 +140,14 @@ public class FlinkMergeAndReplaceHandle<T, I, K, O>
   protected HoodieRecord<T> updateFileName(HoodieRecord<T> record, Schema schema, Schema targetSchema, String fileName, Properties prop) {
     // update specific meta field: FILENAME_METADATA_FIELD
     return record.updateMetaField(schema, HoodieRecord.FILENAME_META_FIELD_ORD, fileName);
+  }
+
+  @Override
+  protected void initializeIncomingRecordsMap() {
+    LOG.info("Initialize on-heap keyToNewRecords for incoming records.");
+    // the incoming records are already buffered on heap and the underlying bytes are managed by memory pool
+    // in Flink write buffer, so there is no need to use ExternalSpillableMap.
+    this.keyToNewRecords = new HashMap<>();
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeHandle.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -159,6 +160,14 @@ public class FlinkMergeHandle<T, I, K, O>
   protected HoodieRecord<T> updateFileName(HoodieRecord<T> record, Schema schema, Schema targetSchema, String fileName, Properties prop) {
     // update specific meta field: FILENAME_METADATA_FIELD
     return record.updateMetaField(schema, HoodieRecord.FILENAME_META_FIELD_ORD, fileName);
+  }
+
+  @Override
+  protected void initializeIncomingRecordsMap() {
+    LOG.info("Initialize on-heap keyToNewRecords for incoming records.");
+    // the incoming records are already buffered on heap and the underlying bytes are managed by memory pool
+    // in Flink write buffer, so there is no need to use ExternalSpillableMap.
+    this.keyToNewRecords = new HashMap<>();
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -392,13 +392,6 @@ public class FlinkOptions extends HoodieConfig {
   // ------------------------------------------------------------------------
 
   @AdvancedConfig
-  public static final ConfigOption<Boolean> INSERT_ROWDATA_MODE_ENABLED = ConfigOptions
-      .key("write.rowdata.mode.enabled")
-      .booleanType()
-      .defaultValue(true)
-      .withDescription("Whether to enable writing RowData directly without converting to Avro.");
-
-  @AdvancedConfig
   public static final ConfigOption<Boolean> INSERT_CLUSTER = ConfigOptions
       .key("write.insert.cluster")
       .booleanType()


### PR DESCRIPTION
…e for Flink COW writing

### Change Logs

* Do not use ExternalSpillableMap in merge handle for Flink COW writing
* Clean IT testing for legacy flink writer.

### Impact

Improve Flink writer perf for COW table.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
