### PR TITLE
[HUDI-9388] Add compaction and clustering plan conflict detection logic

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TableServicePlanConflictDetection.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TableServicePlanConflictDetection.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.transaction;
+
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.exception.HoodieIOException;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * Handles conflict detection for the plans of various table services.
+ * Cleaning and archiving are not included in this class as they do not require conflict detection.
+ */
+public class TableServicePlanConflictDetection {
+  private final ConflictResolutionStrategy conflictResolutionStrategy;
+  private final HoodieTableMetaClient metaClient;
+  private final String lastKnownCompletionTime;
+
+  /**
+   * Constructors a new instance to detect conflicts for a table service plan.
+   * Note that this should be used within a transaction to prevent race conditions. The meta client used must be constructed or reloaded within the transaction.
+   * @param conflictResolutionStrategy The strategy to use for conflict resolution for the writer.
+   * @param metaClient The meta client for the table. This must be constructed or reloaded during the transaction.
+   * @param lastKnownCompletionTime The last completion time of an instant on the timeline when the planner started.
+   */
+  public TableServicePlanConflictDetection(ConflictResolutionStrategy conflictResolutionStrategy, HoodieTableMetaClient metaClient, String lastKnownCompletionTime) {
+    this.conflictResolutionStrategy = conflictResolutionStrategy;
+    this.metaClient = metaClient;
+    this.lastKnownCompletionTime = lastKnownCompletionTime;
+  }
+
+  /**
+   * Checks if there are any potential conflicts with actions that have happened since the planner start instant.
+   * The compaction requires a check for conflicts with any commits for ingesting new data since the compaction plan is expected to contain all the log files for the slice it is compacting.
+   * It also requires checks for new plans for clustering or potentially another compaction on the timeline to avoid multiple services operating on the same file groups.
+   * @param compactionPlan the requested plan
+   * @param requestedInstantTime the requested instant time that will be used when persisting the plan to the timeline
+   * @return true if there is a conflict with the requested plan, false otherwise
+   */
+  public boolean hasConflict(HoodieCompactionPlan compactionPlan, String requestedInstantTime) {
+    ConcurrentOperation compactionOperation = new ConcurrentOperation(compactionPlan, requestedInstantTime);
+    return hasConflict(compactionOperation);
+  }
+
+  /**
+   * Checks if there are any potential conflicts with actions that have happened since the planner start instant.
+   * The clustering requires a check for conflicts with any commits for ingesting new data since the clustering plan will also contain log files,
+   * and all the log files for the slice it is clustering must be in the plan.
+   * It also requires checks for new plans for compaction or potentially another clustering on the timeline to avoid multiple services operating on the same file groups.
+   * @param clusteringPlan the requested plan
+   * @param requestedInstantTime the requested instant time that will be used when persisting the plan to the timeline
+   * @return true if there is a conflict with the requested plan, false otherwise
+   */
+  public boolean hasConflict(HoodieClusteringPlan clusteringPlan, String requestedInstantTime) {
+    ConcurrentOperation clusteringOperation = new ConcurrentOperation(clusteringPlan, requestedInstantTime);
+    return hasConflict(clusteringOperation);
+  }
+
+  private boolean hasConflict(ConcurrentOperation plannedOperation) {
+    return generateCandidateInstants().anyMatch(instant -> {
+      try {
+        ConcurrentOperation otherOperation = new ConcurrentOperation(instant, metaClient);
+        return conflictResolutionStrategy.hasConflict(plannedOperation, otherOperation);
+      } catch (IOException ex) {
+        throw new HoodieIOException("Unable to parse instant details for conflict detection", ex);
+      }
+    });
+  }
+
+  private Stream<HoodieInstant> generateCandidateInstants() {
+    Stream<HoodieInstant> commitsCompletedDuringPlanning = metaClient
+        .getCommitsTimeline()
+        .findInstantsModifiedAfterByCompletionTime(lastKnownCompletionTime)
+        .getInstantsAsStream();
+    Stream<HoodieInstant> newClusteringPlans = metaClient
+        .getActiveTimeline()
+        .filterPendingClusteringTimeline()
+        .getInstantsAsStream();
+    Stream<HoodieInstant> newCompactionPlans = metaClient
+        .getActiveTimeline()
+        .filterPendingCompactionTimeline()
+        .getInstantsAsStream();
+    return Stream.concat(Stream.concat(newClusteringPlans, newCompactionPlans), commitsCompletedDuringPlanning);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TableServicePlanConflictDetection.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TableServicePlanConflictDetection.java
@@ -90,6 +90,7 @@ public class TableServicePlanConflictDetection {
   private Stream<HoodieInstant> generateCandidateInstants() {
     Stream<HoodieInstant> commitsCompletedDuringPlanning = metaClient
         .getCommitsTimeline()
+        .filterCompletedInstants()
         .findInstantsModifiedAfterByCompletionTime(lastKnownCompletionTime)
         .getInstantsAsStream();
     Stream<HoodieInstant> newClusteringPlans = metaClient

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTableServicePlanConflictDetection.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTableServicePlanConflictDetection.java
@@ -237,6 +237,7 @@ class TestTableServicePlanConflictDetection extends HoodieCommonTestHarness {
     commitMetadata.addWriteStat(partitionPath, writeStat2);
     commitMetadata.setOperationType(WriteOperationType.INSERT);
     metaClient.getActiveTimeline().transitionRequestedToInflight(commitInstant, Option.of(commitMetadata));
+    metaClient.reloadActiveTimeline();
 
     TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
     if (isClusteringPlan) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTableServicePlanConflictDetection.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTableServicePlanConflictDetection.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.transaction;
+
+import org.apache.hudi.avro.model.HoodieClusteringGroup;
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieCompactionOperation;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieSliceInfo;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestTableServicePlanConflictDetection extends HoodieCommonTestHarness {
+  private final ConflictResolutionStrategy conflictResolutionStrategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+  private final String lastKnownCompletionTime = "20250101010101";
+  private final String newInstantTime = "20250101010102";
+  private final String partitionPath = "2025/01/01";
+  private final String fileId1 = "file_id_1";
+  private final String fileId2 = "file_id_2";
+  private final String fileId3 = "file_id_3";
+  private final String fileId4 = "file_id_4";
+
+  @BeforeEach
+  void init() throws IOException {
+    initPath();
+    initMetaClient();
+  }
+
+  @Override
+  protected HoodieTableType getTableType() {
+    return HoodieTableType.MERGE_ON_READ;
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newClusteringPlanConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant clusteringInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, newInstantTime);
+    HoodieClusteringPlan clusteringPlan = buildClusteringPlan(Stream.of(fileId1, fileId2));
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
+        .setOperationType(WriteOperationType.CLUSTER.name())
+        .setExtraMetadata(Collections.emptyMap())
+        .setClusteringPlan(clusteringPlan)
+        .build();
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newCompactionPlanConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant compactionInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, buildCompactionPlan(Stream.of(fileId2, fileId3)));
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newDeltaCommitConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant commitInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().createNewInstant(commitInstant);
+    metaClient.getActiveTimeline().transitionRequestedToInflight(commitInstant, Option.empty());
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat1 = new HoodieWriteStat();
+    writeStat1.setFileId(fileId1);
+    HoodieWriteStat writeStat2 = new HoodieWriteStat();
+    writeStat2.setFileId(fileId2);
+    commitMetadata.addWriteStat(partitionPath, writeStat1);
+    commitMetadata.addWriteStat(partitionPath, writeStat2);
+    commitMetadata.setOperationType(WriteOperationType.INSERT);
+    commitInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().saveAsComplete(commitInstant, Option.of(commitMetadata));
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId3));
+      assertTrue(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newClusteringPlanNoConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant clusteringInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, newInstantTime);
+    HoodieClusteringPlan clusteringPlan = buildClusteringPlan(Stream.of(fileId1, fileId2));
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
+        .setOperationType(WriteOperationType.CLUSTER.name())
+        .setExtraMetadata(Collections.emptyMap())
+        .setClusteringPlan(clusteringPlan)
+        .build();
+    metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId3, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId3, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newCompactionPlanNoConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant compactionInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, buildCompactionPlan(Stream.of(fileId2, fileId3)));
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void newDeltaCommitNoConflictsWithServicePlan(boolean isClusteringPlan) {
+    HoodieInstant commitInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().createNewInstant(commitInstant);
+    metaClient.getActiveTimeline().transitionRequestedToInflight(commitInstant, Option.empty());
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat1 = new HoodieWriteStat();
+    writeStat1.setFileId(fileId1);
+    HoodieWriteStat writeStat2 = new HoodieWriteStat();
+    writeStat2.setFileId(fileId2);
+    commitMetadata.addWriteStat(partitionPath, writeStat1);
+    commitMetadata.addWriteStat(partitionPath, writeStat2);
+    commitMetadata.setOperationType(WriteOperationType.INSERT);
+    commitInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().saveAsComplete(commitInstant, Option.of(commitMetadata));
+
+    metaClient.reloadActiveTimeline();
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId3, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId3, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void noNewCommitsDuringPlanning(boolean isClusteringPlan) {
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void noCompletedDeltaCommitsDuringPlanning(boolean isClusteringPlan) {
+    // create an inflight commit and ensure it is ignored
+    HoodieInstant commitInstant = metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, newInstantTime);
+    metaClient.getActiveTimeline().createNewInstant(commitInstant);
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat1 = new HoodieWriteStat();
+    writeStat1.setFileId(fileId1);
+    HoodieWriteStat writeStat2 = new HoodieWriteStat();
+    writeStat2.setFileId(fileId2);
+    commitMetadata.addWriteStat(partitionPath, writeStat1);
+    commitMetadata.addWriteStat(partitionPath, writeStat2);
+    commitMetadata.setOperationType(WriteOperationType.INSERT);
+    metaClient.getActiveTimeline().transitionRequestedToInflight(commitInstant, Option.of(commitMetadata));
+
+    TableServicePlanConflictDetection conflictDetection = new TableServicePlanConflictDetection(conflictResolutionStrategy, metaClient, lastKnownCompletionTime);
+    if (isClusteringPlan) {
+      HoodieClusteringPlan compactionPlan = buildClusteringPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    } else {
+      HoodieCompactionPlan compactionPlan = buildCompactionPlan(Stream.of(fileId1, fileId4));
+      assertFalse(conflictDetection.hasConflict(compactionPlan, newInstantTime));
+    }
+  }
+
+  private HoodieClusteringPlan buildClusteringPlan(Stream<String> filedIds) {
+    List<HoodieSliceInfo> affectedSlices = filedIds
+        .map(fileId -> HoodieSliceInfo.newBuilder().setPartitionPath(partitionPath).setFileId(fileId).build())
+        .collect(Collectors.toList());
+    return HoodieClusteringPlan.newBuilder().setVersion(2).setInputGroups(Collections.singletonList(HoodieClusteringGroup.newBuilder().setSlices(affectedSlices).build())).build();
+  }
+
+  private HoodieCompactionPlan buildCompactionPlan(Stream<String> filedIds) {
+    List<HoodieCompactionOperation> compactionOperations = filedIds
+        .map(fileId -> HoodieCompactionOperation.newBuilder().setPartitionPath(partitionPath).setFileId(fileId).setBaseInstantTime("001").build())
+        .collect(Collectors.toList());
+    return HoodieCompactionPlan.newBuilder().setVersion(2).setOperations(compactionOperations).build();
+  }
+}


### PR DESCRIPTION
### Change Logs

- Adds a helper class that can be used for detecting conflicts with table service plans and new actions on the timeline. This will allow us to move the service planning outside of the lock which will help minimize the time the lock is held and help with throughput of concurrent writers.

Scenarios that Require the compaction or clustering plans to be discarded:
1. There is concurrent compaction or clustering planning by another writer that touches the same set of file groups. Typically users will not have this issue since they will have one writer handling table services but it is best to defend against it.
2. There is an ingestion commit (delta-commit for MoR or plain commit for CoW) that completes and modifies the file group in the compaction or clustering plan. For Compaction, this causes issues since the completion time ordering assumes that log files from commits that complete before the compaction will have been compacted into the new base file and the updates from those new log files are lost. For Clustering, the log files will similarly be missed in the plan and therefore the updates from those log files are lost.

### Impact

- This sets us up for more improvements that will help with throughput of concurrent writers and async table services

### Risk level (write none, low medium or high below)

Low, this PR uses existing functionality for conflict detection and does not wire any of this into the table service planning at this point in time. That will come in a future PR

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
