### PR TITLE
[HUDI-9385] Remove start commit with time

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
@@ -23,6 +23,7 @@ import org.apache.hudi.cli.HoodieCLI;
 import org.apache.hudi.cli.functional.CLIFunctionalTestHarness;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -83,7 +84,7 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";
       int numRecords = 10;
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = context().getJavaSparkContext().parallelize(records, 1);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
@@ -25,6 +25,7 @@ import org.apache.hudi.cli.functional.CLIFunctionalTestHarness;
 import org.apache.hudi.cli.testutils.HoodieTestCommitMetadataGenerator;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -334,7 +335,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";
       int numRecords = 10;
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = context().getJavaSparkContext().parallelize(records, 1);
@@ -357,7 +358,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
         }
       });
 
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       // ingest records2 which has null for partition path fields, but goes into "default" partition.
       JavaRDD<HoodieRecord> writeRecords2 = context().getJavaSparkContext().parallelize(records2, 1);
       List<WriteStatus> result2 = client.bulkInsert(writeRecords2, newCommitTime).collect();
@@ -401,7 +402,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";
       int numRecords = 20;
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = context().getJavaSparkContext().parallelize(records, 1);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
@@ -23,6 +23,7 @@ import org.apache.hudi.cli.commands.TableCommand;
 import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -188,7 +189,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
   private List<HoodieRecord> insert(JavaSparkContext jsc, SparkRDDWriteClient<HoodieAvroPayload> client,
       HoodieTestDataGenerator dataGen, String newCommitTime) throws IOException {
     // inserts
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
@@ -24,6 +24,7 @@ import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.TestCompactionAdminClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.CompactionOperation;
@@ -300,7 +301,7 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
       HoodieTestDataGenerator dataGen) throws IOException {
     // inserts
     String newCommitTime = "001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -313,7 +314,7 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
       throws IOException {
     // updates
     String newCommitTime = "002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<HoodieRecord> toBeUpdated = dataGen.generateUpdates(newCommitTime, 2);
     records.addAll(toBeUpdated);
@@ -325,7 +326,7 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
        List<HoodieRecord> records) {
     // Delete
     String newCommitTime = "003";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     // just delete half of the records
     int numToDelete = records.size() / 2;

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestTableCommand.java
@@ -22,6 +22,7 @@ import org.apache.hudi.cli.HoodieCLI;
 import org.apache.hudi.cli.commands.TableCommand;
 import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -204,7 +205,7 @@ public class ITTestTableCommand extends HoodieCLIIntegrationTestBase {
 
   private void upsert(JavaSparkContext jsc, SparkRDDWriteClient<HoodieAvroPayload> client,
                       List<HoodieRecord> records, String newCommitTime) throws IOException {
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     operateFunc(SparkRDDWriteClient::upsert, client, writeRecords, newCommitTime);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -957,15 +957,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   }
 
   /**
-   * Provides a new commit time for a write operation (insert/update/delete/insert_overwrite/insert_overwrite_table) without specified action.
-   * @param instantTime Instant time to be generated
-   */
-  public void startCommitWithTime(String instantTime) {
-    HoodieTableMetaClient metaClient = createMetaClient(true);
-    startCommit(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
-  }
-
-  /**
    * Starts a new commit time for a write operation against the metadata table with the provided instant and action type.
    */
   public void startCommitForMetadataTable(HoodieTableMetaClient metadataMetaClient, String instantTime, String actionType) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 
 public class WriteClientTestUtils {
@@ -26,5 +27,10 @@ public class WriteClientTestUtils {
 
   public static void startCommitWithTime(BaseHoodieWriteClient<?, ?, ?, ?> writeClient, String instantTime, String actionType) {
     writeClient.startCommit(Option.of(instantTime), actionType, writeClient.createMetaClient(false));
+  }
+
+  public static void startCommitWithTime(BaseHoodieWriteClient<?, ?, ?, ?> writeClient, String instantTime) {
+    HoodieTableMetaClient metaClient = writeClient.createMetaClient(false);
+    writeClient.startCommit(Option.of(instantTime), metaClient.getCommitActionType(), metaClient);
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utils;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -696,7 +697,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     HoodieWriteConfig cfg = getConsistencyCheckWriteConfig(enableOptimisticConsistencyGuard);
     BaseHoodieWriteClient client = getHoodieWriteClient(cfg);
 
-    client.startCommitWithTime(instantTime);
+    WriteClientTestUtils.startCommitWithTime(client, instantTime);
     List<HoodieRecord> writeRecords = dataGen.generateInserts(instantTime, 200);
     List<WriteStatus> result = (List<WriteStatus>) transformOutputFn.apply(client.bulkInsert(transformInputFn.apply(writeRecords), instantTime));
 
@@ -869,7 +870,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     try (BaseHoodieWriteClient client = getHoodieWriteClient(cfgBuilder.build())) {
       HoodieTableMetaClient metaClient = createMetaClient();
       String instantTime = "000";
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
       List<HoodieRecord> records = dataGen.generateInserts(instantTime, 200);
 
       assertTrue(client.commit(instantTime, client.bulkInsert(transformInputFn.apply(records), instantTime)), "Commit should succeed");
@@ -902,7 +903,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     BaseHoodieWriteClient client = getHoodieWriteClient(cfg);
 
     String instantTime0 = "000";
-    client.startCommitWithTime(instantTime0);
+    WriteClientTestUtils.startCommitWithTime(client, instantTime0);
     List<HoodieRecord> records0 = dataGen.generateInserts(instantTime0, 200);
     assertTrue(client.commit(instantTime0, client.bulkInsert(transformInputFn.apply(records0), instantTime0)), "Commit should succeed");
     assertTrue(testTable.commitExists(instantTime0), "After explicit commit, commit file should be created");
@@ -921,7 +922,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
 
     // Update + Inserts such that they just expand file1
     String instantTime1 = "001";
-    client.startCommitWithTime(instantTime1);
+    WriteClientTestUtils.startCommitWithTime(client, instantTime1);
     List<HoodieRecord> records1 = dataGen.generateUpdates(instantTime1, records0);
     assertTrue(client.commit(instantTime1, client.upsert(transformInputFn.apply(records1), instantTime1)), "Commit should succeed");
     assertTrue(testTable.commitExists(instantTime1), "After explicit commit, commit file should be created");
@@ -970,7 +971,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     BaseHoodieWriteClient client = getHoodieWriteClient(config);
     // delete non existent keys
     String commitTime1 = "001";
-    client.startCommitWithTime(commitTime1);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime1);
 
     List<HoodieRecord> dummyInserts = dataGen.generateInserts(commitTime1, 20);
     List<HoodieKey> hoodieKeysToDelete = randomSelectAsHoodieKeys(dummyInserts, 20);
@@ -1004,7 +1005,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     try (BaseHoodieWriteClient client = getHoodieWriteClient(config)) {
       String commitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(commitTime, 200);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<WriteStatus> statusList = (List<WriteStatus>) transformOutputFn.apply(client.insert(transformInputFn.apply(records), commitTime));
       assertNoWriteErrors(statusList);
       client.commit(commitTime, transformInputFn.apply(statusList));
@@ -1034,7 +1035,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     }
     // Perform write-action and check
     try (BaseHoodieWriteClient client = getHoodieWriteClient(writeConfig)) {
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> statuses = writeFn.apply(client, recordList, newCommitTime);
       assertNoWriteErrors(statuses);
       assertEquals(2, statuses.size());

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
@@ -163,7 +163,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
     int startInstant = 1;
     String firstCommitTime = makeNewCommitTime(startInstant++, "%09d");
     // First insert
-    writeClient.startCommitWithTime(firstCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, firstCommitTime);
     writeClient.insert(records1, firstCommitTime);
 
     String partitionPath = "2021/09/11";
@@ -190,7 +190,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
     records2.add(new HoodieAvroRecord(new HoodieKey(insertRow2.getRowKey(), insertRow2.getPartitionPath()), insertRow2));
 
     String newCommitTime = makeNewCommitTime(startInstant++, "%09d");
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     // Second insert is the same as the _row_key of the first one,test allowDuplicateInserts
     writeClient.insert(records2, newCommitTime);
 
@@ -231,7 +231,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
     List<HoodieRecord> records1 = dataGenerator.generateInserts(firstCommitTime, 100);
 
     // First insert
-    writeClient.startCommitWithTime(firstCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, firstCommitTime);
     writeClient.insert(records1, firstCommitTime);
 
     FileStatus[] allFiles = getIncrementalFiles(partitionPath, "0", -1);
@@ -246,7 +246,7 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
 
     String newCommitTime = makeNewCommitTime(startInstant++, "%09d");
     List<HoodieRecord> records2 = dataGenerator.generateUpdates(newCommitTime, 100);
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     // Second insert is the same as the _row_key of the first one,test allowDuplicateInserts
     writeClient.insert(records2, newCommitTime);
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -719,19 +719,19 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime1 = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime1, 100);
-      client.startCommitWithTime(newCommitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime1);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime1);
       client.commit(newCommitTime1, writeStatuses);
 
       String newCommitTime2 = "0000002";
       records = dataGen.generateUniqueUpdates(newCommitTime2, 20);
-      client.startCommitWithTime(newCommitTime2);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime2);
       writeStatuses = client.upsert(records, newCommitTime2);
       client.commit(newCommitTime2, writeStatuses);
 
       String newCommitTime3 = "0000003";
       records = dataGen.generateUniqueUpdates(newCommitTime3, 20);
-      client.startCommitWithTime(newCommitTime3);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime3);
       writeStatuses = client.upsert(records, newCommitTime3);
       client.commit(newCommitTime3, writeStatuses);
 
@@ -748,7 +748,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // re-ingest w/ same commit time.
       records = dataGen.generateUniqueUpdates(newCommitTime3, 20);
-      client.startCommitWithTime(newCommitTime3);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime3);
       writeStatuses = client.upsert(records, newCommitTime3);
       client.commit(newCommitTime3, writeStatuses);
 
@@ -1232,7 +1232,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -1278,7 +1278,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
 
@@ -1313,7 +1313,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1
       String commitTime = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(commitTime, 20);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<WriteStatus> writeStatuses = client.insert(records, commitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -1324,7 +1324,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 2
       commitTime = "0000002";
       records = dataGen.generateInserts(commitTime, 10);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       writeStatuses = client.upsert(records, commitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -1420,13 +1420,13 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
               new HoodieAvroRecord(new HoodieKey("key1_" + counter.getAndIncrement(), entry.getPartitionPath()), (HoodieRecordPayload) entry.getData()))
           .collect(Collectors.toList());
 
-      client.startCommitWithTime(firstCommit);
+      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
       List<WriteStatus> writeStatuses = client.insert(processedRecords, firstCommit);
       assertNoWriteErrors(writeStatuses);
 
       // Write 2 (inserts)
       String secondCommit = "0000002";
-      client.startCommitWithTime(secondCommit);
+      WriteClientTestUtils.startCommitWithTime(client, secondCommit);
       records = dataGen.generateInserts(secondCommit, 20);
       AtomicInteger counter1 = new AtomicInteger();
       processedRecords = records.stream().map(entry ->
@@ -1526,13 +1526,13 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String commit1 = client.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 20);
-    client.startCommitWithTime(commit1);
+    WriteClientTestUtils.startCommitWithTime(client, commit1);
     List<WriteStatus> writeStatuses = client.bulkInsert(records, commit1);
     assertNoWriteErrors(writeStatuses);
 
     // Write 2 (inserts)
     String commit2 = client.createNewInstantTime();
-    client.startCommitWithTime(commit2);
+    WriteClientTestUtils.startCommitWithTime(client, commit2);
     records = dataGen.generateInserts(commit2, 20);
     writeStatuses = client.insert(records, commit2);
     assertNoWriteErrors(writeStatuses);
@@ -1547,7 +1547,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     client.close();
     client = new HoodieJavaWriteClient(engineContext, writeConfig);
     String commit3 = client.createNewInstantTime();
-    client.startCommitWithTime(commit3);
+    WriteClientTestUtils.startCommitWithTime(client, commit3);
     records = dataGen.generateUniqueUpdates(commit3, 10);
     writeStatuses = client.upsert(records, commit3);
     assertNoWriteErrors(writeStatuses);
@@ -1594,14 +1594,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 20);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       writeStatuses = client.bulkInsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
 
       // Write 2 (inserts)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       validateMetadata(client);
 
       records = dataGen.generateInserts(newCommitTime, 20);
@@ -1611,14 +1611,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // Write 3 (updates)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUniqueUpdates(newCommitTime, 10);
       writeStatuses = client.upsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
 
       // Write 4 (updates and inserts)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 10);
       writeStatuses = client.upsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
@@ -1635,7 +1635,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 5 (updates and inserts)
       newCommitTime = client.createNewInstantTime();
       instantToRestore = newCommitTime;
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 5);
       writeStatuses = client.upsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
@@ -1655,7 +1655,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // upserts
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 5);
       writeStatuses = client.upsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
@@ -1696,7 +1696,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieJavaWriteClient writeClient = new HoodieJavaWriteClient(engineContext, writeConfig);
     String initialCommit = "0000000";
     List<HoodieRecord> initialRecords = dataGen.generateInserts(initialCommit, 100);
-    writeClient.startCommitWithTime(initialCommit);
+    WriteClientTestUtils.startCommitWithTime(writeClient, initialCommit);
     List<WriteStatus> initialWriteStatuses = writeClient.insert(initialRecords, initialCommit);
     assertNoWriteErrors(initialWriteStatuses);
     writeClient.close();
@@ -1716,7 +1716,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       Future future = executors.submit(() -> {
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 100, dataGen.getPartitionPaths()[index]);
         HoodieJavaWriteClient localWriteClient = writeClients[index];
-        writeClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
         List<WriteStatus> writeStatuses = localWriteClient.insert(records, newCommitTime);
         assertNoWriteErrors(writeStatuses);
       });
@@ -1772,7 +1772,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int j = 0; j < 6; j++) {
         String newCommitTime = writeClient.createNewInstantTime();
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 100, partitionPath);
-        writeClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
         List<WriteStatus> writeStatuses = writeClient.insert(records, newCommitTime);
         writeClient.commit(newCommitTime, writeStatuses);
       }
@@ -1808,14 +1808,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String newCommitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
     validateMetadata(client);
 
     // Write 2 (inserts)
     newCommitTime = "0000002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
@@ -1848,7 +1848,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     // trigger new write to mimic other writes succeeding before re-attempt.
     newCommitTime = "0000003";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
@@ -1884,14 +1884,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String newCommitTime = client.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
     validateMetadata(client);
 
     // Write 2 (inserts)
     newCommitTime = client.createNewInstantTime();
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
@@ -1925,7 +1925,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     client = getHoodieWriteClient(updatedWriteConfig);
 
     newCommitTime = client.createNewInstantTime();
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
     assertNoWriteErrors(writeStatuses);
