### PR TITLE
[HUDI-9159] Fix LP validity bug

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -165,7 +165,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
             LOCKS_FOLDER_NAME,
             StoragePath.SEPARATOR,
             DEFAULT_TABLE_LOCK_FILE_NAME);
-    this.heartbeatManager = heartbeatManagerLoader.apply(ownerId, heartbeatPollSeconds * 1000, this::renewLock);
+    this.heartbeatManager = heartbeatManagerLoader.apply(ownerId, TimeUnit.SECONDS.toMillis(heartbeatPollSeconds), this::renewLock);
     this.storageLockClient = storageLockClientLoader.apply(ownerId, lockFilePath, properties);
     this.ownerId = ownerId;
     this.logger = logger;
@@ -282,7 +282,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     }
 
     // Try to acquire the lock
-    StorageLockData newLockData = new StorageLockData(false, getCurrentTime() + lockValiditySecs * 1000, ownerId);
+    StorageLockData newLockData = new StorageLockData(false, getCurrentEpochMs() + TimeUnit.SECONDS.toMillis(lockValiditySecs), ownerId);
     Pair<LockUpsertResult, Option<StorageLockFile>> lockUpdateStatus = this.storageLockClient.tryUpsertLockFile(
         newLockData,
         latestLock.getRight());
@@ -452,7 +452,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
       // prevents further data corruption by
       // letting someone else acquire the lock.
       Pair<LockUpsertResult, Option<StorageLockFile>> currentLock = this.storageLockClient.tryUpsertLockFile(
-          new StorageLockData(false, getCurrentTime() + lockValiditySecs * 1000, ownerId),
+          new StorageLockData(false, getCurrentEpochMs() + TimeUnit.SECONDS.toMillis(lockValiditySecs), ownerId),
           Option.of(getLock()));
       switch (currentLock.getLeft()) {
         case ACQUIRED_BY_OTHERS:
@@ -470,7 +470,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           // Only positive outcome
           this.setLock(currentLock.getRight().get());
           logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}.",
-              ownerId, oldExpirationMs - getCurrentTime(), lockFilePath);
+              ownerId, oldExpirationMs - getCurrentEpochMs(), lockFilePath);
           // Let heartbeat continue to renew lock lease again later.
           return true;
         default:
@@ -490,8 +490,8 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
    * Method to calculate whether a timestamp from a distributed source has
    * definitively occurred yet.
    */
-  protected boolean isCurrentTimeCertainlyOlderThanDistributedTime(long epoch) {
-    return getCurrentTime() > epoch + CLOCK_DRIFT_BUFFER_MS;
+  protected boolean isCurrentTimeCertainlyOlderThanDistributedTime(long epochMs) {
+    return getCurrentEpochMs() > epochMs + CLOCK_DRIFT_BUFFER_MS;
   }
 
   private String generateLockStateMessage(LockState state) {
@@ -528,7 +528,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
   }
 
   @VisibleForTesting
-  long getCurrentTime() {
+  long getCurrentEpochMs() {
     return System.currentTimeMillis();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -282,7 +282,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     }
 
     // Try to acquire the lock
-    StorageLockData newLockData = new StorageLockData(false, System.currentTimeMillis() + lockValiditySecs, ownerId);
+    StorageLockData newLockData = new StorageLockData(false, getCurrentTime() + lockValiditySecs * 1000, ownerId);
     Pair<LockUpsertResult, Option<StorageLockFile>> lockUpdateStatus = this.storageLockClient.tryUpsertLockFile(
         newLockData,
         latestLock.getRight());
@@ -452,7 +452,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
       // prevents further data corruption by
       // letting someone else acquire the lock.
       Pair<LockUpsertResult, Option<StorageLockFile>> currentLock = this.storageLockClient.tryUpsertLockFile(
-          new StorageLockData(false, System.currentTimeMillis() + lockValiditySecs, ownerId),
+          new StorageLockData(false, getCurrentTime() + lockValiditySecs * 1000, ownerId),
           Option.of(getLock()));
       switch (currentLock.getLeft()) {
         case ACQUIRED_BY_OTHERS:
@@ -470,7 +470,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           // Only positive outcome
           this.setLock(currentLock.getRight().get());
           logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}.",
-              ownerId, oldExpirationMs - System.currentTimeMillis(), lockFilePath);
+              ownerId, oldExpirationMs - getCurrentTime(), lockFilePath);
           // Let heartbeat continue to renew lock lease again later.
           return true;
         default:
