### PR TITLE
[HUDI-9423] Use completion time based ordering of log files in file group

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/BaseFileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/BaseFileGroupReaderBasedMergeHandle.java
@@ -82,7 +82,7 @@ public abstract class BaseFileGroupReaderBasedMergeHandle<T, I, K, O> extends Ho
         operation.getFileGroupId(),
         operation.getBaseInstantTime(),
         baseFileOpt.isPresent() ? baseFileOpt.get() : null,
-        logFiles);
+        logFiles, hoodieTable.getMetaClient());
     this.preserveMetadata = true;
     init(operation, this.partitionPath, baseFileOpt);
     validateAndSetAndKeyGenProps(keyGeneratorOpt, config.populateMetaFields());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
@@ -150,7 +150,7 @@ public class MarkerBasedRollbackStrategy<T, I, K, O> implements BaseRollbackPlan
         // NOTE: Since we're rolling back incomplete Delta Commit, it only could have appended its
         //       block to the latest log-file
         try {
-          latestLogFileOption = FSUtils.getLatestLogFile(table.getMetaClient().getStorage(), partitionPath, fileId,
+          latestLogFileOption = FSUtils.getLatestLogFile(table.getStorage(), partitionPath, fileId,
               HoodieFileFormat.HOODIE_LOG.getFileExtension(), baseCommitTime);
           if (latestLogFileOption.isPresent() && baseCommitTime.equals(instantToRollback.requestedTime())) {
             // Log file can be deleted if the commit to rollback is also the commit that created the fileGroup

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestFileSliceMetricUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestFileSliceMetricUtils.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.testutils.InProcessTimeGenerator;
+import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
@@ -99,7 +100,7 @@ public class TestFileSliceMetricUtils {
       String logFilePath = "." + UUID.randomUUID().toString() + "_20170101134598.log." + logVersion;
       HoodieLogFile logFile = new HoodieLogFile(logFilePath);
       logFile.setFileLen(logFileLen);
-      slice.addLogFile(logFile);
+      slice.addLogFile(logFile, Option.empty());
       logVersion++;
     }
     return slice;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -318,7 +318,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     RDD<InternalRow> internalRowRDD = jsc.parallelize(clusteringOps, clusteringOps.size()).flatMap(new FlatMapFunction<ClusteringOperation, InternalRow>() {
       @Override
       public Iterator<InternalRow> call(ClusteringOperation clusteringOperation) throws Exception {
-        FileSlice fileSlice = clusteringOperationToFileSlice(basePath, clusteringOperation);
+        FileSlice fileSlice = clusteringOperationToFileSlice(metaClient, clusteringOperation);
         // instantiate other supporting cast
         Schema readerSchema = serializableTableSchemaWithMetaFields.get();
         Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(internalSchemaStr);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -316,7 +316,8 @@ public class SparkMetadataWriterUtils {
     } else {
       HoodieLogFile logFile = new HoodieLogFile(filePath);
       fileSlice = new FileSlice(partition, logFile.getDeltaCommitTime(), logFile.getFileId());
-      fileSlice.addLogFile(logFile);
+      // Since we are reading the file slice, completion time is not needed here
+      fileSlice.addLogFile(logFile, Option.empty());
     }
     HoodieFileGroupReader<InternalRow> fileGroupReader = HoodieFileGroupReader.<InternalRow>newBuilder()
         .withReaderContext(readerContext)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkConsistentBucketClusteringPlanStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkConsistentBucketClusteringPlanStrategy.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -201,7 +202,7 @@ public class TestSparkConsistentBucketClusteringPlanStrategy extends HoodieSpark
     for (int i = 0; i < numLogFiles; ++i) {
       HoodieLogFile f = new HoodieLogFile(String.format(".%s_%s.log.%d", fileId, "12345678", i));
       f.setFileLen(logFileSize);
-      fs.addLogFile(f);
+      fs.addLogFile(f, Option.empty());
     }
 
     return fs;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -522,7 +523,7 @@ public class TestHoodieCompactionStrategy {
       List<HoodieLogFile> logFiles = v.stream().map(TestHoodieLogFile::newLogFile).collect(Collectors.toList());
       FileSlice slice = new FileSlice(new HoodieFileGroupId(partitionPath, df.getFileId()), df.getCommitTime());
       slice.setBaseFile(df);
-      logFiles.stream().forEach(f -> slice.addLogFile(f));
+      logFiles.stream().forEach(logFile -> slice.addLogFile(logFile, Option.empty()));
       operations.add(new HoodieCompactionOperation(df.getCommitTime(),
           logFiles.stream().map(s -> s.getPath().toString()).collect(Collectors.toList()), df.getPath(), df.getFileId(),
           partitionPath,
@@ -545,7 +546,7 @@ public class TestHoodieCompactionStrategy {
         List<HoodieLogFile> logFiles = v.stream().map(TestHoodieLogFile::newLogFile).collect(Collectors.toList());
         FileSlice slice = new FileSlice(new HoodieFileGroupId(partitionPath, df.getFileId()), df.getCommitTime());
         slice.setBaseFile(df);
-        logFiles.stream().forEach(f -> slice.addLogFile(f));
+        logFiles.forEach(logFile -> slice.addLogFile(logFile, Option.empty()));
         operations.add(new HoodieCompactionOperation(df.getCommitTime(),
             logFiles.stream().map(s -> s.getPath().toString()).collect(Collectors.toList()),
             df.getPath(), df.getFileId(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -109,11 +109,12 @@ public class HoodieFileGroup implements Serializable {
    * <p>CAUTION: the log file must be added in sequence of the delta commit time.
    */
   public void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
+    Option<String> completionTimeOpt = completionTimeQueryView.getCompletionTime(fileSlices.firstKey(), logFile.getDeltaCommitTime());
     String baseInstantTime = getBaseInstantTime(completionTimeQueryView, logFile);
     if (!fileSlices.containsKey(baseInstantTime)) {
       fileSlices.put(baseInstantTime, new FileSlice(fileGroupId, baseInstantTime));
     }
-    fileSlices.get(baseInstantTime).addLogFile(logFile);
+    fileSlices.get(baseInstantTime).addLogFile(logFile, completionTimeOpt);
   }
 
   @VisibleForTesting

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -109,8 +109,8 @@ public class HoodieFileGroup implements Serializable {
    * <p>CAUTION: the log file must be added in sequence of the delta commit time.
    */
   public void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
-    Option<String> completionTimeOpt = completionTimeQueryView.getCompletionTime(fileSlices.firstKey(), logFile.getDeltaCommitTime());
     String baseInstantTime = getBaseInstantTime(completionTimeQueryView, logFile);
+    Option<String> completionTimeOpt = completionTimeQueryView.getCompletionTime(baseInstantTime, logFile.getDeltaCommitTime());
     if (!fileSlices.containsKey(baseInstantTime)) {
       fileSlices.put(baseInstantTime, new FileSlice(fileGroupId, baseInstantTime));
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -275,7 +275,7 @@ public class HoodieCDCExtractor {
           ).orElseThrow(() ->
               new HoodieIOException("Can not get the previous version of the base file")
           );
-          FileSlice beforeFileSlice = new FileSlice(fileGroupId, writeStat.getPrevCommit(), beforeBaseFile, Collections.emptyList());
+          FileSlice beforeFileSlice = new FileSlice(fileGroupId, writeStat.getPrevCommit(), beforeBaseFile, Collections.emptyList(), metaClient);
           cdcFileSplit = new HoodieCDCFileSplit(instantTs, BASE_FILE_DELETE, new ArrayList<>(), Option.of(beforeFileSlice), Option.empty());
         } else if ((writeStat.getNumUpdateWrites() == 0L && writeStat.getNumWrites() == writeStat.getNumInserts())) {
           // all the records in this file are new.
@@ -303,9 +303,9 @@ public class HoodieCDCExtractor {
           FileSlice currentFileSlice = new FileSlice(fileGroupId, instant.requestedTime(),
               new HoodieBaseFile(
                   storage.getPathInfo(new StoragePath(basePath, writeStat.getPath()))),
-              new ArrayList<>());
+              new ArrayList<>(), metaClient);
           if (supplementalLoggingMode == HoodieCDCSupplementalLoggingMode.OP_KEY_ONLY) {
-            beforeFileSlice = new FileSlice(fileGroupId, writeStat.getPrevCommit(), beforeBaseFile, new ArrayList<>());
+            beforeFileSlice = new FileSlice(fileGroupId, writeStat.getPrevCommit(), beforeBaseFile, new ArrayList<>(), metaClient);
           }
           cdcFileSplit = new HoodieCDCFileSplit(instantTs, AS_IS, writeStat.getCdcStats().keySet(),
               Option.ofNullable(beforeFileSlice), Option.ofNullable(currentFileSlice));
@@ -343,7 +343,7 @@ public class HoodieCDCExtractor {
               .collect(Collectors.toList());
           List<HoodieLogFile> logFiles = storage.listDirectEntries(logFilePaths).stream()
               .map(HoodieLogFile::new).collect(Collectors.toList());
-          return Option.of(new FileSlice(fgId, instant.requestedTime(), baseFile, logFiles));
+          return Option.of(new FileSlice(fgId, instant.requestedTime(), baseFile, logFiles, metaClient));
         } catch (Exception e) {
           throw new HoodieException("Fail to get the dependent file slice for a log file", e);
         }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileSliceDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileSliceDTO.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.util.Option;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -56,7 +57,7 @@ public class FileSliceDTO {
   public static FileSlice toFileSlice(FileSliceDTO dto) {
     FileSlice slice = new FileSlice(dto.partitionPath, dto.baseInstantTime, dto.fileId);
     slice.setBaseFile(BaseFileDTO.toHoodieBaseFile(dto.baseFile));
-    dto.logFiles.stream().forEach(lf -> slice.addLogFile(LogFileDTO.toHoodieLogFile(lf)));
+    dto.logFiles.forEach(lf -> slice.addLogFile(LogFileDTO.toHoodieLogFile(lf), Option.empty()));
     return slice;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/LogFileDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/LogFileDTO.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.storage.StoragePathInfo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -36,11 +38,15 @@ public class LogFileDTO {
   private String pathStr;
   @JsonProperty("len")
   private long fileLen;
+  @JsonProperty("completionTime")
+  private String completionTime;
 
   public static HoodieLogFile toHoodieLogFile(LogFileDTO dto) {
     StoragePathInfo pathInfo = FileStatusDTO.toStoragePathInfo(dto.fileStatus);
     HoodieLogFile logFile = (pathInfo == null) ? new HoodieLogFile(dto.pathStr) : new HoodieLogFile(pathInfo);
     logFile.setFileLen(dto.fileLen);
+    Option<String> completionTimeOpt = StringUtils.isNullOrEmpty(dto.completionTime) ? Option.empty() : Option.of(dto.completionTime);
+    logFile.setCompletionTime(completionTimeOpt);
     return logFile;
   }
 
@@ -49,6 +55,7 @@ public class LogFileDTO {
     logFile.fileLen = dataFile.getFileSize();
     logFile.pathStr = dataFile.getPath().toString();
     logFile.fileStatus = FileStatusDTO.fromStoragePathInfo(dataFile.getPathInfo());
+    logFile.completionTime = dataFile.getCompletionTime().orElse("");
     return logFile;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -557,7 +557,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       // Base file is filtered out of the file-slice as the corresponding compaction
       // instant not completed yet.
       FileSlice transformed = new FileSlice(fileSlice.getPartitionPath(), fileSlice.getBaseInstantTime(), fileSlice.getFileId());
-      fileSlice.getLogFiles().forEach(transformed::addLogFile);
+      fileSlice.getLogFiles().forEach(logFile -> transformed.addLogFile(logFile, Option.empty()));
       if (transformed.isEmpty() && !includeEmptyFileSlice) {
         return Stream.of();
       }
@@ -582,7 +582,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       // instant has not completed yet.
       FileSlice transformed = new FileSlice(fileSlice.getPartitionPath(), fileSlice.getBaseInstantTime(), fileSlice.getFileId());
       committedBaseFile.ifPresent(transformed::setBaseFile);
-      committedLogFiles.forEach(transformed::addLogFile);
+      committedLogFiles.forEach(logFile -> transformed.addLogFile(logFile, Option.empty()));
       if (transformed.isEmpty() && !includeEmptyFileSlice) {
         return Stream.of();
       }
@@ -604,7 +604,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       // instant has not completed yet.
       FileSlice transformed = new FileSlice(fileSlice.getPartitionPath(), fileSlice.getBaseInstantTime(), fileSlice.getFileId());
       fileSlice.getBaseFile().ifPresent(transformed::setBaseFile);
-      committedLogFiles.forEach(transformed::addLogFile);
+      committedLogFiles.forEach(logFile -> transformed.addLogFile(logFile, Option.empty()));
       return transformed;
     }
     return fileSlice;
@@ -1525,8 +1525,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       merged.setBaseFile(penultimateSlice.getBaseFile().get());
     }
     // Add Log files from penultimate and last slices
-    penultimateSlice.getLogFiles().forEach(merged::addLogFile);
-    lastSlice.getLogFiles().forEach(merged::addLogFile);
+    penultimateSlice.getLogFiles().forEach(logFile -> merged.addLogFile(logFile, Option.empty()));
+    lastSlice.getLogFiles().forEach(logFile -> merged. addLogFile(logFile, Option.empty()));
     return merged;
   }
 
@@ -1573,7 +1573,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
         latestSlice.getFileId());
 
     // add log files from the latest slice to the earliest
-    fileSlices.forEach(slice -> slice.getLogFiles().forEach(merged::addLogFile));
+    fileSlices.forEach(slice -> slice.getLogFiles().forEach(logFile -> merged.addLogFile(logFile, Option.empty())));
     return Option.of(merged);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
@@ -341,7 +341,7 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
                     Map<String, HoodieLogFile> newLogFiles = new HashMap<>(logFiles);
                     deltaLogFiles.entrySet().stream().filter(e -> !logFiles.containsKey(e.getKey()))
                         .forEach(p -> newLogFiles.put(p.getKey(), p.getValue()));
-                    newLogFiles.values().forEach(newFileSlice::addLogFile);
+                    newLogFiles.values().forEach(logFile -> newFileSlice.addLogFile(logFile, Option.empty()));
                     LOG.info("Adding back new File Slice after add FS={}", newFileSlice);
                     return newFileSlice;
                   }
@@ -355,7 +355,7 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
                     deltaLogFiles.keySet().forEach(logFiles::remove);
                     // Add remaining log files back
-                    logFiles.values().forEach(newFileSlice::addLogFile);
+                    logFiles.values().forEach(logFile -> newFileSlice.addLogFile(logFile, Option.empty()));
                     if (newFileSlice.getBaseFile().isPresent() || (newFileSlice.getLogFiles().count() > 0)) {
                       LOG.info("Adding back new file-slice after remove FS={}", newFileSlice);
                       return newFileSlice;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1689,7 +1689,8 @@ public class HoodieTableMetadataUtil {
       // read log files without merging for lower overhead, log files may contain multiple records for the same key resulting in a wider range of values than the merged result
       HoodieLogFile logFile = new HoodieLogFile(filePath);
       FileSlice fileSlice = new FileSlice(partitionPath, logFile.getDeltaCommitTime(), logFile.getFileId());
-      fileSlice.addLogFile(logFile);
+      // since we are only fetching column range metadata from the log file here, completion time should not be required in the file slice
+      fileSlice.addLogFile(logFile, Option.empty());
       TypedProperties properties = new TypedProperties();
       properties.setProperty(MAX_MEMORY_FOR_MERGE.key(), Long.toString(maxBufferSize));
       properties.setProperty(HoodieReaderConfig.MERGE_TYPE.key(), REALTIME_SKIP_MERGE);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestFileSlice.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestFileSlice.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.model;
 
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.Test;
@@ -38,10 +39,10 @@ public class TestFileSlice {
     FileSlice fileSlice = new FileSlice("par1", baseInstant, "fg1");
     assertThat(fileSlice.getLatestInstantTime(), is(baseInstant));
 
-    fileSlice.addLogFile(new HoodieLogFile(new StoragePath(getLogFileName(deltaInstant2))));
+    fileSlice.addLogFile(new HoodieLogFile(new StoragePath(getLogFileName(deltaInstant2))), Option.empty());
     assertThat(fileSlice.getLatestInstantTime(), is(baseInstant));
 
-    fileSlice.addLogFile(new HoodieLogFile(new StoragePath(getLogFileName(deltaInstant4))));
+    fileSlice.addLogFile(new HoodieLogFile(new StoragePath(getLogFileName(deltaInstant4))), Option.empty());
     assertThat(fileSlice.getLatestInstantTime(), is(deltaInstant4));
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestDefaultSerializer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestDefaultSerializer.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 
+import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.getMockMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestDefaultSerializer {
@@ -40,8 +42,9 @@ class TestDefaultSerializer {
     String partition = "1";
     String fileId1 = UUID.randomUUID().toString();
     HoodieInstant instant1 = new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", "001", InstantComparatorV1.REQUESTED_TIME_BASED_COMPARATOR);
+    HoodieTableMetaClient metaClient = getMockMetaClient();
     FileSlice fileSlice = new FileSlice(new HoodieFileGroupId(partition, fileId1), instant1.requestedTime(),
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId1, "parquet")), Collections.emptyList());
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId1, "parquet")), Collections.emptyList(), metaClient);
 
     DefaultSerializer<FileSlice> serializer = new DefaultSerializer<>();
     byte[] serializedValue = serializer.serialize(fileSlice);

--- a/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileGroupSerializer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileGroupSerializer.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.getMockMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -47,11 +49,12 @@ class TestHoodieFileGroupSerializer {
     String partition = "1";
     String fileId1 = UUID.randomUUID().toString();
     String fileId2 = UUID.randomUUID().toString();
+    HoodieTableMetaClient metaClient = getMockMetaClient();
     HoodieInstant instant1 = new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", "001", InstantComparatorV1.REQUESTED_TIME_BASED_COMPARATOR);
     FileSlice fileSlice1 = new FileSlice(new HoodieFileGroupId(partition, fileId1), instant1.requestedTime(),
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId1, "parquet")), Collections.emptyList());
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId1, "parquet")), Collections.emptyList(), metaClient);
     FileSlice fileSlice2 = new FileSlice(new HoodieFileGroupId(partition, fileId2), instant1.requestedTime(),
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId2, "parquet")), Collections.emptyList());
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant1.requestedTime(), "1-0-1", fileId2, "parquet")), Collections.emptyList(), metaClient);
     HoodieTimeline mockTimeline1 = new MockHoodieTimeline(Collections.singletonList(instant1));
 
     HoodieFileGroup hoodieFileGroup1 = new HoodieFileGroup(partition, fileId1, mockTimeline1);
@@ -64,7 +67,7 @@ class TestHoodieFileGroupSerializer {
     HoodieInstant instant2 = new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", "002", InstantComparatorV1.REQUESTED_TIME_BASED_COMPARATOR);
     HoodieTimeline mockTimeline2 = new MockHoodieTimeline(Collections.singletonList(instant2));
     FileSlice fileSlice3 = new FileSlice(new HoodieFileGroupId(partition, fileId3), instant1.requestedTime(),
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant2.requestedTime(), "1-0-1", fileId3, "parquet")), Collections.emptyList());
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName(instant2.requestedTime(), "1-0-1", fileId3, "parquet")), Collections.emptyList(), metaClient);
     HoodieFileGroup hoodieFileGroup3 = new HoodieFileGroup(partition, fileId3, mockTimeline2);
     hoodieFileGroup3.addFileSlice(fileSlice3);
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileSliceSerializer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestHoodieFileSliceSerializer.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.getMockMetaClient;
 
 class TestHoodieFileSliceSerializer {
   private static final String LOG_FILE_PATH_FORMAT = "file:///tmp/basePath/partitionPath/.fileId%s_100.log.%s_1-0-1";
@@ -43,6 +46,7 @@ class TestHoodieFileSliceSerializer {
 
   @Test
   void testSerDe() throws IOException {
+    HoodieTableMetaClient metaClient = getMockMetaClient();
     HoodieFileSliceSerializer hoodieFileSliceSerializer = new HoodieFileSliceSerializer();
     HoodieBaseFile baseFile1 = new HoodieBaseFile(new StoragePathInfo(BASE_FILE_STORAGE_PATH_1, 100, false, BLOCK_REPLICATION, 1024, 0));
     HoodieLogFile logFile1 = new HoodieLogFile(new StoragePathInfo(LOG_FILE_STORAGE_PATH_1, 100, false, BLOCK_REPLICATION, 1024, 0));
@@ -53,8 +57,8 @@ class TestHoodieFileSliceSerializer {
     HoodieLogFile logFile4 = new HoodieLogFile("/dummy/base/" + FSUtils.makeLogFileName("fileId-2", HoodieLogFile.DELTA_EXTENSION, "002", 2, "1-0-1"));
 
     List<FileSlice> fileSliceList = Arrays.asList(
-        new FileSlice(new HoodieFileGroupId("partition1", "fileId-1"), "001", baseFile1, Arrays.asList(logFile1, logFile2)),
-        new FileSlice(new HoodieFileGroupId("partition2", "fileId-2"), "001", baseFile2, Arrays.asList(logFile3, logFile4)),
+        new FileSlice(new HoodieFileGroupId("partition1", "fileId-1"), "001", baseFile1, Arrays.asList(logFile1, logFile2), metaClient),
+        new FileSlice(new HoodieFileGroupId("partition2", "fileId-2"), "001", baseFile2, Arrays.asList(logFile3, logFile4), metaClient),
         new FileSlice("partition3", "002", "fileId-3")
     );
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieFileGroupSizeEstimator.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.ObjectSizeCalculator;
 
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils.getMockMetaClient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -44,13 +46,14 @@ import static org.mockito.Mockito.when;
 class TestHoodieFileGroupSizeEstimator {
   @Test
   void estimatorSkipsTimeline() {
+    HoodieTableMetaClient metaClient = getMockMetaClient();
     HoodieFileGroup fileGroup1 = mock(HoodieFileGroup.class);
     HoodieFileGroup fileGroup2 = mock(HoodieFileGroup.class);
 
     // setup mocks
     HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
     List<FileSlice> fileSlices = Collections.singletonList(new FileSlice(fileGroupId, "001",
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList()));
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("001", "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList(), metaClient));
     when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
     when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());
 
@@ -65,13 +68,14 @@ class TestHoodieFileGroupSizeEstimator {
 
   @Test
   void estimatorWithManyFileSlices() {
+    HoodieTableMetaClient metaClient = getMockMetaClient();
     HoodieFileGroup fileGroup1 = mock(HoodieFileGroup.class);
     HoodieFileGroup fileGroup2 = mock(HoodieFileGroup.class);
 
     // setup mocks
     HoodieFileGroupId fileGroupId = new HoodieFileGroupId("path1", UUID.randomUUID().toString());
     List<FileSlice> fileSlices = IntStream.range(1, 100).mapToObj(i -> new FileSlice(fileGroupId, "001",
-        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("00" + i, "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList()))
+        new HoodieBaseFile("/tmp/" + FSUtils.makeBaseFileName("00" + i, "1-0-1", fileGroupId.getFileId(), "parquet")), Collections.emptyList(), metaClient))
         .collect(Collectors.toList());
     when(fileGroup1.getFileGroupId()).thenReturn(fileGroupId);
     when(fileGroup1.getAllFileSlices()).thenReturn(fileSlices.stream()).thenReturn(fileSlices.stream());

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/CompactionTestUtils.java
@@ -177,8 +177,8 @@ public class CompactionTestUtils {
             Paths.get(basePath, partition, logFileName(instantTime, fileId, 1)).toString();
         String logFilePath2 =
             Paths.get(basePath, partition, logFileName(instantTime, fileId, 2)).toString();
-        slice.addLogFile(new HoodieLogFile(new StoragePath(logFilePath1)));
-        slice.addLogFile(new HoodieLogFile(new StoragePath(logFilePath2)));
+        slice.addLogFile(new HoodieLogFile(new StoragePath(logFilePath1)), Option.empty());
+        slice.addLogFile(new HoodieLogFile(new StoragePath(logFilePath2)), Option.empty());
         HoodieCompactionOperation op =
             CompactionUtils.buildFromFileSlice(partition, slice, Option.empty());
         if (deltaCommitsAfterCompactionRequests) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
@@ -241,7 +241,7 @@ public class BootstrapOperator
     // filter out crushed log files
     fileSlice.getLogFiles()
         .filter(logFile -> isValidFile(logFile.getPathInfo()))
-        .forEach(scanFileSlice::addLogFile);
+        .forEach(logFile1 -> scanFileSlice.addLogFile(logFile1, Option.empty()));
 
     HoodieFileGroupReader<RowData> fileGroupReader = FormatUtils.createFileGroupReader(metaClient, writeConfig, internalSchemaManager, scanFileSlice,
         tableSchema, tableSchema, scanFileSlice.getLatestInstantTime(), FlinkOptions.REALTIME_PAYLOAD_COMBINE, true, Collections.emptyList(), Option.empty());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -282,7 +282,8 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
         // baseInstantTime in FileSlice is not used in FG reader
         "",
         Option.ofNullable(clusterOperation.getDataFilePath()).map(HoodieBaseFile::new).orElse(null),
-        clusterOperation.getDeltaFilePaths().stream().map(HoodieLogFile::new).collect(Collectors.toList()));
+        clusterOperation.getDeltaFilePaths().stream().map(HoodieLogFile::new).collect(Collectors.toList()),
+        table.getMetaClient());
 
     HoodieFileGroupReader<RowData> fileGroupReader = FormatUtils.createFileGroupReader(table.getMetaClient(), writeConfig, InternalSchemaManager.DISABLED,
         fileSlice, schema, readerSchema, instantTime, FlinkOptions.REALTIME_PAYLOAD_COMBINE, false, Collections.emptyList(), Option.empty());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -332,7 +332,8 @@ public class MergeOnReadInputFormat
         // baseInstantTime in FileSlice is not used in FG reader
         "",
         split.getBasePath().map(HoodieBaseFile::new).orElse(null),
-        split.getLogPaths().map(logFiles -> logFiles.stream().map(HoodieLogFile::new).collect(Collectors.toList())).orElse(Collections.emptyList()));
+        split.getLogPaths().map(logFiles -> logFiles.stream().map(HoodieLogFile::new).collect(Collectors.toList())).orElse(Collections.emptyList()),
+        metaClient);
     return FormatUtils.createFileGroupReader(metaClient, writeConfig, internalSchemaManager, fileSlice,
         tableSchema, requiredSchema, split.getLatestCommit(), mergeType, emitDelete, predicates, split.getInstantRange());
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
@@ -126,10 +126,10 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
     FileSlice noDataFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noData1");
     noDataFileSlice.addLogFile(
         new HoodieLogFile(new StoragePath(FSUtils.makeLogFileName("noData1", ".log", "000", 1,
-            TEST_WRITE_TOKEN))));
+            TEST_WRITE_TOKEN))), Option.empty());
     noDataFileSlice.addLogFile(
         new HoodieLogFile(new StoragePath(
-            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))), Option.empty());
     op = CompactionUtils.buildFromFileSlice(DEFAULT_PARTITION_PATHS[0], noDataFileSlice,
         Option.of(metricsCaptureFn));
     testFileSliceCompactionOpEquality(noDataFileSlice, op, DEFAULT_PARTITION_PATHS[0],
@@ -140,10 +140,10 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
     fileSlice.setBaseFile(new DummyHoodieBaseFile("/tmp/noLog_1_000" + extension));
     fileSlice.addLogFile(
         new HoodieLogFile(new StoragePath(
-            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))), Option.empty());
     fileSlice.addLogFile(
         new HoodieLogFile(new StoragePath(
-            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))), Option.empty());
     op = CompactionUtils.buildFromFileSlice(DEFAULT_PARTITION_PATHS[0], fileSlice,
         Option.of(metricsCaptureFn));
     testFileSliceCompactionOpEquality(fileSlice, op, DEFAULT_PARTITION_PATHS[0],
@@ -164,20 +164,20 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
         new DummyHoodieBaseFile(fullPartitionPath.toString() + "/data1_1_000" + extension));
     fileSlice.addLogFile(new HoodieLogFile(
         new StoragePath(fullPartitionPath,
-            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))), Option.empty());
     fileSlice.addLogFile(new HoodieLogFile(
         new StoragePath(fullPartitionPath,
-            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))), Option.empty());
     FileSlice noLogFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noLog1");
     noLogFileSlice.setBaseFile(
         new DummyHoodieBaseFile(fullPartitionPath.toString() + "/noLog_1_000" + extension));
     FileSlice noDataFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noData1");
     noDataFileSlice.addLogFile(new HoodieLogFile(
         new StoragePath(fullPartitionPath,
-            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN))), Option.empty());
     noDataFileSlice.addLogFile(new HoodieLogFile(
         new StoragePath(fullPartitionPath,
-            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))));
+            FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))), Option.empty());
     List<FileSlice> fileSliceList = Arrays.asList(emptyFileSlice, noDataFileSlice, fileSlice, noLogFileSlice);
     List<Pair<String, FileSlice>> input =
         fileSliceList.stream().map(f -> Pair.of(DEFAULT_PARTITION_PATHS[0], f)).collect(Collectors.toList());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -253,7 +253,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         StoragePath storagePath2 = new StoragePath(partitionMetadataPath.getParent(), hoodieTestTable.getLogFileNameById(fileId1, 1));
         writeLogFiles(new StoragePath(metaClient.getBasePath(), p), HoodieTestDataGenerator.AVRO_SCHEMA_WITH_METADATA_FIELDS, dataGen.generateInsertsForPartition(instant2, 10, p), 1,
             metaClient.getStorage(), new Properties(), fileId1, instant2);