@@ -1944,7 +1944,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       String[] commitTimestamps = {client.createNewInstantTime(), client.createNewInstantTime()};
 
       records = dataGen.generateInserts(commitTimestamps[0], 5);
-      client.startCommitWithTime(commitTimestamps[0]);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamps[0]);
       writeStatuses = client.bulkInsert(records, commitTimestamps[0]);
       assertNoWriteErrors(writeStatuses);
 
@@ -1973,7 +1973,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       for (int i = 0; i < commitTimestamps.length; ++i) {
         records = dataGen.generateInserts(commitTimestamps[i], 5);
-        client.startCommitWithTime(commitTimestamps[i]);
+        WriteClientTestUtils.startCommitWithTime(client, commitTimestamps[i]);
         writeStatuses = client.bulkInsert(records, commitTimestamps[i]);
         assertNoWriteErrors(writeStatuses);
       }
@@ -2046,7 +2046,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int i = 0; i < maxDeltaCommitsBeforeCompaction - 2; ++i) {
         newCommitTime = client.createNewInstantTime();
         records = dataGen.generateInserts(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.insert(records, newCommitTime);
       }
 
@@ -2063,7 +2063,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Next commit will initiate a compaction
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 5);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.insert(records, newCommitTime);
       metadataTimeline = metadataMetaClient.reloadActiveTimeline();
       assertEquals(metadataTimeline.getCommitAndReplaceTimeline().filterCompletedInstants().countInstants(), 1);
@@ -2075,7 +2075,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int i = 0; i < maxDeltaCommitsBeforeCompaction + 1; ++i) {
         newCommitTime = client.createNewInstantTime();
         records = dataGen.generateInserts(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.insert(records, newCommitTime);
         if (i == 0) {
           // Mark this commit inflight so compactions don't take place
@@ -2097,7 +2097,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Next commit should lead to compaction
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 5);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.insert(records, newCommitTime);
 
       // Ensure compactions took place
@@ -2140,7 +2140,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (HoodieJavaWriteClient client = new HoodieJavaWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(records, commitTimestamp);
       client.commit(commitTimestamp, writeStatuses);
     }
@@ -2155,7 +2155,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (HoodieJavaWriteClient client = new HoodieJavaWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(records, commitTimestamp);
     }
 
@@ -2179,7 +2179,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (HoodieJavaWriteClient client = new HoodieJavaWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(records, commitTimestamp);
       assertNoWriteErrors(writeStatuses);
     }
@@ -2205,7 +2205,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
         true, Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       List<HoodieRecord> upsertRecords = new ArrayList<>();
       for (HoodieRecord entry : records) {
@@ -2219,7 +2219,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       validateMetadata(client);
 
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 20);
       writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
@@ -2260,7 +2260,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 1);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -2279,7 +2279,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 1);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
     }
@@ -2316,14 +2316,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
         true, Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
 
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 5);
       writeStatuses = client.bulkInsert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
@@ -2382,7 +2382,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime = "0000001";
       List<HoodieRecord> records = nonPartitionedGenerator.generateInserts(newCommitTime, 10);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.bulkInsert(records, newCommitTime);
       validateMetadata(client);
 
@@ -2404,7 +2404,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -2461,7 +2461,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         String newCommitTime = "00" + index;
         List<HoodieRecord> records = index == 0 ? dataGen.generateInsertsForPartition(newCommitTime, 10, partition)
             : dataGen.generateUniqueUpdates(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.upsert(records, newCommitTime);
       }
     }
@@ -2564,14 +2564,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert one batch 0000001
     String commitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> writeStatuses = client.insert(records, commitTime);
     assertNoWriteErrors(writeStatuses);
 
     // Insert second batch 0000002
     commitTime = "0000002";
     records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(records, commitTime);
     assertNoWriteErrors(writeStatuses);
 
@@ -2623,14 +2623,14 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert one batch 0000001
     String commitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> writeStatuses = client.insert(records, commitTime);
     assertNoWriteErrors(writeStatuses);
 
     // Insert second batch 0000002
     commitTime = "0000002";
     records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(records, commitTime);
     assertNoWriteErrors(writeStatuses);
 
@@ -2649,7 +2649,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     commitTime = "0000004";
     records = dataGen.generateInserts(commitTime, 100);
     client = getHoodieWriteClient(cfg);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(records, commitTime);
     assertNoWriteErrors(writeStatuses);
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
@@ -99,8 +99,7 @@ public abstract class HoodieFileGroupReaderOnJavaTestBase<T> extends TestHoodieF
     }
 
     try (HoodieJavaWriteClient writeClient = new HoodieJavaWriteClient(context, writeConfig)) {
-      String instantTime = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(instantTime);
+      String instantTime = writeClient.startCommit();
       // Make a copy of the records for writing. The writer will clear out the data field.
       List<HoodieRecord> recordsCopy = new ArrayList<>(recordList.size());
       recordList.forEach(hoodieRecord -> recordsCopy.add(new HoodieAvroRecord<>(hoodieRecord.getKey(), (HoodieRecordPayload) hoodieRecord.getData())));

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.action.commit;
 
 import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -129,7 +130,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     int startInstant = 1;
     String firstCommitTime = makeNewCommitTime(startInstant++, "%09d");
     HoodieJavaWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(firstCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, firstCommitTime);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     FileFormatUtils fileUtils = getFileUtilsInstance(metaClient);
 
@@ -190,7 +191,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
 
     String newCommitTime = makeNewCommitTime(startInstant++, "%09d");
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     List<WriteStatus> statuses = writeClient.upsert(updatedRecords, newCommitTime);
 
     allFiles = getIncrementalFiles(partitionPath, firstCommitTime, -1);
@@ -458,7 +459,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
         .withBulkInsertParallelism(2).withBulkInsertSortMode(bulkInsertMode).build();
     String instantTime = makeNewCommitTime();
     HoodieJavaWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(instantTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, instantTime);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieJavaCopyOnWriteTable table = (HoodieJavaCopyOnWriteTable) HoodieJavaTable.create(config, context, metaClient);
 
@@ -477,7 +478,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     int startInstant = 1;
     String firstCommitTime = makeNewCommitTime(startInstant++, "%09d");
     HoodieJavaWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(firstCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, firstCommitTime);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     FileFormatUtils fileUtils = getFileUtilsInstance(metaClient);
 
@@ -521,7 +522,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     }
 
     String newCommitTime = makeNewCommitTime(startInstant++, "%09d");
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     // Test delete two records
     List<HoodieKey> keysForDelete = new ArrayList(Arrays.asList(records.get(0).getKey(), records.get(2).getKey()));
