### PR TITLE
[HUDI-9528] Support database and table name for Glue/ Datahub catalog

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -118,9 +118,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_T
 import static org.apache.hudi.hive.util.HiveSchemaUtil.getPartitionKeyType;
 import static org.apache.hudi.hive.util.HiveSchemaUtil.parquetSchemaToMapSchema;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.util.TableUtils.tableId;
 
 /**
@@ -159,7 +157,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   AWSGlueCatalogSyncClient(GlueAsyncClient awsGlue, HiveSyncConfig config, HoodieTableMetaClient metaClient) {
     super(config, metaClient);
     this.awsGlue = awsGlue;
-    this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
+    this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, GLUE_SYNC_DATABASE_NAME.getInferFunction().get().apply(config).get());
     this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
     this.enableMetadataTable = Boolean.toString(config.getBoolean(GLUE_METADATA_FILE_LISTING)).toUpperCase();
     this.allPartitionsReadParallelism = config.getIntOrDefault(ALL_PARTITIONS_READ_PARALLELISM);
@@ -183,7 +181,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   @Override
   public String getTableName() {
-    return this.config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
+    return config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, GLUE_SYNC_TABLE_NAME.getInferFunction().get().apply(config).get());
   }
 
   @Override

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -142,6 +142,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
    */
   private static final String ENABLE_MDT_LISTING = "hudi.metadata-listing-enabled";
   private final String databaseName;
+  private final String tableName;
 
   private final boolean skipTableArchive;
   private final String enableMetadataTable;
@@ -158,6 +159,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     super(config, metaClient);
     this.awsGlue = awsGlue;
     this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, GLUE_SYNC_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    this.tableName = config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, GLUE_SYNC_TABLE_NAME.getInferFunction().get().apply(config).get());
     this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
     this.enableMetadataTable = Boolean.toString(config.getBoolean(GLUE_METADATA_FILE_LISTING)).toUpperCase();
     this.allPartitionsReadParallelism = config.getIntOrDefault(ALL_PARTITIONS_READ_PARALLELISM);
@@ -181,7 +183,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   @Override
   public String getTableName() {
-    return config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, GLUE_SYNC_TABLE_NAME.getInferFunction().get().apply(config).get());
+    return this.tableName;
   }
 
   @Override

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -144,7 +144,6 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
    */
   private static final String ENABLE_MDT_LISTING = "hudi.metadata-listing-enabled";
   private final String databaseName;
-  private final String configuredTableName;
 
   private final boolean skipTableArchive;
   private final String enableMetadataTable;
@@ -161,7 +160,6 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     super(config, metaClient);
     this.awsGlue = awsGlue;
     this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
-    this.configuredTableName = config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
     this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
     this.enableMetadataTable = Boolean.toString(config.getBoolean(GLUE_METADATA_FILE_LISTING)).toUpperCase();
     this.allPartitionsReadParallelism = config.getIntOrDefault(ALL_PARTITIONS_READ_PARALLELISM);