@@ -491,7 +491,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
    * definitively occurred yet.
    */
   protected boolean isCurrentTimeCertainlyOlderThanDistributedTime(long epoch) {
-    return System.currentTimeMillis() > epoch + CLOCK_DRIFT_BUFFER_MS;
+    return getCurrentTime() > epoch + CLOCK_DRIFT_BUFFER_MS;
   }
 
   private String generateLockStateMessage(LockState state) {
@@ -525,5 +525,10 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
 
   private void logErrorLockState(LockState state, String msg) {
     logger.error(LOCK_STATE_LOGGER_MSG_WITH_INFO, ownerId, lockFilePath, Thread.currentThread(), state, msg);
+  }
+
+  @VisibleForTesting
+  long getCurrentTime() {
+    return System.currentTimeMillis();
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -175,7 +175,7 @@ class TestStorageBasedLockProvider {
   @Test
   void testTryLockSuccess() {
     long t0 = 1_000L;
-    when(lockProvider.getCurrentTime())
+    when(lockProvider.getCurrentEpochMs())
         .thenReturn(t0);
     when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, t0 + DEFAULT_LOCK_VALIDITY_MS, ownerId);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -75,7 +75,7 @@ class TestStorageBasedLockProvider {
   private HeartbeatManager mockHeartbeatManager;
   private Logger mockLogger;
   private final String ownerId = UUID.randomUUID().toString();
-  private static final int DEFAULT_LOCK_VALIDITY_MS = 5000;
+  private static final int DEFAULT_LOCK_VALIDITY_MS = 10000;
 
   @BeforeEach
   void setupLockProvider() {
@@ -174,10 +174,13 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testTryLockSuccess() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
-    StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
+    long t0 = 1_000L;
+    when(lockProvider.getCurrentTime())
+        .thenReturn(t0);
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
+    StorageLockData data = new StorageLockData(false, t0 + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(refEq(data), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
 
@@ -189,10 +192,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testTryLockSuccessButFailureToStartHeartbeat() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(false);
     when(mockLockService.tryUpsertLockFile(any(), eq(Option.of(realLockFile))))
@@ -204,10 +207,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testTryLockFailsFromOwnerMismatch() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockFile returnedLockFile = new StorageLockFile(
         new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, "different-owner"), "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(returnedLockFile)));
 
     HoodieLockException ex = assertThrows(HoodieLockException.class, () -> lockProvider.tryLock());
@@ -227,15 +230,15 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testTryLockFailsToUpdateFile() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
-        .thenReturn(Pair.of(LockUpsertResult.ACQUIRED_BY_OTHERS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
+        .thenReturn(Pair.of(LockUpsertResult.ACQUIRED_BY_OTHERS, Option.empty()));
     assertFalse(lockProvider.tryLock());
   }
 
   @Test
   void testTryLockFailsDueToUnknownState() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.UNKNOWN_ERROR, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.UNKNOWN_ERROR, Option.empty()));
     assertFalse(lockProvider.tryLock());
   }
 
@@ -257,10 +260,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testTryLockReentrancySucceeds() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
 
@@ -284,11 +287,11 @@ class TestStorageBasedLockProvider {
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() - DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile expiredLock = new StorageLockFile(data, "v1");
     doReturn(expiredLock).when(lockProvider).getLock();
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData validData = new StorageLockData(false, System.currentTimeMillis() - DEFAULT_LOCK_VALIDITY_MS,
         ownerId);
     StorageLockFile validLock = new StorageLockFile(validData, "v2");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(validLock)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
 
@@ -309,11 +312,11 @@ class TestStorageBasedLockProvider {
     StorageLockData data = new StorageLockData(true, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile expiredLock = new StorageLockFile(data, "v1");
     doReturn(expiredLock).when(lockProvider).getLock();
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData validData = new StorageLockData(false, System.currentTimeMillis() - DEFAULT_LOCK_VALIDITY_MS,
         ownerId);
     StorageLockFile validLock = new StorageLockFile(validData, "v2");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(validLock)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
 
@@ -334,17 +337,17 @@ class TestStorageBasedLockProvider {
     StorageLockData data = new StorageLockData(true, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile expiredLock = new StorageLockFile(data, "v1");
     doReturn(expiredLock).when(lockProvider).getLock();
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     when(mockHeartbeatManager.hasActiveHeartbeat()).thenReturn(true);
     assertThrows(HoodieLockException.class, () -> lockProvider.tryLock());
   }
 
   @Test
   void testUnlockSucceedsAndReentrancy() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
     when(mockHeartbeatManager.stopHeartbeat(true)).thenReturn(true);
@@ -363,10 +366,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testUnlockFailsToStopHeartbeat() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
     assertTrue(lockProvider.tryLock());
@@ -378,10 +381,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testCloseFailsToStopHeartbeat() {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
     assertTrue(lockProvider.tryLock());
@@ -427,7 +430,7 @@ class TestStorageBasedLockProvider {
     // Signal the upsert attempt failed, but may be transient. See interface for
     // more details.
     when(mockLockService.tryUpsertLockFile(any(), eq(Option.of(lockFile))))
-        .thenReturn(Pair.of(LockUpsertResult.UNKNOWN_ERROR, null));
+        .thenReturn(Pair.of(LockUpsertResult.UNKNOWN_ERROR, Option.empty()));
     assertTrue(lockProvider.renewLock());
   }
 
@@ -439,7 +442,7 @@ class TestStorageBasedLockProvider {
     // Signal the upsert attempt failed, but may be transient. See interface for
     // more details.
     when(mockLockService.tryUpsertLockFile(any(), eq(Option.of(lockFile))))
-        .thenReturn(Pair.of(LockUpsertResult.UNKNOWN_ERROR, null));
+        .thenReturn(Pair.of(LockUpsertResult.UNKNOWN_ERROR, Option.empty()));
     // renewLock return true so it will be retried.
     assertTrue(lockProvider.renewLock());
 
@@ -522,10 +525,10 @@ class TestStorageBasedLockProvider {
 
   @Test
   public void testShutdownHookViaReflection() throws Exception {
-    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, null));
+    when(mockLockService.readCurrentLockFile()).thenReturn(Pair.of(LockGetResult.NOT_EXISTS, Option.empty()));
     StorageLockData data = new StorageLockData(false, System.currentTimeMillis() + DEFAULT_LOCK_VALIDITY_MS, ownerId);
     StorageLockFile realLockFile = new StorageLockFile(data, "v1");
-    when(mockLockService.tryUpsertLockFile(any(), isNull()))
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.empty())))
             .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(realLockFile)));
     when(mockHeartbeatManager.startHeartbeatForThread(any())).thenReturn(true);
 


### PR DESCRIPTION
### Change Logs

Small miss where the LP validity was defaulting to 300ms instead of 300 seconds due to ms -> seconds conversion.

### Impact

Fixes existing bug

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