-        fileSlice2.addLogFile(new HoodieLogFile(storagePath2.toUri().toString()));
+        fileSlice2.addLogFile(new HoodieLogFile(storagePath2.toUri().toString()), Option.empty());
         partitionFileSlicePairs.add(Pair.of(p, fileSlice1));
         partitionFileSlicePairs.add(Pair.of(p, fileSlice2));
         // NOTE: we need to set table config as we are not using write client explicitly and these configs are needed for log record reader

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -244,7 +244,7 @@ public class TestHoodieRealtimeRecordReader {
         FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
 
         // create a split with baseFile (parquet file written earlier) and new log file(s)
-        fileSlice.addLogFile(writer.getLogFile());
+        fileSlice.addLogFile(writer.getLogFile(), Option.empty());
         HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
             new FileSplit(new Path(partitionDir + "/fileid0_1-0-1_" + baseInstant + ".parquet"), 0, 1, baseJobConf),
             basePath.toUri().toString(), fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
@@ -882,7 +882,7 @@ public class TestHoodieRealtimeRecordReader {
               schema.toString(), HoodieTimeline.COMMIT_ACTION);
       FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
       // create a split with new log file(s)
-      fileSlice.addLogFile(new HoodieLogFile(writer.getLogFile().getPath(), size));
+      fileSlice.addLogFile(new HoodieLogFile(writer.getLogFile().getPath(), size), Option.empty());
       RealtimeFileStatus realtimeFileStatus = new RealtimeFileStatus(
           new FileStatus(writer.getLogFile().getFileSize(), false, 1, 1, 0,
               new Path(writer.getLogFile().getPath().toUri())),

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -715,7 +715,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       FileSlice fileSlice = new FileSlice(partition, baseInstantTime, fileId);
       logFilePaths.forEach(logFilePath -> {
         HoodieLogFile logFile = new HoodieLogFile(logFilePath);
-        fileSlice.addLogFile(logFile);
+        fileSlice.addLogFile(logFile, Option.empty());
       });
       TypedProperties properties = new TypedProperties();
       // configure un-merged log file reader

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
@@ -153,7 +153,7 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
     val sizePerLogRecord = fixedSizePerRecordWithParquetFormat / logFraction
     logRecordNums.zipWithIndex.foreach { case (logRecordNum, index) => {
       val logFile = buildHoodieLogFile(fileId, logRecordNum, sizePerLogRecord.toLong, index)
-      slice.addLogFile(logFile)
+      slice.addLogFile(logFile, org.apache.hudi.common.util.Option.empty())
     }}
     slice
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -995,7 +995,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
         originalFileSlice.getFileGroupId(),
         TimelineUtils.generateInstantTime(true, timeGenerator),
         originalFileSlice.getBaseFile().get(),
-        originalFileSlice.getLogFiles().collect(Collectors.toList()));
+        originalFileSlice.getLogFiles().collect(Collectors.toList()), metaClient);
     listMdt.set(i, mismatchFileSlice);
     exception = assertThrows(
         HoodieValidationException.class,
@@ -1013,7 +1013,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
         originalFileSlice.getFileGroupId(),
         originalFileSlice.getBaseInstantTime(),
         generateRandomBaseFile().getLeft(),
-        originalFileSlice.getLogFiles().collect(Collectors.toList()));
+        originalFileSlice.getLogFiles().collect(Collectors.toList()), metaClient);
     listMdt.set(i, mismatchFileSlice);
     exception = assertThrows(
         HoodieValidationException.class,
@@ -1135,11 +1135,11 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     logFileList.add(generateRandomLogFile(fileId, logInstantTime2));
     FileSlice fileSlice = new FileSlice(
         new HoodieFileGroupId(partition, fileId), baseInstantTime,
-        baseFilePair.getLeft(), logFileList);
+        baseFilePair.getLeft(), logFileList, metaClient);
     return Pair.of(fileSlice,
         new FileSlice(new HoodieFileGroupId(partition, fileId),
             new String(baseInstantTime), baseFilePair.getRight(),
-            logFileList.stream().map(HoodieLogFile::new).collect(Collectors.toList())));
+            logFileList.stream().map(HoodieLogFile::new).collect(Collectors.toList()), metaClient));
   }
 
   private HoodieLogFile generateRandomLogFile(String fileId, String instantTime) {
@@ -1518,7 +1518,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
       FileSlice slice = new FileSlice(new HoodieFileGroupId(partition, fileId), baseInstantTime);
       slice.setBaseFile(baseFile);
-      logFiles.forEach(slice::addLogFile);
+      logFiles.forEach(logFile -> slice.addLogFile(logFile, Option.empty()));
       mdtFileSlices.add(slice);
 
       // Add to FS list for first 15 entries


### PR DESCRIPTION
### Change Logs

Currently completion time is not taken into account while ordering log files in file group. This can lead to log files being unordered. The Jira aims to add a fix for the same in table version 8.
The PR ensures that the reverse log file comparator in the file slice is replaced by completion time log file comparator. For example `LOG_FILE_COMPARATOR_REVERSED` is replaced by a log file comparator which uses completion time comparison as well.
The PR does not change or impact usages of `LOG_FILE_COMPARATOR`
Only `org.apache.hudi.common.fs.FSUtils#getLatestLogFile` still uses the reverse log file comparator. This API is used by table version 6 for rollback which does not require completion time. Also it is used to get latest log version for a file slice which should not ideally need completion time based ordering.

### Impact

Ensures that log files are sorted by completion time for table version 8

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