@@ -181,6 +179,16 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public String getTableName() {
+    return this.config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return this.databaseName;
   }
 
   private List<Partition> getPartitionsSegment(Segment segment, String tableName) {

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -111,6 +111,8 @@ import static org.apache.hudi.config.GlueCatalogSyncClientConfig.META_SYNC_PARTI
 import static org.apache.hudi.config.GlueCatalogSyncClientConfig.PARTITION_CHANGE_PARALLELISM;
 import static org.apache.hudi.config.HoodieAWSConfig.AWS_GLUE_ENDPOINT;
 import static org.apache.hudi.config.HoodieAWSConfig.AWS_GLUE_REGION;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_DATABASE_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_TABLE_NAME;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.util.HiveSchemaUtil.getPartitionKeyType;
@@ -118,6 +120,7 @@ import static org.apache.hudi.hive.util.HiveSchemaUtil.parquetSchemaToMapSchema;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.util.TableUtils.tableId;
 
 /**
@@ -141,6 +144,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
    */
   private static final String ENABLE_MDT_LISTING = "hudi.metadata-listing-enabled";
   private final String databaseName;
+  private final String configuredTableName;
 
   private final boolean skipTableArchive;
   private final String enableMetadataTable;
@@ -156,7 +160,8 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   AWSGlueCatalogSyncClient(GlueAsyncClient awsGlue, HiveSyncConfig config, HoodieTableMetaClient metaClient) {
     super(config, metaClient);
     this.awsGlue = awsGlue;
-    this.databaseName = config.getStringOrDefault(META_SYNC_DATABASE_NAME);
+    this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
+    this.configuredTableName = config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
     this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
     this.enableMetadataTable = Boolean.toString(config.getBoolean(GLUE_METADATA_FILE_LISTING)).toUpperCase();
     this.allPartitionsReadParallelism = config.getIntOrDefault(ALL_PARTITIONS_READ_PARALLELISM);

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -97,4 +97,16 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Glue sync may fail if the Glue table exists with partitions differing from the Hoodie table or if schema evolution is not supported by Glue."
           + "Enabling this configuration will drop and create the table to match the Hoodie config");
+
+  public static final ConfigProperty<String> GLUE_SYNC_DATABASE_NAME = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "database_name")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The name of the destination database that we should sync the hudi table to.");
+
+  public static final ConfigProperty<String> GLUE_SYNC_TABLE_NAME = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "table_name")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -108,7 +108,7 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "database_name")
       .noDefaultValue()
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_DATABASE_NAME.key()))
-          .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, DATABASE_NAME.defaultValue()))))
+          .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, META_SYNC_DATABASE_NAME.defaultValue()))))
       .markAdvanced()
       .withDocumentation("The name of the destination database that we should sync the hudi table to.");
 

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -28,6 +28,12 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import java.util.stream.IntStream;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+
 /**
  * Hoodie Configs for Glue.
  */
@@ -101,12 +107,17 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
   public static final ConfigProperty<String> GLUE_SYNC_DATABASE_NAME = ConfigProperty
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "database_name")
       .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_DATABASE_NAME.key()))
+          .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, DATABASE_NAME.defaultValue()))))
       .markAdvanced()
       .withDocumentation("The name of the destination database that we should sync the hudi table to.");
 
   public static final ConfigProperty<String> GLUE_SYNC_TABLE_NAME = ConfigProperty
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "table_name")
       .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_TABLE_NAME.key()))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY)))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
       .markAdvanced()
       .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -259,6 +259,12 @@ class TestAWSGlueSyncClient {
     assertThrows(HoodieGlueSyncException.class, () -> awsGlueSyncClient.updateTableProperties(tableName, newTableProperties));
   }
 
+  @Test
+  void testTableAndDatabaseName() {
+    assertEquals(GlueTestUtil.DB_NAME, awsGlueSyncClient.getDatabaseName());
+    assertEquals(GlueTestUtil.TABLE_NAME, awsGlueSyncClient.getTableName());
+  }
+
   private CompletableFuture<GetTableResponse> getTableWithDefaultProps(String tableName, List<Column> columns, List<Column> partitionColumns) {
     String databaseName = "testdb";
     String inputFormatClass = "inputFormat";

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
@@ -42,15 +42,15 @@ import java.nio.file.Files;
 import java.time.Instant;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_DATABASE_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_TABLE_NAME;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USER;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USE_PRE_APACHE_INPUT_FORMAT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 
 public class GlueTestUtil {
 
@@ -69,8 +69,8 @@ public class GlueTestUtil {
     glueSyncProps = new TypedProperties();
     glueSyncProps.setProperty(HIVE_USER.key(), "");
     glueSyncProps.setProperty(HIVE_PASS.key(), "");
-    glueSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), DB_NAME);
-    glueSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), TABLE_NAME);
+    glueSyncProps.setProperty(GLUE_SYNC_DATABASE_NAME.key(), DB_NAME);
+    glueSyncProps.setProperty(GLUE_SYNC_TABLE_NAME.key(), TABLE_NAME);
     glueSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
     glueSyncProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key(), "false");
     glueSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