@@ -538,7 +539,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     assertEquals(records.get(1).getRecordKey(), fileRecords.get(0).get("_row_key").toString());
 
     newCommitTime = makeNewCommitTime(startInstant++, "%09d");
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     // Test delete last record
     keysForDelete = new ArrayList(Arrays.asList(records.get(1).getKey()));

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestSchemaEvolutionClient.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestSchemaEvolutionClient.java
@@ -77,8 +77,7 @@ public class TestSchemaEvolutionClient extends HoodieJavaClientTestHarness {
   }
 
   private void prepareTable(HoodieJavaWriteClient<RawTripTestPayload> writeClient) throws IOException {
-    String commitTime = "1";
-    writeClient.startCommitWithTime(commitTime);
+    String commitTime = writeClient.startCommit();
     String jsonRow = "{\"_row_key\": \"1\", \"time\": \"2000-01-01T00:00:00.000Z\", \"number\": 1}";
     RawTripTestPayload payload = new RawTripTestPayload(jsonRow);
     HoodieAvroRecord<RawTripTestPayload> record = new HoodieAvroRecord<>(

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
@@ -19,6 +19,7 @@ package org.apache.hudi.testutils;
 
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -280,7 +281,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
 
   @Override
   protected List<WriteStatus> writeAndVerifyBatch(BaseHoodieWriteClient client, List<HoodieRecord> inserts, String commitTime, boolean populateMetaFields, boolean autoCommitOff) throws IOException {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> statusRDD = ((HoodieJavaWriteClient) client).upsert(inserts, commitTime);
     if (autoCommitOff) {
       client.commit(commitTime, statusRDD);
@@ -610,7 +611,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
           generateWrapRecordsFn(isPreppedAPI, writeConfig, dataGen::generateUniqueDeleteRecords);
 
       // Delete 1 (only deletes)
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> deleteRecords = recordGenFunction.apply(newCommitTime, numRecordsInThisCommit);
 
       Function3<List<WriteStatus>, HoodieJavaWriteClient, List<HoodieRecord>, String> deleteFn = HoodieJavaWriteClient::deletePrepped;
@@ -622,7 +623,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
           generateWrapDeleteKeysFn(isPreppedAPI, writeConfig, dataGen::generateUniqueDeletes);
 
       // Delete 1 (only deletes)
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieKey> deleteRecords = keyGenFunction.apply(numRecordsInThisCommit);
 
@@ -708,7 +709,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
                                              boolean assertForCommit, int expRecordsInThisCommit, int expTotalRecords,
                                              int expTotalCommits, boolean doCommit, boolean filterForCommitTimeWithAssert, InstantGenerator instantGenerator) throws IOException {
     // Write 1 (only inserts)
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<WriteStatus> result = writeFn.apply(client, records, newCommitTime);
     assertNoWriteErrors(result);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
@@ -105,7 +105,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -117,7 +117,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 2 (updates)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -130,7 +130,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 3 (updates)
        */
       newCommitTime = "003";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -157,7 +157,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 4 (updates)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -221,7 +221,7 @@ public class TestClientRollback extends HoodieClientTestBase {
   }
 
   private List<HoodieRecord> updateRecords(SparkRDDWriteClient client, List<HoodieRecord> records, String newCommitTime) throws IOException {
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> recs = dataGen.generateUpdates(newCommitTime, records);
     List<WriteStatus> statuses = client.upsert(jsc.parallelize(recs, 1), newCommitTime).collect();
     assertNoWriteErrors(statuses);
@@ -241,7 +241,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -286,7 +286,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -298,7 +298,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 2 (updates)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -311,7 +311,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 3 (updates)
        */
       newCommitTime = "003";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -338,7 +338,7 @@ public class TestClientRollback extends HoodieClientTestBase {
        * Write 4 (updates)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
@@ -657,7 +657,7 @@ public class TestClientRollback extends HoodieClientTestBase {
 
       final String commitTime4 = "20160506030621";
       try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-        client.startCommitWithTime(commitTime4);
+        WriteClientTestUtils.startCommitWithTime(client, commitTime4);
         // Check results, nothing changed
         assertTrue(testTable.commitExists(commitTime1));
         assertTrue(testTable.inflightCommitExists(commitTime2));
@@ -674,7 +674,7 @@ public class TestClientRollback extends HoodieClientTestBase {
           .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMetadataIndexColumnStats(false).build()).build();
       final String commitTime5 = "20160506030631";
       try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-        client.startCommitWithTime(commitTime5);
+        WriteClientTestUtils.startCommitWithTime(client, commitTime5);
         assertTrue(testTable.commitExists(commitTime1));
         assertFalse(testTable.inflightCommitExists(commitTime2));
         assertFalse(testTable.inflightCommitExists(commitTime3));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieSparkIndex.java
@@ -59,7 +59,7 @@ public class TestHoodieSparkIndex extends HoodieClientTestBase {
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
       String commitTime1 = "001";
-      client.startCommitWithTime(commitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime1);
       List<HoodieRecord> records1 = dataGen.generateInserts(commitTime1, 200);
       JavaRDD<HoodieRecord> writeRecords1 = jsc.parallelize(records1, 1);
       List<WriteStatus> statuses1 = client.upsert(writeRecords1, commitTime1).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
@@ -174,7 +174,7 @@ public class TestPartitionTTLManagement extends HoodieClientTestBase {
 
   private void writeRecordsForPartition(SparkRDDWriteClient client, HoodieTestDataGenerator dataGen, String partition, String instantTime) {
     List<HoodieRecord> records = dataGen.generateInsertsForPartition(instantTime, 10, partition);
-    client.startCommitWithTime(instantTime);
+    WriteClientTestUtils.startCommitWithTime(client, instantTime);
     JavaRDD writeStatuses = client.insert(jsc.parallelize(records, 1), instantTime);
     client.commit(instantTime, writeStatuses);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
@@ -83,14 +83,14 @@ public class TestSavepoint extends HoodieClientTestBase {
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
 
       String commitTime1 = "001";
-      client.startCommitWithTime(commitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime1);
       List<HoodieRecord> records1 = dataGen.generateInserts(commitTime1, 200);
       JavaRDD<HoodieRecord> writeRecords1 = jsc.parallelize(records1, 1);
       List<WriteStatus> statuses1 = client.upsert(writeRecords1, commitTime1).collect();
       assertNoWriteErrors(statuses1);
 
       String commitTime2 = "002";
-      client.startCommitWithTime(commitTime2);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime2);
       List<HoodieRecord> records2 = dataGen.generateInserts(commitTime2, 200);
       JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(records2, 1);
       List<WriteStatus> statuses2 = client.upsert(writeRecords2, commitTime2).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider.java
@@ -122,7 +122,7 @@ public class TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockPr
     final List<HoodieRecord> records1 = recordGenFunction1.apply(nextCommitTime1, 200);
     final JavaRDD<HoodieRecord> writeRecords1 = jsc.parallelize(records1, 1);
     // Finish first base commit
-    client1.startCommitWithTime(nextCommitTime1);
+    WriteClientTestUtils.startCommitWithTime(client1, nextCommitTime1);
     JavaRDD<WriteStatus> writeStatusList1 =  client1.insert(writeRecords1, nextCommitTime1);
     assertTrue(client1.commit(nextCommitTime1, writeStatusList1), "Commit should succeed");
 
@@ -136,7 +136,7 @@ public class TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockPr
     final List<HoodieRecord> records2 = recordGenFunction2.apply(nextCommitTime2, 200);
     final JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(records2, 1);
     // start to write commit 002
-    client2.startCommitWithTime(nextCommitTime2);
+    WriteClientTestUtils.startCommitWithTime(client2, nextCommitTime2);
     JavaRDD<WriteStatus> writeStatusList2 =  client2.upsert(writeRecords2, nextCommitTime2);
     assertNoWriteErrors(writeStatusList2.collect());
 
@@ -146,7 +146,7 @@ public class TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockPr
     assertThrows(SparkException.class, () -> {
       final List<HoodieRecord> records3 = recordGenFunction2.apply(nextCommitTime3, 200);
       final JavaRDD<HoodieRecord> writeRecords3 = jsc.parallelize(records3, 1);
-      client3.startCommitWithTime(nextCommitTime3);
+      WriteClientTestUtils.startCommitWithTime(client3, nextCommitTime3);
       JavaRDD<WriteStatus> writeStatusList3 =  client3.upsert(writeRecords3, nextCommitTime3);
       client3.commit(nextCommitTime3, writeStatusList3);
     }, "Early conflict detected but cannot resolve conflicts for overlapping writes");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
@@ -137,7 +137,7 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
     SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig);
     List<HoodieRecord> records = dataGen.generateInserts(instant1, 10);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 2);
-    writeClient.startCommitWithTime(instant1);
+    WriteClientTestUtils.startCommitWithTime(writeClient, instant1);
     List<WriteStatus> writeStatuses = writeClient.insert(writeRecords, instant1).collect();
     assertNoWriteErrors(writeStatuses);
     String metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(writeConfig.getBasePath());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieFileSystemViews.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieFileSystemViews.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.function.SerializableFunctionUnchecked;
@@ -281,7 +282,7 @@ public class TestHoodieFileSystemViews extends HoodieClientTestBase {
   }
 
   private void insertRecords(SparkRDDWriteClient client, String commitTime, int numRecords, WriteOperationType operationType) {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<HoodieRecord> inserts1 = dataGen.generateInserts(commitTime, numRecords);
     JavaRDD<HoodieRecord> insertRecordsRDD1 = jsc.parallelize(inserts1, 2);
     List<WriteStatus> statuses = operationType == WriteOperationType.BULK_INSERT ? client.bulkInsert(insertRecordsRDD1, commitTime, Option.empty()).collect() :
@@ -290,7 +291,7 @@ public class TestHoodieFileSystemViews extends HoodieClientTestBase {
   }
 
   private void upsertRecords(SparkRDDWriteClient client, String commitTime, int numRecords) {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<HoodieRecord> updates = dataGen.generateUniqueUpdates(commitTime, numRecords);
     JavaRDD<HoodieRecord> updatesRdd = jsc.parallelize(updates, 2);
     List<WriteStatus> statuses = client.upsert(updatesRdd, commitTime).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -235,7 +236,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
 
     // Insert totalRecords records
     String newCommitTime = writeClient.createNewInstantTime();
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatusRdd = writeClient.upsert(writtenRecords, newCommitTime);
     List<WriteStatus> writeStatuses = writeStatusRdd.collect();
     assertNoWriteErrors(writeStatuses);
@@ -300,7 +301,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     assertTrue(javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().isEmpty());
 
     // Insert totalRecords records
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
     assertNoWriteErrors(writeStatues.collect());
 
@@ -351,7 +352,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
 
     String newCommitTime = writeClient.createNewInstantTime();
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
     JavaRDD<HoodieRecord> javaRDD1 = tagLocation(index, writeRecords, hoodieTable);
 
@@ -592,7 +593,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String newCommitTime = writeClient.createNewInstantTime();
     List<HoodieRecord> records = getInserts();
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
     assertNoWriteErrors(writeStatues.collect());
     writeClient.commit(newCommitTime, writeStatues);
@@ -626,7 +627,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     final int numDeletes = records.size() / 2;
     List<HoodieKey> keysToDelete = records.stream().limit(numDeletes).map(r -> new HoodieKey(r.getRecordKey(), r.getPartitionPath())).collect(Collectors.toList());
     String deleteCommitTime = writeClient.createNewInstantTime();
-    writeClient.startCommitWithTime(deleteCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, deleteCommitTime);
     writeStatues = writeClient.delete(jsc.parallelize(keysToDelete, 1), deleteCommitTime);
     assertNoWriteErrors(writeStatues.collect());
     writeClient.commit(deleteCommitTime, writeStatues);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestRDDSimpleBucketBulkInsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestRDDSimpleBucketBulkInsertPartitioner.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -111,12 +112,12 @@ public class TestRDDSimpleBucketBulkInsertPartitioner extends HoodieSparkClientT
     }
 
     // 1st write, will create new bucket files based on the records
-    getHoodieWriteClient(config).startCommitWithTime("0");
+    WriteClientTestUtils.startCommitWithTime(getHoodieWriteClient(config), "0");
     List<WriteStatus> writeStatuses = getHoodieWriteClient(config).bulkInsert(HoodieJavaRDD.getJavaRDD(javaRDD), "0").collect();
     Map<String, WriteStatus> writeStatusesMap = new HashMap<>();
     writeStatuses.forEach(ws -> writeStatusesMap.put(ws.getFileId(), ws));
 
-    getHoodieWriteClient(config).startCommitWithTime("1");
+    WriteClientTestUtils.startCommitWithTime(getHoodieWriteClient(config),"1");
     // 2nd write of the same records, all records should be mapped to the same bucket files for MOR,
     // for COW with disabled Spark native row writer, 2nd bulk insert should fail with exception
     try {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBloomIndexTagWithColStats.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBloomIndexTagWithColStats.java
@@ -20,6 +20,7 @@
 
 package org.apache.hudi.index.bloom;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.functional.TestHoodieMetadataBase;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -150,7 +151,7 @@ public class TestBloomIndexTagWithColStats extends TestHoodieMetadataBase {
     // Should not find any files
     assertFalse(taggedRecordRDD.first().isCurrentLocationKnown());
 
-    writeClient.startCommitWithTime("001");
+    WriteClientTestUtils.startCommitWithTime(writeClient, "001");
     JavaRDD<WriteStatus> status = writeClient.upsert(taggedRecordRDD, "001");
     String fileId = status.first().getFileId();
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestSparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestSparkHoodieHBaseIndex.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.index.hbase;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -176,7 +177,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
       assertEquals(0, records1.filter(record -> record.isCurrentLocationKnown()).count());
 
       // Insert 200 records
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
       assertNoWriteErrors(writeStatues.collect());
 
@@ -242,7 +243,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
 
     HoodieWriteConfig config = getConfigBuilder(100, false, false).build();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(oldWriteRecords, newCommitTime);
     writeClient.commit(newCommitTime, writeStatues);
     assertNoWriteErrors(writeStatues.collect());
@@ -253,7 +254,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
     assertEquals(numRecords, notAllowPathChangeRecords.stream().count());
 
     String newCommitTime1 = "002";
-    writeClient.startCommitWithTime(newCommitTime1);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime1);
     JavaRDD<WriteStatus> writeStatues1 = writeClient.upsert(newWriteRecords, newCommitTime1);
     writeClient.commit(newCommitTime1, writeStatues1);
     assertNoWriteErrors(writeStatues1.collect());
@@ -280,7 +281,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
 
     HoodieWriteConfig config = getConfigBuilder(100, true, false).build();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(oldWriteRecords, newCommitTime);
     writeClient.commit(newCommitTime, writeStatues);
     assertNoWriteErrors(writeStatues.collect());
@@ -292,7 +293,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
     assertEquals(numRecords, pathChangeRecords.stream().filter(HoodieRecord::isCurrentLocationKnown).count());
 
     String newCommitTime1 = "002";
-    writeClient.startCommitWithTime(newCommitTime1);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime1);
     JavaRDD<WriteStatus> writeStatues1 = writeClient.upsert(newWriteRecords, newCommitTime1);
     writeClient.commit(newCommitTime1, writeStatues1);
     assertNoWriteErrors(writeStatues1.collect());
@@ -315,7 +316,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
     HoodieWriteConfig config = getConfig();
     SparkHoodieHBaseIndex index = new SparkHoodieHBaseIndex(config);
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       metaClient = HoodieTableMetaClient.reload(metaClient);
       HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
 
@@ -780,7 +781,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
       JavaRDD<HoodieRecord> records1 = tagLocation(index, writeRecords, hoodieTable);
       assertEquals(0, records1.filter(record -> record.isCurrentLocationKnown()).count());
       // Insert 200 records
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
       assertNoWriteErrors(writeStatues.collect());
 
@@ -821,7 +822,7 @@ public class TestSparkHoodieHBaseIndex extends SparkClientFunctionalTestHarness 
       assertEquals(0, records1.filter(record -> record.isCurrentLocationKnown()).count());
 
       // Insert records
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
       assertNoWriteErrors(writeStatues.collect());
       writeClient.commit(newCommitTime, writeStatues);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -104,7 +105,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
        * each. id1 (21 records), id2 (21 records), id3, id4
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 4);
       HoodieRecord record1 = records.get(0);
       HoodieRecord record2 = records.get(1);
@@ -136,7 +137,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
        * records), id3, id4 File 2 - id1
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       // Do 1 more bulk insert with the same dup record1
       List<HoodieRecord> newRecords = new ArrayList<>();
@@ -160,7 +161,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
        * id6
        */
       newCommitTime = "003";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       newRecords = dataGen.generateInserts(newCommitTime, 2);
       writeRecords = jsc.parallelize(newRecords, 1);
       statuses = client.bulkInsert(writeRecords, newCommitTime).collect();
@@ -181,7 +182,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
        * records in File 1, File 2 and File 3 must be updated.
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> updateRecords = new ArrayList<>();
 
       // This exists in 001 and 002 and should be updated in both
@@ -266,7 +267,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
         .build();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config);) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
@@ -290,7 +291,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
       metaClient = HoodieTableMetaClient.reload(metaClient);
 
       newCommitTime = "101";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> updatedRecords = dataGen.generateUpdates(newCommitTime, records);
       JavaRDD<HoodieRecord> updatedRecordsRDD = jsc.parallelize(updatedRecords, 1);
@@ -311,7 +312,7 @@ public class TestHoodieMergeHandle extends HoodieSparkClientTestHarness {
           (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get());
 
       newCommitTime = "102";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> allRecords = dataGen.generateInserts(newCommitTime, 100);
       allRecords.addAll(updatedRecords);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergedReadHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergedReadHandle.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
@@ -102,27 +103,27 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       // 1st batch: inserts
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
       List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, partition, 0, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch0);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch0);
       assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 0, payloadClass);
 
       // 2nd batch: normal updates
       String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
       List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch5);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch5);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 3rd batch: delete the record with id 3 (the last one)
       String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
-      client.startCommitWithTime(commitTimeAtEpoch6);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch6);
       List<HoodieRecord> deletesAtEpoch6 = getDeletes(updatesAtEpoch5.subList(totalRecords - 1, totalRecords), 6, payloadClass);
       assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch6, 1), commitTimeAtEpoch6).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords - 1, partition, 5, payloadClass);
 
       // 4th batch: delete the record with id 2 (the 2nd last one) using EmptyHoodieRecordPayload
       String commitTimeAtEpoch7 = getCommitTimeAtUTC(7);
-      client.startCommitWithTime(commitTimeAtEpoch7);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch7);
       List<HoodieRecord> deletesAtEpoch7 = getDeletesWithEmptyPayload(updatesAtEpoch5.subList(totalRecords - 2, totalRecords - 1));
       assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch7, 1), commitTimeAtEpoch7).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords - 2, partition, 5, payloadClass);
@@ -130,7 +131,7 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       // 5th batch: normal updates
       String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
       List<HoodieRecord> updatesAtEpoch9 = getUpdates(updatesAtEpoch5, 9, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch9);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 9, payloadClass);
     }
@@ -161,28 +162,28 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       // 1st batch: inserts
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
       List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, partition, 0, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch0);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch0);
       assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 0, payloadClass);
 
       // 2nd batch: normal updates
       String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
       List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch5);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch5);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 3rd batch: updates with old timestamp will be discarded
       String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
       List<HoodieRecord> updatesAtEpoch1 = getUpdates(insertsAtEpoch0, 1, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch6);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch6);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch1, 1), commitTimeAtEpoch6).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 4th batch: normal updates
       String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
       List<HoodieRecord> updatesAtEpoch9 = getUpdates(updatesAtEpoch5, 9, payloadClass);
-      client.startCommitWithTime(commitTimeAtEpoch9);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 9, payloadClass);
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieSliceInfo;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.timeline.versioning.v2.TimelineArchiverV2;
@@ -316,7 +317,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
           earliestInstantToRetain = instantTime;
         }
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(instantTime, 1, partition1);
-        client.startCommitWithTime(instantTime);
+        WriteClientTestUtils.startCommitWithTime(client, instantTime);
         client.insert(jsc.parallelize(records, 1), instantTime).collect();
       }
 
@@ -333,7 +334,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
 
       instantTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInsertsForPartition(instantTime, 1, partition1);
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
       client.insert(recordsRDD, instantTime).collect();
 
@@ -344,7 +345,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       JavaRDD<HoodieRecord> updatedRecordsRDD = jsc.parallelize(updatedRecords, 1);
       SparkRDDReadClient readClient = new SparkRDDReadClient(context, writeConfig);
       JavaRDD<HoodieRecord> updatedTaggedRecordsRDD = readClient.tagLocation(updatedRecordsRDD);
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
       client.upsertPreppedRecords(updatedTaggedRecordsRDD, instantTime).collect();
 
       table.getMetaClient().reloadActiveTimeline();
@@ -354,7 +355,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       for (int idx = 0; idx < 3; ++idx) {
         instantTime = client.createNewInstantTime();
         records = dataGen.generateInsertsForPartition(instantTime, 1, partition2);
-        client.startCommitWithTime(instantTime);
+        WriteClientTestUtils.startCommitWithTime(client, instantTime);
         client.insert(jsc.parallelize(records, 1), instantTime).collect();
       }
 
@@ -392,7 +393,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       for (int idx = 0; idx < 3; ++idx) {
         instantTime = client.createNewInstantTime();
         List<HoodieRecord> records = dataGen.generateInserts(instantTime, 1);
-        client.startCommitWithTime(instantTime);
+        WriteClientTestUtils.startCommitWithTime(client, instantTime);
         client.insert(jsc.parallelize(records, 1), instantTime).collect();
       }
 
@@ -440,7 +441,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       for (; index < 3; ++index) {
         String newCommitTime = "00" + index;
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 1, partition);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       }
     }
