### PR TITLE
[HUDI-9451] Avoid broadcasting unnecessary `FileSlice` when reading

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -189,7 +189,7 @@ case class HoodieFileIndex(spark: SparkSession,
           val files = logPathInfoStream.collect(Collectors.toList[StoragePathInfo]).asScala
           baseFileStatusOpt.foreach(f => files.append(f))
           val allCandidateFiles = files.map(fileInfo => new FileStatus(fileInfo.getLength, fileInfo.isDirectory, 0, fileInfo.getBlockSize,
-              fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri)))
+              fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri))).toSeq
           sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
             InternalRow.fromSeq(partitionOpt.get.values), allCandidateFiles)
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -172,22 +172,23 @@ case class HoodieFileIndex(spark: SparkSession,
    * @return list of PartitionDirectory containing partition to base files mapping
    */
   override def listFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
-    val prunedPartitionsAndFilteredFileSlices = filterFileSlices(dataFilters, partitionFilters).map {
-      case (partitionOpt, fileSlices) =>
+    val prunedPartitionsAndFilteredFileSlices = filterFileSlices(dataFilters, partitionFilters).flatMap(
+      { case (partitionOpt, fileSlices) =>
+        fileSlices.filter(!_.isEmpty).map(fs => (partitionOpt, fs))
+      }
+    ).map {
+      case (partitionOpt, fileSlice) =>
         if (shouldEmbedFileSlices) {
-          PartitionDirectoryConverter.convertFileSlicesToPartitionDirectory(
+          PartitionDirectoryConverter.convertFileSliceToPartitionDirectory(
             partitionOpt,
-            fileSlices,
+            fileSlice,
             options)
         } else {
-          val allCandidateFiles: Seq[FileStatus] = fileSlices.flatMap(fs => {
-            val baseFileStatusOpt = getBaseFileInfo(Option.apply(fs.getBaseFile.orElse(null)))
-            val logPathInfoStream = fs.getLogFiles.map[StoragePathInfo](JFunction.toJavaFunction[HoodieLogFile, StoragePathInfo](lf => lf.getPathInfo))
-            val files = logPathInfoStream.collect(Collectors.toList[StoragePathInfo]).asScala
-            baseFileStatusOpt.foreach(f => files.append(f))
-            files
-          })
-            .map(fileInfo => new FileStatus(fileInfo.getLength, fileInfo.isDirectory, 0, fileInfo.getBlockSize,
+          val baseFileStatusOpt = getBaseFileInfo(Option.apply(fileSlice.getBaseFile.orElse(null)))
+          val logPathInfoStream = fileSlice.getLogFiles.map[StoragePathInfo](JFunction.toJavaFunction[HoodieLogFile, StoragePathInfo](lf => lf.getPathInfo))
+          val files = logPathInfoStream.collect(Collectors.toList[StoragePathInfo]).asScala
+          baseFileStatusOpt.foreach(f => files.append(f))
+          val allCandidateFiles = files.map(fileInfo => new FileStatus(fileInfo.getLength, fileInfo.isDirectory, 0, fileInfo.getBlockSize,
               fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri)))
           sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
             InternalRow.fromSeq(partitionOpt.get.values), allCandidateFiles)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionDirectoryConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionDirectoryConverter.scala
@@ -20,6 +20,7 @@ package org.apache.hudi
 import org.apache.hudi.BaseHoodieTableFileIndex.PartitionPath
 import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.FileSlice
+import org.apache.hudi.exception.HoodieException
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -27,36 +28,35 @@ import org.apache.spark.sql.execution.datasources.PartitionDirectory
 
 object PartitionDirectoryConverter extends SparkAdapterSupport {
 
-  def convertFileSlicesToPartitionDirectory(partitionOpt: Option[PartitionPath],
-                                            fileSlices: Seq[FileSlice],
-                                            options: Map[String, String]): PartitionDirectory = {
+  def convertFileSliceToPartitionDirectory(partitionOpt: Option[PartitionPath],
+                                           fileSlice: FileSlice,
+                                           options: Map[String, String]): PartitionDirectory = {
     val logFileEstimationFraction = options.getOrElse(HoodieStorageConfig.LOGFILE_TO_PARQUET_COMPRESSION_RATIO_FRACTION.key(),
       HoodieStorageConfig.LOGFILE_TO_PARQUET_COMPRESSION_RATIO_FRACTION.defaultValue()).toDouble
-    // 1. Generate a delegate file for each file slice, which spark uses to optimize rdd partition parallelism based on data such as file size
-    // For file slice only has base file, we directly use the base file size as delegate file size
-    // For file slice has log file, we estimate the delegate file size based on the log file size and option(base file) size
-    val delegateFiles = fileSlices.map(slice => {
-      val estimationFileSize = slice.getTotalFileSizeAsParquetFormat(logFileEstimationFraction)
-      val fileInfo = if (slice.getBaseFile.isPresent) {
-        slice.getBaseFile.get().getPathInfo
-      } else if (slice.hasLogFiles) {
-        slice.getLogFiles.findAny().get().getPathInfo
-      } else {
-        null
-      }
-      (fileInfo, estimationFileSize)
-    }).filter(_._1 != null).map(f => {
-      val (fileInfo, estimationFileSize) = f
-      new FileStatus(estimationFileSize, fileInfo.isDirectory, 0, fileInfo.getBlockSize, fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri))
-    })
-    // 2. Generate a mapping from fileId to file slice
-    val c = fileSlices.filter(f => f.hasLogFiles || f.hasBootstrapBase).foldLeft(Map[String, FileSlice]()) { (m, f) => m + (f.getFileId -> f) }
-    if (c.nonEmpty) {
+    if (fileSlice.isEmpty) {
+      throw new HoodieException(
+        s"File slice is empty for partition: ${partitionOpt.map(_.values.mkString("/")).getOrElse("N/A")}, fileId: ${fileSlice.getFileId}")
+    }
+    // 1. Generate a delegate file for file slice, which spark uses to optimize rdd partition parallelism based on data such as file size
+    //    - For file slice only has base file, we directly use the base file size as delegate file size
+    //    - For file slice has log file, we estimate the delegate file size based on the log file size and option(base file) size
+    val estimationFileSize = fileSlice.getTotalFileSizeAsParquetFormat(logFileEstimationFraction)
+    val fileInfo = if (fileSlice.getBaseFile.isPresent) {
+      fileSlice.getBaseFile.get().getPathInfo
+    } else {
+      fileSlice.getLogFiles.findAny().get().getPathInfo
+    }
+    // create a delegate file status based on the file size estimation
+    val delegateFile = new FileStatus(estimationFileSize, fileInfo.isDirectory, 0, fileInfo.getBlockSize, fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri))
+
+    // 2. Generate a partition directory based on the delegate file and partition values
+    if (fileSlice.hasLogFiles || fileSlice.hasBootstrapBase) {
+      // should read as file slice, so we need to create a mapping from fileId to file slice
       sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
-        new HoodiePartitionFileSliceMapping(InternalRow.fromSeq(partitionOpt.get.values), c), delegateFiles)
+        new HoodiePartitionFileSliceMapping(InternalRow.fromSeq(partitionOpt.get.values), Map(fileSlice.getFileId -> fileSlice)), Seq(delegateFile))
     } else {
       sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
-        InternalRow.fromSeq(partitionOpt.get.values), delegateFiles)
+        InternalRow.fromSeq(partitionOpt.get.values), Seq(delegateFile))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
@@ -53,7 +53,6 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
     // 1. base file only
     // 2. log files only
     // 3. base file + log files
-    // 4. empty file slice
 
     // iterate 100000 times to create file slices
     val slicesAndNum = (0 until 10000).map { i =>
@@ -64,7 +63,7 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
       } else {
         0
       }
-      val logRecordNums = if (nextInt(2) == 0) {
+      val logRecordNums = if (baseRecordNum == 0 || nextInt(2) == 0) {
         Seq(nextInt(300), nextInt(300), nextInt(300))
       } else {
         Seq()
@@ -81,21 +80,23 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
     val maxSplitSize = totalSize / expectedTaskCount
     val partitionValues = Seq("2025-01-01")
     val partitionOpt = Some(new PartitionPath(partitionPath, partitionValues.toArray))
-    val partitionDirectory = PartitionDirectoryConverter.convertFileSlicesToPartitionDirectory(partitionOpt, slices, options)
 
-    val partitionedFiles = partitionDirectory.files.flatMap(file => {
-      // getPath() is very expensive so we only want to call it once in this block:
-      val filePath = file.getPath
-      val isSplitable = false
-      PartitionedFileUtil.splitFiles(
-        spark,
-        file = file,
-        filePath = filePath,
-        isSplitable = isSplitable,
-        maxSplitBytes = maxSplitSize,
-        partitionValues = partitionDirectory.values
-      )
-    })
+    val partitionedFiles = slices.flatMap(slice => {
+      val dir = PartitionDirectoryConverter.convertFileSliceToPartitionDirectory(partitionOpt, slice, options)
+      dir.files.flatMap(file => {
+        // getPath() is very expensive so we only want to call it once in this block:
+        val filePath = file.getPath
+        val isSplitable = false
+        PartitionedFileUtil.splitFiles(
+          spark,
+          file = file,
+          filePath = filePath,
+          isSplitable = isSplitable,
+          maxSplitBytes = maxSplitSize,
+          partitionValues = dir.values
+        )
+      })
+    }).toSeq
 
     val tasks = sparkAdapter.getFilePartitions(spark, partitionedFiles, maxSplitSize)
     verifyBalanceByNum(tasks, totalRecordNum, logFraction)
@@ -125,7 +126,7 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
       if (totalRecordNum < expectedToleranceMin || totalRecordNum > expectedToleranceMax) {
         outOfRangeCount += 1
       }
-      assert(outOfRangeCount <= 1 , s"Record num $totalRecordNum is not in the range [$expectedToleranceMin, $expectedToleranceMax]")
+      assert(outOfRangeCount <= 1, s"Record num $totalRecordNum is not in the range [$expectedToleranceMin, $expectedToleranceMax]")
       totalRecordNum
     })
   }
@@ -154,7 +155,8 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
     logRecordNums.zipWithIndex.foreach { case (logRecordNum, index) => {
       val logFile = buildHoodieLogFile(fileId, logRecordNum, sizePerLogRecord.toLong, index)
       slice.addLogFile(logFile)
-    }}
+    }
+    }
     slice
   }
 


### PR DESCRIPTION
Our current logic is that we will disguise all the files under each partition as a `PartitionDirectory` together. In order to enable the task to know the files that really need to be read, we have also put the collection of all `FileSlice` under this partition into the `PartitionValue`. 
It is convenient to find the corresponding file slice to be read from the file slice mapping set in the `PartitionValue` when each subsequent task is executed and read. 
However, I found that when the number of files in one partition increases, for example, when there are tens of thousands of files in one partition, the file slices in the `PartitionValue` will be 100MB+ in size. And when spark creates reading tasks, it needs to pass this mapping of `FileSlice` to each task. Therefore, under our default configuration, it will lead to the failure of job. Moreover, for each task, it only cares about the `FileSlice` it needs to read and does not need to pass all the `FileSlice` under the partition to it. 
Therefore, I optimized the above logic. I will only pass the `FileSlice` object that each reading task needs to read, successively reducing the invalid broadcast overhead of task creation.

### Change Logs

1. Avoid broadcasting unnecessary `FileSlice` when reading

### Impact

improve query stability

### Risk level (write none, low medium or high below)

low

### Documentation Update


none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
