### PR TITLE
[HUDI-9412] Support displaying metrics of Update/Delete/MergeIntoHoodieTableCommand in Spark Web UI

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/DeleteHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/DeleteHoodieTableCommand.scala
@@ -27,8 +27,10 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, Filter, LogicalPlan, Project, UpdateTable}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.isMetaField
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
+import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateInsertMetrics
 import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand.stripMetaFieldAttributes
 
 case class DeleteHoodieTableCommand(catalogTable: HoodieCatalogTable, query: LogicalPlan, config: Map[String, String]) extends DataWritingCommand
@@ -41,11 +43,17 @@ case class DeleteHoodieTableCommand(catalogTable: HoodieCatalogTable, query: Log
     query.output.map(_.name)
   }
 
+  override lazy val metrics: Map[String, SQLMetric] = HoodieCommandMetrics.metrics
+
   override def run(sparkSession: SparkSession, queryPlan: SparkPlan): Seq[Row] = {
     val tableId = catalogTable.table.qualifiedName
     logInfo(s"Executing 'DELETE FROM' command for $tableId")
     val df = sparkSession.internalCreateDataFrame(queryPlan.execute(), queryPlan.schema)
-    HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, config, df)
+    val (success, commitInstantTime, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, config, df)
+    if(success) {
+      updateInsertMetrics(metrics, catalogTable.metaClient, commitInstantTime.get())
+      DataWritingCommand.propogateMetrics(sparkSession.sparkContext, this, metrics)
+    }
     sparkSession.catalog.refreshTable(tableId)
     logInfo(s"Finished executing 'DELETE FROM' command for $tableId")
     Seq.empty[Row]

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/HoodieCommandMetrics.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/HoodieCommandMetrics.scala
@@ -29,30 +29,30 @@ import scala.collection.JavaConverters._
 
 object HoodieCommandMetrics {
 
-  def updateInsertMetrics(metrics: Map[String, SQLMetric], metaClient: HoodieTableMetaClient, commitInstantTime: String): Unit = {
+  def updateCommitMetrics(metrics: Map[String, SQLMetric], metaClient: HoodieTableMetaClient, commitInstantTime: String): Unit = {
     val timeline = metaClient.getActiveTimeline.reload().getCommitsTimeline()
     val commitInstant = timeline.getInstants.asScala
       .filter(instant => InstantComparison.EQUALS.test(instant.requestedTime(), commitInstantTime))
     commitInstant.map { commit: HoodieInstant =>
       val metadata = timeline.readCommitMetadata(commit)
-      updateInsertMetrics(metrics, metadata)
+      updateCommitMetrics(metrics, metadata)
     }
   }
 
-  def updateInsertMetrics(metrics: Map[String, SQLMetric], metadata: HoodieCommitMetadata): Unit = {
-    updateInsertMetric(metrics, NUM_PARTITION_KEY, metadata.fetchTotalPartitionsWritten())
-    updateInsertMetric(metrics, NUM_INSERT_FILE_KEY, metadata.fetchTotalFilesInsert())
-    updateInsertMetric(metrics, NUM_UPDATE_FILE_KEY, metadata.fetchTotalFilesUpdated())
-    updateInsertMetric(metrics, NUM_WRITE_ROWS_KEY, metadata.fetchTotalRecordsWritten())
-    updateInsertMetric(metrics, NUM_UPDATE_ROWS_KEY, metadata.fetchTotalUpdateRecordsWritten())
-    updateInsertMetric(metrics, NUM_INSERT_ROWS_KEY, metadata.fetchTotalInsertRecordsWritten())
-    updateInsertMetric(metrics, NUM_DELETE_ROWS_KEY, metadata.getTotalRecordsDeleted())
-    updateInsertMetric(metrics, NUM_OUTPUT_BYTES_KEY, metadata.fetchTotalBytesWritten())
-    updateInsertMetric(metrics, INSERT_TIME, metadata.getTotalCreateTime())
-    updateInsertMetric(metrics, UPSERT_TIME, metadata.getTotalUpsertTime())
+  def updateCommitMetrics(metrics: Map[String, SQLMetric], metadata: HoodieCommitMetadata): Unit = {
+    updateCommitMetric(metrics, NUM_PARTITION_KEY, metadata.fetchTotalPartitionsWritten())
+    updateCommitMetric(metrics, NUM_INSERT_FILE_KEY, metadata.fetchTotalFilesInsert())
+    updateCommitMetric(metrics, NUM_UPDATE_FILE_KEY, metadata.fetchTotalFilesUpdated())
+    updateCommitMetric(metrics, NUM_WRITE_ROWS_KEY, metadata.fetchTotalRecordsWritten())
+    updateCommitMetric(metrics, NUM_UPDATE_ROWS_KEY, metadata.fetchTotalUpdateRecordsWritten())
+    updateCommitMetric(metrics, NUM_INSERT_ROWS_KEY, metadata.fetchTotalInsertRecordsWritten())
+    updateCommitMetric(metrics, NUM_DELETE_ROWS_KEY, metadata.getTotalRecordsDeleted())
+    updateCommitMetric(metrics, NUM_OUTPUT_BYTES_KEY, metadata.fetchTotalBytesWritten())
+    updateCommitMetric(metrics, INSERT_TIME, metadata.getTotalCreateTime())
+    updateCommitMetric(metrics, UPSERT_TIME, metadata.getTotalUpsertTime())
   }
 
-  private def updateInsertMetric(metrics: Map[String, SQLMetric], name: String, value: Long): Unit = {
+  private def updateCommitMetric(metrics: Map[String, SQLMetric], name: String, value: Long): Unit = {
     val metric = metrics.get(name)
     metric.foreach(_.set(value))
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
-import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateInsertMetrics
+import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateCommitMetrics
 import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand.stripMetaFieldAttributes
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
@@ -118,7 +118,7 @@ object InsertIntoHoodieTableCommand extends Logging with ProvidesHoodieConfig wi
     }
 
     if (success && commitInstantTime.isPresent) {
-      updateInsertMetrics(metrics, catalogTable.metaClient, commitInstantTime.get())
+      updateCommitMetrics(metrics, catalogTable.metaClient, commitInstantTime.get())
     }
 
     if (success && refreshTable) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -46,9 +46,11 @@ import org.apache.spark.sql.catalyst.plans.{LeftOuter, QueryPlan}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{combineOptions, getPartitionPathFieldWriteConfig}
+import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateInsertMetrics
 import org.apache.spark.sql.hudi.command.MergeIntoHoodieTableCommand._
 import org.apache.spark.sql.hudi.command.PartialAssignmentMode.PartialAssignmentMode
 import org.apache.spark.sql.hudi.command.payload.ExpressionPayload
@@ -119,6 +121,8 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
   override def outputColumnNames: Seq[String] = {
     query.output.map(_.name)
   }
+
+  override lazy val metrics: Map[String, SQLMetric] = HoodieCommandMetrics.metrics
 
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(query = newChild)
 
@@ -493,10 +497,12 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
       PAYLOAD_ORIGINAL_AVRO_PAYLOAD -> hoodieCatalogTable.tableConfig.getPayloadClass
     )
 
-    val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, writeParams, sourceDF)
+    val (success, commitInstantTime, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, writeParams, sourceDF)
     if (!success) {
       throw new HoodieException("Merge into Hoodie table command failed")
     }
+    updateInsertMetrics(metrics, hoodieCatalogTable.metaClient, commitInstantTime.get())
+    DataWritingCommand.propogateMetrics(sparkSession.sparkContext, this, metrics)
   }
 
   private def isPartialUpdateActionForMOR(parameters: Map[String, String]) = {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -50,7 +50,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{combineOptions, getPartitionPathFieldWriteConfig}
-import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateInsertMetrics
+import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateCommitMetrics
 import org.apache.spark.sql.hudi.command.MergeIntoHoodieTableCommand._
 import org.apache.spark.sql.hudi.command.PartialAssignmentMode.PartialAssignmentMode
 import org.apache.spark.sql.hudi.command.payload.ExpressionPayload
@@ -501,8 +501,10 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
     if (!success) {
       throw new HoodieException("Merge into Hoodie table command failed")
     }
-    updateInsertMetrics(metrics, hoodieCatalogTable.metaClient, commitInstantTime.get())
-    DataWritingCommand.propogateMetrics(sparkSession.sparkContext, this, metrics)
+    if (commitInstantTime.isPresent) {
+      updateCommitMetrics(metrics, hoodieCatalogTable.metaClient, commitInstantTime.get())
+      DataWritingCommand.propogateMetrics(sparkSession.sparkContext, this, metrics)
+    }
   }
 
   private def isPartialUpdateActionForMOR(parameters: Map[String, String]) = {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -31,9 +31,11 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, LogicalPlan, Project, UpdateTable}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.failAnalysis
+import org.apache.spark.sql.hudi.command.HoodieCommandMetrics.updateInsertMetrics
 
 case class UpdateHoodieTableCommand(ut: UpdateTable, query: LogicalPlan) extends DataWritingCommand
   with SparkAdapterSupport with ProvidesHoodieConfig {
@@ -43,6 +45,8 @@ case class UpdateHoodieTableCommand(ut: UpdateTable, query: LogicalPlan) extends
   override def outputColumnNames: Seq[String] = {
     query.output.map(_.name)
   }
+
+  override lazy val metrics: Map[String, SQLMetric] = HoodieCommandMetrics.metrics
 
   override def run(sparkSession: SparkSession, plan: SparkPlan): Seq[Row] = {
     val catalogTable = UpdateHoodieTableCommand.catalogTable(sparkSession, ut)
@@ -58,7 +62,11 @@ case class UpdateHoodieTableCommand(ut: UpdateTable, query: LogicalPlan) extends
     }
 
     val df = sparkSession.internalCreateDataFrame(plan.execute(), plan.schema)
-    HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, config, df)
+    val (success, commitInstantTime, _, _, _, _) = HoodieSparkSqlWriter.write(sparkSession.sqlContext, SaveMode.Append, config, df)
+    if(success) {
+      updateInsertMetrics(metrics, catalogTable.metaClient, commitInstantTime.get())
+      DataWritingCommand.propogateMetrics(sparkSession.sparkContext, this, metrics)
+    }
 
     sparkSession.catalog.refreshTable(tableId)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/TestHoodieCommandMetrics.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/TestHoodieCommandMetrics.scala
@@ -33,7 +33,7 @@ class TestHoodieCommandMetrics extends HoodieSparkSqlTestBase {
     assert(metrics != null)
     assert(metrics.size == 10)
 
-    HoodieCommandMetrics.updateInsertMetrics(metrics, mockedCommitMetadata())
+    HoodieCommandMetrics.updateCommitMetrics(metrics, mockedCommitMetadata())
     assertResult(1L)(metrics(HoodieCommandMetrics.NUM_PARTITION_KEY).value)
     assertResult(2L)(metrics(HoodieCommandMetrics.NUM_INSERT_FILE_KEY).value)
     assertResult(3L)(metrics(HoodieCommandMetrics.NUM_UPDATE_FILE_KEY).value)


### PR DESCRIPTION
### Change Logs
Support displaying metrics of Update/Delete/MergeIntoHoodieTableCommand in Spark Web UI

### implement steps
Similar to #13068 
### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