@@ -456,7 +457,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       // Next commit. This is required so that there is an additional file version to clean.
       String newCommitTime = "00" + index++;
       List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 1, partition);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
 
       // Try to schedule another clean

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByCommits.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByCommits.java
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.model.HoodieCleaningPolicy.KEEP_LATEST_COMMITS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
-import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.table.TestCleaner.insertFirstBigBatchForClientCleanerTest;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.apache.hudi.testutils.HoodieClientTestBase.Function2;
@@ -150,8 +149,7 @@ public class TestCleanerInsertAndCleanByCommits extends SparkClientFunctionalTes
       Map<String, List<HoodieWriteStat>> commitWriteStatsMap = new HashMap<>();
       // Keep doing some writes and clean inline. Make sure we have expected number of files remaining.
       for (int i = 0; i < 8; i++) {
-        String newCommitTime = makeNewCommitTime();
-        client.startCommitWithTime(newCommitTime);
+        String newCommitTime = client.startCommit();
         List<HoodieRecord> records = recordUpsertGenWrappedFunction.apply(newCommitTime, BATCH_SIZE);
 
         List<WriteStatus> statuses = upsertFn.apply(client, jsc().parallelize(records, PARALLELISM), newCommitTime).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.action.clean;
 
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.fs.FSUtils;
@@ -174,7 +175,7 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
       // Keep doing some writes and clean inline. Make sure we have expected number of files
       // remaining.
       for (String newInstantTime : instantTimes) {
-        client.startCommitWithTime(newInstantTime);
+        WriteClientTestUtils.startCommitWithTime(client, newInstantTime);
         List<HoodieRecord> records = recordUpsertGenWrappedFunction.apply(newInstantTime, BATCH_SIZE);
 
         List<WriteStatus> statuses = upsertFn.apply(client, jsc().parallelize(records, PARALLELISM), newInstantTime).collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/TestIncrementalClustering.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/TestIncrementalClustering.java
@@ -203,8 +203,7 @@ public class TestIncrementalClustering extends SparkClientFunctionalTestHarness 
     SparkRDDWriteClient client = getHoodieWriteClient(writeConfig);
     HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(partitions);
     for (int i = 0; i < partitions.length; i++) {
-      String instantTime = client.createNewInstantTime();
-      client.startCommitWithTime(instantTime);
+      String instantTime = client.startCommit();
       client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime, 10, partitions[i]), 1), instantTime);
     }
     client.close();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -171,9 +171,8 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
     // Prepare the AvroParquetIO
     HoodieWriteConfig config = makeHoodieClientConfigBuilder()
         .withProps(makeIndexConfig(indexType)).build();
-    String firstCommitTime = makeNewCommitTime();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(firstCommitTime);
+    String firstCommitTime = writeClient.startCommit();
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
     String partitionPath = "2016/01/31";
@@ -237,9 +236,8 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
     List<HoodieRecord> updatedRecords = Arrays.asList(updatedRecord1, insertedRecord1);
 
     Thread.sleep(1000);
-    String newCommitTime = makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    writeClient.startCommitWithTime(newCommitTime);
+    String newCommitTime = writeClient.startCommit();
     List<WriteStatus> statuses = writeClient.upsert(jsc.parallelize(updatedRecords), newCommitTime).collect();
 
     allFiles = getIncrementalFiles(partitionPath, firstCommitTime, -1);
@@ -505,9 +503,8 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
         .withBulkInsertParallelism(2).withBulkInsertSortMode(bulkInsertMode).build();
-    String instantTime = makeNewCommitTime();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(instantTime);
+    String instantTime = writeClient.startCommit();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
 
@@ -545,9 +542,8 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
       assertTrue(table.getPartitionMetafileFormat().isPresent());
     }
 
-    String instantTime = makeNewCommitTime();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
-    writeClient.startCommitWithTime(instantTime);
+    String instantTime = writeClient.startCommit();
 
     // Insert new records
     final JavaRDD<HoodieRecord> inputRecords = generateTestRecordsForBulkInsert(jsc, 50);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.model.HoodieCompactionOperation;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -130,7 +131,7 @@ public class CompactionTestBase extends HoodieClientTestBase {
       String firstInstant = deltaInstants.get(0);
       deltaInstants = deltaInstants.subList(1, deltaInstants.size());
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-      client.startCommitWithTime(firstInstant);
+      WriteClientTestUtils.startCommitWithTime(client, firstInstant);
       JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, firstInstant);
       List<WriteStatus> statusList = statuses.collect();
 
@@ -260,7 +261,7 @@ public class CompactionTestBase extends HoodieClientTestBase {
                                                     HoodieTableMetaClient metaClient, HoodieWriteConfig cfg, boolean skipCommit) {
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
 
-    client.startCommitWithTime(instantTime);
+    WriteClientTestUtils.startCommitWithTime(client, instantTime);
 
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, instantTime);
     List<WriteStatus> statusList = statuses.collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
@@ -63,7 +63,7 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
      * Write 1 (only inserts)
      */
     String newCommitTime = "001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
@@ -74,7 +74,7 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
      * Write 2 (updates)
      */
     newCommitTime = "002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateUpdates(newCommitTime, records);
     statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime);
     Assertions.assertNoWriteErrors(statuses.collect());
@@ -122,7 +122,7 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
     String newCommitTime = "001";
     List<HoodieRecord> records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
     Assertions.assertNoWriteErrors(statuses.collect());
     client.commit(newCommitTime, statuses);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieRollbackRequest;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.HoodieRollbackStat;
@@ -67,8 +68,8 @@ import java.util.stream.IntStream;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -174,14 +175,14 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
 
     String newCommitTime = "001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 3);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
     Assertions.assertNoWriteErrors(statuses.collect());
 
     newCommitTime = "002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateUpdates(newCommitTime, records);
     statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime);
     Assertions.assertNoWriteErrors(statuses.collect());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
@@ -63,14 +63,11 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
          HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(DEFAULT_PARTITION_PATHS)) {
 
       // 1st write batch; 3 commits for 3 partitions
-      String instantTime1 = client.createNewInstantTime();
-      client.startCommitWithTime(instantTime1);
+      String instantTime1 = client.startCommit();
       client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime1, 10, DEFAULT_FIRST_PARTITION_PATH), 1), instantTime1);
-      String instantTime2 = client.createNewInstantTime();
-      client.startCommitWithTime(instantTime2);
+      String instantTime2 = client.startCommit();
       client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime2, 10, DEFAULT_SECOND_PARTITION_PATH), 1), instantTime2);
-      String instantTime3 = client.createNewInstantTime();
-      client.startCommitWithTime(instantTime3);
+      String instantTime3 = client.startCommit();
       client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime3, 1, DEFAULT_THIRD_PARTITION_PATH), 1), instantTime3);
 
       final HoodieTimeline timeline1 = metaClient.getCommitsTimeline().filterCompletedInstants();
@@ -82,8 +79,7 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
 
       // 2nd write batch; 6 commits for the 4th partition; the 6th commit to trigger archiving the replace commit
       for (int i = 5; i < 11; i++) {
-        String instantTime = client.createNewInstantTime();
-        client.startCommitWithTime(instantTime);
+        String instantTime = client.startCommit();
         client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime, 1, DEFAULT_THIRD_PARTITION_PATH), 1), instantTime);
       }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.model.HoodieInstantInfo;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.avro.model.HoodieRollbackRequest;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
@@ -43,9 +44,9 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.table.action.rollback.RollbackHelper;
 import org.apache.hudi.table.action.rollback.MarkerBasedRollbackStrategy;
 import org.apache.hudi.table.action.rollback.MergeOnReadRollbackActionExecutor;
+import org.apache.hudi.table.action.rollback.RollbackHelper;
 import org.apache.hudi.table.marker.DirectWriteMarkers;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable;
@@ -237,7 +238,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
 
   private List<HoodieRollbackStat> testInsertAndRollback(SparkRDDWriteClient writeClient) {
     String newCommitTime = "001";
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
     JavaRDD<WriteStatus> writeStatuses = writeClient.insert(jsc.parallelize(records, 1), newCommitTime);
@@ -258,7 +259,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
 
   private List<HoodieRollbackStat> testUpdateAndRollback(boolean useFileListingMetadata, HoodieWriteConfig writeConfig, SparkRDDWriteClient writeClient) {
     String newCommitTime = "001";
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
     JavaRDD<WriteStatus> writeStatuses = writeClient.insert(jsc.parallelize(records, 1), newCommitTime);
@@ -266,7 +267,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
 
     // Updates
     newCommitTime = "002";
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     records = dataGen.generateUniqueUpdates(newCommitTime, 50);
     writeStatuses = writeClient.upsert(jsc.parallelize(records, 1), newCommitTime);
     writeStatuses.collect();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.upgrade;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -462,7 +463,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
   private void doInsert(SparkRDDWriteClient client) {
     // Write 1 (only inserts)
     String commit1 = "000";
-    client.startCommitWithTime(commit1);
+    WriteClientTestUtils.startCommitWithTime(client, commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     client.insert(writeRecords, commit1).collect();
@@ -472,7 +473,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     // Write 1 (only inserts)
     dataGen = new HoodieTestDataGenerator(new String[] {DEPRECATED_DEFAULT_PARTITION_PATH});
     String commit1 = "005";
-    client.startCommitWithTime(commit1);
+    WriteClientTestUtils.startCommitWithTime(client, commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     client.insert(writeRecords, commit1).collect();
@@ -482,7 +483,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     // Write 1 (only inserts)
     dataGen = new HoodieTestDataGenerator(new String[] {"partition_path=" + DEPRECATED_DEFAULT_PARTITION_PATH});
     String commit1 = "005";
-    client.startCommitWithTime(commit1);
+    WriteClientTestUtils.startCommitWithTime(client, commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     client.insert(writeRecords, commit1).collect();
@@ -811,7 +812,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     HoodieWriteConfig cfg = getConfigBuilder().withAutoCommit(false).withRollbackUsingMarkers(enableMarkedBasedRollback).withProps(params).build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
 
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<HoodieRecord> records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -875,7 +876,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
      * Write 1 (only inserts)
      */
     String newCommitTime = "001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGen.generateInsertsContainsAllPartitions(newCommitTime, 2);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
@@ -885,7 +886,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
      * Write 2 (updates)
      */
     newCommitTime = "002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     List<HoodieRecord> records2 = dataGen.generateUpdates(newCommitTime, records);
     statuses = client.upsert(jsc.parallelize(records2, 1), newCommitTime);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.testutils;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.HoodieCleanStat;
@@ -375,7 +376,7 @@ public class HoodieClientTestBase extends HoodieSparkClientTestHarness {
           generateWrapRecordsFn(isPreppedAPI, writeConfig, dataGen::generateUniqueDeleteRecords);
 
       // Delete 1 (only deletes)
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = recordGenFunction.apply(newCommitTime, numRecordsInThisCommit);
       JavaRDD<HoodieRecord> deleteRecords = jsc.parallelize(records, 1);
 
@@ -388,7 +389,7 @@ public class HoodieClientTestBase extends HoodieSparkClientTestHarness {
           generateWrapDeleteKeysFn(isPreppedAPI, writeConfig, dataGen::generateUniqueDeletes);
 
       // Delete 1 (only deletes)
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieKey> keysToDelete = keyGenFunction.apply(numRecordsInThisCommit);
       JavaRDD<HoodieKey> deleteRecords = jsc.parallelize(keysToDelete, 1);
@@ -477,7 +478,7 @@ public class HoodieClientTestBase extends HoodieSparkClientTestHarness {
                                                 int expTotalCommits, boolean doCommit, boolean filterForCommitTimeWithAssert,
                                                 InstantGenerator instantGenerator) throws IOException {
     // Write 1 (only inserts)
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
 
@@ -596,7 +597,7 @@ public class HoodieClientTestBase extends HoodieSparkClientTestHarness {
         .build();
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
@@ -621,7 +622,7 @@ public class HoodieClientTestBase extends HoodieSparkClientTestHarness {
         .build();
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateUpdates(newCommitTime, baseRecordsToUpdate);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
       client.upsert(writeRecords, newCommitTime);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
@@ -25,6 +25,7 @@ import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.SparkTaskContextSupplier;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.HoodieCleanStat;
@@ -479,7 +480,7 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
 
   @Override
   protected List<WriteStatus> writeAndVerifyBatch(BaseHoodieWriteClient client, List<HoodieRecord> inserts, String commitTime, boolean populateMetaFields, boolean autoCommitOff) {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     JavaRDD<HoodieRecord> insertRecordsRDD1 = jsc.parallelize(inserts, 2);
     JavaRDD<WriteStatus> statusRDD = ((SparkRDDWriteClient) client).upsert(insertRecordsRDD1, commitTime);
     if (autoCommitOff) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
@@ -20,6 +20,7 @@
 package org.apache.hudi;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -155,7 +156,7 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
     List<HoodieRecord> recordList = str2HoodieRecord(records);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(recordList, 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses = client.upsert(writeRecords, instant).collect();
     assertNoWriteErrors(writeStatuses);
     metaClient = HoodieTableMetaClient.reload(metaClient);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
@@ -21,6 +21,7 @@
 package org.apache.hudi;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -262,7 +263,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
 
       // (1) Write: insert.
       String instantTime = "001";
-      writeClient.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instantTime);
       List<HoodieRecord> records = generateRecords(100, instantTime);
       Stream<HoodieBaseFile> baseFileStream = insertRecordsToMORTable(reloadedMetaClient, records, writeClient, writeConfig, instantTime);
       assertTrue(baseFileStream.findAny().isPresent());
@@ -285,7 +286,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
 
       // (2) Write: append.
       instantTime = "002";
-      writeClient.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instantTime);
 
       List<HoodieRecord> records2 = generateEmptyRecords(getKeys(records).subList(0, 17)); // 17 records with old keys.
       List<HoodieRecord> records3 = generateRecordUpdates(getKeys(records).subList(17, 36), "001"); // 19 update records.
@@ -313,7 +314,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
 
       // (3) Write: append, generate the log file.
       instantTime = "003";
-      writeClient.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instantTime);
 
       List<HoodieRecord> records5 = generateEmptyRecords(getKeys(records).subList(50, 59)); // 9 deletes only
       assertEquals(9, records5.size());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestMetadataTableSupport.java
@@ -20,6 +20,7 @@
 package org.apache.hudi;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -66,7 +67,7 @@ class TestMetadataTableSupport extends HoodieSparkClientTestBase {
       List<HoodieRecord> records0 = dataGen.generateInserts(timestamp0, 100);
       JavaRDD<HoodieRecord> dataset0 = jsc.parallelize(records0, 2);
 
-      writeClient.startCommitWithTime(timestamp0);
+      WriteClientTestUtils.startCommitWithTime(writeClient, timestamp0);
       writeClient.insert(dataset0, timestamp0).collect();
 
       // Confirm MDT enabled.

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -309,7 +309,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
       final SparkRDDWriteClient client22 = getHoodieWriteClient(writeConfig22);
       JavaRDD<HoodieRecord> emptyRDD = jsc.emptyRDD();
       // Perform upsert with empty RDD
-      client22.startCommitWithTime("0013");
+      WriteClientTestUtils.startCommitWithTime(client22, "0013");
       JavaRDD<WriteStatus> writeStatusRDD = client22.upsert(emptyRDD, "0013");
       client22.commit("0013", writeStatusRDD);
       totalCommits += 1;
@@ -1301,7 +1301,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
   private void ingestBatch(Function3<JavaRDD<WriteStatus>, SparkRDDWriteClient, JavaRDD<HoodieRecord>, String> writeFn,
                            SparkRDDWriteClient writeClient, String commitTime, JavaRDD<HoodieRecord> records,
                            CountDownLatch countDownLatch) throws IOException, InterruptedException {
-    writeClient.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
     countDownLatch.countDown();
     countDownLatch.await();
     JavaRDD<WriteStatus> statusJavaRDD = writeFn.apply(writeClient, records, commitTime);
@@ -1362,7 +1362,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
   private JavaRDD<WriteStatus> startCommitForUpdate(HoodieWriteConfig writeConfig, SparkRDDWriteClient writeClient,
                                                     String newCommitTime, int numRecords) throws Exception {
     // Start the new commit
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     // Prepare update records
     final Function2<List<HoodieRecord>, String, Integer> recordGenFunction =

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestConsistentBucketIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestConsistentBucketIndex.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
@@ -261,7 +262,7 @@ public class TestConsistentBucketIndex extends HoodieSparkClientTestHarness {
 
   private List<WriteStatus> writeData(JavaRDD<HoodieRecord> records, String commitTime, WriteOperationType op, boolean doCommit) {
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    writeClient.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
     List<WriteStatus> writeStatues;
     switch (op) {
       case UPSERT:

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
@@ -197,7 +198,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
 
   private boolean writeOnMainTable(TestTableContents mainTable, int curr) throws IOException {
     String commitTime = mainTable.client.createNewInstantTime();
-    mainTable.client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(mainTable.client, commitTime);
 
     int actionType = pickAWriteAction();
     JavaRDD<WriteStatus> result;
@@ -234,7 +235,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
 
   private void writeOnExperimentTable(TestTableContents mainTable, TestTableContents experimentTable) throws IOException {
     String commitTime = mainTable.commitTimeOnMainTable;
-    experimentTable.client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(experimentTable.client, commitTime);
     int actionType = mainTable.previousActionType;
     JavaRDD<WriteStatus> result;
     if (actionType == 0) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -24,6 +24,7 @@ import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
@@ -281,13 +282,13 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Insert
       String commitTime = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(commitTime, 20);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
 
       // Upsert
       commitTime = "0000002";
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       records = dataGen.generateUniqueUpdates(commitTime, 10);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -313,7 +314,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, cfgWithColStatsEnabled)) {
       // Upsert
       String commitTime = "0000003";
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<HoodieRecord> records = dataGen.generateUniqueUpdates(commitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -340,7 +341,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, cfgWithColStatsDisabled)) {
       // Upsert
       String commitTime = "0000004";
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<HoodieRecord> records = dataGen.generateUniqueUpdates(commitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -366,7 +367,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, cfgWithBloomFilterEnabled)) {
       // Upsert
       String commitTime = "0000005";
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<HoodieRecord> records = dataGen.generateUniqueUpdates(commitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -389,7 +390,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, cfgWithMetadataDisabled)) {
       // Upsert
       String commitTime = "0000006";
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<HoodieRecord> records = dataGen.generateUniqueUpdates(commitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -777,14 +778,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
 
       // Write 2 (upserts)
       newCommitTime = "0000002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       validateMetadata(client);
 
       records = dataGen.generateInserts(newCommitTime, 10);
@@ -1087,19 +1088,19 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime1 = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime1, 100);
-      client.startCommitWithTime(newCommitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime1);
       JavaRDD writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime1);
       client.commit(newCommitTime1, writeStatuses);
 
       String newCommitTime2 = "0000002";
       records = dataGen.generateUniqueUpdates(newCommitTime2, 20);
-      client.startCommitWithTime(newCommitTime2);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime2);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime2);
       client.commit(newCommitTime2, writeStatuses);
 
       String newCommitTime3 = "0000003";
       records = dataGen.generateUniqueUpdates(newCommitTime3, 20);
-      client.startCommitWithTime(newCommitTime3);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime3);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime3);
       client.commit(newCommitTime3, writeStatuses);
 
@@ -1115,7 +1116,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // re-ingest w/ same commit time.
       records = dataGen.generateUniqueUpdates(newCommitTime3, 20);
-      client.startCommitWithTime(newCommitTime3);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime3);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime3);
       client.commit(newCommitTime3, writeStatuses);
 
@@ -1155,7 +1156,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     String newCommitTime1 = "20230809230000000";
     List<HoodieRecord> records1 = dataGen.generateInserts(newCommitTime1, 100);
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
-      client.startCommitWithTime(newCommitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime1);
       JavaRDD writeStatuses = client.insert(jsc.parallelize(records1, 1), newCommitTime1);
       client.commit(newCommitTime1, writeStatuses);
     }
@@ -1168,7 +1169,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     String newCommitTime2 = "20230809232000000";
     List<HoodieRecord> records2 = dataGen.generateInserts(newCommitTime2, 20);
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
-      client.startCommitWithTime(newCommitTime2);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime2);
       JavaRDD writeStatuses = client.insert(jsc.parallelize(records2, 1), newCommitTime2);
       client.commit(newCommitTime2, writeStatuses);
     }
@@ -1745,7 +1746,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses =
           client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -1793,7 +1794,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
 
@@ -1828,7 +1829,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1
       String commitTime = "0000001";
       List<HoodieRecord> records = dataGen.generateInserts(commitTime, 20);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -1839,7 +1840,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 2
       commitTime = "0000002";
       records = dataGen.generateInserts(commitTime, 10);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -1937,13 +1938,13 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
               new HoodieAvroRecord(new HoodieKey("key1_" + counter.getAndIncrement(), entry.getPartitionPath()), (HoodieRecordPayload) entry.getData()))
           .collect(Collectors.toList());
 
-      client.startCommitWithTime(firstCommit);
+      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(processedRecords, 1), firstCommit).collect();
       assertNoWriteErrors(writeStatuses);
 
       // Write 2 (inserts)
       String secondCommit = "0000002";
-      client.startCommitWithTime(secondCommit);
+      WriteClientTestUtils.startCommitWithTime(client, secondCommit);
       records = dataGen.generateInserts(secondCommit, 20);
       AtomicInteger counter1 = new AtomicInteger();
       processedRecords = records.stream().map(entry ->
@@ -2038,14 +2039,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String commit1 = client.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 20);
-    client.startCommitWithTime(commit1);
+    WriteClientTestUtils.startCommitWithTime(client, commit1);
     List<WriteStatus> writeStatuses =
         client.bulkInsert(jsc.parallelize(records, 1), commit1).collect();
     assertNoWriteErrors(writeStatuses);
 
     // Write 2 (inserts)
     String commit2 = client.createNewInstantTime();
-    client.startCommitWithTime(commit2);
+    WriteClientTestUtils.startCommitWithTime(client, commit2);
     records = dataGen.generateInserts(commit2, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), commit2).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2060,7 +2061,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     client.close();
     client = new SparkRDDWriteClient(engineContext, writeConfig);
     String commit3 = client.createNewInstantTime();
-    client.startCommitWithTime(commit3);
+    WriteClientTestUtils.startCommitWithTime(client, commit3);
     records = dataGen.generateUniqueUpdates(commit3, 10);
     writeStatuses = client.upsert(jsc.parallelize(records, 1), commit3).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2107,14 +2108,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 20);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
 
       // Write 2 (inserts)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       validateMetadata(client);
 
       records = dataGen.generateInserts(newCommitTime, 20);
@@ -2124,14 +2125,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // Write 3 (updates)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUniqueUpdates(newCommitTime, 10);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
 
       // Write 4 (updates and inserts)
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 10);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2148,7 +2149,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 5 (updates and inserts)
       newCommitTime = client.createNewInstantTime();
       instantToRestore = newCommitTime;
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 5);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2168,7 +2169,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // upserts
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 5);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2208,7 +2209,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, writeConfig);
     String initialCommit = "0000000";
     List<HoodieRecord> initialRecords = dataGen.generateInserts(initialCommit, 100);
