### PR TITLE
[HUDI-9504] support in-memory buffer sort in append write

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -632,6 +632,30 @@ public class FlinkOptions extends HoodieConfig {
           + "it flushes the max size data bucket to avoid OOM, default 1GB");
 
   @AdvancedConfig
+  public static final ConfigOption<Boolean> WRITE_BUFFER_SORT_ENABLED = ConfigOptions
+      .key("write.buffer.sort.enabled")
+      .booleanType()
+      .defaultValue(false) // default no sort
+      .withDescription("Whether to enable buffer sort within append write function. Data is sorted within the buffer configured by number of records or buffer size."
+          + " The order of entire parquet file is not guaranteed.");
+
+  @AdvancedConfig
+  public static final ConfigOption<String> WRITE_BUFFER_SORT_KEYS = ConfigOptions
+      .key("write.buffer.sort.keys")
+      .stringType()
+      .noDefaultValue() // default no sort key
+      .withDescription("Sort keys concatenated by comma for buffer sort in append write function. Data is sorted within the buffer configured by number of records or buffer size."
+          + " The order of entire parquet file is not guaranteed.");
+
+  @AdvancedConfig
+  public static final ConfigOption<Long> WRITE_BUFFER_SIZE = ConfigOptions
+      .key("write.buffer.size")
+      .longType()
+      .defaultValue(1000L) // 1000 records
+      .withDescription("Buffer size of each partition key for buffer sort in append write function. Data is sorted within the buffer configured by number of records."
+          +  " The order of entire parquet file is not guaranteed.");
+
+  @AdvancedConfig
   public static final ConfigOption<Long> WRITE_RATE_LIMIT = ConfigOptions
       .key("write.rate.limit")
       .longType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -58,17 +58,17 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   /**
    * Helper class for log mode.
    */
-  private transient BulkInsertWriterHelper writerHelper;
+  protected transient BulkInsertWriterHelper writerHelper;
 
   /**
    * Table row type.
    */
-  private final RowType rowType;
+  protected final RowType rowType;
 
   /**
    * Metrics for flink stream write.
    */
