### PR TITLE
[HUDI-9435] Use cache to get table schema from commit metadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -344,7 +344,7 @@ public class TableSchemaResolver {
     HoodieTimeline completedInstants = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
     HoodieTimeline timeline = completedInstants
         .filter(instant -> { // consider only instants that can update/change schema.
-            return WriteOperationType.canUpdateSchema(getCachedCommitMetadata(instant).getOperationType());
+          return WriteOperationType.canUpdateSchema(getCachedCommitMetadata(instant).getOperationType());
         });
     return timeline.lastInstant().flatMap(this::getTableInternalSchemaFromCommitMetadata);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -344,13 +344,7 @@ public class TableSchemaResolver {
     HoodieTimeline completedInstants = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
     HoodieTimeline timeline = completedInstants
         .filter(instant -> { // consider only instants that can update/change schema.
-          try {
-            HoodieCommitMetadata commitMetadata =
-                completedInstants.readCommitMetadata(instant);
-            return WriteOperationType.canUpdateSchema(commitMetadata.getOperationType());
-          } catch (IOException e) {
-            throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", instant), e);
-          }
+            return WriteOperationType.canUpdateSchema(getCachedCommitMetadata(instant).getOperationType());
         });
     return timeline.lastInstant().flatMap(this::getTableInternalSchemaFromCommitMetadata);
   }


### PR DESCRIPTION
### Change Logs

From Hudi 0.14.0 to 0.14.1, Hudi changed its logic to load all commits that can change schema to respect schema evolution: https://github.com/apache/hudi/pull/9743/files#diff-79515156c9d8e0421cea5a397ea00bbff098dd9c9c04afa57ba1ba3abf0f2f7bR392. 

This logic can benefit from the caching method `getCachedCommitMetadata` to boost performance

Use cache to load

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
