### PR TITLE
[HUDI-8902] Fix schema evolution from float to double for avro log blocks

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -1296,6 +1296,9 @@ public class HoodieAvroUtils {
       case STRING:
       case BYTES:
         return needsRewriteToString(writerSchema, false);
+      case DOUBLE:
+        // To maintain precision, you need to convert Float -> String -> Double
+        return writerSchema.getType().equals(Schema.Type.FLOAT);
       default:
         return false;
     }

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
@@ -171,7 +171,7 @@ class Spark3ParquetSchemaEvolutionUtils(sharedConf: Configuration,
                             int96RebaseTz: String,
                             useOffHeap: Boolean,
                             capacity: Int): VectorizedParquetRecordReader = {
-    if (!typeChangeInfos.isEmpty) {
+    if (shouldUseInternalSchema) {
       new Spark3HoodieVectorizedParquetRecordReader(
         convertTz,
         datetimeRebaseMode,

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3ParquetSchemaEvolutionUtils.scala
@@ -171,7 +171,7 @@ class Spark3ParquetSchemaEvolutionUtils(sharedConf: Configuration,
                             int96RebaseTz: String,
                             useOffHeap: Boolean,
                             capacity: Int): VectorizedParquetRecordReader = {
-    if (shouldUseInternalSchema) {
+    if (!typeChangeInfos.isEmpty) {
       new Spark3HoodieVectorizedParquetRecordReader(
         convertTz,
         datetimeRebaseMode,


### PR DESCRIPTION
### Change Logs

The precision is incorrect for evolution from float to double and has been fixed for most of spark by https://github.com/apache/hudi/pull/13188. However, there are some edge cases that still need to be fixed.

This pr fixes avro log blocks the evolution is fixed by adding the float -> double conversion into the method that determines if we need to manually convert the record (and the manual conversion already has the float->double conversion correct)


### Impact

Fix float -> double precision issue for avro log blocks

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
