### PR TITLE
[HUDI-9523][Minor] [UT] Fix UT Only one SparkContext should be running in this JVM

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hive/TestHiveClientUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hive/TestHiveClientUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.junit.Assume
-import org.junit.jupiter.api.{BeforeAll, Disabled, TestInstance}
+import org.junit.jupiter.api.{AfterAll, BeforeAll, Disabled, TestInstance}
 import org.junit.jupiter.api.TestInstance.Lifecycle
 
 @TestInstance(Lifecycle.PER_CLASS)
@@ -49,5 +49,10 @@ class TestHiveClientUtils {
   def reuseHiveClientFromSparkSession(): Unit = {
     assert(spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive")
     assert(HiveClientUtils.getSingletonClientForMetadata(spark) == hiveClient)
+  }
+
+  @AfterAll
+  def afterEach(): Unit = {
+    spark.close()
   }
 }


### PR DESCRIPTION
### Change Logs

Fix Only one SparkContext should be running in this JVM
### Impact

UT

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
