### PR TITLE
Upgarde parquet-avro version to address CVE-2025-46762

### DIFF
--- a/hudi-client/hudi-flink-client/pom.xml
+++ b/hudi-client/hudi-flink-client/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>${parquet.version}</version>
+            <version>${parquet.avro.version}</version>
         </dependency>
 
         <dependency>

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>${parquet.version}</version>
+            <version>${parquet.avro.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -394,7 +394,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${hive.parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${parquet.avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>
+    <parquet.avro.version>1.15.2</parquet.avro.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.vintage.version>5.8.2</junit.vintage.version>
     <junit.platform.version>1.8.2</junit.platform.version>
@@ -983,7 +984,7 @@
       <dependency>
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
-        <version>${parquet.version}</version>
+        <version>${parquet.avro.version}</version>
         <scope>provided</scope>
         <exclusions>
           <exclusion>
@@ -992,6 +993,13 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.parquet</groupId>
+        <artifactId>parquet-jackson</artifactId>
+        <version>${parquet.version}</version>
+      </dependency>
+
 
       <!-- Orc -->
       <dependency>


### PR DESCRIPTION
### Change Logs

The last published [hudi-presto-bundle, 1.0.2](https://mvnrepository.com/artifact/org.apache.hudi/hudi-presto-bundle/1.0.2), is using parquet-avro version 1.13.1

This unfortunately has two rather bothersome CVEs -

[CVE-2025-46762](https://github.com/advisories/GHSA-53wx-pr6q-m3j5), score 7.1/10 - Apache Parquet Java: Potential malicious code execution from trusted packages in the parquet-avro module when reading an Avro schema from a Parquet file metadata
[CVE-2025-30065](https://github.com/advisories/GHSA-2c59-37c4-qrx5), score 10/10 - Apache Parquet Avro Module Vulnerable to Arbitrary Code Execution
Upgrading to parquet-avro 1.15.2 should fix these

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
