### PR TITLE
[MINOR] TestPositionBasedFileGroupRecordBuffer setup fixes

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -29,27 +29,37 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.read.CustomPayloadForTesting;
 import org.apache.hudi.common.table.read.HoodieReadStats;
 import org.apache.hudi.common.table.read.PositionBasedFileGroupRecordBuffer;
 import org.apache.hudi.common.table.read.PositionBasedSchemaHandler;
-import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderOnSpark;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.testutils.RawTripTestPayload;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.parquet.SparkParquetReader;
+import org.apache.spark.sql.sources.Filter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -57,27 +67,27 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import scala.collection.JavaConverters;
+import scala.collection.immutable.Map$;
+
 import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.createMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupReaderOnSpark {
+public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctionalTestHarness {
   private final HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF);
-  private HoodieTableMetaClient metaClient;
   private Schema avroSchema;
   private PositionBasedFileGroupRecordBuffer<InternalRow> buffer;
-  private String partitionPath;
-  private HoodieReadStats readStats;
 
-  public void prepareBuffer(RecordMergeMode mergeMode, String baseFileInstantTime) throws Exception {
+  private void prepareBuffer(RecordMergeMode mergeMode, String baseFileInstantTime) throws Exception {
     Map<String, String> writeConfigs = new HashMap<>();
     writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
     writeConfigs.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
@@ -94,21 +104,27 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     writeConfigs.put(HoodieWriteConfig.WRITE_RECORD_POSITIONS.key(), "true");
     writeConfigs.put(HoodieWriteConfig.RECORD_MERGE_MODE.key(), mergeMode.name());
     if (mergeMode.equals(RecordMergeMode.CUSTOM)) {
-      writeConfigs.put(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), getCustomPayload());
+      writeConfigs.put(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), CustomPayloadForTesting.class.getName());
       writeConfigs.put(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID);
     }
     commitToTable(dataGen.generateInserts("001", 100), INSERT.value(), writeConfigs);
 
     String[] partitionPaths = dataGen.getPartitionPaths();
     String[] partitionValues = new String[1];
-    partitionPath = partitionPaths[0];
+    String partitionPath = partitionPaths[0];
     partitionValues[0] = partitionPath;
 
-    metaClient = createMetaClient(getStorageConf(), getBasePath());
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(basePath())
+        .setConf(storageConf())
+        .build();
     avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
 
-    HoodieReaderContext<InternalRow> ctx = getHoodieReaderContext(getBasePath(), avroSchema, getStorageConf(), metaClient);
-    ctx.setTablePath(getBasePath());
+    SparkParquetReader reader = SparkAdapterSupport$.MODULE$.sparkAdapter().createParquetFileReader(false, spark().sessionState().conf(),
+        Map$.MODULE$.empty(), storageConf().unwrapAs(Configuration.class));
+    HoodieReaderContext<InternalRow> ctx = new SparkFileFormatInternalRowReaderContext(reader, JavaConverters.asScalaBufferConverter(Collections.<Filter>emptyList()).asScala().toSeq(),
+        JavaConverters.asScalaBufferConverter(Collections.<Filter>emptyList()).asScala().toSeq(), storageConf(), metaClient.getTableConfig());
+    ctx.setTablePath(basePath());
     ctx.setLatestCommitTime(WriteClientTestUtils.createNewInstantTime());
     ctx.setShouldMergeUseRecordPosition(true);
     ctx.setHasBootstrapBaseFile(false);
@@ -128,10 +144,10 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     props.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
     props.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
     if (mergeMode.equals(RecordMergeMode.CUSTOM)) {
-      writeConfigs.put(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), getCustomPayload());
+      writeConfigs.put(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), CustomPayloadForTesting.class.getName());
       writeConfigs.put(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID);
     }
-    readStats = new HoodieReadStats();
+    HoodieReadStats readStats = new HoodieReadStats();
     buffer = new PositionBasedFileGroupRecordBuffer<>(
         ctx,
         metaClient,
@@ -143,7 +159,20 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
         false);
   }
 
-  public Map<HoodieLogBlock.HeaderMetadataType, String> getHeader(boolean shouldWriteRecordPositions,
+  private void commitToTable(List<HoodieRecord> recordList, String operation, Map<String, String> options) {
+    List<String> recs = RawTripTestPayload.recordsToStrings(recordList);
+    Dataset<Row> inputDF = spark().read().json(jsc().parallelize(recs, 2));
+
+    inputDF.write().format("hudi")
+        .options(options)
+        .option("hoodie.compact.inline", "false") // else fails due to compaction & deltacommit instant times being same
+        .option("hoodie.datasource.write.operation", operation)
+        .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+        .mode(operation.equalsIgnoreCase(WriteOperationType.INSERT.value()) ? SaveMode.Overwrite : SaveMode.Append)
+      .save(basePath());
+  }
+
+  private Map<HoodieLogBlock.HeaderMetadataType, String> getHeader(boolean shouldWriteRecordPositions,
                                                                   String baseFileInstantTime) {
     Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
     header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, avroSchema.toString());
@@ -154,7 +183,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     return header;
   }
 
-  public List<DeleteRecord> getDeleteRecords() throws IOException, URISyntaxException {
+  private List<DeleteRecord> getDeleteRecords() throws IOException, URISyntaxException {
     SchemaTestUtil testUtil = new SchemaTestUtil();
     List<IndexedRecord> records = testUtil.generateHoodieTestRecords(0, 100);
 
@@ -165,7 +194,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     return deletedRecords;
   }
 
-  public HoodieDeleteBlock getDeleteBlockWithPositions(String baseFileInstantTime)
+  private HoodieDeleteBlock getDeleteBlockWithPositions(String baseFileInstantTime)
       throws IOException, URISyntaxException {
     List<DeleteRecord> deletedRecords = getDeleteRecords();
     List<Pair<DeleteRecord, Long>> deleteRecordList = new ArrayList<>();
@@ -177,7 +206,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     return new HoodieDeleteBlock(deleteRecordList, getHeader(true, baseFileInstantTime));
   }
 
-  public HoodieDeleteBlock getDeleteBlockWithoutPositions() throws IOException, URISyntaxException {
+  private HoodieDeleteBlock getDeleteBlockWithoutPositions() throws IOException, URISyntaxException {
     List<DeleteRecord> deletedRecords = getDeleteRecords();
     List<Pair<DeleteRecord, Long>> deleteRecordList = new ArrayList<>();
 
@@ -245,6 +274,11 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
     public HoodieRecord.HoodieRecordType getRecordType() {
       return HoodieRecord.HoodieRecordType.SPARK;
     }
+  }
+
+  @Override
+  public SparkConf conf() {
+    return super.conf(Collections.singletonMap("spark.sql.parquet.enableVectorizedReader", "false"));
   }
 }
 


### PR DESCRIPTION
### Change Logs

The `TestPositionBasedFileGroupRecordBuffer` currently extends `TestHoodieFileGroupReaderOnSpark` which causes the tests in `TestHoodieFileGroupReaderOnSpark` to be run twice, increasing run time in CI. The PR avoids extending that class and instead extends `SparkClientFunctionalTestHarness`.

### Impact

Avoids running tests twice

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