-  private FlinkStreamWriteMetrics writeMetrics;
+  protected FlinkStreamWriteMetrics writeMetrics;
 
   /**
    * Constructs an AppendWriteFunction.
@@ -121,7 +121,7 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
-  private void initWriterHelper() {
+  void initWriterHelper() {
     final String instant = instantToWrite(true);
     if (instant == null) {
       // in case there are empty checkpoints that has no input data

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBufferSort.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
+import org.apache.flink.table.runtime.generated.GeneratedNormalizedKeyComputer;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.operators.sort.BinaryInMemorySortBuffer;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.hudi.sink.buffer.MemorySegmentPoolFactory;
+import org.apache.hudi.sink.bulk.sort.SortOperatorGen;
+import org.apache.hudi.sink.utils.BufferUtils;
+import org.apache.flink.runtime.operators.sort.QuickSort;
+import org.apache.hudi.util.MutableIteratorWrapperIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Sink function to write the data to the underneath filesystem with buffer sort
+ * to improve the parquet compression rate.
+ *
+ * <p>The function writes base files directly for each checkpoint,
+ * the file may roll over when it’s size hits the configured threshold.
+ *
+ * @param <T> Type of the input record
+ * @see StreamWriteOperatorCoordinator
+ */
+public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(AppendWriteFunctionWithBufferSort.class);
+  private final long writeBufferSize;
+  private transient BinaryInMemorySortBuffer buffer;
+
+  public AppendWriteFunctionWithBufferSort(Configuration config, RowType rowType) {
+    super(config, rowType);
+    this.writeBufferSize = config.get(FlinkOptions.WRITE_BUFFER_SIZE);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    String sortKeys = config.get(FlinkOptions.WRITE_BUFFER_SORT_KEYS);
+    if (sortKeys == null) {
+      throw new IllegalArgumentException("Sort keys can't be null for append write with buffer sort.");
+    }
+    List<String> sortKeyList = Arrays.stream(sortKeys.split(",")).map(key -> key.trim()).collect(Collectors.toList());
+    SortOperatorGen sortOperatorGen = new SortOperatorGen(rowType, sortKeyList.toArray(new String[0]));
+    SortCodeGenerator codeGenerator = sortOperatorGen.createSortCodeGenerator();
+    GeneratedNormalizedKeyComputer keyComputer = codeGenerator.generateNormalizedKeyComputer("SortComputer");
+    GeneratedRecordComparator recordComparator = codeGenerator.generateRecordComparator("SortComparator");
+    MemorySegmentPool memorySegmentPool = MemorySegmentPoolFactory.createMemorySegmentPool(config);
+    this.buffer = BufferUtils.createBuffer(rowType,
+            memorySegmentPool,
+            keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
+            recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
+  }
+
+  @Override
+  public void processElement(T value, Context ctx, Collector<RowData> out) throws Exception {
+    RowData data = (RowData) value;
+
+    // 1.try to write data into memory pool
+    boolean success = buffer.write(data);
+    if (!success) {
+      // 2. flushes the bucket if the memory pool is full
+      sortAndSend();
+      // 3. write the row again
+      success = buffer.write(data);
+      if (!success) {
+        throw new RuntimeException("Buffer is too small to hold a single record.");
+      }
+    }
+
+    if (buffer.size() >= writeBufferSize) {
+      sortAndSend();
+    }
+  }
+
+  @Override
+  public void snapshotState() {
+    try {
+      sortAndSend();
+    } catch (IOException e) {
+      LOG.error("Fail to sort and flush data in buffer during snapshot state.", e);
+      throw new FlinkRuntimeException(e);
+    }
+    super.snapshotState();
+  }
+
+  /**
+   *  For append writing, the flushing can be triggered with two conditions:
+   *  1. Checkpoint trigger. in which current remaining data in buffer are flushed and committed.
+   *  2. Binary buffer is full.
+   *
+   *  set the size of buffer as the max size of parquet file, e.g., PARQUET_MAX_FILE_SIZE, to keep aligned
+   *  with current behavior considering the file's size / quantity.
+   *
+   * @throws IOException
+   */
+  private void sortAndSend() throws IOException {
+    if (this.writerHelper == null) {
+      initWriterHelper();
+    }
+
+    sort(buffer);
+    Iterator<BinaryRowData> iterator =
+            new MutableIteratorWrapperIterator<>(
+                    buffer.getIterator(), () -> new BinaryRowData(rowType.getFieldCount()));
+    while (iterator.hasNext()) {
+      writerHelper.write(iterator.next());
+    }
+    buffer.reset();
+  }
+
+  private static void sort(BinaryInMemorySortBuffer dataBuffer) {
+    new QuickSort().sort(dataBuffer);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctions.java
@@ -36,6 +36,8 @@ public abstract class AppendWriteFunctions {
   public static <I> AppendWriteFunction<I> create(Configuration conf, RowType rowType) {
     if (conf.get(FlinkOptions.WRITE_RATE_LIMIT) > 0) {
       return new AppendWriteFunctionWithRateLimit<>(rowType, conf);
+    } else if (conf.get(FlinkOptions.WRITE_BUFFER_SORT_ENABLED)) {
+      return new AppendWriteFunctionWithBufferSort<>(conf, rowType);
     } else {
       return new AppendWriteFunction<>(conf, rowType);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/BufferUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/BufferUtils.java
@@ -36,13 +36,14 @@ public class BufferUtils {
   private static final int MIN_REQUIRED_BUFFERS = 3;
 
   public static BinaryInMemorySortBuffer createBuffer(RowType rowType, MemorySegmentPool memorySegmentPool) {
+    return createBuffer(rowType, memorySegmentPool,  new NaturalOrderKeyComputer(), new NaturalOrderRecordComparator());
+  }
+
+  public static BinaryInMemorySortBuffer createBuffer(RowType rowType, MemorySegmentPool memorySegmentPool, NormalizedKeyComputer keyComputer, RecordComparator recordComparator) {
     if (memorySegmentPool.freePages() < MIN_REQUIRED_BUFFERS) {
       // there is no enough free pages to create a binary buffer, may need flush first.
       throw new MemoryPagesExhaustedException("Free pages are not enough to create a BinaryInMemorySortBuffer.");
     }
-    // currently do not need to sort records in the binary buffer.
-    NormalizedKeyComputer keyComputer = new NaturalOrderKeyComputer();
-    RecordComparator recordComparator = new NaturalOrderRecordComparator();
     return BinaryInMemorySortBuffer.createBuffer(
         keyComputer,
         new RowDataSerializer(rowType),

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithBufferSort.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.utils.TestWriteBase;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test cases for {@link AppendWriteFunctionWithBufferSort}.
+ */
+public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
+
+  private Configuration conf;
+  private RowType rowType;
+
+  @BeforeEach
+  public void before(@TempDir File tempDir) throws Exception {
+    super.before();
+    this.conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SORT_ENABLED, true);
+    this.conf.set(FlinkOptions.OPERATION, "insert");
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SORT_KEYS, "name,age");
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 100L);
+
+    // Define the row type with fields: name (STRING), age (INT), partition (STRING)
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("uuid", VarCharType.STRING_TYPE));
+    fields.add(new RowType.RowField("name", VarCharType.STRING_TYPE));
+    fields.add(new RowType.RowField("age", new IntType()));
+    fields.add(new RowType.RowField("ts", new TimestampType()));
+    fields.add(new RowType.RowField("partition", VarCharType.STRING_TYPE));
+    this.rowType = new RowType(fields);
+  }
+
+  @Test
+  public void testBufferFlushOnRecordNumberLimit() throws Exception {
+    // Create test data that exceeds buffer size
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 150; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
+    }
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(100, actualData.size());
+  }
+
+  @Test
+  public void testBufferFlushOnCheckpoint() throws Exception {
+    // Create test data
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
+    );
+
+    // Write the data and wait for timer
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .checkpoint(1)
+        .endInput();
+
+    // Verify data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(2, actualData.size());
+  }
+
+  @Test
+  public void testBufferFlushOnBufferSizeLimit() throws Exception {
+    // enlarge the wirte buffer record size
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 10000L);
+    // use a very small buffer memory size here
+    this.conf.set(FlinkOptions.WRITE_TASK_MAX_SIZE, 200.1D);
+
+    // Create test data that exceeds buffer size
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 2000; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
+    }
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+            .preparePipeline(tempFile, conf)
+            .consume(inputData)
+            .endInput();
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(1198, actualData.size());
+  }
+
+  @Test
+  public void testSortedResult() throws Exception {
+    // Create test data
+    List<RowData> inputData = Arrays.asList(
+            createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+            createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
+            createRowData("uuid1", "Bob", 21, "1970-01-01 00:00:31.124", "p1")
+    );
+
+    List<String> expected = Arrays.asList(
+            "uuid1,Alice,25,1970-01-01 00:00:01.124,p1",
+            "uuid1,Bob,21,1970-01-01 00:00:31.124,p1",
+            "uuid1,Bob,30,1970-01-01 00:00:01.123,p1");
+
+    // Write the data and wait for timer
+    TestWriteBase.TestHarness.instance()
+            .preparePipeline(tempFile, conf)
+            .consume(inputData)
+            .checkpoint(1)
+            .endInput();
+
+    // Verify data was written
+    List<GenericRecord> result = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(3, result.size());
+
+    List<String> filteredResult =
+            result.stream().map(TestData::filterOutVariablesWithoutHudiMetadata).collect(Collectors.toList());
+
+    assertArrayEquals(expected.toArray(), filteredResult.toArray());
+  }
+
+  private GenericRowData createRowData(String uuid, String name, int age, String timestamp, String partition) {
+    return GenericRowData.of(StringData.fromString(uuid), StringData.fromString(name),
+        age, TimestampData.fromTimestamp(Timestamp.valueOf(timestamp)), StringData.fromString(partition));
+  }
+} 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
@@ -22,6 +22,7 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.append.AppendWriteFunction;
+import org.apache.hudi.sink.append.AppendWriteFunctions;
 import org.apache.hudi.sink.bulk.BulkInsertWriterHelper;
 import org.apache.hudi.sink.common.AbstractWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
