### PR TITLE
[HUDI-9359] add TIMESTAMP_MILLIS and TIME_MILLIS to InternalSchema

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkInternalSchemaConverter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkInternalSchemaConverter.java
@@ -267,10 +267,13 @@ public class SparkInternalSchemaConverter {
       case DATE:
         return DateType$.MODULE$;
       case TIME:
+      case TIME_MILLIS:
         throw new UnsupportedOperationException(String.format("cannot convert %s type to Spark", type));
       case TIMESTAMP:
+      case TIMESTAMP_MILLIS:
         // todo support TimeStampNTZ
         return TimestampType$.MODULE$;
+
       case STRING:
         return StringType$.MODULE$;
       case UUID:

--- a/hudi-common/src/main/java/org/apache/hudi/expression/Comparators.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/Comparators.java
@@ -39,7 +39,9 @@ public class Comparators {
           put(Types.DoubleType.get(), Comparator.naturalOrder());
           put(Types.DateType.get(), Comparator.naturalOrder());
           put(Types.TimeType.get(), Comparator.naturalOrder());
+          put(Types.TimeMillisType.get(), Comparator.naturalOrder());
           put(Types.TimestampType.get(), Comparator.naturalOrder());
+          put(Types.TimestampMillisType.get(), Comparator.naturalOrder());
           put(Types.StringType.get(), Comparator.naturalOrder());
           put(Types.UUIDType.get(), Comparator.naturalOrder());
         }

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/Type.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/Type.java
@@ -62,7 +62,9 @@ public interface Type extends Serializable {
     DATE(Integer.class),
     BOOLEAN(Boolean.class),
     TIME(Long.class),
+    TIME_MILLIS(Long.class),
     TIMESTAMP(Long.class),
+    TIMESTAMP_MILLIS(Long.class),
     DECIMAL(BigDecimal.class),
     UUID(UUID.class);
     private final String name;

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/Types.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/Types.java
@@ -190,6 +190,30 @@ public class Types {
   /**
    * Time primitive type.
    */
+  public static class TimeMillisType extends PrimitiveType {
+    private static final TimeMillisType INSTANCE = new TimeMillisType();
+
+    public static TimeMillisType get() {
+      return INSTANCE;
+    }
+
+    private TimeMillisType() {
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIME_MILLIS;
+    }
+
+    @Override
+    public String toString() {
+      return "time-millis";
+    }
+  }
+
+  /**
+   * Time primitive type.
+   */
   public static class TimestampType extends PrimitiveType {
     private static final TimestampType INSTANCE = new TimestampType();
 
@@ -208,6 +232,30 @@ public class Types {
     @Override
     public String toString() {
       return "timestamp";
+    }
+  }
+
+  /**
+   * Time primitive type.
+   */
+  public static class TimestampMillisType extends PrimitiveType {
+    private static final TimestampMillisType INSTANCE = new TimestampMillisType();
+
+    public static TimestampMillisType get() {
+      return INSTANCE;
+    }
+
+    private TimestampMillisType() {
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIMESTAMP_MILLIS;
+    }
+
+    @Override
+    public String toString() {
+      return "timestamp-millis";
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/convert/AvroInternalSchemaConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/convert/AvroInternalSchemaConverter.java
@@ -345,14 +345,13 @@ public class AvroInternalSchemaConverter {
       } else if (logical instanceof LogicalTypes.Date) {
         return Types.DateType.get();
 
-      } else if (
-              logical instanceof LogicalTypes.TimeMillis
-                      || logical instanceof LogicalTypes.TimeMicros) {
+      } else if  (logical instanceof LogicalTypes.TimeMillis) {
+        return Types.TimeMillisType.get();
+      } else if (logical instanceof LogicalTypes.TimeMicros) {
         return Types.TimeType.get();
-
-      } else if (
-              logical instanceof LogicalTypes.TimestampMillis
-                      || logical instanceof LogicalTypes.TimestampMicros) {
+      } else if (logical instanceof LogicalTypes.TimestampMillis) {
+        return Types.TimestampMillisType.get();
+      } else if (logical instanceof LogicalTypes.TimestampMicros) {
         return Types.TimestampType.get();
       } else if (LogicalTypes.uuid().getName().equals(name)) {
         return Types.UUIDType.get();
@@ -542,8 +541,14 @@ public class AvroInternalSchemaConverter {
       case TIME:
         return LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
 
+      case TIME_MILLIS:
+        return LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.LONG));
+
       case TIMESTAMP:
         return LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+
+      case TIMESTAMP_MILLIS:
+        return LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
 
       case STRING:
         return Schema.create(Schema.Type.STRING);

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/SerDeHelper.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/SerDeHelper.java
@@ -217,8 +217,12 @@ public class SerDeHelper {
           return Types.DateType.get();
         case TIME:
           return Types.TimeType.get();
+        case TIME_MILLIS:
+          return Types.TimeMillisType.get();
         case TIMESTAMP:
           return Types.TimestampType.get();
+        case TIMESTAMP_MILLIS:
+          return Types.TimestampMillisType.get();
         case STRING:
           return Types.StringType.get();
         case UUID:

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
@@ -319,6 +319,7 @@ public class SchemaEvolutionContext {
       case DOUBLE:
       case DATE:
       case TIMESTAMP:
+      case TIMESTAMP_MILLIS:
       case STRING:
       case UUID:
       case FIXED:
@@ -326,6 +327,7 @@ public class SchemaEvolutionContext {
       case DECIMAL:
         return typeInfo;
       case TIME:
+      case TIME_MILLIS:
         throw new UnsupportedOperationException(String.format("cannot convert %s type to hive", type));
       default:
         LOG.error("cannot convert unknown type: {} to Hive", type);


### PR DESCRIPTION
### Change Logs

add new types TIMESTAMP_MILLIS and TIME_MILLIS to InternalSchema

### Impact

Prevent information loss when converting avro schema to internal schema

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