-    writeClient.startCommitWithTime(initialCommit);
+    WriteClientTestUtils.startCommitWithTime(writeClient, initialCommit);
     List<WriteStatus> initialWriteStatuses = writeClient.insert(jsc.parallelize(initialRecords, 1), initialCommit).collect();
     assertNoWriteErrors(initialWriteStatuses);
     writeClient.close();
@@ -2228,7 +2229,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       Future future = executors.submit(() -> {
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 100, dataGen.getPartitionPaths()[index]);
         SparkRDDWriteClient localWriteClient = writeClients[index];
-        writeClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
         List<WriteStatus> writeStatuses = localWriteClient.insert(jsc.parallelize(records, 1), newCommitTime).collect();
         assertNoWriteErrors(writeStatuses);
       });
@@ -2285,7 +2286,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int j = 0; j < 6; j++) {
         String newCommitTime = writeClient.createNewInstantTime();
         List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 100, partitionPath);
-        writeClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
         JavaRDD writeStatuses = writeClient.insert(jsc.parallelize(records, 1), newCommitTime);
         writeClient.commit(newCommitTime, writeStatuses);
       }
@@ -2322,14 +2323,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String newCommitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
     validateMetadata(client);
 
     // Write 2 (inserts)
     newCommitTime = "0000002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2359,7 +2360,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     // trigger new write to mimic other writes succeeding before re-attempt.
     newCommitTime = "0000003";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2395,14 +2396,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Write 1 (Bulk insert)
     String newCommitTime = client.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
     validateMetadata(client);
 
     // Write 2 (inserts)
     newCommitTime = client.createNewInstantTime();
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2433,7 +2434,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     client = getHoodieWriteClient(updatedWriteConfig);
 
     newCommitTime = client.createNewInstantTime();
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
     assertNoWriteErrors(writeStatuses);
@@ -2451,7 +2452,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, getWriteConfig(true, true))) {
       String[] commitTimestamps = {client.createNewInstantTime(), client.createNewInstantTime()};
       records = dataGen.generateInserts(commitTimestamps[0], 5);
-      client.startCommitWithTime(commitTimestamps[0]);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamps[0]);
       writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), commitTimestamps[0]).collect();
       assertNoWriteErrors(writeStatuses);
 
@@ -2480,7 +2481,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       for (int i = 0; i < commitTimestamps.length; ++i) {
         records = dataGen.generateInserts(commitTimestamps[i], 5);
-        client.startCommitWithTime(commitTimestamps[i]);
+        WriteClientTestUtils.startCommitWithTime(client, commitTimestamps[i]);
         writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), commitTimestamps[i]).collect();
         assertNoWriteErrors(writeStatuses);
       }
@@ -2553,7 +2554,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int i = 0; i < maxDeltaCommitsBeforeCompaction - 2; ++i) {
         newCommitTime = client.createNewInstantTime();
         records = dataGen.generateInserts(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       }
 
@@ -2570,7 +2571,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Next commit will initiate a compaction
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 5);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       metadataTimeline = metadataMetaClient.reloadActiveTimeline();
       assertEquals(metadataTimeline.getCommitAndReplaceTimeline().filterCompletedInstants().countInstants(), 1);
@@ -2582,7 +2583,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       for (int i = 0; i < maxDeltaCommitsBeforeCompaction + 1; ++i) {
         newCommitTime = client.createNewInstantTime();
         records = dataGen.generateInserts(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
         if (i == 0) {
           // Mark this commit inflight so compactions don't take place
@@ -2604,7 +2605,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Next commit should lead to compaction
       newCommitTime = client.createNewInstantTime();
       records = dataGen.generateInserts(newCommitTime, 5);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
 
       // Ensure compactions took place
@@ -2635,7 +2636,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), commitTimestamp).collect();
       assertNoWriteErrors(writeStatuses);
     }
@@ -2660,7 +2661,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig2)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), commitTimestamp).collect();
       assertNoWriteErrors(writeStatuses);
     }
@@ -2720,7 +2721,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(jsc.parallelize(records, 1), commitTimestamp);
       client.commit(commitTimestamp, writeStatuses);
     }
@@ -2735,7 +2736,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(jsc.parallelize(records, 1), commitTimestamp);
     }
 
@@ -2759,7 +2760,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       commitTimestamp = client.createNewInstantTime();
       records = dataGen.generateInserts(commitTimestamp, 5);
-      client.startCommitWithTime(commitTimestamp);
+      WriteClientTestUtils.startCommitWithTime(client, commitTimestamp);
       writeStatuses = client.insert(jsc.parallelize(records, 1), commitTimestamp);
       assertNoWriteErrors(writeStatuses.collect());
     }
@@ -2785,7 +2786,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
         Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       List<HoodieRecord> upsertRecords = new ArrayList<>();
       for (HoodieRecord entry : records) {
@@ -2799,7 +2800,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       validateMetadata(client);
 
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 20);
       writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2841,7 +2842,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert first batch
     String commitTime = client.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
@@ -2853,7 +2854,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert second batch
     commitTime = client2.createNewInstantTime();
     records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client2.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
@@ -2872,11 +2873,11 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     if (performUpsert) {
       records = dataGen.generateUpdates(commitTime, 100);
       records.addAll(dataGen.generateInserts(commitTime, 20));
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
     } else {
       records = dataGen.generateInserts(commitTime, 100);
-      client.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
       writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     }
     assertNoWriteErrors(writeStatuses);
@@ -2905,7 +2906,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 1);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses =
           client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2925,7 +2926,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 1);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses =
           client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -2968,7 +2969,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       List<HoodieRecord> upsertRecords = new ArrayList<>();
       for (HoodieRecord entry : records) {
@@ -2987,7 +2988,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // add 1 more commit
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 10);
       upsertRecords = new ArrayList<>();
       for (HoodieRecord entry : records) {
@@ -3017,14 +3018,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, true, false, false, false).build(),
         Option.empty())) {
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       List<WriteStatus> writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
 
       newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 5);
       writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -3116,7 +3117,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime = "0000001";
       List<HoodieRecord> records = nonPartitionedGenerator.generateInserts(newCommitTime, 10);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
       validateMetadata(client);
 
@@ -3137,7 +3138,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime = "0000001";
       List<HoodieRecord> records = nonPartitionedGenerator.generateInserts(newCommitTime, 10);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
       validateMetadata(client);
 
@@ -3166,7 +3167,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write 1 (Bulk insert)
       String newCommitTime = "0000001";
       List<HoodieRecord> records = partitionedGenerator.generateInserts(newCommitTime, 10);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
 
       HoodieTableMetadata tableMetadata = metadata(client, metaClient.getStorage());
@@ -3223,7 +3224,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Write
       String newCommitTime = client.createNewInstantTime();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
       validateMetadata(client);
@@ -3268,7 +3269,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       recordsFirstBatch.addAll(insertRecords);
       // To test duplicates during bootstrap, insert duplicates in the first batch.
       recordsFirstBatch.addAll(insertRecords);
-      client.startCommitWithTime(firstCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, firstCommitTime);
       List<WriteStatus> writeStatuses =
           client.insert(jsc.parallelize(recordsFirstBatch, 1), firstCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
@@ -3291,7 +3292,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Create a commit, with record index enabled
       String secondCommitTime = client.createNewInstantTime();
       List<HoodieRecord> recordsSecondBatch = dataGen.generateInserts(secondCommitTime, 100);
-      client.startCommitWithTime(secondCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, secondCommitTime);
       assertThrows(HoodieException.class, () -> client.insert(jsc.parallelize(recordsSecondBatch, 1), secondCommitTime));
     }
   }