@@ -207,7 +208,7 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   // -------------------------------------------------------------------------
 
   private void setupWriteFunction() throws Exception {
-    writeFunction = new AppendWriteFunction<>(conf, rowType);
+    writeFunction = AppendWriteFunctions.create(conf, rowType);
     writeFunction.setRuntimeContext(runtimeContext);
     writeFunction.setOperatorEventGateway(gateway);
     writeFunction.initializeState(this.stateInitializationContext);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -44,6 +44,7 @@ import org.apache.hudi.sink.utils.TestFunctionWrapper;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
+import org.apache.hudi.util.AvroToRowDataConverters;
 import org.apache.hudi.util.RowDataAvroQueryContexts;
 
 import org.apache.avro.Schema;
@@ -836,6 +837,38 @@ public class TestData {
     }
   }
 
+  public static List<GenericRecord> readAllData(
+      File baseFile, RowType rowType, int partitions) throws IOException {
+    assert baseFile.isDirectory();
+    FileFilter filter = file -> !file.getName().startsWith(".");
+    File[] partitionDirs = baseFile.listFiles(filter);
+
+    assertNotNull(partitionDirs);
+    assertThat(partitionDirs.length, is(partitions));
+
+    List<GenericRecord> result = new ArrayList<>();
+    AvroToRowDataConverters.AvroToRowDataConverter converter =
+        AvroToRowDataConverters.createConverter(rowType, true);
+
+    for (File partitionDir : partitionDirs) {
+      File[] dataFiles = partitionDir.listFiles(filter);
+      assertNotNull(dataFiles);
+
+      for (File dataFile : dataFiles) {
+        ParquetReader<GenericRecord> reader = AvroParquetReader
+            .<GenericRecord>builder(new Path(dataFile.getAbsolutePath())).build();
+
+        GenericRecord nextRecord = reader.read();
+        while (nextRecord != null) {
+          result.add(nextRecord);
+          nextRecord = reader.read();
+        }
+      }
+    }
+
+    return result;
+  }
+
   /**
    * Checks the source data are written as expected.
    *
@@ -960,6 +993,22 @@ public class TestData {
       readBuffer.sort(String::compareTo);
       assertThat(readBuffer.toString(), is(expected.get(partitionDir.getName())));
     }
+  }
+
+  /**
+   * Filter out the variables like _hoodie_record_key and _hoodie_partition_path.
+   *
+   * @param genericRecord data record
+   * @return field values joined with comma
+   */
+  public static String filterOutVariablesWithoutHudiMetadata(GenericRecord genericRecord) {
+    List<String> fields = new ArrayList<>();
+    fields.add(getFieldValue(genericRecord, "uuid"));
+    fields.add(getFieldValue(genericRecord, "name"));
+    fields.add(getFieldValue(genericRecord, "age"));
+    fields.add(TimestampData.fromEpochMillis((long) genericRecord.get("ts")).toTimestamp().toString());
+    fields.add(genericRecord.get("partition").toString());
+    return String.join(",", fields);
   }
 
   private static ClosableIterator<RowData> getRecordIterator(


### PR DESCRIPTION
### Change Logs
Add in memory buffer sort in append write function to improve the parquet compression ratio. From our experiment and testing, It can improve 300% compression ratio with right sort key and buffer size configuration.

### Impact

User can use the feature by enable the buffer sort configurations

### Risk level (write none, low medium or high below)

low

### Documentation Update

It is a new feature. Jira will be created to update the website.

- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
