### PR TITLE
[HUDI-9518] Upgrade Flink 1.15/1.16 parquet version from 1.12.2 to 1.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2590,7 +2590,7 @@
         <flink.bundle.version>1.16</flink.bundle.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.avro.version>1.11.4</flink.avro.version>
-        <flink.format.parquet.version>1.12.2</flink.format.parquet.version>
+        <flink.format.parquet.version>1.12.3</flink.format.parquet.version>
         <flink.connector.kafka.version>${flink1.16.version}</flink.connector.kafka.version>
       </properties>
       <activation>
@@ -2607,7 +2607,7 @@
         <flink.bundle.version>1.15</flink.bundle.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.avro.version>1.11.4</flink.avro.version>
-        <flink.format.parquet.version>1.12.2</flink.format.parquet.version>
+        <flink.format.parquet.version>1.12.3</flink.format.parquet.version>
         <flink.connector.kafka.version>${flink1.15.version}</flink.connector.kafka.version>
       </properties>
       <activation>


### PR DESCRIPTION
### Change Logs
https://github.com/apache/parquet-java/compare/apache-parquet-1.12.2...apache-parquet-1.12.3

For example ZSTD related enhance 
https://github.com/apache/parquet-java/pull/889
https://github.com/apache/parquet-java/pull/903

### Impact

flink 1.15 fllink 1.16 read/write parquet

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
