### PR TITLE
[HUDI-9146][par1] Support unmerged flink reader based on FileGroup re…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/FlinkFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/FlinkFileGroupReaderBasedMergeHandle.java
@@ -35,6 +35,7 @@ import org.apache.hudi.internal.schema.utils.SerDeHelper;
 import org.apache.hudi.io.BaseFileGroupReaderBasedMergeHandle;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.util.FlinkClientUtil;
 
 import org.apache.avro.Schema;
 import org.apache.flink.table.data.RowData;
@@ -78,9 +79,7 @@ public class FlinkFileGroupReaderBasedMergeHandle<T, I, K, O> extends BaseFileGr
     if (!StringUtils.isNullOrEmpty(config.getInternalSchema())) {
       internalSchemaOption = SerDeHelper.fromJson(config.getInternalSchema());
     }
-    TypedProperties props = new TypedProperties();
-    hoodieTable.getMetaClient().getTableConfig().getProps().forEach(props::putIfAbsent);
-    config.getProps().forEach(props::putIfAbsent);
+    TypedProperties props = FlinkClientUtil.getMergedTableAndWriteProps(hoodieTable.getMetaClient().getTableConfig(), config);
     // Initializes file group reader
     try (HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<>(
         readerContext,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
@@ -18,7 +18,10 @@
 
 package org.apache.hudi.util;
 
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 
 import org.apache.flink.api.java.hadoop.mapred.utils.HadoopUtils;
@@ -88,5 +91,20 @@ public class FlinkClientUtil {
       return hadoopConfiguration;
     }
     return null;
+  }
+
+  /**
+   * Get merged {@link TypedProperties} from {@link HoodieTableConfig} and {@link HoodieWriteConfig}.
+   *
+   * @param tableConfig The hoodie table configuration
+   * @param writeConfig the hoodie write configuration
+   *
+   * @return Merged {@link TypedProperties} from {@link HoodieTableConfig} and {@link HoodieWriteConfig}
+   */
+  public static TypedProperties getMergedTableAndWriteProps(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
+    TypedProperties props = new TypedProperties();
+    props.putAll(tableConfig.getProps());
+    writeConfig.getProps().forEach(props::putIfAbsent);
+    return props;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
@@ -247,6 +247,10 @@ public class FileGroupReaderSchemaHandler<T> {
     if (customDeleteMarkerKeyAndValue.isPresent()) {
       requiredFields.add(customDeleteMarkerKeyAndValue.get().getLeft());
     }
+    // Add _hoodie_operation if it exists in table schema
+    if (tableSchema.getField(HoodieRecord.OPERATION_METADATA_FIELD) != null) {
+      requiredFields.add(HoodieRecord.OPERATION_METADATA_FIELD);
+    }
 
     return requiredFields.toArray(new String[0]);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
@@ -19,7 +19,6 @@
 
 package org.apache.hudi.common.table.read;
 
-import org.apache.hudi.avro.AvroSchemaCache;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
@@ -28,22 +27,23 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.KeySpec;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.exception.HoodieException;
 
 import org.apache.avro.Schema;
 
-import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 
 public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
-  // Used to order the records in the record map.
-  private Long putIndex = 0L;
-  private Long getIndex = 0L;
+
+  private final Deque<HoodieLogBlock> currentInstantLogBlocks;
+  private ClosableIterator<T> recordIterator;
 
   public UnmergedFileGroupRecordBuffer(
       HoodieReaderContext<T> readerContext,
@@ -54,10 +54,11 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       TypedProperties props,
       HoodieReadStats readStats) {
     super(readerContext, hoodieTableMetaClient, recordMergeMode, partitionNameOverrideOpt, partitionPathFieldOpt, props, readStats);
+    this.currentInstantLogBlocks = new ArrayDeque<>();
   }
 
   @Override
-  protected boolean doHasNext() throws IOException {
+  protected boolean doHasNext() {
     ValidationUtils.checkState(baseFileIterator != null, "Base file iterator has not been set yet");
 
     // Output from base file first.
@@ -66,28 +67,25 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       return true;
     }
 
-    // Output records based on the index to preserve the order.
-    if (!records.isEmpty()) {
-      BufferedRecord<T> nextRecordInfo = records.remove(getIndex++);
-
-      if (nextRecordInfo == null) {
-        throw new HoodieException("Row index should be continuous!");
+    while ((recordIterator == null || !recordIterator.hasNext()) && !currentInstantLogBlocks.isEmpty()) {
+      HoodieLogBlock logBlock = currentInstantLogBlocks.pop();
+      if (logBlock instanceof HoodieDataBlock) {
+        HoodieDataBlock dataBlock = (HoodieDataBlock) logBlock;
+        Pair<ClosableIterator<T>, Schema> iteratorSchemaPair = getRecordsIterator(dataBlock, Option.empty());
+        recordIterator = iteratorSchemaPair.getLeft();
       }
-
-      if (!nextRecordInfo.isDelete()) {
-        nextRecord = nextRecordInfo.getRecord();
-      } else {
-        throw new IllegalStateException("No deletes should exist in unmerged reading mode");
-      }
-      return true;
     }
-
-    return false;
+    if (recordIterator == null || !recordIterator.hasNext()) {
+      return false;
+    }
+    nextRecord = recordIterator.next();
+    readStats.incrementNumInserts();
+    return true;
   }
 
   @Override
   public Iterator<BufferedRecord<T>> getLogRecordIterator() {
-    return records.values().iterator();
+    throw new UnsupportedOperationException("Not supported for " + this.getClass().getSimpleName());
   }
 
   @Override
@@ -97,26 +95,12 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
 
   @Override
   public void processDataBlock(HoodieDataBlock dataBlock, Option<KeySpec> keySpecOpt) {
-    Pair<ClosableIterator<T>, Schema> recordsIteratorSchemaPair =
-        getRecordsIterator(dataBlock, keySpecOpt);
-    if (dataBlock.containsPartialUpdates()) {
-      throw new HoodieException("Partial update is not supported for unmerged record read");
-    }
-
-    Schema schema = AvroSchemaCache.intern(recordsIteratorSchemaPair.getRight());
-
-    try (ClosableIterator<T> recordIterator = recordsIteratorSchemaPair.getLeft()) {
-      while (recordIterator.hasNext()) {
-        T nextRecord = recordIterator.next();
-        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(nextRecord, schema, readerContext, orderingFieldName, false);
-        processNextDataRecord(bufferedRecord, putIndex++);
-      }
-    }
+    this.currentInstantLogBlocks.add(dataBlock);
   }
 
   @Override
   public void processNextDataRecord(BufferedRecord<T> record, Serializable index) {
-    records.put(index, record.toBinary(readerContext));
+    // no-op
   }
 
   @Override
@@ -126,12 +110,11 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
 
   @Override
   public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable index) {
-    // never used for now
-    records.put(index, BufferedRecord.forDeleteRecord(deleteRecord, getOrderingValue(readerContext, deleteRecord)));
+    // no-op
   }
 
   @Override
   public boolean containsLogRecord(String recordKey) {
-    return records.containsKey(recordKey);
+    throw new UnsupportedOperationException("Not supported for " + this.getClass().getSimpleName());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
@@ -72,6 +72,9 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       if (logBlock instanceof HoodieDataBlock) {
         HoodieDataBlock dataBlock = (HoodieDataBlock) logBlock;
         Pair<ClosableIterator<T>, Schema> iteratorSchemaPair = getRecordsIterator(dataBlock, Option.empty());
+        if (recordIterator != null) {
+          recordIterator.close();
+        }
         recordIterator = iteratorSchemaPair.getLeft();
       }
     }
@@ -116,5 +119,13 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
   @Override
   public boolean containsLogRecord(String recordKey) {
     throw new UnsupportedOperationException("Not supported for " + this.getClass().getSimpleName());
+  }
+
+  @Override
+  public void close() {
+    if (recordIterator != null) {
+      recordIterator.close();
+    }
+    super.close();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
@@ -78,7 +78,7 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
     if (recordIterator == null || !recordIterator.hasNext()) {
       return false;
     }
-    nextRecord = recordIterator.next();
+    nextRecord = readerContext.seal(recordIterator.next());
     readStats.incrementNumInserts();
     return true;
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -534,7 +534,6 @@ public class HoodieTableSource implements
         // use the explicit fields' data type because the AvroSchemaConverter
         // is not very stable.
         .fieldTypes(rowDataType.getChildren())
-        .defaultPartName(conf.getString(FlinkOptions.PARTITION_DEFAULT_NAME))
         .predicates(this.predicates)
         .limit(this.limit)
         .emitDelete(false) // the change logs iterator can handle the DELETE records
@@ -561,7 +560,6 @@ public class HoodieTableSource implements
         // use the explicit fields' data type because the AvroSchemaConverter
         // is not very stable.
         .fieldTypes(rowDataType.getChildren())
-        .defaultPartName(conf.getString(FlinkOptions.PARTITION_DEFAULT_NAME))
         .predicates(this.predicates)
         .limit(this.limit)
         .emitDelete(emitDelete)

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
@@ -103,11 +103,10 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
       Configuration conf,
       MergeOnReadTableState tableState,
       List<DataType> fieldTypes,
-      String defaultPartName,
       List<Predicate> predicates,
       long limit,
       boolean emitDelete) {
-    super(conf, tableState, fieldTypes, defaultPartName, predicates, limit, emitDelete, InternalSchemaManager.DISABLED);
+    super(conf, tableState, fieldTypes, predicates, limit, emitDelete, InternalSchemaManager.DISABLED);
   }
 
   @Override
@@ -872,11 +871,6 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
       return this;
     }
 
-    public Builder defaultPartName(String defaultPartName) {
-      this.defaultPartName = defaultPartName;
-      return this;
-    }
-
     public Builder predicates(List<Predicate> predicates) {
       this.predicates = predicates;
       return this;
@@ -893,8 +887,7 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
     }
 
     public CdcInputFormat build() {
-      return new CdcInputFormat(conf, tableState, fieldTypes,
-          defaultPartName, predicates, limit, emitDelete);
+      return new CdcInputFormat(conf, tableState, fieldTypes, predicates, limit, emitDelete);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -18,14 +18,21 @@
 
 package org.apache.hudi.table.format.mor;
 
+import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
 import org.apache.hudi.common.table.log.InstantRange;
+import org.apache.hudi.common.table.read.HoodieFileGroupReader;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -34,10 +41,13 @@ import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.HoodieUpsertException;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
 import org.apache.hudi.table.format.FilePathUtils;
+import org.apache.hudi.table.format.FlinkRowDataReaderContext;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
@@ -66,12 +76,14 @@ import org.apache.flink.types.RowKind;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.HOODIE_COMMIT_TIME_COL_POS;
@@ -112,11 +124,6 @@ public class MergeOnReadInputFormat
   private final List<DataType> fieldTypes;
 
   /**
-   * Default partition name when the field value is null.
-   */
-  private final String defaultPartName;
-
-  /**
    * Required field positions.
    */
   private final int[] requiredPos;
@@ -148,11 +155,12 @@ public class MergeOnReadInputFormat
 
   protected final InternalSchemaManager internalSchemaManager;
 
+  private transient HoodieTableMetaClient metaClient;
+
   protected MergeOnReadInputFormat(
       Configuration conf,
       MergeOnReadTableState tableState,
       List<DataType> fieldTypes,
-      String defaultPartName,
       List<Predicate> predicates,
       long limit,
       boolean emitDelete,
@@ -161,7 +169,6 @@ public class MergeOnReadInputFormat
     this.tableState = tableState;
     this.fieldNames = tableState.getRowType().getFieldNames();
     this.fieldTypes = fieldTypes;
-    this.defaultPartName = defaultPartName;
     // Needs improvement: this requiredPos is only suitable for parquet reader,
     // because we need to
     this.requiredPos = tableState.getRequiredPositions();
@@ -183,6 +190,7 @@ public class MergeOnReadInputFormat
     this.currentReadCount = 0L;
     this.closed = false;
     this.hadoopConf = HadoopConfigurations.getHadoopConf(this.conf);
+    this.metaClient = StreamerUtil.metaClientForReader(conf, hadoopConf);
     this.iterator = initIterator(split);
     mayShiftInputSplit(split);
   }
@@ -423,48 +431,51 @@ public class MergeOnReadInputFormat
     };
   }
 
+  /**
+   * Get record iterator using {@link HoodieFileGroupReader}.
+   *
+   * @param split input split
+   * @return {@link RowData} iterator.
+   */
   private ClosableIterator<RowData> getUnMergedLogFileIterator(MergeOnReadInputSplit split) {
     final Schema tableSchema = new Schema.Parser().parse(tableState.getAvroSchema());
     final Schema requiredSchema = new Schema.Parser().parse(tableState.getRequiredAvroSchema());
-    final GenericRecordBuilder recordBuilder = new GenericRecordBuilder(requiredSchema);
-    final AvroToRowDataConverters.AvroToRowDataConverter avroToRowDataConverter =
-        AvroToRowDataConverters.createRowConverter(tableState.getRequiredRowType(), conf.getBoolean(FlinkOptions.READ_UTC_TIMEZONE));
-    final FormatUtils.BoundedMemoryRecords records = new FormatUtils.BoundedMemoryRecords(split, tableSchema, internalSchemaManager.getQuerySchema(), hadoopConf, conf);
-    final Iterator<HoodieRecord<?>> recordsIterator = records.getRecordsIterator();
 
-    return new ClosableIterator<RowData>() {
-      private RowData currentRecord;
+    FileSlice fileSlice = new FileSlice(
+        new HoodieFileGroupId("", split.getFileId()),
+        split.getLatestCommit(),
+        split.getBasePath().map(HoodieBaseFile::new).orElse(null),
+        split.getLogPaths().map(logFiles -> logFiles.stream().map(HoodieLogFile::new).collect(Collectors.toList())).orElse(Collections.emptyList()));
 
-      @Override
-      public boolean hasNext() {
-        while (recordsIterator.hasNext()) {
-          final HoodieAvroRecord<?> hoodieRecord = (HoodieAvroRecord) recordsIterator.next();
-          Option<IndexedRecord> curAvroRecord = getInsertVal(hoodieRecord, tableSchema);
-          if (curAvroRecord.isPresent()) {
-            final IndexedRecord avroRecord = curAvroRecord.get();
-            GenericRecord requiredAvroRecord = buildAvroRecordBySchema(
-                avroRecord,
-                requiredSchema,
-                requiredPos,
-                recordBuilder);
-            currentRecord = (RowData) avroToRowDataConverter.convert(requiredAvroRecord);
-            FormatUtils.setRowKind(currentRecord, avroRecord, tableState.getOperationPos());
-            return true;
-          }
-        }
-        return false;
-      }
+    FlinkRowDataReaderContext readerContext =
+        new FlinkRowDataReaderContext(
+            HadoopFSUtils.getStorageConf(hadoopConf),
+            () -> internalSchemaManager,
+            predicates,
+            metaClient.getTableConfig());
+    TypedProperties typedProperties = new TypedProperties();
+    metaClient.getTableConfig().getProps().forEach(typedProperties::putIfAbsent);
+    typedProperties.put(HoodieReaderConfig.MERGE_TYPE.key(), HoodieReaderConfig.REALTIME_SKIP_MERGE);
 
-      @Override
-      public RowData next() {
-        return currentRecord;
-      }
-
-      @Override
-      public void close() {
-        records.close();
-      }
-    };
+    try (HoodieFileGroupReader<RowData> fileGroupReader = new HoodieFileGroupReader<>(
+        readerContext,
+        metaClient.getStorage(),
+        split.getTablePath(),
+        split.getLatestCommit(),
+        fileSlice,
+        tableSchema,
+        requiredSchema,
+        Option.ofNullable(internalSchemaManager.getQuerySchema()),
+        metaClient,
+        typedProperties,
+        0,
+        Long.MAX_VALUE,
+        false)) {
+      fileGroupReader.initRecordIterators();
+      return fileGroupReader.getClosableIterator();
+    } catch (IOException e) {
+      throw new HoodieUpsertException("Failed to compact file slice: " + fileSlice, e);
+    }
   }
 
   protected static Option<IndexedRecord> getInsertVal(HoodieAvroRecord<?> hoodieRecord, Schema tableSchema) {
@@ -835,7 +846,6 @@ public class MergeOnReadInputFormat
     protected Configuration conf;
     protected MergeOnReadTableState tableState;
     protected List<DataType> fieldTypes;
-    protected String defaultPartName;
     protected List<Predicate> predicates;
     protected long limit = -1;
     protected boolean emitDelete = false;
@@ -853,11 +863,6 @@ public class MergeOnReadInputFormat
 
     public Builder fieldTypes(List<DataType> fieldTypes) {
       this.fieldTypes = fieldTypes;
-      return this;
-    }
-
-    public Builder defaultPartName(String defaultPartName) {
-      this.defaultPartName = defaultPartName;
       return this;
     }
 
@@ -882,8 +887,8 @@ public class MergeOnReadInputFormat
     }
 
     public MergeOnReadInputFormat build() {
-      return new MergeOnReadInputFormat(conf, tableState, fieldTypes,
-          defaultPartName, predicates, limit, emitDelete, internalSchemaManager);
+      return new MergeOnReadInputFormat(conf, tableState,
+          fieldTypes, predicates, limit, emitDelete, internalSchemaManager);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadOperator.java
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.configuration.FlinkOptions.PARTITION_DEFAULT_NAME;
 import static org.apache.hudi.configuration.FlinkOptions.TABLE_TYPE;
 import static org.apache.hudi.configuration.FlinkOptions.TABLE_TYPE_MERGE_ON_READ;
 import static org.hamcrest.CoreMatchers.is;
@@ -267,7 +266,7 @@ public class TestStreamReadOperator {
         .config(conf)
         .tableState(hoodieTableState)
         .fieldTypes(rowDataType.getChildren())
-        .defaultPartName(PARTITION_DEFAULT_NAME.defaultValue()).limit(1000L)
+        .limit(1000L)
         .emitDelete(true)
         .build();
 


### PR DESCRIPTION
…ader

### Change Logs

Support unmerged log reader for Flink changelog source based on FileGroup reader.

### Impact
* remove dependency on legacy log scanner
* improve reading performance 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