@@ -3320,7 +3321,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         String newCommitTime = "00" + index;
         List<HoodieRecord> records = index == 0 ? dataGen.generateInsertsForPartition(newCommitTime, 10, partition)
             : dataGen.generateUniqueUpdates(newCommitTime, 5);
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       }
     }
@@ -3425,14 +3426,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert one batch 0000001
     String commitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
     // Insert second batch 0000002
     commitTime = "0000002";
     records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
@@ -3484,14 +3485,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Insert one batch 0000001
     String commitTime = "0000001";
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
     // Insert second batch 0000002
     commitTime = "0000002";
     records = dataGen.generateInserts(commitTime, 100);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
@@ -3509,7 +3510,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     commitTime = "0000004";
     records = dataGen.generateInserts(commitTime, 100);
     client = getHoodieWriteClient(cfg);
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     writeStatuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
     assertNoWriteErrors(writeStatuses);
 
@@ -3558,7 +3559,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       String firstCommitTime = client.createNewInstantTime();
       // First commit
       List<HoodieRecord> firstBatchOfrecords = dataGen.generateInserts(firstCommitTime, 10);
-      client.startCommitWithTime(firstCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, firstCommitTime);
       client.insert(jsc.parallelize(firstBatchOfrecords, 1), firstCommitTime).collect();
 
       // Records got inserted and RI is initialized
@@ -3570,7 +3571,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Another batch of records added
       secondCommitTime = client.createNewInstantTime();
       List<HoodieRecord> secondBatchOfrecords = dataGen.generateInserts(secondCommitTime, 5);
-      client.startCommitWithTime(secondCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, secondCommitTime);
       client.bulkInsert(jsc.parallelize(secondBatchOfrecords, 1), secondCommitTime).collect();
 
       assertEquals(secondBatchOfrecords.size(),
@@ -3592,7 +3593,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       keysToDelete = recordsToDelete.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toList());
 
       String deleteTime = client.createNewInstantTime();
-      client.startCommitWithTime(deleteTime);
+      WriteClientTestUtils.startCommitWithTime(client, deleteTime);
       client.delete(jsc.parallelize(recordsToDelete, 1).map(HoodieRecord::getKey), deleteTime);
 
       // RI should not return mappings for deleted records

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -107,9 +107,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       // Insert
-      String commitTime = client.createNewInstantTime();
+      String commitTime = client.startCommit();
       List<HoodieRecord> records1 = dataGen.generateInserts(commitTime, 100);
-      client.startCommitWithTime(commitTime);
       List<WriteStatus> writeStatuses1 = client.insert(jsc.parallelize(records1, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses1);
 
@@ -142,8 +141,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertEquals(expectedRecordToPartitionMapping1, recordKeyToPartitionMapping1);
 
       // lets update some records and assert RLI records.
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       String finalCommitTime2 = commitTime;
       List<HoodieRecord> deletes2 = dataGen.generateUniqueDeleteRecords(commitTime, 30);
       List<HoodieRecord> updates2 = dataGen.generateUniqueUpdates(commitTime, 30);
@@ -211,9 +209,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       // Insert
-      String commitTime = client.createNewInstantTime();
+      String commitTime = client.startCommit();
       List<HoodieRecord> records1 = dataGen.generateInserts(commitTime, 100);
-      client.startCommitWithTime(commitTime);
       List<WriteStatus> writeStatuses1 = client.insert(jsc.parallelize(records1, 1), commitTime).collect();
       assertNoWriteErrors(writeStatuses1);
 
@@ -246,8 +243,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertEquals(expectedRecordToPartitionMapping1, recordKeyToPartitionMapping1);
 
       // lets update some records and assert RLI records.
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       List<HoodieRecord> deletes2 = dataGen.generateUniqueDeleteRecords(commitTime, 30);
       List<HoodieRecord> updates2 = dataGen.generateUniqueUpdates(commitTime, 30);
       List<HoodieRecord> inserts2 = dataGen.generateInserts(commitTime, 30);
@@ -261,8 +257,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertRLIandSIRecordGenerationAPIs(inserts2, updates2, deletes2, writeStatuses2, commitTime, writeConfig);
 
       // trigger 2nd commit.
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       String finalCommitTime3 = commitTime;
       List<HoodieRecord> deletes3 = dataGen.generateUniqueDeleteRecords(commitTime, 30);
       List<HoodieRecord> updates3 = dataGen.generateUniqueUpdates(commitTime, 30);
@@ -308,10 +303,9 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       // Insert
-      String commitTime = client.createNewInstantTime();
+      String commitTime = client.startCommit();
       int initialRecordsCount = 10;
       List<HoodieRecord> records1 = dataGen.generateInserts(commitTime, initialRecordsCount);
-      client.startCommitWithTime(commitTime);
       JavaRDD<WriteStatus> writeStatuses1 = client.insert(jsc.parallelize(records1, 1), commitTime);
       assertNoWriteErrors(writeStatuses1.collect());
       client.commit(commitTime, writeStatuses1);
@@ -339,8 +333,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertListEquality(expectedSecondaryIndexKeys, secondaryIndexRecords.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toList()));
 
       // update and insert some records and assert SI records
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       List<HoodieRecord> updates2 = dataGen.generateUniqueUpdates(commitTime, 1);
       List<String> expectedUpdatedIndexKeys = updates2.stream().map(TestMetadataUtilRLIandSIRecordGeneration::getSecondaryIndexKey).collect(Collectors.toList());
       List<HoodieRecord> inserts2 = dataGen.generateInserts(commitTime, 1);
@@ -377,8 +370,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertTrue(expectedSecondaryIndexKeys.containsAll(deletedSecondaryIndexRecords.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toList())));
 
       // let us create one more file slice with delete
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       List<HoodieRecord> deletes = dataGen.generateUniqueDeleteRecords(commitTime, 1);
       List<String> expectedDeletedIndexKeys = deletes.stream().map(TestMetadataUtilRLIandSIRecordGeneration::getSecondaryIndexKey).collect(Collectors.toList());
       List<HoodieRecord> records3 = new ArrayList<>();
@@ -409,8 +401,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertEquals(getRecordKeyFromSecondaryIndexKey(expectedDeletedIndexKeys.get(0)), getRecordKeyFromSecondaryIndexKey(deletedSecondaryIndexRecords2.get(0).getRecordKey()));
 
       // revive the deleted keys
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       List<HoodieRecord> inserts4 = dataGen.generateSameKeyInserts(commitTime, deletes);
       List<String> expectedRevivedIndexKeys = inserts4.stream().map(TestMetadataUtilRLIandSIRecordGeneration::getSecondaryIndexKey).collect(Collectors.toList());
       List<HoodieRecord> records4 = new ArrayList<>();
@@ -433,8 +424,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       assertEquals(expectedRevivedIndexKeys.get(0), secondaryIndexRecords.get(0).getRecordKey());
 
       // generate update for the same key, but with the same rider value
-      commitTime = client.createNewInstantTime();
-      client.startCommitWithTime(commitTime);
+      commitTime = client.startCommit();
       List<HoodieRecord> updates5 = dataGen.generateUpdatesWithTimestamp(fourthCommitTime, inserts4, Long.parseLong(commitTime));
       List<String> expectedUpdatedIndexKeys2 = updates5.stream().map(TestMetadataUtilRLIandSIRecordGeneration::getSecondaryIndexKey).collect(Collectors.toList());
       List<HoodieRecord> records5 = new ArrayList<>();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -263,8 +263,7 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
   }
 
   private void writeToTable(int round, SparkRDDWriteClient writeClient) throws IOException {
-    String instantTime = writeClient.createNewInstantTime();
-    writeClient.startCommitWithTime(instantTime);
+    String instantTime = writeClient.startCommit();
     List<HoodieRecord> records = round == 0
         ? dataGen.generateInserts(instantTime, 100)
         : dataGen.generateUpdates(instantTime, 100);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreMergeOnRead.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreMergeOnRead.java
@@ -78,9 +78,8 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
       final int numRecords = 10;
       List<HoodieRecord> baseRecordsToUpdate = null;
       for (int i = 1; i <= 3; i++) {
-        String newCommitTime = client.createNewInstantTime();
+        String newCommitTime = client.startCommit();
         // Write 4 inserts with the 2td commit been rolled back
-        client.startCommitWithTime(newCommitTime);
         List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
         JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
         client.insert(writeRecords, newCommitTime);
@@ -97,8 +96,7 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
       // write another 3 delta commits
       String compactionCommit = null;
       for (int i = 1; i <= 3; i++) {
-        String newCommitTime = client.createNewInstantTime();
-        client.startCommitWithTime(newCommitTime);
+        String newCommitTime = client.startCommit();
         List<HoodieRecord> records = dataGen.generateUpdates(newCommitTime, Objects.requireNonNull(baseRecordsToUpdate, "The records to update should not be null"));
         JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
         client.upsert(writeRecords, newCommitTime);
@@ -138,21 +136,19 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
     String secondCommit;
     try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
       // 1st commit insert
-      String newCommitTime = client.createNewInstantTime();
+      String newCommitTime = client.startCommit();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-      client.startCommitWithTime(newCommitTime);
       client.insert(writeRecords, newCommitTime);
       firstCommit = newCommitTime;
 
       // 2nd commit with inserts and updates which will create new file slice due to small file handling.
-      newCommitTime = client.createNewInstantTime();
+      newCommitTime = client.startCommit();
       List<HoodieRecord> records2 = dataGen.generateUniqueUpdates(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(records2, 1);
       List<HoodieRecord> records3 = dataGen.generateInserts(newCommitTime, 30);
       JavaRDD<HoodieRecord> writeRecords3 = jsc.parallelize(records3, 1);
 
-      client.startCommitWithTime(newCommitTime);
       client.upsert(writeRecords2.union(writeRecords3), newCommitTime);
       secondCommit = newCommitTime;
       // add savepoint to 2nd commit
@@ -179,16 +175,14 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
 
     // add 2 more updates which will create log files.
     try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
-      String newCommitTime = client.createNewInstantTime();
+      String newCommitTime = client.startCommit();
       List<HoodieRecord> records = dataGen.generateUniqueUpdates(newCommitTime, numRecords);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-      client.startCommitWithTime(newCommitTime);
       client.upsert(writeRecords, newCommitTime);
 
-      newCommitTime = client.createNewInstantTime();
+      newCommitTime = client.startCommit();
       records = dataGen.generateUniqueUpdates(newCommitTime, numRecords);
       writeRecords = jsc.parallelize(records, 1);
-      client.startCommitWithTime(newCommitTime);
       client.upsert(writeRecords, newCommitTime);
     }
     assertRowNumberEqualsTo(130);
@@ -237,9 +231,8 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
       final int numRecords = 10;
       List<HoodieRecord> baseRecordsToUpdate = null;
       for (int i = 1; i <= 3; i++) {
-        String newCommitTime = client.createNewInstantTime();
+        String newCommitTime = client.startCommit();
         // Write 4 inserts with the 2td commit been rolled back
-        client.startCommitWithTime(newCommitTime);
         List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
         JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
         client.insert(writeRecords, newCommitTime);
@@ -290,9 +283,8 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
       final int numRecords = 10;
       List<HoodieRecord> baseRecordsToUpdate = null;
       for (int i = 1; i <= 2; i++) {
-        String newCommitTime = client.createNewInstantTime();
+        String newCommitTime = client.startCommit();
         // Write 4 inserts with the 2td commit been rolled back
-        client.startCommitWithTime(newCommitTime);
         List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, numRecords);
         JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
         client.insert(writeRecords, newCommitTime);
@@ -326,8 +318,7 @@ public class TestSavepointRestoreMergeOnRead extends HoodieClientTestBase {
   }
 
   private void upsertBatch(SparkRDDWriteClient client, List<HoodieRecord> baseRecordsToUpdate) throws IOException {
-    String newCommitTime = client.createNewInstantTime();
-    client.startCommitWithTime(newCommitTime);
+    String newCommitTime = client.startCommit();
     List<HoodieRecord> records = dataGen.generateUpdates(newCommitTime, Objects.requireNonNull(baseRecordsToUpdate, "The records to update should not be null"));
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     client.upsert(writeRecords, newCommitTime);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
@@ -21,6 +21,7 @@ package org.apache.hudi.functional;
 import org.apache.hudi.avro.model.DecimalWrapper;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineProperty;
@@ -517,7 +518,7 @@ public class TestColStatsRecordWithMetadataRecord extends HoodieSparkClientTestH
     metaClient = HoodieTableMetaClient.reload(metaClient);
     JavaRDD records = jsc.parallelize(dataGen.generateInserts(instant, numRecords), 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses = client.upsert(records, instant).collect();
     org.apache.hudi.testutils.Assertions.assertNoWriteErrors(writeStatuses);
     if (doCommit) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -21,6 +21,7 @@ package org.apache.hudi.functional;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -111,7 +112,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 400);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records.subList(0, 200), client, cfg, newCommitTime);
@@ -122,7 +123,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
        */
       // we already set small file size to small number to force inserts to go into new file.
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       dataFiles = insertRecordsToMORTable(metaClient, records.subList(200, 400), client, cfg, newCommitTime);
       assertTrue(dataFiles.findAny().isPresent(), "should list the base files we wrote in the delta commit");
 
@@ -131,7 +132,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
          * Write 3 (updates)
          */
         newCommitTime = "003";
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         records = dataGen.generateUpdates(newCommitTime, 100);
         updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
       }
@@ -202,18 +203,18 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
       // test 2 inserts
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 400);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records.subList(0, 200), client, cfg, newCommitTime);
       assertTrue(!dataFiles.findAny().isPresent(), "should not have any base files");
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       dataFiles = insertRecordsToMORTable(metaClient, records.subList(200, 400), client, cfg, newCommitTime);
       assertTrue(!dataFiles.findAny().isPresent(), "should not have any base files");
       // run updates
       if (doUpdates) {
         newCommitTime = "003";
-        client.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
         records = dataGen.generateUpdates(newCommitTime, 100);
         updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkClusteringCornerCases.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkClusteringCornerCases.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
@@ -71,7 +72,7 @@ public class TestSparkClusteringCornerCases extends HoodieClientTestBase {
 
   private List<HoodieRecord> writeData(SparkRDDWriteClient client, String instant, List<HoodieRecord> recordList) {
     JavaRDD records = jsc.parallelize(recordList, 2);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses = client.upsert(records, instant).collect();
     org.apache.hudi.testutils.Assertions.assertNoWriteErrors(writeStatuses);
     return recordList;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.functional;
 
 import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.clustering.plan.strategy.SparkConsistentBucketClusteringPlanStrategy;
 import org.apache.hudi.client.clustering.update.strategy.SparkConsistentBucketDuplicateUpdateStrategy;
@@ -342,7 +343,7 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    writeClient.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
     List<WriteStatus> writeStatues = writeClient.upsert(writeRecords, commitTime).collect();
     org.apache.hudi.testutils.Assertions.assertNoWriteErrors(writeStatues);
     if (doCommit) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
@@ -20,6 +20,7 @@ package org.apache.hudi.functional;
 
 import org.apache.hudi.avro.model.HoodieClusteringGroup;
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -152,7 +153,7 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records);
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    writeClient.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
     List<WriteStatus> writeStatues = writeClient.insert(writeRecords, commitTime).collect();
     org.apache.hudi.testutils.Assertions.assertNoWriteErrors(writeStatues);
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -67,7 +68,7 @@ public class TestWriteClient extends HoodieSparkClientTestBase {
       addConfigsForPopulateMetaFields(cfgBuilder, false);
       client = getHoodieWriteClient(cfgBuilder.build());
       String secondCommit = "002";
-      client.startCommitWithTime(secondCommit);
+      WriteClientTestUtils.startCommitWithTime(client, secondCommit);
       JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
       result = client.insert(emptyRdd, secondCommit);
       assertTrue(client.commit(secondCommit, result), "Commit should succeed");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table;
 import org.apache.hudi.client.HoodieReadClient;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -128,7 +129,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
 
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime).collect();
       assertNoWriteErrors(statuses);
@@ -157,7 +158,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
        * Write 1 (only inserts, written as base file)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -191,7 +192,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
        * Write 2 (only updates + inserts, written to .log file + correction of existing base file size)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> newRecords = dataGen.generateUpdates(newCommitTime, records);
       newRecords.addAll(dataGen.generateInserts(newCommitTime, 20));
@@ -244,7 +245,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg);) {
       // batch 1 insert
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
       List<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime).collect();
@@ -281,7 +282,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
   private void writeAndValidateLogFileBaseInstantTimeMatches(SparkRDDWriteClient client, String newCommitTime, List<HoodieRecord> records,
                                                              HoodieWriteConfig cfg, Map<String, String> baseFileMapping,
                                                              Map<String, List<String>> baseFileToLogFileMapping) throws IOException {
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> newRecords = dataGen.generateUpdates(newCommitTime, records);
     List<WriteStatus> statuses = client.upsert(jsc().parallelize(newRecords), newCommitTime).collect();
     // validate the data itself
@@ -355,7 +356,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config);) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc().parallelize(records, 1);
@@ -369,7 +370,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       SparkRDDReadClient readClient = new SparkRDDReadClient(context(), config);
       JavaRDD<HoodieRecord> updatedTaggedRecordsRDD = readClient.tagLocation(updatedRecordsRDD);
 
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       writeClient.upsertPreppedRecords(updatedTaggedRecordsRDD, newCommitTime).collect();
 
       // Write them to corresponding avro logfiles
