### PR TITLE
[HUDI-9413] Add API in WriteStatus to handle metadata stats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/FailOnFirstErrorWriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/FailOnFirstErrorWriteStatus.java
@@ -38,6 +38,10 @@ public class FailOnFirstErrorWriteStatus extends WriteStatus {
     super(trackSuccessRecords, failureFraction);
   }
 
+  public FailOnFirstErrorWriteStatus(Boolean trackSuccessRecords, Double failureFraction, Boolean isMetadataTable) {
+    super(trackSuccessRecords, failureFraction, isMetadataTable);
+  }
+
   @Override
   public void markFailure(HoodieRecord record, Throwable t, Option<Map<String, String>> optionalRecordMetadata) {
     LOG.error(String.format("Error writing record %s with data %s and optionalRecordMetadata %s", record, record.getData(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -61,6 +61,8 @@ public class WriteStatus implements Serializable {
 
   private final List<Pair<HoodieRecordDelegate, Throwable>> failedRecords = new ArrayList<>();
 
+  // true if this WriteStatus refers to a write happening in metadata table.
+  private boolean isMetadataTable;
   private Throwable globalError = null;
 
   private String fileId = null;
@@ -76,10 +78,15 @@ public class WriteStatus implements Serializable {
   private final boolean trackSuccessRecords;
   private final transient Random random;
 
-  public WriteStatus(Boolean trackSuccessRecords, Double failureFraction) {
+  public WriteStatus(Boolean trackSuccessRecords, Double failureFraction, Boolean isMetadataTable) {
     this.trackSuccessRecords = trackSuccessRecords;
     this.failureFraction = failureFraction;
     this.random = new Random(RANDOM_SEED);
+    this.isMetadataTable = isMetadataTable;
+  }
+
+  public WriteStatus(Boolean trackSuccessRecords, Double failureFraction) {
+    this(trackSuccessRecords, failureFraction, false);
   }
 
   public WriteStatus() {
@@ -181,6 +188,11 @@ public class WriteStatus implements Serializable {
     totalErrorRecords++;
   }
 
+  public void removeMetadataStats() {
+    this.writtenRecordDelegates.clear();
+    this.stat.removeRecordStats();
+  }
+
   public String getFileId() {
     return fileId;
   }
@@ -257,9 +269,19 @@ public class WriteStatus implements Serializable {
     return trackSuccessRecords;
   }
 
+  public void setIsMetadata(boolean isMetadataTable) {
+    this.isMetadataTable = isMetadataTable;
+  }
+
+  public boolean isMetadataTable() {
+    return isMetadataTable;
+  }
+
   @Override
   public String toString() {
-    return "WriteStatus {" + "fileId=" + fileId
+    return "WriteStatus {"
+        + "isMetadata=" + isMetadataTable
+        + ", fileId=" + fileId
         + ", writeStat=" + stat
         + ", globalError='" + globalError + '\''
         + ", hasErrors='" + hasErrors() + '\''

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/BootstrapWriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/BootstrapWriteStatus.java
@@ -34,6 +34,10 @@ public class BootstrapWriteStatus extends WriteStatus {
     super(trackSuccessRecords, failureFraction);
   }
 
+  public BootstrapWriteStatus(Boolean trackSuccessRecords, Double failureFraction, Boolean isMetadataTable) {
+    super(trackSuccessRecords, failureFraction, isMetadataTable);
+  }
+
   public BootstrapFileMapping getBootstrapSourceFileMapping() {
     return sourceFileMapping;
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/MetadataMergeWriteStatus.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/MetadataMergeWriteStatus.java
@@ -40,6 +40,11 @@ public class MetadataMergeWriteStatus extends WriteStatus {
     super(trackSuccessRecords, failureFraction);
   }
 
+  public MetadataMergeWriteStatus(Boolean trackSuccessRecords, Double failureFraction,
+                                  Boolean isMetadata) {
+    super(trackSuccessRecords, failureFraction, isMetadata);
+  }
+
   public static Map<String, String> mergeMetadataForWriteStatuses(List<WriteStatus> writeStatuses) {
     Map<String, String> allWriteStatusMergedMetadataMap = new HashMap<>();
     for (WriteStatus writeStatus : writeStatuses) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
@@ -19,7 +19,10 @@
 package org.apache.hudi.client;
 
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordDelegate;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.util.Option;
 
@@ -201,5 +204,23 @@ public class TestWriteStatus {
     Throwable t = new Exception("some error in writing");
     status.setGlobalError(t);
     assertEquals(t, status.getGlobalError());
+  }
+
+  @Test
+  public void testRemoveMetadataStats() {
+    WriteStatus status = new WriteStatus(true, 0.1);
+    status.markSuccess(HoodieRecordDelegate.create(new HoodieKey("key", "partition")), Option.empty());
+    //status.markSuccess(new HoodieRecordDelegate(new HoodieKey("key", "partition"), new HoodieRecordLocation(), new HoodieRecordLocation(), false), Option.empty());
+    Map<String, HoodieColumnRangeMetadata<Comparable>> stats = new HashMap<>();
+    stats.put("field1", HoodieColumnRangeMetadata.<Comparable>create("f1", "field1", 1, 2, 0, 2, 5, 10));
+    status.setStat(new HoodieWriteStat());
+    status.getStat().putRecordsStats(stats);
+    assertEquals(1, status.getWrittenRecordDelegates().size());
+    assertEquals(1, status.getStat().getColumnStats().get().size());
+
+    // Remove metadata stats
+    status.removeMetadataStats();
+    assertEquals(0, status.getWrittenRecordDelegates().size());
+    assertTrue(status.getStat().getColumnStats().isEmpty());
   }
 }


### PR DESCRIPTION
### Change Logs

The Jira adds API in WriteStatus to remove metadata stats which are required for the metadata partitions and indexes.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
