### PR TITLE
[HUDI-9235] Plugin FG reader into MDT

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -446,6 +446,12 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "The index name either starts with or matches exactly can be one of the following: "
           + StringUtils.join(Arrays.stream(MetadataPartitionType.values()).map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList()), ", "));
 
+  public static final ConfigProperty<Boolean> FILE_GROUP_READER_ENABLED = ConfigProperty
+      .key(METADATA_PREFIX + ".file.group.reader.enabled")
+      .defaultValue(true)
+      .sinceVersion("1.1.0")
+      .withDocumentation("Use file group reader interface to merge metadata records");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -653,6 +659,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public String getMetadataIndexToDrop() {
     return getString(DROP_METADATA_INDEX);
+  }
+
+  public boolean isFileGroupReaderEnabled() {
+    return getBoolean(FILE_GROUP_READER_ENABLED);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -484,7 +484,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
         return false;
       } else if (metaClient.getTableConfig().isMultipleBaseFileFormatsEnabled()) {
         return pathName.contains(HoodieFileFormat.PARQUET.getFileExtension())
-            || pathName.contains(HoodieFileFormat.ORC.getFileExtension());
+            || pathName.contains(HoodieFileFormat.ORC.getFileExtension())
+            || pathName.contains(HoodieFileFormat.HFILE.getFileExtension());
       } else {
         return pathName.contains(metaClient.getTableConfig().getBaseFileFormat().getFileExtension());
       }

--- a/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
@@ -406,4 +406,40 @@ public class Predicates {
       }
     }
   }
