### PR TITLE
[HUDI-9524] Fix include in DFSPropertiesConfiguration

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -90,7 +90,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
   }
 
   public DFSPropertiesConfiguration() {
-    this.hadoopConfig = null;
+    this.hadoopConfig = new Configuration();
     this.mainFilePath = null;
     this.hoodieConfig = new HoodieConfig();
     this.visitedFilePaths = new HashSet<>();

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
@@ -208,4 +208,26 @@ public class TestDFSPropertiesConfiguration {
     assertEquals("BLOOM", DFSPropertiesConfiguration.getGlobalProps().get("hoodie.index.type"));
     assertEquals("true", DFSPropertiesConfiguration.getGlobalProps().get("hoodie.metadata.enable"));
   }
+
+  @Test
+  public void testDefaultConstructorHandlesIncludes() {
+    // Use default ctor (hadoopConfig should be non-null internally)
+    DFSPropertiesConfiguration cfg = new DFSPropertiesConfiguration();
+
+    // Should load t3.props (which includes t2.props → t1.props) without NPE
+    cfg.addPropsFromFile(new Path(dfsBasePath + "/t3.props"));
+    TypedProperties props = cfg.getProps();
+
+    // Values from t1, t2 and t3 should be resolved in order
+    assertEquals(123, props.getInteger("int.prop"));
+    assertEquals(243.4, props.getDouble("double.prop"), 0.001);
+    assertTrue(props.getBoolean("boolean.prop"));
+    assertEquals("t3.value", props.getString("string.prop"));
+    assertEquals(1354354354L, props.getLong("long.prop"));
+
+    // And a self-include still triggers the loop-detection
+    assertThrows(IllegalStateException.class, () -> {
+      cfg.addPropsFromFile(new Path(dfsBasePath + "/t4.props"));
+    });
+  }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
@@ -214,8 +214,8 @@ public class TestDFSPropertiesConfiguration {
     // Use default ctor (hadoopConfig should be non-null internally)
     DFSPropertiesConfiguration cfg = new DFSPropertiesConfiguration();
 
-    // Should load t3.props (which includes t2.props → t1.props) without NPE
-    cfg.addPropsFromFile(new Path(dfsBasePath + "/t3.props"));
+    // Should load t3.props (which includes t2.props which includes t1.props) without NPE
+    cfg.addPropsFromFile(new StoragePath(dfsBasePath + "/t3.props"));
     TypedProperties props = cfg.getProps();
 
     // Values from t1, t2 and t3 should be resolved in order
@@ -225,9 +225,9 @@ public class TestDFSPropertiesConfiguration {
     assertEquals("t3.value", props.getString("string.prop"));
     assertEquals(1354354354L, props.getLong("long.prop"));
 
-    // And a self-include still triggers the loop-detection
+    // And a self include still triggers the loop detection
     assertThrows(IllegalStateException.class, () -> {
-      cfg.addPropsFromFile(new Path(dfsBasePath + "/t4.props"));
+      cfg.addPropsFromFile(new StoragePath(dfsBasePath + "/t4.props"));
     });
   }
 }


### PR DESCRIPTION
### Change Logs

`hudi-defaults.conf` does not work with `include=`

### Impact

Before this was producing NPE.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
