### PR TITLE
[HUDI-9493] Avoid redundant String encode/decode during conversion be…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
@@ -21,6 +21,7 @@ package org.apache.hudi.util;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
@@ -138,7 +139,7 @@ public class AvroToRowDataConverters {
         return createTimestampConverter(((TimestampType) type).getPrecision(), utcTimezone);
       case CHAR:
       case VARCHAR:
-        return avroObject -> StringData.fromString(avroObject.toString());
+        return avroObject -> avroObject instanceof Utf8 ? StringData.fromBytes(((Utf8) avroObject).getBytes()) : StringData.fromString(avroObject.toString());
       case BINARY:
       case VARBINARY:
         return AvroToRowDataConverters::convertToBytes;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -143,7 +144,7 @@ public class RowDataToAvroConverters {
 
               @Override
               public Object convert(Schema schema, Object object) {
-                return new Utf8(object.toString());
+                return new Utf8(((BinaryStringData) object).toBytes());
               }
             };
         break;


### PR DESCRIPTION
…tween RowData and Avro Record

### Change Logs

Avro use `Utf8` to represent a String field, and `Utf8` always initializes bytes[] field `bytes` internally. Additional costs of encoding/decoding can be avoided by converting `StringData` from/to `Utf8` based on bytes[] directly.

### Impact

Improve perf for flink reader.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
