### PR TITLE
[HUDI-8401] Add config to support preference to old records

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -73,6 +73,13 @@ public class HoodieReaderConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Whether to use positions in the block header for data blocks containing updates and delete blocks for merging.");
 
+  public static final ConfigProperty<Boolean> MERGE_PREFER_OLD_RECORD = ConfigProperty
+      .key("hoodie.merge.prefer.old.record")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Prefer old record when two records have the same ordering value");
+
   public static final String REALTIME_SKIP_MERGE = "skip_merge";
   public static final String REALTIME_PAYLOAD_COMBINE = "payload_combine";
   public static final ConfigProperty<String> MERGE_TYPE = ConfigProperty


### PR DESCRIPTION
### Change Logs

When we want to support `FirstValueAvroPayload` by merge mode, we need to add this config to support the same logic.

### Impact

Enable `EVENT_TIME_ORDERING` to support first value logic.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
