### PR TITLE
[HUDI-9473] Set memory config properly for FileGroup reader in Flink …

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/FlinkFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/FlinkFileGroupReaderBasedMergeHandle.java
@@ -80,7 +80,7 @@ public class FlinkFileGroupReaderBasedMergeHandle<T, I, K, O> extends BaseFileGr
     if (!StringUtils.isNullOrEmpty(config.getInternalSchema())) {
       internalSchemaOption = SerDeHelper.fromJson(config.getInternalSchema());
     }
-    TypedProperties props = FlinkClientUtil.getMergedTableAndWriteProps(hoodieTable.getMetaClient().getTableConfig(), config);
+    TypedProperties props = FlinkClientUtil.getReadProps(hoodieTable.getMetaClient().getTableConfig(), config);
     // Initializes file group reader
     try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder()
         .withReaderContext(readerContext).withHoodieTableMetaClient(hoodieTable.getMetaClient())

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.util;
 
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -94,17 +95,19 @@ public class FlinkClientUtil {
   }
 
   /**
-   * Get merged {@link TypedProperties} from {@link HoodieTableConfig} and {@link HoodieWriteConfig}.
+   * Get merged {@link TypedProperties} from {@link HoodieTableConfig} and {@link HoodieWriteConfig}, which is used by FileGroup reader.
    *
    * @param tableConfig The hoodie table configuration
    * @param writeConfig the hoodie write configuration
    *
    * @return Merged {@link TypedProperties} from {@link HoodieTableConfig} and {@link HoodieWriteConfig}
    */
-  public static TypedProperties getMergedTableAndWriteProps(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
+  public static TypedProperties getReadProps(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {
     TypedProperties props = new TypedProperties();
     props.putAll(tableConfig.getProps());
     writeConfig.getProps().forEach(props::putIfAbsent);
+    // For compatibility, log scanner uses MAX_MEMORY_FOR_COMPACTION for merging and FileGroup reader uses MAX_MEMORY_FOR_MERGE for merging.
+    props.put(HoodieMemoryConfig.MAX_MEMORY_FOR_MERGE.key(), writeConfig.getString(HoodieMemoryConfig.MAX_MEMORY_FOR_COMPACTION));
     return props;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
@@ -126,7 +126,7 @@ public class FormatUtils {
             predicates,
             metaClient.getTableConfig(),
             instantRangeOption);
-    final TypedProperties typedProps = FlinkClientUtil.getMergedTableAndWriteProps(metaClient.getTableConfig(), writeConfig);
+    final TypedProperties typedProps = FlinkClientUtil.getReadProps(metaClient.getTableConfig(), writeConfig);
     typedProps.put(HoodieReaderConfig.MERGE_TYPE.key(), mergeType);
 
     return HoodieFileGroupReader.<RowData>newBuilder()

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utils;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.client.model.PartialUpdateFlinkRecordMerger;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieRecordMerger;
@@ -905,6 +906,12 @@ public class TestData {
     // 1. init flink table
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .fromFile(hoodiePropertiesFile)
+        .withMemoryConfig(
+            HoodieMemoryConfig.newBuilder()
+                .withMaxMemoryMaxSize(
+                    FlinkOptions.WRITE_MERGE_MAX_MEMORY.defaultValue() * 1024 * 1024L,
+                    FlinkOptions.COMPACTION_MAX_MEMORY.defaultValue() * 1024 * 1024L)
+                .build())
         .withPath(basePath)
         .build();
     // deal with partial update merger


### PR DESCRIPTION
…reader

### Change Logs

Set memory config properly for FileGroup reader in Flink reader

### Impact

Correct the memory conf for FileGroup reader

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
