### PR TITLE
Update CachingIterator.scala

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/CachingIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/util/CachingIterator.scala
@@ -33,7 +33,7 @@ trait CachingIterator[T >: Null] extends Iterator[T] {
 
   protected def doHasNext: Boolean
 
-  override final def hasNext: Boolean = nextRecord != null || doHasNext
+  override final def hasNext: Boolean = nextRecord != null && doHasNext
 
   override final def next: T = {
     val record = nextRecord


### PR DESCRIPTION
If the next record is null, hasNext will be false; if it is true, it will run doHasNext. It must be the and condition.

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