@@ -55,8 +55,8 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_F
 public class GlueTestUtil {
 
   public static TypedProperties glueSyncProps;
-  private static final String DB_NAME = "testdb";
-  private static final String TABLE_NAME = "test1";
+  public static final String DB_NAME = "testdb";
+  public static final String TABLE_NAME = "test1";
   private static String basePath;
   public static FileSystem fileSystem;
   private static HiveSyncConfig hiveSyncConfig;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
@@ -115,7 +115,7 @@ public class ConfigProperty<T> implements Serializable {
     return getInferFunction().isPresent();
   }
 
-  Option<Function<HoodieConfig, Option<T>>> getInferFunction() {
+  public Option<Function<HoodieConfig, Option<T>>> getInferFunction() {
     return inferFunction;
   }
 

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -69,6 +69,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
+
 public class DataHubSyncClient extends HoodieSyncClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataHubSyncClient.class);
@@ -95,6 +100,16 @@ public class DataHubSyncClient extends HoodieSyncClient {
     this.databaseUrn = datasetIdentifier.getDatabaseUrn();
     this.tableName = datasetIdentifier.getTableName();
     this.databaseName = datasetIdentifier.getDatabaseName();
+  }
+
+  @Override
+  public String getTableName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -102,12 +102,12 @@ public class DataHubSyncClient extends HoodieSyncClient {
 
   @Override
   public String getDatabaseName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    return this.databaseName;
   }
 
   @Override
   public String getTableName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
+    return this.tableName;
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -69,8 +69,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 
@@ -103,13 +101,13 @@ public class DataHubSyncClient extends HoodieSyncClient {
   }
 
   @Override
-  public String getTableName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
+  public String getDatabaseName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
   }
 
   @Override
