### PR TITLE
[MINOR] Fix SparkContext conflict error in HoodieSparkQuickstart

### DIFF
--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
@@ -53,9 +53,8 @@ public final class HoodieSparkQuickstart {
     String tableName = args[1];
 
     SparkSession spark = HoodieExampleSparkUtils.defaultSparkSession("Hudi Spark basic example");
-    SparkConf sparkConf = HoodieExampleSparkUtils.defaultSparkConf("hoodie-client-example");
 
-    try (JavaSparkContext jsc = new JavaSparkContext(sparkConf)) {
+    try (JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext())) {
       runQuickstart(jsc, spark, tableName, tablePath);
     }
   }


### PR DESCRIPTION
Avoids `Only one SparkContext should be running in this JVM` error.

### Change Logs

A hotfix for spark quickstart example class `HoodieSparkQuickstart`.

Error logs:
![image](https://github.com/user-attachments/assets/803e138a-e695-427b-a660-14fae3c307c2)

Toubleshooting:

`HoodieExampleSparkUtils.defaultSparkSession(...)` creates a `SparkContext`. However, the example also calls `new JavaSparkContext(sparkConf)`, resulting in a duplicate `SparkContext` in the same JVM, which is not allowed and causes a SparkException.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
