### PR TITLE
[HUDI-9481] Remove extra io.netty dependencies from hudi-aws bundle

### DIFF
--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -77,6 +77,10 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -113,6 +117,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -89,6 +89,12 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <version>${zk-curator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/hudi-tests-common/pom.xml
+++ b/hudi-tests-common/pom.xml
@@ -170,6 +170,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -209,6 +213,12 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- scala -->

--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,10 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Change Logs

Remove redundant io.netty dependencies from hudi-aws-bundle package.

Compared the classes from prevous and new bundles, and no io.netty classes differeces.
#### classes from updated branch
[hudi-aws-bundle-1.1.0-SNAPSHOT.classes.txt](https://github.com/user-attachments/files/20657392/hudi-aws-bundle-1.1.0-SNAPSHOT.classes.txt)
#### classes from master branch (before hbase deps removal)
[hudi-aws-bundle-1.1.0-SNAPSHOT.classes.txt](https://github.com/user-attachments/files/20657396/hudi-aws-bundle-1.1.0-SNAPSHOT.classes.txt)

Also compared all other bundles, e.g., hudi-presto-bundle, hudi-trino-bundle, hudi-spark-bundle, hudi-utilities-bundle and hudi-utilities-slim-bundle, and there were no differences.

### Impact

Less redundant dependency.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
