### PR TITLE
[HUDI-9148] Refactor error handling for UtilHelpers#CreateSource

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -116,6 +116,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
@@ -152,17 +153,29 @@ public class UtilHelpers {
     sourceConstructorAndArgs.add(Pair.of(constructorArgsMetrics, new Object[] {cfg, jssc, sparkSession, streamContext.getSchemaProvider(), metrics}));
     sourceConstructorAndArgs.add(Pair.of(constructorArgs, new Object[] {cfg, jssc, sparkSession, streamContext.getSchemaProvider()}));
 
-    HoodieException sourceClassLoadException = null;
+    List<HoodieException> nonMatchingConstructorExceptions = new ArrayList<>();
     for (Pair<Class<?>[], Object[]> constructor : sourceConstructorAndArgs) {
       try {
-        return (Source) ReflectionUtils.loadClass(sourceClass, constructor.getLeft(), constructor.getRight());
+        return ReflectionUtils.loadClass(sourceClass, constructor.getLeft(), constructor.getRight());
       } catch (HoodieException e) {
-        sourceClassLoadException = e;
+        if (e.getCause() instanceof NoSuchMethodException) {
+          // If the cause is a NoSuchMethodException, ignore
+          continue;
+        }
+        nonMatchingConstructorExceptions.add(e);
+        String constructorSignature = Arrays.stream(constructor.getLeft())
+            .map(Class::getSimpleName)
+            .collect(Collectors.joining(", ", "[", "]"));
+        LOG.error("Unexpected error while loading source class {} with constructor signature {}", sourceClass, constructorSignature, e);
       } catch (Throwable t) {
-        throw new IOException("Could not load source class " + sourceClass, t);
+        throw new IOException("Could not load source class due to unexpected error " + sourceClass, t);
       }
     }
-    throw new IOException("Could not load source class " + sourceClass, sourceClassLoadException);
+
+    // Rather than throw the last failure, we will only throw failures that did not occur due to NoSuchMethodException.
+    IOException ioe = new IOException("Could not load any source class for " + sourceClass);
+    nonMatchingConstructorExceptions.forEach(ioe::addSuppressed);
+    throw ioe;
   }
 
   public static JsonKafkaSourcePostProcessor createJsonKafkaSourcePostProcessor(String postProcessorClassNames, TypedProperties props) throws IOException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -156,7 +156,7 @@ public class UtilHelpers {
     List<HoodieException> nonMatchingConstructorExceptions = new ArrayList<>();
     for (Pair<Class<?>[], Object[]> constructor : sourceConstructorAndArgs) {
       try {
-        return ReflectionUtils.loadClass(sourceClass, constructor.getLeft(), constructor.getRight());
+        return (Source) ReflectionUtils.loadClass(sourceClass, constructor.getLeft(), constructor.getRight());
       } catch (HoodieException e) {
         if (e.getCause() instanceof NoSuchMethodException) {
           // If the cause is a NoSuchMethodException, ignore

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
@@ -20,11 +20,25 @@ package org.apache.hudi.utilities;
 
 import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.utilities.sources.AvroKafkaSource;
+import org.apache.hudi.utilities.sources.Source;
+import org.apache.hudi.utilities.sources.helpers.SchemaTestProvider;
+import org.apache.hudi.utilities.streamer.DefaultStreamContext;
+import org.apache.hudi.utilities.streamer.HoodieStreamerMetrics;
 
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test cases for {@link UtilHelpers}.
@@ -40,5 +54,37 @@ public class TestUtilHelpers {
     props2.put(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), "Dummy");
     UtilHelpers.addLockOptions("path2", "file", props2);
     assertEquals(1, props2.size(), "Should not add lock options if the lock provider is already there.");
+  }
+
+  @Test
+  void testCreateSource() throws IOException {
+    SparkSession sparkSession = mock(SparkSession.class);
+    JavaSparkContext javaSparkContext = mock(JavaSparkContext.class);
+    TypedProperties typedProperties = new TypedProperties();
+    typedProperties.setProperty("hoodie.streamer.source.kafka.topic", "topic");
+    Source source = UtilHelpers.createSource(
+        "org.apache.hudi.utilities.sources.AvroKafkaSource",
+        typedProperties,
+        javaSparkContext,
+        sparkSession,
+        new HoodieStreamerMetrics(HoodieWriteConfig.newBuilder().withPath("mypath").build()),
+        new DefaultStreamContext(new SchemaTestProvider(typedProperties), Option.empty()));
+    assertTrue(source instanceof AvroKafkaSource);
+  }
+
+  @Test
+  void testCreateSourceWithErrors() {
+    SparkSession sparkSession = mock(SparkSession.class);
+    JavaSparkContext javaSparkContext = mock(JavaSparkContext.class);
+    TypedProperties typedProperties = new TypedProperties();
+    Throwable e = assertThrows(IOException.class, () -> UtilHelpers.createSource(
+        "org.apache.hudi.utilities.sources.AvroKafkaSource",
+        typedProperties,
+        javaSparkContext,
+        sparkSession,
+        new HoodieStreamerMetrics(HoodieWriteConfig.newBuilder().withPath("mypath").build()),
+        new DefaultStreamContext(new SchemaTestProvider(typedProperties), Option.empty())));
+    // We expect two constructors to complain about this error.
+    assertEquals(2, e.getSuppressed().length);
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.utilities.sources.AvroKafkaSource;
 import org.apache.hudi.utilities.sources.Source;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.utilities.sources.AvroKafkaSource;
 import org.apache.hudi.utilities.sources.Source;
 import org.apache.hudi.utilities.sources.helpers.SchemaTestProvider;
@@ -35,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,7 +70,9 @@ public class TestUtilHelpers {
         typedProperties,
         javaSparkContext,
         sparkSession,
-        new HoodieStreamerMetrics(HoodieWriteConfig.newBuilder().withPath("mypath").build()),
+        new HoodieStreamerMetrics(
+                HoodieWriteConfig.newBuilder().withPath("mypath").build(),
+                HoodieStorageUtils.getStorage(getDefaultStorageConf())),
         new DefaultStreamContext(new SchemaTestProvider(typedProperties), Option.empty()));
     assertTrue(source instanceof AvroKafkaSource);
   }
@@ -82,7 +87,9 @@ public class TestUtilHelpers {
         typedProperties,
         javaSparkContext,
         sparkSession,
-        new HoodieStreamerMetrics(HoodieWriteConfig.newBuilder().withPath("mypath").build()),
+        new HoodieStreamerMetrics(
+                HoodieWriteConfig.newBuilder().withPath("mypath").build(),
+                HoodieStorageUtils.getStorage(getDefaultStorageConf())),
         new DefaultStreamContext(new SchemaTestProvider(typedProperties), Option.empty())));
     // We expect two constructors to complain about this error.
     assertEquals(2, e.getSuppressed().length);


### PR DESCRIPTION
### Change Logs

When a HoodieException occurs in a constructor in CreateSource we fail to log it and instead throw an error at the end when the final constructor does not support the parameters we tried.

### Impact

Fixes error handling in CreateSource

### Risk level (write none, low medium or high below)

Low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