+
+  public static class StringStartsWithAny implements Predicate {
+    private final Operator operator;
+    private final Expression left;
+    private final List<Expression> right;
+
+    public StringStartsWithAny(Expression left, List<Expression> right) {
+      this.left = left;
+      this.operator = Operator.STARTS_WITH;
+      this.right = right;
+    }
+
+    @Override
+    public List<Expression> getChildren() {
+      List<Expression> children = new ArrayList<>();
+      children.add(left);
+      children.addAll(right);
+      return children;
+    }
+
+    @Override
+    public Operator getOperator() {
+      return operator;
+    }
+
+    @Override
+    public Object eval(StructLike data) {
+      for (Expression e : right) {
+        Expression exp = new StringStartsWith(left, e);
+        if ((boolean) exp.eval(data)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -18,13 +18,16 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -33,7 +36,9 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.HoodieFileGroupReader;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -47,6 +52,8 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.expression.BindVisitor;
 import org.apache.hudi.expression.Expression;
+import org.apache.hudi.expression.Predicate;
+import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.Types;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.io.storage.HoodieSeekingFileReader;
@@ -57,6 +64,7 @@ import org.apache.hudi.util.Transient;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +76,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -210,38 +219,95 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         getEngineContext().parallelize(partitionFileSlices))
         .flatMap(
             (SerializableFunction<FileSlice, Iterator<HoodieRecord<HoodieMetadataPayload>>>) fileSlice -> {
-              // NOTE: Since this will be executed by executors, we can't access previously cached
-              //       readers, and therefore have to always open new ones
-              Pair<HoodieSeekingFileReader<?>, HoodieMetadataLogRecordReader> readers =
-                  openReaders(partitionName, fileSlice);
-              try {
-                List<Long> timings = new ArrayList<>();
-
-                HoodieSeekingFileReader<?> baseFileReader = readers.getKey();
-                HoodieMetadataLogRecordReader logRecordScanner = readers.getRight();
-
-                if (baseFileReader == null && logRecordScanner == null) {
-                  // TODO: what do we do if both does not exist? should we throw an exception and let caller do the fallback ?
-                  return Collections.emptyIterator();
-                }
-
-                boolean fullKeys = false;
-
-                Map<String, HoodieRecord<HoodieMetadataPayload>> logRecords =
-                    readLogRecords(logRecordScanner, sortedKeyPrefixes, fullKeys, timings);
-
-                Map<String, HoodieRecord<HoodieMetadataPayload>> mergedRecords =
-                    readFromBaseAndMergeWithLogRecords(baseFileReader, sortedKeyPrefixes, fullKeys, logRecords, timings, partitionName);
-
-                LOG.debug("Metadata read for {} keys took [baseFileRead, logMerge] {} ms", sortedKeyPrefixes.size(), timings);
-
-                return mergedRecords.values().iterator();
-              } catch (IOException ioe) {
-                throw new HoodieIOException("Error merging records from metadata table for  " + sortedKeyPrefixes.size() + " key : ", ioe);
-              } finally {
-                closeReader(readers);
+              if (!metadataConfig.isFileGroupReaderEnabled()) {
+                return getByKeyPrefixes(fileSlice, sortedKeyPrefixes, partitionName);
+              } else {
+                return getByKeyPrefixesWithFileGroupReader(fileSlice, partitionName);
               }
             });
+  }
+
+  private Iterator<HoodieRecord<HoodieMetadataPayload>> getByKeyPrefixes(FileSlice fileSlice,
+                                                                         List<String> sortedKeyPrefixes,
+                                                                         String partitionName) {
+    // NOTE: Since this will be executed by executors, we can't access previously cached
+    //       readers, and therefore have to always open new ones
+    Pair<HoodieSeekingFileReader<?>, HoodieMetadataLogRecordReader> readers =
+        openReaders(partitionName, fileSlice);
+    try {
+      List<Long> timings = new ArrayList<>();
+      HoodieSeekingFileReader<?> baseFileReader = readers.getKey();
+      HoodieMetadataLogRecordReader logRecordScanner = readers.getRight();
+
+      if (baseFileReader == null && logRecordScanner == null) {
+        // TODO: what do we do if both does not exist? should we throw an exception and let caller do the fallback ?
+        return Collections.emptyIterator();
+      }
+      boolean fullKeys = false;
+
+      Map<String, HoodieRecord<HoodieMetadataPayload>> logRecords =
+          readLogRecords(logRecordScanner, sortedKeyPrefixes, fullKeys, timings);
+      Map<String, HoodieRecord<HoodieMetadataPayload>> mergedRecords =
+          readFromBaseAndMergeWithLogRecords(baseFileReader, sortedKeyPrefixes, fullKeys, logRecords, timings, partitionName);
+
+      LOG.debug("Metadata read for {} keys took [baseFileRead, logMerge] {} ms", sortedKeyPrefixes.size(), timings);
+
+      return mergedRecords.values().iterator();
+    } catch (IOException ioe) {
+      throw new HoodieIOException("Error merging records from metadata table for  " + sortedKeyPrefixes.size() + " key : ", ioe);
+    } finally {
+      closeReader(readers);
+    }
+  }
+
+  // TODO: add predicate support.
+  private Iterator<HoodieRecord<HoodieMetadataPayload>> getByKeyPrefixesWithFileGroupReader(FileSlice fileSlice,
+                                                                                            String partitionName) throws IOException {
+    Option<HoodieInstant> latestMetadataInstant =
+        metadataMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
+    String latestMetadataInstantTime =
+        latestMetadataInstant.map(HoodieInstant::requestedTime).orElse(SOLO_COMMIT_TIMESTAMP);
+    Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+    HoodieFileGroupReader fileGroupReader = getFileGroupReader(
+        metadataMetaClient.getTableConfig(),
+        metadataMetaClient.getBasePath().toString(),
+        latestMetadataInstantTime,
+        fileSlice,
+        schema,
+        schema,
+        Option.empty(),
+        metadataMetaClient,
+        new TypedProperties(),
+        Collections.emptyList()); // TODO: Any properties?
+    fileGroupReader.initRecordIterators();
+    ClosableIterator it = fileGroupReader.getClosableIterator();
+    return new HoodieRecordIterator(it, partitionName);
+  }
+
+  public static class HoodieRecordIterator implements Iterator<HoodieRecord<HoodieMetadataPayload>> {
+    private final ClosableIterator<IndexedRecord> baseIterator;
+    private final String partitionName;
+
+    public HoodieRecordIterator(ClosableIterator<IndexedRecord> baseIterator, String partitionName) {
+      this.baseIterator = baseIterator;
+      this.partitionName = partitionName;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return baseIterator.hasNext();
+    }
+
+    @Override
+    public HoodieRecord<HoodieMetadataPayload> next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      HoodieMetadataRecord r = (HoodieMetadataRecord) baseIterator.next();
+      HoodieMetadataPayload payload = new HoodieMetadataPayload(r, r.getKey());
+      HoodieKey key = new HoodieKey(r.getKey(), partitionName);
+      return new HoodieAvroRecord<>(key, payload);
+    }
   }
 
   @Override
@@ -301,6 +367,11 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
    * @return A {@code Map} of key name to {@code HoodieRecord} for the keys which were found in the file slice
    */
   private Map<String, HoodieRecord<HoodieMetadataPayload>> lookupKeysFromFileSlice(String partitionName, List<String> keys, FileSlice fileSlice) {
+    // If file group reader has been enabled, we read from it.
+    if (metadataConfig.isFileGroupReaderEnabled()) {
+      return lookupKeysWithFileGroupReader(partitionName, keys, fileSlice);
+    }
+
     Pair<HoodieSeekingFileReader<?>, HoodieMetadataLogRecordReader> readers = getOrCreateReaders(partitionName, fileSlice);
     try {
       HoodieSeekingFileReader<?> baseFileReader = readers.getKey();
@@ -322,6 +393,46 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       if (!reuse) {
         closeReader(readers);
       }
+    }
+  }
+
+  private Map<String, HoodieRecord<HoodieMetadataPayload>> lookupKeysWithFileGroupReader(String partitionName,
+                                                                                         List<String> keys,
+                                                                                         FileSlice fileSlice) {
+    try {
+      // Sort it here once so that we don't need to sort individually for base file and for each individual log files.
+      List<String> sortedKeys = new ArrayList<>(keys);
+      // So we use the natural order to sort.
+      Collections.sort(sortedKeys);
+      Option<HoodieInstant> latestMetadataInstant =
+          metadataMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
+      String latestMetadataInstantTime =
+          latestMetadataInstant.map(HoodieInstant::requestedTime).orElse(SOLO_COMMIT_TIMESTAMP);
+      Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+      HoodieFileGroupReader fileGroupReader = getFileGroupReader(
+          metadataMetaClient.getTableConfig(),
+          metadataMetaClient.getBasePath().toString(),
+          latestMetadataInstantTime,
+          fileSlice,
+          schema,
+          schema,
+          Option.empty(),
+          metadataMetaClient,
+          new TypedProperties(),
+          Collections.emptyList()); // TODO: Any properties?
+      fileGroupReader.initRecordIterators();
+      ClosableIterator it = fileGroupReader.getClosableIterator();
+      Map<String, HoodieRecord<HoodieMetadataPayload>> records = new HashMap<>();
+      while (it.hasNext()) {
+        HoodieMetadataRecord r = (HoodieMetadataRecord) it.next();
+        HoodieMetadataPayload payload = new HoodieMetadataPayload(r, r.getKey());
+        HoodieKey key = new HoodieKey(r.getKey(), partitionName);
+        HoodieAvroRecord record = new HoodieAvroRecord(key, payload);
+        records.put(key.getRecordKey(), record);
+      }
+      return records;
+    } catch (IOException e) {
+      throw new HoodieIOException("Error merging records from metadata table for  " + keys.size() + " keys : ", e);
     }
   }
 
@@ -685,5 +796,36 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         .collectAsList()
         .stream()
         .collect(Collectors.groupingBy(Pair::getKey, Collectors.mapping(Pair::getValue, Collectors.toSet())));
+  }
+
+  private HoodieFileGroupReader<IndexedRecord> getFileGroupReader(HoodieTableConfig tableConfig,
+                                                                  String tablePath,
+                                                                  String latestCommitTime,
+                                                                  FileSlice fileSlice,
+                                                                  Schema dataSchema,
+                                                                  Schema requestedSchema,
+                                                                  Option<InternalSchema> internalSchemaOpt,
+                                                                  HoodieTableMetaClient metaClient,
+                                                                  TypedProperties props,
+                                                                  List<Predicate> predicates) throws IOException {
+    HoodieReaderContext readerContext =
+        new HoodieAvroReaderContext(storageConf, tableConfig);
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader =
+        new HoodieFileGroupReader<>(
+            readerContext,
+            storage,
+            tablePath,
+            latestCommitTime,
+            fileSlice,
+            dataSchema,
+            requestedSchema,
+            internalSchemaOpt,
+            metaClient,
+            props,
+            0,
+            Long.MAX_VALUE,
+            false);
+    fileGroupReader.initRecordIterators();
+    return fileGroupReader;
   }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -25,14 +25,17 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.compress.CompressionCodec;
 import org.apache.hudi.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieHBaseKVComparator;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.io.storage.HoodieNativeAvroHFileReader;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -52,12 +55,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -110,22 +115,61 @@ public class HFileUtils extends FileFormatUtils {
 
   @Override
   public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
-    throw new UnsupportedOperationException("HFileUtils does not support fetchRecordKeysWithPositions");
+    return fetchRecordKeysWithPositions(storage, filePath, Option.empty(), Option.empty());
   }
 
   @Override
   public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt, Option<String> partitionPath) {
-    throw new UnsupportedOperationException("HFileUtils does not support getHoodieKeyIterator");
+    try {
+      Configuration conf = storage.getConf().unwrapCopyAs(Configuration.class);
+      conf.addResource(HadoopFSUtils.getFs(filePath.toString(), conf).getConf());
+      HoodieNativeAvroHFileReader reader = new HoodieNativeAvroHFileReader(storage, filePath, Option.empty());
+      ClosableIterator<String> keyIterator = reader.getRecordKeyIterator();
+      return new ClosableIterator<HoodieKey>() {
+        @Override
+        public void close() {
+          keyIterator.close();
+        }
+
+        @Override
+        public boolean hasNext() {
+          return keyIterator.hasNext();
+        }
+
+        @Override
+        public HoodieKey next() {
+          String key = keyIterator.next();
+          if (partitionPath.isPresent()) {
+            return new HoodieKey(key, partitionPath.get());
+          } else {
+            return new HoodieKey(key, null);
+          }
+        }
+      };
+    } catch (IOException e) {
+      throw new HoodieIOException("Unable to read the HFile: ", e);
+    }
   }
 
   @Override
   public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage, StoragePath filePath) {
-    throw new UnsupportedOperationException("HFileUtils does not support getHoodieKeyIterator");
+    return getHoodieKeyIterator(storage, filePath, Option.empty(), Option.empty());
   }
 
   @Override
   public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath, Option<BaseKeyGenerator> keyGeneratorOpt, Option<String> partitionPath) {
-    throw new UnsupportedOperationException("HFileUtils does not support fetchRecordKeysWithPositions");
+    try {
+      if (filePath == null || !storage.exists(filePath)) {
+        return ClosableIterator.wrap(Collections.emptyIterator());
+      } else {
+        AtomicLong position = new AtomicLong(0);
+        return new CloseableMappingIterator<>(
+            getHoodieKeyIterator(storage, filePath, keyGeneratorOpt, partitionPath),
+            key -> Pair.of(key, position.getAndIncrement()));
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read from HFile: " + filePath, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

1. Define a flag to enable FG reader for MDT.
2. Translate set of keys into IN clause, set of key prefixes into StringStartsWithAny clause.
3. Refactor the reader context to take predicates.
4. Plug FG reader into two places: a. lookup with keys; b. look up with key prefixes.

### Impact

Enable FG reader for MDT safely.

### Risk level (write none, low medium or high below)

Medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
