### PR TITLE
[HUDI-9482] Fix the issue where the file slice was wrongly filtered out

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteCommitActionExecutor.java
@@ -96,8 +96,8 @@ public class SparkInsertOverwriteCommitActionExecutor<T>
   }
 
   protected List<String> getAllExistingFileIds(String partitionPath) {
-    // because new commit is not complete. it is safe to mark all existing file Ids as old files
-    return table.getSliceView().getLatestFileSlices(partitionPath).map(FileSlice::getFileId).distinct().collect(Collectors.toList());
+    // we should only fetch the latest merged file slices with committed data
+    return table.getSliceView().getLatestMergedFileSlicesBeforeOrOn(partitionPath, instantTime).filter(slice -> !slice.isEmpty()).map(FileSlice::getFileId).distinct().collect(Collectors.toList());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/CompletionTimeQueryView.java
@@ -18,30 +18,39 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.Option;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.function.Function;
 
-public interface CompletionTimeQueryView extends AutoCloseable {
+public abstract class CompletionTimeQueryView implements AutoCloseable, Serializable {
 
-  boolean isCompleted(String beginInstantTime);
+  protected HoodieTableMetaClient metaClient;
+
+  public CompletionTimeQueryView(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
+  public abstract boolean isCompleted(String beginInstantTime);
 
   /**
    * Returns whether the instant is archived.
    */
-  boolean isArchived(String instantTime);
+  public abstract boolean isArchived(String instantTime);
 
   /**
    * Returns whether the give instant time {@code instantTime} completed before the base instant {@code baseInstant}.
    */
-  boolean isCompletedBefore(String baseInstant, String instantTime);
+  public abstract boolean isCompletedBefore(String baseInstant, String instantTime);
 
   /**
    * Returns whether the given instant time {@code instantTime} is sliced after or on the base instant {@code baseInstant}.
    */
-  boolean isSlicedAfterOrOn(String baseInstant, String instantTime);
+  public abstract boolean isSlicedAfterOrOn(String baseInstant, String instantTime);
 
   /**
    * Get completion time with a base instant time as a reference to fix the compatibility.
@@ -51,7 +60,7 @@ public interface CompletionTimeQueryView extends AutoCloseable {
    *
    * @return Probability fixed completion time.
    */
-  Option<String> getCompletionTime(String baseInstant, String instantTime);
+  public abstract Option<String> getCompletionTime(String baseInstant, String instantTime);
 
   /**
    * Queries the completion time with given instant time.
@@ -60,7 +69,7 @@ public interface CompletionTimeQueryView extends AutoCloseable {
    *
    * @return The completion time if the instant finished or empty if it is still pending.
    */
-  Option<String> getCompletionTime(String beginTime);
+  public abstract Option<String> getCompletionTime(String beginTime);
 
   /**
    * Queries the instant times with given completion time range.
@@ -74,7 +83,7 @@ public interface CompletionTimeQueryView extends AutoCloseable {
    *
    * @return The sorted instant time list.
    */
-  List<String> getInstantTimes(
+  public abstract List<String> getInstantTimes(
       HoodieTimeline timeline,
       Option<String> startCompletionTime,
       Option<String> endCompletionTime,
@@ -90,7 +99,7 @@ public interface CompletionTimeQueryView extends AutoCloseable {
    *
    * @return The sorted instant time list.
    */
-  List<String> getInstantTimes(
+  public abstract List<String> getInstantTimes(
       String startCompletionTime,
       String endCompletionTime,
       Function<String, String> earliestInstantTimeFunc);
@@ -99,11 +108,15 @@ public interface CompletionTimeQueryView extends AutoCloseable {
    *  Get Cursor Instant
    * @return
    */
-  String getCursorInstant();
+  public abstract String getCursorInstant();
 
   /**
    * Return true if the table is empty.
    * @return
    */
-  boolean isEmptyTable();
+  public abstract boolean isEmptyTable();
+
+  public HoodieTableVersion getTableVersion() {
+    return metaClient.getTableConfig().getTableVersion();
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.VisibleForTesting;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -39,14 +38,12 @@ import java.util.function.Function;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
 
-public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Serializable {
+public class CompletionTimeQueryViewV1 extends CompletionTimeQueryView {
   private static final long serialVersionUID = 1L;
 
   private static final long MILLI_SECONDS_IN_THREE_DAYS = 3 * 24 * 3600 * 1000;
 
   private static final long MILLI_SECONDS_IN_ONE_DAY = 24 * 3600 * 1000;
-
-  private final HoodieTableMetaClient metaClient;
 
   /**
    * Mapping from instant start time -> completion time.
@@ -83,7 +80,7 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
    * @param eagerLoadInstant The earliest instant time to eagerly load from, by default load last N days of completed instants.
    */
   public CompletionTimeQueryViewV1(HoodieTableMetaClient metaClient, String eagerLoadInstant) {
-    this.metaClient = metaClient;
+    super(metaClient);
     this.beginToCompletionInstantTimeMap = new ConcurrentHashMap<>();
     this.cursorInstant = InstantComparison.minInstant(eagerLoadInstant, metaClient.getActiveTimeline().firstInstant().map(HoodieInstant::requestedTime).orElse(""));
     // Note: use getWriteTimeline() to keep sync with the fs view visibleCommitsAndCompactionTimeline, see AbstractTableFileSystemView.refreshTimeline.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.util.VisibleForTesting;
 
 import org.apache.avro.generic.GenericRecord;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
@@ -53,7 +52,7 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THA
 /**
  * Query view for instant completion time.
  */
-public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Serializable {
+public class CompletionTimeQueryViewV2 extends CompletionTimeQueryView {
   private static final long serialVersionUID = 1L;
 
   private static final long MILLI_SECONDS_IN_THREE_DAYS = 3 * 24 * 3600 * 1000;
@@ -62,8 +61,6 @@ public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Seria
 
   private static final Function<String, String> GET_INSTANT_ONE_DAY_BEFORE = instant ->
       HoodieInstantTimeGenerator.instantTimeMinusMillis(instant, MILLI_SECONDS_IN_ONE_DAY);
-
-  private final HoodieTableMetaClient metaClient;
 
   /**
    * Mapping from instant time -> completion time.
@@ -100,7 +97,7 @@ public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Seria
    * @param eagerLoadInstant The earliest instant time to eagerly load from, by default load last N days of completed instants.
    */
   public CompletionTimeQueryViewV2(HoodieTableMetaClient metaClient, String eagerLoadInstant) {
-    this.metaClient = metaClient;
+    super(metaClient);
     this.instantTimeToCompletionTimeMap = new ConcurrentHashMap<>();
     this.cursorInstant = InstantComparison.minInstant(eagerLoadInstant, metaClient.getActiveTimeline().firstInstant().map(HoodieInstant::requestedTime).orElse(""));
     // Note: use getWriteTimeline() to keep sync with the fs view visibleCommitsAndCompactionTimeline, see AbstractTableFileSystemView.refreshTimeline.

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.transaction.BucketIndexConcurrentFileWritesConflictResolutionStrategy;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.fs.FSUtils;
@@ -79,6 +80,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -210,6 +212,63 @@ public class TestSparkNonBlockingConcurrencyControl extends SparkClientFunctiona
     // the data files belongs 3rd commit is not included in the last compaction.
     Map<String, String> result = Collections.singletonMap("par1", "[id1,par1,id1,Danny,null,1,par1]");
     checkWrittenData(result, 1);
+  }
+
+  /**
+   * case: query with pending instant
+   *
+   * 1. insert-txn1 start
+   * 2. insert-txn2 start
+   * 3. insert-txn2 commit
+   * 4. query-txn3 execute
+   * 5. insert-txn1 commit
+   *
+   *  |-------------------------------- txn1: insert --------------------------------------|
+   *               |------ txn2: insert ------|
+   *                                            |---txn3: query---|
+   *
+   *  we expected txn3's query should see the data of txn2
+   */
+  @Test
+  public void testNonBlockingConcurrencyControlWithPendingInstant() throws Exception {
+    HoodieWriteConfig config = createHoodieWriteConfig();
+    metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, config.getProps());
+
+    // start the 1st txn and insert record: [id1,Danny,null,1,par2], suspend the tx commit
+    SparkRDDWriteClient client0 = getHoodieWriteClient(config);
+    List<String> dataset0 = Collections.singletonList("id1,lcy,13,1,par0");
+    String insertTime0 = client0.createNewInstantTime();
+    writeData(client0, insertTime0, dataset0, true, WriteOperationType.INSERT);
+
+    // start the 1st txn and insert record: [id1,Danny,null,1,par1], suspend the tx commit
+    SparkRDDWriteClient client1 = getHoodieWriteClient(config);
+    List<String> dataset1 = Collections.singletonList("id1,Danny,,1,par1");
+    String insertTime1 = client1.createNewInstantTime();
+    writeData(client1, insertTime1, dataset1, false, WriteOperationType.INSERT);
+
+    // start the 2nd txn and insert record: [id1,null,23,2,par1], suspend the tx commit
+    SparkRDDWriteClient client2 = getHoodieWriteClient(config);
+    List<String> dataset2 = Collections.singletonList("id1,,23,2,par1");
+    String insertTime2 = client2.createNewInstantTime();
+    List<WriteStatus> writeStatuses2 = writeData(client2, insertTime2, dataset2, false, WriteOperationType.INSERT);
+
+    // step to commit the 2nd txn
+    client1.commitStats(
+        insertTime2,
+        writeStatuses2.stream().map(WriteStatus::getStat).collect(Collectors.toList()),
+        Option.empty(),
+        metaClient.getCommitActionType());
+
+    // schedule compaction
+    String compactionTime = (String) client1.scheduleCompaction(Option.empty()).get();
+
+    // do compaction for later query with parquet format
+    client1.compact(compactionTime);
+
+    Map<String, String> result = new HashMap<>();
+    result.put("par0", "[id1,par0,id1,lcy,13,1,par0]");
+    result.put("par1", "[id1,par1,id1,null,23,2,par1]");
+    checkWrittenData(result, 2);
   }
 
   // Validate that multiple writers will only produce base files for bulk insert
@@ -587,6 +646,8 @@ public class TestSparkNonBlockingConcurrencyControl extends SparkClientFunctiona
     String basePath = basePath();
     return HoodieWriteConfig.newBuilder()
         .withProps(Collections.singletonMap(HoodieTableConfig.PRECOMBINE_FIELD.key(), "ts"))
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(false).build())
         .forTable("test")
         .withPath(basePath)
         .withSchema(jsonSchema)


### PR DESCRIPTION
Please consider following case:

``` 

  /**
   * case: query with pending instant
   *
   * 1. insert-txn1 start, will create a log file
   * 2. insert-txn2 start, will create a log file
   * 3. insert-txn2 commit
   * 4. query-txn3 execute
   * 5. insert-txn1 commit
   *
   *  |-------------------------------- txn1: insert --------------------------------------|
   *               |------ txn2: insert ------|
   *                                            |---txn3: query---|
   *
   *  we expected txn3's query should see the data of txn2
   */

```



### Change Logs

1. Fix the issue where the file slice was wrongly filtered out when there were committed and pending logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