-  public String getDatabaseName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
+  public String getTableName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
@@ -36,10 +36,8 @@ import java.util.Properties;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL_SYNC;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.HoodieTableMetadata;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.getTableProperties;
-import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 
 /**
  * To sync with DataHub via REST APIs.
@@ -62,9 +60,9 @@ public class DataHubSyncTool extends HoodieSyncTool {
   public DataHubSyncTool(Properties props, Configuration hadoopConf, Option<HoodieTableMetaClient> metaClientOption) {
     super(props, hadoopConf);
     this.config = new DataHubSyncConfig(props);
-    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
     this.metaClient = metaClientOption.orElseGet(() -> buildMetaClient(config));
     this.syncClient = new DataHubSyncClient(config, metaClient);
+    this.tableName = this.syncClient.getTableName();
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
@@ -39,6 +39,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.HoodieTableMetadata;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.getTableProperties;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 
 /**
  * To sync with DataHub via REST APIs.
@@ -61,7 +62,7 @@ public class DataHubSyncTool extends HoodieSyncTool {
   public DataHubSyncTool(Properties props, Configuration hadoopConf, Option<HoodieTableMetaClient> metaClientOption) {
     super(props, hadoopConf);
     this.config = new DataHubSyncConfig(props);
-    this.tableName = config.getString(META_SYNC_TABLE_NAME);
+    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, config.getString(META_SYNC_TABLE_NAME));
     this.metaClient = metaClientOption.orElseGet(() -> buildMetaClient(config));
     this.syncClient = new DataHubSyncClient(config, metaClient);
   }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.sync.common.HoodieSyncConfig;
 
@@ -36,6 +37,9 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.Properties;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
 import static org.apache.hudi.sync.datahub.config.HoodieDataHubDatasetIdentifier.DEFAULT_DATAHUB_ENV;
 import static org.apache.hudi.sync.datahub.config.HoodieDataHubDatasetIdentifier.DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME;
 
@@ -118,12 +122,17 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATABASE_NAME = ConfigProperty
       .key("hoodie.meta.sync.datahub.database.name")
       .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_DATABASE_NAME.key()))
+          .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, META_SYNC_DATABASE_NAME.defaultValue()))))
       .markAdvanced()
       .withDocumentation("The name of the destination database that we should sync the hudi table to.");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_TABLE_NAME = ConfigProperty
       .key("hoodie.meta.sync.datahub.table.name")
       .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_TABLE_NAME.key()))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY)))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
       .markAdvanced()
       .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -234,7 +234,7 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
         props.setProperty(META_SYNC_DATAHUB_SYNC_SUPPRESS_EXCEPTIONS.key(), String.valueOf(suppressExceptions));
       }
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATABASE_NAME.key(), databaseName);
-      props.setPropertyIfNonNull(META_SYNC_DATAHUB_TABLE_NAME.key(), hoodieSyncConfigParams.tableName);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_TABLE_NAME.key(), tableName);
       return props;
     }
   }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -234,7 +234,7 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
         props.setProperty(META_SYNC_DATAHUB_SYNC_SUPPRESS_EXCEPTIONS.key(), String.valueOf(suppressExceptions));
       }
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATABASE_NAME.key(), databaseName);
-      props.setPropertyIfNonNull(META_SYNC_DATAHUB_TABLE_NAME.key(), tableName);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_TABLE_NAME.key(), hoodieSyncConfigParams.tableName);
       return props;
     }
   }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -115,6 +115,17 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       .defaultValue(true)
       .markAdvanced()
       .withDocumentation("Suppress exceptions during DataHub sync. This is true by default to ensure that when running inline with other jobs, the sync does not fail the job.");
+  public static final ConfigProperty<String> META_SYNC_DATAHUB_DATABASE_NAME = ConfigProperty
+      .key("hoodie.meta.sync.datahub.database.name")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The name of the destination database that we should sync the hudi table to.");
+
+  public static final ConfigProperty<String> META_SYNC_DATAHUB_TABLE_NAME = ConfigProperty
+      .key("hoodie.meta.sync.datahub.table.name")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 
   public DataHubSyncConfig(Properties props) {
     super(props);
@@ -188,6 +199,12 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
     @Parameter(names = {"--dataset-env"}, description = "Which Datahub Environment to use when pushing entities")
     public String datasetEnv;
 
+    @Parameter(names = {"--database-name"}, description = "Database name to use for datahub sync")
+    public String databaseName;
+
+    @Parameter(names = {"--table-name"}, description = "Table name to use for datahub sync")
+    public String tableName;
+
     @Parameter(names = {
         "--domain"}, description = "Domain identifier for the dataset. When provided all datasets will be attached to the provided domain. Must be in urn form (e.g., urn:li:domain:_domain_id).")
     public String domainIdentifier;
@@ -216,6 +233,8 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       } else {
         props.setProperty(META_SYNC_DATAHUB_SYNC_SUPPRESS_EXCEPTIONS.key(), String.valueOf(suppressExceptions));
       }
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATABASE_NAME.key(), databaseName);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_TABLE_NAME.key(), tableName);
       return props;
     }
   }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
@@ -32,8 +32,10 @@ import java.util.Properties;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATASET_ENV;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 
 /**
  * Construct and provide the default {@link DatasetUrn} to identify the Dataset on DataHub.
@@ -69,14 +71,13 @@ public class HoodieDataHubDatasetIdentifier {
         this.dataPlatformUrn,
         Option.ofNullable(config.getString(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME))
     );
+    this.databaseName = config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
+    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME,config.getString(META_SYNC_TABLE_NAME));
     this.datasetUrn = new DatasetUrn(
             this.dataPlatformUrn,
-            createDatasetName(this.dataPlatformInstance, config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)),
+            createDatasetName(this.dataPlatformInstance, this.databaseName, this.tableName),
             FabricType.valueOf(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV))
     );
-
-    this.tableName = config.getString(META_SYNC_TABLE_NAME);
-    this.databaseName = config.getString(META_SYNC_DATABASE_NAME);
 
     // https://github.com/datahub-project/datahub/blob/0b105395e913cc47a59bdeed0c56d7c0d4b71b63/metadata-ingestion/src/datahub/emitter/mcp_builder.py#L69-L72
     DatabaseKey databaseKey = DatabaseKey.builder()

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
@@ -29,8 +29,6 @@ import io.datahubproject.models.util.DatabaseKey;
 
 import java.util.Properties;
 
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_NAME;
@@ -71,8 +69,8 @@ public class HoodieDataHubDatasetIdentifier {
         this.dataPlatformUrn,
         Option.ofNullable(config.getString(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME))
     );
-    this.databaseName = config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, config.getString(META_SYNC_DATABASE_NAME));
-    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME,config.getString(META_SYNC_TABLE_NAME));
+    this.databaseName = config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
     this.datasetUrn = new DatasetUrn(
             this.dataPlatformUrn,
             createDatasetName(this.dataPlatformInstance, this.databaseName, this.tableName),

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
@@ -20,9 +20,11 @@
 package org.apache.hudi.sync.datahub;
 
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.sync.common.HoodieSyncConfig;
 import org.apache.hudi.sync.datahub.config.DataHubSyncConfig;
 
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -51,8 +53,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_SYNC_SUPPRESS_EXCEPTIONS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -345,16 +350,43 @@ public class TestDataHubSyncClient {
 
   @Test
   public void testTableAndDatabaseName() {
+    String dbName = "test_db1";
+    String tableName = "test_table1";
+    setAndAssertDbAndTableName(DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME.key(), dbName, DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME.key(), tableName);
+
+    dbName = "test_db2";
+    tableName = "test_table2";
+    setAndAssertDbAndTableName(HoodieSyncConfig.META_SYNC_DATABASE_NAME.key(), dbName, DataHubSyncConfig.META_SYNC_TABLE_NAME.key(), tableName);
+
+    dbName = "test_db3";
+    tableName = "test_table3";
+    setAndAssertDbAndTableName(HoodieTableConfig.DATABASE_NAME.key(), dbName, HOODIE_TABLE_NAME_KEY, tableName);
+
+    dbName = "test_db4";
+    tableName = "test_table4";
+    setAndAssertDbAndTableName(HoodieTableConfig.DATABASE_NAME.key(), dbName, HOODIE_WRITE_TABLE_NAME_KEY, tableName);
+
+    // not setting any properties
     Properties props = new Properties();
     props.put(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), DummyPartitionValueExtractor.class.getName());
-    props.put("hoodie.meta.sync.datahub.database.name", DATABASE_NAME);
-    props.put("hoodie.meta.sync.datahub.table.name", TABLE_NAME);
+    DatahubSyncConfigStub configStub = new DatahubSyncConfigStub(props, restEmitterMock);
+    DataHubSyncClientStub dhClient = new DataHubSyncClientStub(configStub);
+
+    Assertions.assertEquals(HoodieSyncConfig.META_SYNC_DATABASE_NAME.defaultValue(), dhClient.getDatabaseName());
+    Assertions.assertEquals(META_SYNC_TABLE_NAME.defaultValue(), dhClient.getTableName());
+  }
+
+  private void setAndAssertDbAndTableName(String dbNameKey, String dbNameValue, String tableNameKey, String tableNameValue) {
+    Properties props = new Properties();
+    props.put(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), DummyPartitionValueExtractor.class.getName());
+    props.put(dbNameKey, dbNameValue);
+    props.put(tableNameKey, tableNameValue);
 
     DatahubSyncConfigStub configStub = new DatahubSyncConfigStub(props, restEmitterMock);
     DataHubSyncClientStub dhClient = new DataHubSyncClientStub(configStub);
 
-    Assertions.assertEquals(DATABASE_NAME, dhClient.getDatabaseName());
-    Assertions.assertEquals(TABLE_NAME, dhClient.getTableName());
+    Assertions.assertEquals(dbNameValue, dhClient.getDatabaseName());
+    Assertions.assertEquals(tableNameValue, dhClient.getTableName());
   }
 
 }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncClient.java
@@ -32,6 +32,7 @@ import datahub.event.MetadataChangeProposalWrapper;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,8 @@ public class TestDataHubSyncClient {
   private static String TRIP_EXAMPLE_SCHEMA;
   private static Schema avroSchema;
   private static String tableBasePath;
+  private static String DATABASE_NAME = "database";
+  private static String TABLE_NAME = "table";
 
   @BeforeAll
   public static void beforeAll() throws IOException {
@@ -338,6 +341,20 @@ public class TestDataHubSyncClient {
       return emitterMock;
     }
 
+  }
+
+  @Test
+  public void testTableAndDatabaseName() {
+    Properties props = new Properties();
+    props.put(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), DummyPartitionValueExtractor.class.getName());
+    props.put("hoodie.meta.sync.datahub.database.name", DATABASE_NAME);
+    props.put("hoodie.meta.sync.datahub.table.name", TABLE_NAME);
+
+    DatahubSyncConfigStub configStub = new DatahubSyncConfigStub(props, restEmitterMock);
+    DataHubSyncClientStub dhClient = new DataHubSyncClientStub(configStub);
+
+    Assertions.assertEquals(DATABASE_NAME, dhClient.getDatabaseName());
+    Assertions.assertEquals(TABLE_NAME, dhClient.getTableName());
   }
 
 }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.sync.datahub;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
@@ -29,16 +30,12 @@ import org.apache.hudi.sync.common.util.SyncUtilHelpers;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
 
-import java.util.Properties;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class TestDataHubSyncTool extends HoodieCommonTestHarness {
   @Test
@@ -68,22 +65,5 @@ class TestDataHubSyncTool extends HoodieCommonTestHarness {
       HoodieSyncTool syncTool = new DataHubSyncTool(typedProperties);
       syncTool.close();
     });
-  }
-
-  @Test
-  void testSyncHoodieTable_actualLines() {
-    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
-
-    try (MockedConstruction<DataHubSyncClient> mocked = org.mockito.Mockito.mockConstruction(DataHubSyncClient.class, (mock, context) -> {
-      when(mock.getTableName()).thenReturn("test_table");
-    })) {
-      DataHubSyncTool tool = new DataHubSyncTool(new Properties(), null, Option.of(mockMetaClient));
-      tool.syncHoodieTable();
-
-      DataHubSyncClient mockClient = mocked.constructed().get(0);
-      verify(mockClient).updateTableSchema("test_table", null);
-      verify(mockClient).updateLastCommitTimeSynced("test_table");
-      verify(mockClient).close();
-    }
   }
 }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.sync.datahub;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
-
 import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -20,7 +20,10 @@
 package org.apache.hudi.sync.datahub;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.sync.common.HoodieSyncTool;
@@ -28,12 +31,20 @@ import org.apache.hudi.sync.common.util.SyncUtilHelpers;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.util.Properties;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TestDataHubSyncTool extends HoodieCommonTestHarness {
   @Test
@@ -63,5 +74,28 @@ class TestDataHubSyncTool extends HoodieCommonTestHarness {
       HoodieSyncTool syncTool = new DataHubSyncTool(typedProperties);
       syncTool.close();
     });
+  }
+
+  @Test
+  void testSyncHoodieTable_actualLines() {
+    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
+    when(mockMetaClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    HoodieTableConfig mockTableConfig = mock(HoodieTableConfig.class);
+    when(mockTableConfig.getTableVersion()).thenReturn(HoodieTableVersion.current());
+    when(mockMetaClient.getTableConfig()).thenReturn(mockTableConfig);
+    MessageType messageType = new MessageType("record", new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.INT32, "int_field"));
+
+    try (MockedConstruction<DataHubSyncClient> mocked = org.mockito.Mockito.mockConstruction(DataHubSyncClient.class, (mock, context) -> {
+      when(mock.getTableName()).thenReturn("test_table");
+      when(mock.getStorageSchema()).thenReturn(messageType);
+    })) {
+      DataHubSyncTool tool = new DataHubSyncTool(new Properties(), null, Option.of(mockMetaClient));
+      tool.syncHoodieTable();
+
+      DataHubSyncClient mockClient = mocked.constructed().get(0);
+      verify(mockClient).updateTableSchema("test_table", null, null);
+      verify(mockClient).updateLastCommitTimeSynced("test_table");
+      verify(mockClient).close();
+    }
   }
 }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -29,11 +29,16 @@ import org.apache.hudi.sync.common.util.SyncUtilHelpers;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.util.Properties;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TestDataHubSyncTool extends HoodieCommonTestHarness {
   @Test
@@ -63,5 +68,22 @@ class TestDataHubSyncTool extends HoodieCommonTestHarness {
       HoodieSyncTool syncTool = new DataHubSyncTool(typedProperties);
       syncTool.close();
     });
+  }
+
+  @Test
+  void testSyncHoodieTable_actualLines() {
+    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
+
+    try (MockedConstruction<DataHubSyncClient> mocked = org.mockito.Mockito.mockConstruction(DataHubSyncClient.class, (mock, context) -> {
+      when(mock.getTableName()).thenReturn("test_table");
+    })) {
+      DataHubSyncTool tool = new DataHubSyncTool(new Properties(), null, Option.of(mockMetaClient));
+      tool.syncHoodieTable();
+
+      DataHubSyncClient mockClient = mocked.constructed().get(0);
+      verify(mockClient).updateTableSchema("test_table", null);
+      verify(mockClient).updateLastCommitTimeSynced("test_table");
+      verify(mockClient).close();
+    }
   }
 }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
@@ -47,19 +47,29 @@ class TestDataHubSyncConfig {
   }
 
   @Test
-  void testDatabaseNameWithProps() {
+  void testDatabaseNameAndTableNameWithProps() {
+    String db = "db";
+    String table = "table";
+
     Properties props = new Properties();
-    props.setProperty(META_SYNC_DATAHUB_DATABASE_NAME.key(), "db");
-    props.setProperty(META_SYNC_DATAHUB_TABLE_NAME.key(), "table");
+    props.setProperty(META_SYNC_DATAHUB_DATABASE_NAME.key(), db);
+    props.setProperty(META_SYNC_DATAHUB_TABLE_NAME.key(), table);
 
     DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
     DatasetUrn datasetUrn = syncConfig.getDatasetIdentifier().getDatasetUrn();
 
-    assertEquals("db.table", datasetUrn.getDatasetNameEntity());
+    assertEquals(String.format("%s.%s", db, table), datasetUrn.getDatasetNameEntity());
+
+    DataHubSyncConfig.DataHubSyncConfigParams params = new DataHubSyncConfig.DataHubSyncConfigParams();
+    params.databaseName = db;
+    params.hoodieSyncConfigParams.tableName = table;
+
+    assertEquals(db, params.toProps().get(META_SYNC_DATAHUB_DATABASE_NAME.key()));
+    assertEquals(table, params.toProps().get(META_SYNC_DATAHUB_TABLE_NAME.key()));
   }
 
   @Test
-  void testDatabaseNameBackwardConfigurationCompatibility() {
+  void testDatabaseNameAndTableNameBackwardConfigurationCompatibility() {
     Properties props = new Properties();
     props.setProperty(META_SYNC_DATABASE_NAME.key(), "db");
     props.setProperty(META_SYNC_TABLE_NAME.key(), "table");

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
@@ -62,7 +62,7 @@ class TestDataHubSyncConfig {
 
     DataHubSyncConfig.DataHubSyncConfigParams params = new DataHubSyncConfig.DataHubSyncConfigParams();
     params.databaseName = db;
-    params.hoodieSyncConfigParams.tableName = table;
+    params.tableName = table;
 
     assertEquals(db, params.toProps().get(META_SYNC_DATAHUB_DATABASE_NAME.key()));
     assertEquals(table, params.toProps().get(META_SYNC_DATAHUB_TABLE_NAME.key()));

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
@@ -53,7 +53,7 @@ class TestDataHubSyncConfig {
     props.setProperty(META_SYNC_DATAHUB_TABLE_NAME.key(), "table");
 
     DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
-    DatasetUrn datasetUrn = syncConfig.datasetIdentifier.getDatasetUrn();
+    DatasetUrn datasetUrn = syncConfig.getDatasetIdentifier().getDatasetUrn();
 
     assertEquals("db.table", datasetUrn.getDatasetNameEntity());
   }
@@ -65,7 +65,7 @@ class TestDataHubSyncConfig {
     props.setProperty(META_SYNC_TABLE_NAME.key(), "table");
 
     DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
-    DatasetUrn datasetUrn = syncConfig.datasetIdentifier.getDatasetUrn();
+    DatasetUrn datasetUrn = syncConfig.getDatasetIdentifier().getDatasetUrn();
 
     assertEquals("db.table", datasetUrn.getDatasetNameEntity());
   }

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/config/TestDataHubSyncConfig.java
@@ -27,8 +27,12 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.util.Properties;
 
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATASET_IDENTIFIER_CLASS;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_EMITTER_SUPPLIER_CLASS;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -40,6 +44,30 @@ class TestDataHubSyncConfig {
     props.setProperty(META_SYNC_DATAHUB_EMITTER_SUPPLIER_CLASS.key(), DummySupplier.class.getName());
     DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
     assertNotNull(syncConfig.getRestEmitter());
+  }
+
+  @Test
+  void testDatabaseNameWithProps() {
+    Properties props = new Properties();
+    props.setProperty(META_SYNC_DATAHUB_DATABASE_NAME.key(), "db");
+    props.setProperty(META_SYNC_DATAHUB_TABLE_NAME.key(), "table");
+
+    DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
+    DatasetUrn datasetUrn = syncConfig.datasetIdentifier.getDatasetUrn();
+
+    assertEquals("db.table", datasetUrn.getDatasetNameEntity());
+  }
+
+  @Test
+  void testDatabaseNameBackwardConfigurationCompatibility() {
+    Properties props = new Properties();
+    props.setProperty(META_SYNC_DATABASE_NAME.key(), "db");
+    props.setProperty(META_SYNC_TABLE_NAME.key(), "table");
+
+    DataHubSyncConfig syncConfig = new DataHubSyncConfig(props);
+    DatasetUrn datasetUrn = syncConfig.datasetIdentifier.getDatasetUrn();
+
+    assertEquals("db.table", datasetUrn.getDatasetNameEntity());
   }
 
   @Test

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -116,6 +116,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NA
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_INCREMENTAL;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2017,6 +2018,28 @@ public class TestHiveSyncTool {
     assertEquals(getLastCommitCompletionTimeSynced(), hiveClient.getLastCommitCompletionTimeSynced(tableName).get());
     assertEquals(commitTime5, hiveClient.getLastCommitTimeSynced(tableName).get());
     assertEquals(3, hiveClient.getAllPartitions(tableName).size());
+  }
+
+  @Test
+  public void testDatabaseAndTableName() {
+    reInitHiveSyncClient();
+
+    assertEquals(HiveTestUtil.DB_NAME, hiveSyncTool.getDatabaseName());
+    assertEquals(HiveTestUtil.TABLE_NAME, hiveSyncTool.getTableName());
+
+    String updatedDb = "updated_db";
+    String updatedTable = "updated_table";
+
+    hiveSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), updatedDb);
+    hiveSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), updatedTable);
+
+    reInitHiveSyncClient();
+
+    assertEquals(updatedDb, hiveSyncTool.getDatabaseName(), "Database name should match the updated value");
+    assertEquals(updatedTable, hiveSyncTool.getTableName(), "Table name should match the updated value");
+
+    assertEquals(updatedDb, hiveClient.getDatabaseName(), "Database name in sync client should match");
+    assertEquals(updatedTable, hiveClient.getTableName(), "Table name in sync client should match");
   }
 
   private void reSyncHiveTable() {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -48,7 +48,9 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_USE_FILE_LISTING_FROM_METADATA;
 
 public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, AutoCloseable {
@@ -86,6 +88,14 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
 
   public HoodieTableMetaClient getMetaClient() {
     return metaClient;
+  }
+
+  public String getTableName() {
+    return config.getString(META_SYNC_TABLE_NAME);
+  }
+
+  public String getDatabaseName() {
+    return config.getString(META_SYNC_DATABASE_NAME);
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Added separate configs for glue and datahub to set database/table name in sync client. We also added infer function for the new configs added, so that previous behavior is intact. 

### Impact

Hudi database/table name can be configured for glue/datahub catalog separately.

### Risk level (write none, low medium or high below)

low

### Documentation Update
```
hoodie.datasource.meta.sync.glue.database_name: "database"
hoodie.datasource.meta.sync.glue.table_name: "table"

hoodie.meta.sync.datahub.database.name: "database"
hoodie.meta.sync.datahub.table.name: "table"
```

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
