### PR TITLE
[HUDI-9494] Fix small shutdown hook race condition in StorageBasedLockProvider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -220,7 +220,11 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
       // Do not execute any further actions
       return;
     } else {
-      Runtime.getRuntime().removeShutdownHook(shutdownThread);
+      try {
+        tryRemoveShutdownHook();
+      } catch (IllegalStateException e) {
+        logger.warn("Owner {}: Failed to remove shutdown hook, JVM is already shutting down.", ownerId, e);
+      }
     }
     try {
       this.unlock();
@@ -239,6 +243,11 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     }
 
     this.isClosed = true;
+  }
+
+  @VisibleForTesting
+  void tryRemoveShutdownHook() {
+    Runtime.getRuntime().removeShutdownHook(shutdownThread);
   }
 
   private synchronized boolean isLockStillValid(StorageLockFile lock) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -564,6 +564,15 @@ class TestStorageBasedLockProvider {
     verify(mockHeartbeatManager, never()).close();
   }
 
+  @Test
+  public void testShutdownHookFailsToBeRemoved() throws Exception {
+    doThrow(new IllegalStateException("Shutdown already in progress")).when(lockProvider).tryRemoveShutdownHook();
+    lockProvider.close();
+    verify(mockLockService, atLeastOnce()).close();
+    verify(mockHeartbeatManager, atLeastOnce()).close();
+    assertNull(lockProvider.getLock());
+  }
+
   public static class StubStorageLockClient implements StorageLockClient {
     public StubStorageLockClient(String ownerId, String lockFileUri, Properties props) {
       assertTrue(lockFileUri.endsWith("table_lock.json"));


### PR DESCRIPTION
### Change Logs

Some code paths seem to directly call close() on the `LockManager` rather than just "unlock". This makes sense, especially if there is a shutdown occurring. However, when we close the `StorageBasedLockProvider` we explicitly remove the shutdown hook. If there is already a shutdown occurring this fails with an `IllegalStateException` and the lock does not get released properly. Therefore we will catch this exception and proceed with normal `close()` logic.

### Impact

Fixes a race condition when shutting down the JVM in `StorageBasedLockProvider`

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
