### PR TITLE
Revert [HUDI-9078] Deprecate POJO commit metadata class and its subclasses

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -45,14 +45,15 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeAvroMetadata;
 
 /**
- * Represents commit metadata.
+ * All the metadata that gets stored along with a commit.
+ * ******** IMPORTANT ********
+ * For any newly added/removed data fields, make sure we have the same definition in
+ * src/main/avro/HoodieCommitMetadata.avsc file!!!!!
  *
- * @deprecated As of Hudi version 1.1.0
- * Please use the standard Avro-generated model
- * {@link org.apache.hudi.avro.model.HoodieCommitMetadata} instead.
- * This class may be removed in a future release.
+ * For any newly added subclass, make sure we add corresponding handler in
+ * org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2#deserialize method.
+ * ***************************
  */
-@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HoodieCommitMetadata implements Serializable {
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieReplaceCommitMetadata.java
@@ -30,14 +30,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Represents replace commit metadata.
+ * All the metadata that gets stored along with a commit.
+ * ******** IMPORTANT ********
+ * For any newly added/removed data fields, make sure we have the same definition in
+ * src/main/avro/HoodieReplaceCommitMetadata.avsc file!!!!!
  *
- * @deprecated As of Hudi version 1.1.0
- * Please use the standard Avro-generated model
- * {@link org.apache.hudi.avro.model.HoodieReplaceCommitMetadata} instead.
- * This class may be removed in a future release.
+ * For any newly added subclass, make sure we add corresponding handler in
+ * org.apache.hudi.common.table.timeline.versioning.v2.CommitMetadataSerDeV2#deserialize method.
+ * ***************************
  */
-@Deprecated // we should only rely on their avro counterpart completely.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HoodieReplaceCommitMetadata extends HoodieCommitMetadata {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieReplaceCommitMetadata.class);


### PR DESCRIPTION
### Change Logs
Revert HUDI-9078 Deprecate POJO commit metadata class and its subclasses
This reverts commit c009ebf3651aa54d97d11a253bd0c229555ef76c.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