@@ -461,7 +462,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc().parallelize(records, 1);
@@ -475,12 +476,12 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       HoodieReadClient readClient = new HoodieReadClient(context(), config);
       JavaRDD<HoodieRecord> updatedTaggedRecordsRDD = readClient.tagLocation(updatedRecordsRDD);
 
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       writeClient.upsertPreppedRecords(updatedTaggedRecordsRDD, newCommitTime).collect();
 
 
       newCommitTime = "102";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       writeClient.upsertPreppedRecords(updatedTaggedRecordsRDD, newCommitTime).collect();
 
 
@@ -566,7 +567,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       activeTimeline.saveAsComplete(instant, Option.empty());
 
       String instant1 = metaClient.createNewInstantTime();
-      client.startCommitWithTime(instant1);
+      WriteClientTestUtils.startCommitWithTime(client, instant1);
 
       List<HoodieRecord> records = dataGen.generateInserts(instant1, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -588,7 +589,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       assertEquals(200, inserts);
 
       String instant2 = metaClient.createNewInstantTime();
-      client.startCommitWithTime(instant2);
+      WriteClientTestUtils.startCommitWithTime(client, instant2);
       records = dataGen.generateUpdates(instant2, records);
       writeRecords = jsc().parallelize(records, 1);
       statuses = client.upsert(writeRecords, instant2);
@@ -642,7 +643,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       Map<String, Long> fileIdToUpsertsMap = new HashMap<>();
 
       String instantTime = "000";
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(instantTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -666,7 +667,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       assertEquals(200, inserts);
 
       instantTime = "001";
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
       // generate updates + inserts. inserts should be handled into small files
       records = dataGen.generateUpdates(instantTime, records);
       records.addAll(dataGen.generateInserts(instantTime, 200));
@@ -714,7 +715,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
       // Write inserts + updates
       instantTime = "003";
-      client.startCommitWithTime(instantTime);
+      WriteClientTestUtils.startCommitWithTime(client, instantTime);
       // generate updates + inserts. inserts should be handled into small files
       records = dataGen.generateUpdates(instantTime, records);
       records.addAll(dataGen.generateInserts(instantTime, 200));
@@ -756,7 +757,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
        * Write 1 (only inserts, written as base file)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -788,7 +789,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
        * Write 2 (only updates, written to .log file)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       metaClient.reloadActiveTimeline();
       records = dataGen.generateUpdates(newCommitTime, records);
       writeRecords = jsc().parallelize(records, 1);
@@ -801,7 +802,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       final String newDeleteTime = "004";
       final String partitionPath = records.get(0).getPartitionPath();
       final String fileId = statuses.get(0).getFileId();
-      client.startCommitWithTime(newDeleteTime);
+      WriteClientTestUtils.startCommitWithTime(client, newDeleteTime);
       metaClient.reloadActiveTimeline();
 
       List<HoodieRecord> fewRecordsForDelete = dataGen.generateDeletesFromExistingRecords(records);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.action.compact;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -159,7 +160,7 @@ public class TestAsyncCompaction extends CompactionTestBase {
       assertEquals(inflightInstantTime, inflightInstant.requestedTime(), "inflight instant has expected instant time");
 
       // This should rollback
-      client.startCommitWithTime(nextInflightInstantTime);
+      WriteClientTestUtils.startCommitWithTime(client, nextInflightInstantTime);
 
       // Validate
       metaClient = HoodieTestUtils.createMetaClient(storageConf.newInstance(), cfg.getBasePath());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.action.compact;
 import org.apache.hudi.avro.model.HoodieCompactionOperation;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.FileSlice;
@@ -178,7 +179,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       // insert 100 records.
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
@@ -186,7 +187,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
 
       // create one inflight instance.
       newCommitTime = "102";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       metaClient.getActiveTimeline().transitionRequestedToInflight(INSTANT_GENERATOR.createNewInstant(State.REQUESTED,
           HoodieTimeline.DELTA_COMMIT_ACTION, newCommitTime), Option.empty());
 
@@ -202,7 +203,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       // insert 100 records.
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       // commit 1
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
@@ -214,7 +215,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
 
       // commit 3 (inflight)
       newCommitTime = "102";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       metaClient.getActiveTimeline().transitionRequestedToInflight(INSTANT_GENERATOR.createNewInstant(State.REQUESTED,
           HoodieTimeline.DELTA_COMMIT_ACTION, newCommitTime), Option.empty());
 
@@ -233,7 +234,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
         .build();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 1000);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
@@ -267,7 +268,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
@@ -320,7 +321,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
         .withMetricsConfig(getMetricsConfig()).build();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 10);
       JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
@@ -404,7 +405,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
   private void prepareRecords(SparkRDDWriteClient writeClient, HoodieWriteConfig config, String[] partitions) throws Exception {
     initTestDataGenerator(partitions);
     String newCommitTime = writeClient.createNewInstantTime();
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
     // insert
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
@@ -436,7 +437,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
     HoodieIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
     JavaRDD<HoodieRecord> updatedTaggedRecordsRDD = tagLocation(index, updatedRecordsRDD, table);
 
-    writeClient.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
     writeClient.upsertPreppedRecords(updatedTaggedRecordsRDD, newCommitTime).collect();
     metaClient.reloadActiveTimeline();
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.action.rollback;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -265,7 +266,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
      * Write 1 (only inserts)
      */
     String newCommitTime = "0000001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGenPartition3.generateInsertsContainsAllPartitions(newCommitTime, 2);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
@@ -353,7 +354,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
     // Write 1 (only inserts)
     String newCommitTime = "001";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGen.generateInsertsForPartition(newCommitTime, 2, DEFAULT_FIRST_PARTITION_PATH);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
     JavaRDD<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime);
@@ -386,7 +387,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
 
     // Write 2 (inserts)
     newCommitTime = "002";
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> updateRecords = Collections.singletonList(dataGen.generateUpdateRecord(records.get(0).getKey(), newCommitTime));
     List<HoodieRecord> insertRecordsInSamePartition = dataGen.generateInsertsForPartition(newCommitTime, 2, DEFAULT_FIRST_PARTITION_PATH);
     List<HoodieRecord> insertRecordsInOtherPartition = dataGen.generateInsertsForPartition(newCommitTime, 2, DEFAULT_SECOND_PARTITION_PATH);
@@ -457,7 +458,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
         .withRollbackUsingMarkers(false)
         .withPath(basePath).build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      client.startCommitWithTime("001");
+      WriteClientTestUtils.startCommitWithTime(client, "001");
       client.insert(jsc.emptyRDD(), "001");
       client.rollback("001");
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.functional;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -422,7 +423,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     metaClient = HoodieTableMetaClient.reload(metaClient);
     JavaRDD<HoodieRecord> records = jsc().parallelize(hoodieRecords, 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses = client.upsert(records, instant).collect();
     assertNoWriteErrors(writeStatuses);
     if (doCommit) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableIncrementalRead.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableIncrementalRead.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.table.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -92,7 +93,7 @@ public class TestHoodieSparkMergeOnReadTableIncrementalRead extends SparkClientF
        * Write 1 (only inserts)
        */
       String commitTime1 = "001";
-      client.startCommitWithTime(commitTime1);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime1);
 
       List<HoodieRecord> records001 = dataGen.generateInserts(commitTime1, 200);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records001, client, cfg, commitTime1);
@@ -115,7 +116,7 @@ public class TestHoodieSparkMergeOnReadTableIncrementalRead extends SparkClientF
        * Write 2 (updates)
        */
       String updateTime = "004";
-      client.startCommitWithTime(updateTime);
+      WriteClientTestUtils.startCommitWithTime(client, updateTime);
       List<HoodieRecord> records004 = dataGen.generateUpdates(updateTime, 100);
       updateRecordsInMORTable(metaClient, records004, client, cfg, updateTime, false);
 
@@ -143,7 +144,7 @@ public class TestHoodieSparkMergeOnReadTableIncrementalRead extends SparkClientF
       // write 3 - more inserts
       String insertsTime = "006";
       List<HoodieRecord> records006 = dataGen.generateInserts(insertsTime, 200);
-      client.startCommitWithTime(insertsTime);
+      WriteClientTestUtils.startCommitWithTime(client, insertsTime);
       dataFiles = insertRecordsToMORTable(metaClient, records006, client, cfg, insertsTime);
       assertTrue(dataFiles.findAny().isPresent(), "should list the base files we wrote in the delta commit");
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.table.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
@@ -122,7 +123,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records, client, cfg, newCommitTime);
@@ -132,7 +133,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 2 (updates)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 100);
       updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
 
@@ -183,7 +184,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records, client, cfg, newCommitTime, true);
@@ -193,7 +194,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 2 (updates)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 100);
       updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, true);
 
@@ -225,7 +226,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records, client, cfg, newCommitTime, true);
@@ -235,7 +236,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 2 (updates)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 100);
       updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, true);
 
@@ -281,7 +282,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 1 (only inserts, written as base file)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -314,7 +315,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 2 (only updates, written to .log file)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       writeRecords = jsc().parallelize(records, 1);
@@ -325,7 +326,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
        * Write 2 (only deletes, written to .log file)
        */
       newCommitTime = "004";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> fewRecordsForDelete = dataGen.generateDeletesFromExistingRecords(records);
 
@@ -367,7 +368,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -122,7 +123,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -141,7 +142,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 2 (updates)
        */
       newCommitTime = "002";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
 
@@ -193,7 +194,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 1 (only inserts)
        */
       String newCommitTime = "000000001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -235,7 +236,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
       // WriteClient with custom config (disable small file handling)
       // NOTE: Second writer will have Metadata table ENABLED
       try (SparkRDDWriteClient secondClient = getHoodieWriteClient(secondCfg);) {
-        secondClient.startCommitWithTime(commitTime1);
+        WriteClientTestUtils.startCommitWithTime(secondClient, commitTime1);
 
         List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
         copyOfRecords = dataGen.generateUpdates(commitTime1, copyOfRecords);
@@ -276,7 +277,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        */
       final String commitTime2 = "000000003";
       try (SparkRDDWriteClient thirdClient = getHoodieWriteClient(secondCfg);) {
-        thirdClient.startCommitWithTime(commitTime2);
+        WriteClientTestUtils.startCommitWithTime(thirdClient, commitTime2);
 
         List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
         copyOfRecords = dataGen.generateUpdates(commitTime2, copyOfRecords);
@@ -325,7 +326,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
          * Write 4 (updates)
          */
         newCommitTime = "000000004";
-        thirdClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(thirdClient, newCommitTime);
 
         writeStatusJavaRDD = thirdClient.upsert(writeRecords, newCommitTime);
 
@@ -391,7 +392,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 1 (only inserts)
        */
       String newCommitTime = "000000001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -430,7 +431,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
       HoodieWriteConfig secondCfg = getHoodieWriteConfigWithSmallFileHandlingOff(true);
       secondCfg.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, "6");
       try (SparkRDDWriteClient secondClient = getHoodieWriteClient(secondCfg);) {
-        secondClient.startCommitWithTime(commitTime1);
+        WriteClientTestUtils.startCommitWithTime(secondClient, commitTime1);
 
         List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
         copyOfRecords = dataGen.generateUpdates(commitTime1, copyOfRecords);
@@ -498,7 +499,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 1 (only inserts)
        */
       String newCommitTime = "001";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -550,7 +551,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
           // Timeline-server-based markers are not used for multi-rollback tests
           .withMarkersType(MarkerType.DIRECT.name()).build();
       try (SparkRDDWriteClient nClient = getHoodieWriteClient(smallFileWriteConfig)) {
-        nClient.startCommitWithTime(newCommitTime);
+        WriteClientTestUtils.startCommitWithTime(nClient, newCommitTime);
 
         List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
         copyOfRecords = dataGen.generateUpdates(newCommitTime, copyOfRecords);
@@ -577,7 +578,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 3 (inserts + updates)
        */
       newCommitTime = "003";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       List<HoodieRecord> newInserts = dataGen.generateInserts(newCommitTime, 100);
       records = dataGen.generateUpdates(newCommitTime, records);
@@ -601,7 +602,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 4 (updates)
        */
       newCommitTime = "005";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
 
       records = dataGen.generateUpdates(newCommitTime, records);
       writeRecords = jsc().parallelize(records, 1);
@@ -633,7 +634,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 5 (updates)
        */
       newCommitTime = "007";
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
       copyOfRecords = dataGen.generateUpdates(newCommitTime, copyOfRecords);
       copyOfRecords.addAll(dataGen.generateInserts(newCommitTime, 200));
@@ -684,7 +685,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
        * Write 1 (only inserts)
        */
       String newCommitTime = client.createNewInstantTime();
-      client.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
       JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
       JavaRDD<WriteStatus> writeStatusJavaRDD = client.upsert(writeRecords, newCommitTime);
@@ -750,7 +751,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   }
 
   private void upsertRecords(SparkRDDWriteClient client, String commitTime, List<HoodieRecord> records, HoodieTestDataGenerator dataGen) throws IOException {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
     List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
     copyOfRecords = dataGen.generateUpdates(commitTime, copyOfRecords);
     List<WriteStatus> statuses = client.upsert(jsc().parallelize(copyOfRecords, 1), commitTime).collect();
@@ -814,7 +815,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   }
 
   private List<HoodieRecord> insertAndGetRecords(String newCommitTime, SparkRDDWriteClient client, HoodieTestDataGenerator dataGen, int count) {
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, count);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
     JavaRDD<WriteStatus> writeStatusJavaRDD = client.upsert(writeRecords, newCommitTime);
@@ -823,7 +824,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   }
 
   private List<HoodieRecord> updateAndGetRecords(String newCommitTime, SparkRDDWriteClient client, HoodieTestDataGenerator dataGen, List<HoodieRecord> records) throws IOException {
-    client.startCommitWithTime(newCommitTime);
+    WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<HoodieRecord> updates = dataGen.generateUpdates(newCommitTime, records);
     JavaRDD<WriteStatus> writeStatusJavaRDD = client.upsert(jsc().parallelize(updates, 1), newCommitTime);
     client.commit(newCommitTime, writeStatusJavaRDD);
@@ -898,7 +899,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
 
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config)) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc().parallelize(records, 1);
@@ -917,7 +918,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
 
       // insert 100 records
       newCommitTime = "101";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
       records = dataGen.generateInserts(newCommitTime, 100);
       recordsRDD = jsc().parallelize(records, 1);
       writeClient.insert(recordsRDD, newCommitTime).collect();
