### PR TITLE
[HUDI-9475] Fix invalid log file name exception during CDC query

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
@@ -97,7 +97,8 @@ public class HoodieCDCFileSplit implements Serializable, Comparable<HoodieCDCFil
     this.instant = instant;
     this.cdcInferCase = cdcInferCase;
     this.cdcFiles = cdcFiles.stream()
-        .sorted(Comparator.comparingInt(FSUtils::getFileVersionFromLog)).collect(Collectors.toList());
+        .sorted(Comparator.comparingInt(path -> FSUtils.getFileVersionFromLog(FSUtils.getFileNameFromPath(path))))
+        .collect(Collectors.toList());
     this.beforeFileSlice = beforeFileSlice;
     this.afterFileSlice = afterFileSlice;
   }


### PR DESCRIPTION
### Change Logs

Strip partition path from CDC log file names before sorting to avoid Invalid log file name exception during CDC query.

### Impact

Low – Affects only scenarios with multiple CDC log files; no behavior change for single-file cases.

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
