### PR TITLE
[HUDI-9450]: Optimizing the hot path using `String#format` leads to performance loss

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -54,7 +54,11 @@ public class BucketIdentifier implements Serializable {
   }
 
   public static String partitionBucketIdStr(String partition, int bucketId) {
-    return String.format("%s_%s", partition, bucketIdStr(bucketId));
+    // format: {partition}_{bucket_id}, bucket id should be 8 digits long, padded with leading zeros
+    StringBuilder sb = new StringBuilder()
+        .append(partition)
+        .append('_');
+    return appendWithPadZero(bucketId, 8, sb).toString();
   }
 
   public static int bucketIdFromFileId(String fileId) {
@@ -62,7 +66,18 @@ public class BucketIdentifier implements Serializable {
   }
 
   public static String bucketIdStr(int n) {
-    return String.format("%08d", n);
+    // bucket str should be 8 digits long, padded with leading zeros, format like: "00000001" for bucket 1
+    return appendWithPadZero(n, 8, new StringBuilder()).toString();
+  }
+
+  private static StringBuilder appendWithPadZero(int num, int targetLength, StringBuilder sb) {
+    String numStr = Integer.toString(num);
+    int zerosNeeded = targetLength - numStr.length();
+    for (int i = 0; i < zerosNeeded; i++) {
+      sb.append('0');
+    }
+    sb.append(numStr);
+    return sb;
   }
 
   public static String newBucketFileIdPrefix(int bucketId, boolean fixed) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -322,7 +322,12 @@ public class FSUtils {
   }
 
   public static String createNewFileId(String idPfx, int id) {
-    return String.format("%s-%d", idPfx, id);
+    // format: {idPrefix}-{id}
+    return new StringBuilder()
+        .append(idPfx)
+        .append('-')
+        .append(id)
+        .toString();
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -423,7 +423,11 @@ public class StreamerUtil {
    * Generates the bucket ID using format {partition path}_{fileID}.
    */
   public static String generateBucketKey(String partitionPath, String fileId) {
-    return partitionPath + "_" + fileId;
+    return new StringBuilder()
+        .append(partitionPath)
+        .append('_')
+        .append(fileId)
+        .toString();
   }
 
   /**


### PR DESCRIPTION
I find that on the hot paths for reading and writing, some string-related operations waste a lot of our cpu time. For example, as shown in the following figure, on the path we write, operations related to `String#format` even occupy more than 20% of the time. 
<img width="532" alt="image" src="https://github.com/user-attachments/assets/692c2507-0678-4b93-aaa1-4a50819327d3" />
<img width="136" alt="image" src="https://github.com/user-attachments/assets/0785aa2b-0566-4190-86d2-bf7a0b403a43" />

Each record will go through a lot of character concatenation during the processing. Using `String#format` for concatenation will cause the jvm to need to parse the format and concatenate the corresponding string each time, which is a very performance-consuming operation. 
There are two ways to optimize it. One is to parse and compile the format in advance, and each time only the strings need to be concatenated. Another way is to use `StringBuilder`. After my micro benchmark, the former can improve performance by nearly 10 times and the latter by nearly a hundred times. Therefore, I used the latter for optimization.

### Change Logs

1. Optimizing the hot path using stringformat leads to performance loss

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

improve string related operations' performance
### Risk level (write none, low medium or high below)

low

### Documentation Update

none
_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
