### PR TITLE
[DRAFT] Avoid timeline server thrashing with async table services

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
@@ -43,7 +43,7 @@ public class AsyncCleanerService extends HoodieAsyncTableService {
 
   protected AsyncCleanerService(BaseHoodieWriteClient writeClient) {
     super(writeClient.getConfig());
-    this.writeClient = writeClient;
+    this.writeClient = writeClient.createNewClient();
   }
 
   @Override
@@ -81,5 +81,11 @@ public class AsyncCleanerService extends HoodieAsyncTableService {
       LOG.info("Shutting down async clean service...");
       asyncCleanerService.shutdown(true);
     }
+  }
+
+  @Override
+  public void shutdown(boolean force) {
+    super.shutdown(force);
+    writeClient.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
@@ -55,7 +55,7 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
 
   public AsyncClusteringService(HoodieEngineContext context, BaseHoodieWriteClient writeClient, boolean runInDaemonMode) {
     super(writeClient.getConfig(), runInDaemonMode);
-    this.clusteringClient = createClusteringClient(writeClient);
+    this.clusteringClient = createClusteringClient(writeClient.createNewClient());
     this.maxConcurrentClustering = 1;
     this.context = context;
   }
@@ -103,6 +103,12 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
    * Update the write client to be used for clustering.
    */
   public synchronized void updateWriteClient(BaseHoodieWriteClient writeClient) {
-    this.clusteringClient.updateWriteClient(writeClient);
+    this.clusteringClient.updateWriteClient(writeClient.createNewClient());
+  }
+
+  @Override
+  public void shutdown(boolean force) {
+    super.shutdown(force);
+    clusteringClient.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -56,7 +56,7 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
   public AsyncCompactService(HoodieEngineContext context, BaseHoodieWriteClient client, boolean runInDaemonMode) {
     super(client.getConfig(), runInDaemonMode);
     this.context = context;
-    this.compactor = createCompactor(client);
+    this.compactor = createCompactor(client.createNewClient());
     this.maxConcurrentCompaction = 1;
   }
 
@@ -111,6 +111,12 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
   }
 
   public synchronized void updateWriteClient(BaseHoodieWriteClient writeClient) {
-    this.compactor.updateWriteClient(writeClient);
+    this.compactor.updateWriteClient(writeClient.createNewClient());
+  }
+
+  @Override
+  public void shutdown(boolean force) {
+    super.shutdown(force);
+    compactor.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 /**
  * Client will run one round of clustering.
  */
-public abstract class BaseClusterer<T, I, K, O> implements Serializable {
+public abstract class BaseClusterer<T, I, K, O> implements Serializable, AutoCloseable {
 
   private static final long serialVersionUID = 1L;
 
@@ -48,5 +48,10 @@ public abstract class BaseClusterer<T, I, K, O> implements Serializable {
    */
   public void updateWriteClient(BaseHoodieWriteClient<T, I, K, O> writeClient) {
     this.clusteringClient = writeClient;
+  }
+
+  @Override
+  public void close() {
+    clusteringClient.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 /**
  * Run one round of compaction.
  */
-public abstract class BaseCompactor<T, I, K, O> implements Serializable {
+public abstract class BaseCompactor<T, I, K, O> implements Serializable, AutoCloseable {
 
   private static final long serialVersionUID = 1L;
 
@@ -40,4 +40,8 @@ public abstract class BaseCompactor<T, I, K, O> implements Serializable {
     this.compactionClient = writeClient;
   }
 
+  @Override
+  public void close() {
+    compactionClient.close();
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1651,4 +1651,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       }
     });
   }
+
+  /**
+   * Creates a new instance of the write client with the same configuration. This is useful when creating new threads that
+   * run actions like async-table services against the same table since the clients are not inherently thread-safe.
+   * @return a new instance of the write client with the same configuration as the current instance.
+   * @param <S> the type of the write client
+   */
+  public abstract <S extends BaseHoodieWriteClient<T, I, K, O>> S createNewClient();
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -244,6 +244,11 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     }
 
     @Override
+    public TestWriteClient createNewClient() {
+      return this;
+    }
+
+    @Override
     protected void updateColumnsToIndexWithColStats(HoodieTableMetaClient metaClient, List<String> columnsToIndex) {
 
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -507,6 +507,11 @@ public class HoodieFlinkWriteClient<T>
     return table.getSliceView().getLatestFileSlices(partitionPath).map(FileSlice::getFileId).distinct().collect(Collectors.toList());
   }
 
+  @Override
+  public HoodieFlinkWriteClient<T> createNewClient() {
+    return new HoodieFlinkWriteClient<>(context, config);
+  }
+
   private final class AutoCloseableWriteHandle implements AutoCloseable {
     private final HoodieWriteHandle<?, ?, ?, ?> writeHandle;
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -220,6 +220,11 @@ public class HoodieJavaWriteClient<T> extends
     initializeMetadataTable(instantTime);
   }
 
+  @Override
+  public HoodieJavaWriteClient<T> createNewClient() {
+    return new HoodieJavaWriteClient<>(context, config);
+  }
+
   /**
    * Initialize the metadata table if needed. Creating the metadata table writer
    * will trigger the initial bootstrapping from the data table.

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -391,6 +391,11 @@ public class SparkRDDWriteClient<T> extends
     SparkReleaseResources.releaseCachedData(context, config, basePath, instantTime);
   }
 
+  @Override
+  public SparkRDDWriteClient<T> createNewClient() {
+    return new SparkRDDWriteClient<>(context, config);
+  }
+
   /**
    * Slim WriteStatus to hold info like total records, total record records,
    * HoodieWriteStat and whether the writeStatus is referring to metadata table or not.


### PR DESCRIPTION
### Change Logs

While running table services asynchronously in the Streamer, we discovered the timeline server can only serve one write client at a time safely. When there are multiple write clients, the "last instant" sent to the service can change and cause the view to be updated. At this point, the first client's view of the table will have been updated mid process which can cause issues with generating a consistent view of the table.

The Streamer also shares the same instance of the WriteClient between multiple threads. The class is not designed to be thread-safe so this can lead to further issues.

This PR adds helper methods to generate a new client with the same config but will use a separate embedded timeline service (if enabled) to solve the above issues.

### Impact

Ensures safe operations with async table services in the Streamer

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
