### PR TITLE
[MINOR] Fix flakiness in TestHoodieFileSystemViews.testFileSystemViewConsistency

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieFileSystemViews.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieFileSystemViews.java
@@ -161,11 +161,7 @@ public class TestHoodieFileSystemViews extends HoodieClientTestBase {
       // mimic failed write for last completed operation and retry few more operations.
       HoodieInstant lastInstant = metaClient.reloadActiveTimeline().getWriteTimeline().lastInstant().get();
       HoodieCommitMetadata commitMetadata = metaClient.getActiveTimeline().readCommitMetadata(lastInstant);
-      StoragePath instantPath = HoodieTestUtils
-          .getCompleteInstantPath(metaClient.getStorage(),
-              metaClient.getTimelinePath(),
-              lastInstant.requestedTime(), lastInstant.getAction(), HoodieTableVersion.fromVersionCode(writeVersion));
-      metaClient.getStorage().deleteFile(instantPath);
+      client.rollback(lastInstant.requestedTime());
 
       expectedFileSystemView.sync();
       actualFileSystemView.sync();


### PR DESCRIPTION
### Change Logs

Fixes the flaky test failure observed in TestHoodieFileSystemViews#testFileSystemViewConsistency. The rollback currently uses marker based rollback so it does not delete the parquet files written by the commit. The FSV shows the parquet file when the test fails. 
The PR modifies the test to ensure we are using the rollback API exposed by the client instead of deleting the completed commit file here. This ensures the correct rollback strategy gets used in the test.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
