### PR TITLE
[HUDI-9273] Upgrade Parquet to 1.15.1 to address CVE-2025-30065

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -97,6 +97,11 @@
                   <include>com.github.davidmoten:hilbert-curve</include>
                   <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.apache.parquet:parquet-avro</include>
+                  <include>org.apache.parquet:parquet-common</include>
+                  <include>org.apache.parquet:parquet-hadoop</include>
+                  <include>org.apache.parquet:parquet-column</include>
+                  <include>org.apache.parquet:parquet-format-structures</include>
+                  <include>org.apache.parquet:parquet-encoding</include>
                   <include>com.twitter:chill-protobuf</include>
 
                   <include>io.dropwizard.metrics:metrics-core</include>

--- a/pom.xml
+++ b/pom.xml
@@ -2431,7 +2431,7 @@
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.spark.version>1.9.1</orc.spark.version>
         <avro.version>1.11.4</avro.version>
         <antlr.version>4.9.3</antlr.version>
@@ -2489,7 +2489,7 @@
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
-        <parquet.version>1.12.2</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.spark.version>1.7.8</orc.spark.version>
         <avro.version>1.11.4</avro.version>
         <antlr.version>4.8</antlr.version>
@@ -2529,7 +2529,7 @@
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
-        <parquet.version>1.12.3</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.spark.version>1.8.3</orc.spark.version>
         <avro.version>1.11.4</avro.version>
         <antlr.version>4.9.3</antlr.version>
@@ -2579,7 +2579,7 @@
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.spark.version>1.9.1</orc.spark.version>
         <avro.version>1.11.4</avro.version>
         <antlr.version>4.9.3</antlr.version>


### PR DESCRIPTION
### Change Logs

This code change is made to update jetty version to fix CVE-2025-30065. Changing the version caused failures for application runs for Apache spark where it was manually tested due to change in the dependencies required for parquet-avro for version 1.15.1. This is currently resolved by shading the required dependencies.

### Impact

Fixes the vulnerability
 
### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