@@ -990,7 +991,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
     HoodieWriteConfig config = getConfigBuilder(false, rollbackUsingMarkers, HoodieIndex.IndexType.INMEMORY).build();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(config);) {
       String newCommitTime = "100";
-      writeClient.startCommitWithTime(newCommitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
       JavaRDD<HoodieRecord> recordsRDD = jsc().parallelize(records, 1);
@@ -1083,7 +1084,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   private List<HoodieRecord> updateRecords(SparkRDDWriteClient client, HoodieTestDataGenerator dataGen, String commitTime,
                                            List<HoodieRecord> records, HoodieTableMetaClient metaClient, HoodieWriteConfig cfg,
                                            boolean assertLogFiles) throws IOException {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
 
     records = dataGen.generateUpdates(commitTime, records);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkRollback.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.functional;
 
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.functional.TestHoodieBackedMetadata;
@@ -77,7 +78,7 @@ public class TestHoodieSparkRollback extends SparkClientFunctionalTestHarness {
     /*
      * Write 1 (only inserts, written as base file)
      */
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
 
     List<HoodieRecord> records = dataGen.generateInserts(commitTime, 20);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);
@@ -89,7 +90,7 @@ public class TestHoodieSparkRollback extends SparkClientFunctionalTestHarness {
 
   protected List<WriteStatus> updateRecords(SparkRDDWriteClient client, HoodieTestDataGenerator dataGen, String commitTime,
                                           List<HoodieRecord> records) throws IOException {
-    client.startCommitWithTime(commitTime);
+    WriteClientTestUtils.startCommitWithTime(client, commitTime);
 
     records = dataGen.generateUpdates(commitTime, records);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 1);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.table.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.transaction.BucketIndexConcurrentFileWritesConflictResolutionStrategy;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
@@ -730,7 +731,7 @@ public class TestSparkNonBlockingConcurrencyControl extends SparkClientFunctiona
     List<HoodieRecord> recordList = str2HoodieRecord(records, fullUpdate);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(recordList, 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses;
     switch (operationType) {
       case INSERT:

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -214,12 +214,11 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
       .build()
     val context = new HoodieJavaEngineContext(HoodieTestUtils.getDefaultStorageConf)
     val writeClient = new HoodieJavaWriteClient(context, writeConfig)
-    val instantTime = makeNewCommitTime()
+    val instantTime = writeClient.startCommit()
 
     val records: java.util.List[HoodieRecord[Nothing]] =
       dataGen.generateInsertsContainsAllPartitions(instantTime, 100)
         .asInstanceOf[java.util.List[HoodieRecord[Nothing]]]
-    writeClient.startCommitWithTime(instantTime)
     writeClient.insert(records, instantTime)
     metaClient.reloadActiveTimeline()
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.client.{SparkRDDWriteClient, WriteClientTestUtils}
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.model.{HoodieFailedWritesCleaningPolicy, HoodieRecord, HoodieTableType}
@@ -63,8 +63,8 @@ class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
         val records1 = sparkContext.parallelize(dataGen.generateInserts(instantTime1, 10).asScala.toSeq, 2)
         val records2 = sparkContext.parallelize(dataGen.generateInserts(instantTime2, 15).asScala.toSeq, 2)
 
-        writeClient.startCommitWithTime(instantTime1)
-        writeClient.startCommitWithTime(instantTime2)
+        WriteClientTestUtils.startCommitWithTime(writeClient, instantTime1)
+        WriteClientTestUtils.startCommitWithTime(writeClient, instantTime2)
         writeClient.insert(records2.toJavaRDD().asInstanceOf[JavaRDD[HoodieRecord[Nothing]]], instantTime2)
         val df = spark.readStream
           .format("hudi")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -43,12 +43,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.SAMPLE_WRITES_FOLDER_PATH;
-import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.getInstantFromTemporalAccessor;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.config.HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE;
 import static org.apache.hudi.utilities.config.HoodieStreamerConfig.SAMPLE_WRITES_ENABLED;
@@ -75,8 +73,7 @@ public class SparkSampleWritesUtils {
       return Option.empty();
     }
     try {
-      String instantTime = getInstantFromTemporalAccessor(Instant.now().atZone(ZoneId.systemDefault()));
-      Pair<Boolean, String> result = doSampleWrites(jsc, recordsOpt, writeConfig, instantTime);
+      Pair<Boolean, String> result = doSampleWrites(jsc, recordsOpt, writeConfig);
       if (result.getLeft()) {
         long avgSize = getAvgSizeFromSampleWrites(jsc, result.getRight());
         LOG.info("Overwriting record size estimate to {}", avgSize);
@@ -90,12 +87,13 @@ public class SparkSampleWritesUtils {
     return Option.empty();
   }
 
-  private static Pair<Boolean, String> doSampleWrites(JavaSparkContext jsc, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieWriteConfig writeConfig, String instantTime)
+  private static Pair<Boolean, String> doSampleWrites(JavaSparkContext jsc, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieWriteConfig writeConfig)
       throws IOException {
-    final String sampleWritesBasePath = getSampleWritesBasePath(jsc, writeConfig, instantTime);
+    String uniqueId = UUID.randomUUID().toString();
+    final String sampleWritesBasePath = getSampleWritesBasePath(jsc, writeConfig, uniqueId);
     HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
-        .setTableName(String.format("%s_samples_%s", writeConfig.getTableName(), instantTime))
+        .setTableName(String.format("%s_samples_%s", writeConfig.getTableName(), uniqueId))
         .setCDCEnabled(false)
         .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), sampleWritesBasePath);
     TypedProperties props = writeConfig.getProps();
@@ -117,7 +115,7 @@ public class SparkSampleWritesUtils {
         if (samples.isEmpty()) {
           return emptyRes;
         }
-        sampleWriteClient.startCommitWithTime(instantTime);
+        String instantTime = sampleWriteClient.startCommit();
         JavaRDD<WriteStatus> writeStatusRDD = sampleWriteClient.bulkInsert(jsc.parallelize(samples, 1), instantTime);
         if (writeStatusRDD.filter(WriteStatus::hasErrors).count() > 0) {
           LOG.error("sample writes for table {} failed with errors.", writeConfig.getTableName());
@@ -137,8 +135,8 @@ public class SparkSampleWritesUtils {
     }
   }
 
-  private static String getSampleWritesBasePath(JavaSparkContext jsc, HoodieWriteConfig writeConfig, String instantTime) throws IOException {
-    StoragePath basePath = new StoragePath(writeConfig.getBasePath(), SAMPLE_WRITES_FOLDER_PATH + StoragePath.SEPARATOR + instantTime);
+  private static String getSampleWritesBasePath(JavaSparkContext jsc, HoodieWriteConfig writeConfig, String uniqueId) throws IOException {
+    StoragePath basePath = new StoragePath(writeConfig.getBasePath(), SAMPLE_WRITES_FOLDER_PATH + StoragePath.SEPARATOR + uniqueId);
     HoodieStorage storage = getMetaClient(jsc, writeConfig.getBasePath()).getStorage();
     if (storage.exists(basePath)) {
       storage.deleteDirectory(basePath);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -24,6 +24,7 @@ import org.apache.hudi.avro.model.HoodieIndexPartitionInfo;
 import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -494,7 +495,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // do one upsert with synchronous metadata update
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig)) {
       String instant = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(instant);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instant);
       List<HoodieRecord> records = DATA_GENERATOR.generateInserts(instant, 100);
       JavaRDD<WriteStatus> result = writeClient.upsert(jsc().parallelize(records, 1), instant);
       List<WriteStatus> statuses = result.collect();
@@ -547,7 +548,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // do one upsert with synchronous metadata update
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig)) {
       String instant = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(instant);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instant);
       List<HoodieRecord> records = DATA_GENERATOR.generateInserts(instant, 100);
       JavaRDD<WriteStatus> result = writeClient.upsert(jsc().parallelize(records, 1), instant);
       List<WriteStatus> statuses = result.collect();
@@ -601,7 +602,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     // do one upsert with synchronous metadata update
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig)) {
       String instant = writeClient.createNewInstantTime();
-      writeClient.startCommitWithTime(instant);
+      WriteClientTestUtils.startCommitWithTime(writeClient, instant);
       List<HoodieRecord> records = DATA_GENERATOR.generateInserts(instant, 100);
       JavaRDD<WriteStatus> result = writeClient.upsert(jsc().parallelize(records, 1), instant);
       List<WriteStatus> statuses = result.collect();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -99,7 +100,7 @@ public class TestHoodieSnapshotExporter extends SparkClientFunctionalTestHarness
     // Prepare data as source Hudi dataset
     HoodieWriteConfig cfg = getHoodieWriteConfig(sourcePath);
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(cfg)) {
-      writeClient.startCommitWithTime(COMMIT_TIME);
+      WriteClientTestUtils.startCommitWithTime(writeClient, COMMIT_TIME);
       HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(new String[] {PARTITION_PATH});
       List<HoodieRecord> records = dataGen.generateInserts(COMMIT_TIME, NUM_RECORDS);
       JavaRDD<HoodieRecord> recordsRDD = jsc().parallelize(records, 1);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.multitable;
 
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -236,7 +237,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     // do one upsert with synchronous metadata update
     SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context, writeConfig);
     List<HoodieRecord> records;
-    writeClient.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(writeClient, instant);
     if (update) {
       records = dataGen.generateUpdates(instant, 100);
     } else {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/HoodieOfflineJobTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/HoodieOfflineJobTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.offlinejob;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -86,7 +87,7 @@ public class HoodieOfflineJobTestBase extends UtilitiesTestBase {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     JavaRDD records = jsc.parallelize(dataGen.generateInserts(instant, numRecords), 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    client.startCommitWithTime(instant);
+    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses;
     if (isUpsert) {
       writeStatuses = client.upsert(records, instant).collect();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSourceHarness.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSourceHarness.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
@@ -218,7 +219,7 @@ public class S3EventsHoodieIncrSourceHarness extends SparkClientFunctionalTestHa
     HoodieWriteConfig writeConfig = getWriteConfig();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
 
-      writeClient.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
       List<HoodieRecord> s3MetadataRecords = Arrays.asList(
           generateS3EventMetadata(commitTime, "bucket-1", "data-file-1.json", 1L)
       );

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
@@ -434,7 +435,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     HoodieWriteConfig writeConfig = getWriteConfig();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
 
-      writeClient.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
       List<HoodieRecord> gcsMetadataRecords = Arrays.asList(
           getGcsMetadataRecord(commitTime, "data-file-1.json", "bucket-1", "1"),
           getGcsMetadataRecord(commitTime, "data-file-2.json", "bucket-1", "1"),

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.BaseHoodieTableFileIndex;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -757,7 +758,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
                                    List<HoodieRecord> insertRecords,
                                    String commit,
                                    int numRecords) throws IOException {
-    writeClient.startCommitWithTime(commit);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commit);
     // Only supports INSERT, UPSERT, and BULK_INSERT
     List<HoodieRecord> records = writeOperationType == WriteOperationType.UPSERT
         ? dataGen.generateUpdates(commit, insertRecords) : dataGen.generateInserts(commit, numRecords);
@@ -779,7 +780,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
                                                WriteOperationType writeOperationType,
                                                String commit,
                                                String partitionPath) {
-    writeClient.startCommitWithTime(commit);
+    WriteClientTestUtils.startCommitWithTime(writeClient, commit);
     List<HoodieRecord> records = dataGen.generateInsertsForPartition(commit, 100, partitionPath);
     JavaRDD<WriteStatus> result = writeOperationType == WriteOperationType.BULK_INSERT
         ? writeClient.bulkInsert(jsc().parallelize(records, 1), commit)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestIncrSourceHelper.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -338,7 +339,7 @@ class TestIncrSourceHelper extends SparkClientFunctionalTestHarness {
     HoodieWriteConfig writeConfig = getWriteConfig();
     try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
 
-      writeClient.startCommitWithTime(commitTime);
+      WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
       List<HoodieRecord> s3MetadataRecords = Arrays.asList(
           generateS3EventMetadata(commitTime, "bucket-1", "data-file-1.json", 1L)
       );


### PR DESCRIPTION
### Change Logs

- Remove startCommitWithTime usage outside of tests
- Update methods so only tests can specify a specific time

### Impact

- Cleans up methods to ensure users start commit to generate a timestamp instead of supplying an arbitrary value

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
