### PR TITLE
[HUDI-9476] Update test usage of createNewInstantTime

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1789,12 +1789,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       writeClient.compact(compactionInstantTime, true);
     } else if (metadataWriteConfig.isLogCompactionEnabled()) {
       // Schedule and execute log compaction with new instant time.
-      final String logCompactionInstantTime = metadataMetaClient.createNewInstantTime(false);
-      if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(logCompactionInstantTime)) {
-        LOG.info("Log compaction with same {} time is already present in the timeline.", logCompactionInstantTime);
-      } else if (writeClient.scheduleLogCompactionAtInstant(logCompactionInstantTime, Option.empty())) {
-        LOG.info("Log compaction is scheduled for timestamp {}", logCompactionInstantTime);
-        writeClient.logCompact(logCompactionInstantTime, true);
+      Option<String> scheduledLogCompaction = writeClient.scheduleLogCompaction(Option.empty());
+      if (scheduledLogCompaction.isPresent()) {
+        LOG.info("Log compaction is scheduled for timestamp {}", scheduledLogCompaction.get());
+        writeClient.logCompact(scheduledLogCompaction.get(), true);
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -21,9 +21,11 @@ package org.apache.hudi.client;
 import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.table.timeline.TimeGenerator;
 import org.apache.hudi.common.util.Option;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class WriteClientTestUtils {
   private WriteClientTestUtils() {
@@ -42,10 +44,21 @@ public class WriteClientTestUtils {
     return writeClient.scheduleTableService(Option.of(instantTime), extraMetadata, tableServiceType);
   }
 
-  /**
-   * Returns next instant time in the correct format. Lock is enabled by default.
-   */
   public static String createNewInstantTime() {
-    return HoodieInstantTimeGenerator.getCurrentInstantTimeStr();
+    return HoodieInstantTimeGenerator.createNewInstantTime(false, TestTimeGenerator.INSTANCE, 0);
+  }
+
+  private static class TestTimeGenerator implements TimeGenerator {
+    private static final TimeGenerator INSTANCE = new TestTimeGenerator();
+
+    @Override
+    public long generateTime(boolean skipLocking) {
+      return System.currentTimeMillis();
+    }
+
+    @Override
+    public void consumeTime(boolean skipLocking, Consumer<Long> func) {
+
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.util.Option;
 
 import java.util.Map;
@@ -39,5 +40,12 @@ public class WriteClientTestUtils {
 
   public static Option<String> scheduleTableService(BaseHoodieWriteClient<?, ?, ?, ?> writeClient, String instantTime, Option<Map<String, String>> extraMetadata, TableServiceType tableServiceType) {
     return writeClient.scheduleTableService(Option.of(instantTime), extraMetadata, tableServiceType);
+  }
+
+  /**
+   * Returns next instant time in the correct format. Lock is enabled by default.
+   */
+  public static String createNewInstantTime() {
+    return HoodieInstantTimeGenerator.getCurrentTimeAsString();
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/WriteClientTestUtils.java
@@ -46,6 +46,6 @@ public class WriteClientTestUtils {
    * Returns next instant time in the correct format. Lock is enabled by default.
    */
   public static String createNewInstantTime() {
-    return HoodieInstantTimeGenerator.getCurrentTimeAsString();
+    return HoodieInstantTimeGenerator.getCurrentInstantTimeStr();
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -83,15 +84,15 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
 
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulCommit() throws Exception {
-    createCommit(metaClient.createNewInstantTime());
+    createCommit(WriteClientTestUtils.createNewInstantTime());
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     // writer 2 starts and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCommit(newInstantTime);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -115,15 +116,15 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
 
   @Test
   public void testConcurrentWritesWithDifferentPartition() throws Exception {
-    createCommit(metaClient.createNewInstantTime());
+    createCommit(WriteClientTestUtils.createNewInstantTime());
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH);
     // writer 2 starts and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCommit(newInstantTime);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestPreferWriterConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestPreferWriterConflictResolutionStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -55,15 +56,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
 
   @Test
   public void testConcurrentWritesWithInterleavingScheduledCompaction() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // compaction 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompactionRequested(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -77,15 +78,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
 
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulCompaction() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // compaction 1 gets scheduled and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompaction(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -109,15 +110,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
 
   @Test
   public void testConcurrentWritesWithInterleavingCompaction() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // compaction 1 gets scheduled and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompactionRequested(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, newInstantTime));
@@ -137,15 +138,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
    */
   @Test
   public void testConcurrentWriteAndCompactionScheduledEarlier() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     // consider commits before this are all successful
     // compaction 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompaction(newInstantTime, metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -161,15 +162,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
    */
   @Test
   public void testConcurrentWritesWithInterleavingScheduledCluster() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // clustering 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createClusterRequested(newInstantTime, metaClient);
     createClusterInflight(newInstantTime, metaClient);
 
@@ -189,15 +190,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
    */
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulCluster() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // clustering writer starts and complete before ingestion commit.
-    String replaceWriterInstant = metaClient.createNewInstantTime();
+    String replaceWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createCluster(replaceWriterInstant, WriteOperationType.CLUSTER, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -222,15 +223,15 @@ public class TestPreferWriterConflictResolutionStrategy extends HoodieCommonTest
 
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulReplace() throws Exception {
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // replace 1 gets scheduled and finished
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createReplace(newInstantTime, WriteOperationType.INSERT_OVERWRITE, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.utils.TransactionUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -98,15 +99,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulCommit() throws Exception {
     initMetaClient();
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // writer 2 starts and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCommit(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -126,11 +127,11 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithReplaceInflightCommit() throws Exception {
     initMetaClient();
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
 
-    String replaceInstant = metaClient.createNewInstantTime();
+    String replaceInstant = WriteClientTestUtils.createNewInstantTime();
     HoodieTestTable.of(metaClient).addRequestedReplace(replaceInstant, Option.empty());
     TestConflictResolutionStrategyUtil.createReplaceInflight(replaceInstant, metaClient);
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
@@ -154,11 +155,11 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   public void testConcurrentWritesWithClusteringInflightCommit() throws Exception {
     initMetaClient();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
 
-    String clusteringInstantTime = metaClient.createNewInstantTime();
+    String clusteringInstantTime = WriteClientTestUtils.createNewInstantTime();
     createClusterRequested(clusteringInstantTime, metaClient);
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
     createClusterInflight(clusteringInstantTime, metaClient);
@@ -181,14 +182,14 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithLegacyClusteringInflightCommit() throws Exception {
     initMetaClient();
-    String clusteringInstantTime = metaClient.createNewInstantTime();
+    String clusteringInstantTime = WriteClientTestUtils.createNewInstantTime();
     // create a replace commit with a clustering operation to mimic a commit written by a v6 writer
     HoodieTestTable.of(metaClient).addRequestedReplace(clusteringInstantTime, Option.of(buildRequestedReplaceMetadata("file-1", WriteOperationType.CLUSTER)));
     Option<HoodieInstant> lastSuccessfulInstant = Option.empty();
     HoodieTestTable.of(metaClient).addInflightReplace(clusteringInstantTime, Option.empty());
 
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
 
@@ -211,15 +212,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @ValueSource(booleans = {false, true})
   public void testConcurrentWritesWithInterleavingScheduledCompaction(boolean preTableVersion8) throws Exception {
     initMetaClient(preTableVersion8, HoodieTableType.MERGE_ON_READ);
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // compaction 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompactionRequested(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -245,15 +246,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @ValueSource(booleans = {false, true})
   public void testConcurrentWritesWithInterleavingSuccessfulCompaction(boolean preTableVersion8) throws Exception {
     initMetaClient(preTableVersion8, HoodieTableType.MERGE_ON_READ);
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // compaction 1 gets scheduled and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompaction(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -279,17 +280,17 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @ValueSource(booleans = {false, true})
   public void testConcurrentWritesWithInterleavingInflightCompaction(boolean preTableVersion8) throws Exception {
     initMetaClient(preTableVersion8, HoodieTableType.MERGE_ON_READ);
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // Consider commits before this are all successful.
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // Writer 1 starts.
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // Compaction 1 gets scheduled and becomes inflight.
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createPendingCompaction(newInstantTime, metaClient);
 
     // Writer 1 tries to commit.
@@ -324,15 +325,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWriteAndCompactionScheduledEarlier() throws Exception {
     initMetaClient(false, HoodieTableType.MERGE_ON_READ);
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     // compaction 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCompaction(newInstantTime, metaClient);
     // consider commits before this are all successful
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -347,15 +348,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithInterleavingScheduledCluster() throws Exception {
     initMetaClient(false, HoodieTableType.MERGE_ON_READ);
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // clustering 1 gets scheduled
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createClusterRequested(newInstantTime, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -375,15 +376,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulCluster() throws Exception {
     initMetaClient();
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // cluster 1 gets scheduled and finishes
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createCluster(newInstantTime, WriteOperationType.CLUSTER, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -403,15 +404,15 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithInterleavingSuccessfulReplace() throws Exception {
     initMetaClient();
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // replace 1 gets scheduled and finished
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createReplace(newInstantTime, WriteOperationType.INSERT_OVERWRITE, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -431,17 +432,17 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testConcurrentWritesWithPendingInsertOverwriteReplace() throws Exception {
     initMetaClient();
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // writer 1 starts
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // insert_overwrite 1 gets scheduled and inflighted
-    String newInstantTime = metaClient.createNewInstantTime();
+    String newInstantTime = WriteClientTestUtils.createNewInstantTime();
     createPendingInsertOverwrite(newInstantTime, WriteOperationType.INSERT_OVERWRITE, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -462,24 +463,24 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   public void testConcurrentWritesWithPendingInstants() throws Exception {
     initMetaClient(false, HoodieTableType.MERGE_ON_READ);
     // step1: create a pending replace/commit/compact instant: C1,C11,C12
-    String newInstantTimeC1 = metaClient.createNewInstantTime();
+    String newInstantTimeC1 = WriteClientTestUtils.createNewInstantTime();
     createPendingCluster(newInstantTimeC1, WriteOperationType.CLUSTER, metaClient);
 
-    String newCompactionInstantTimeC11 = metaClient.createNewInstantTime();
+    String newCompactionInstantTimeC11 = WriteClientTestUtils.createNewInstantTime();
     createPendingCompaction(newCompactionInstantTimeC11, metaClient);
 
-    String newCommitInstantTimeC12 = metaClient.createNewInstantTime();
+    String newCommitInstantTimeC12 = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(newCommitInstantTimeC12, metaClient);
     // step2: create a complete commit which has no conflict with C1,C11,C12, named it as C2
-    createCommit(metaClient.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     // consider commits before this are all successful
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // step3: write 1 starts, which has conflict with C1,C11,C12, named it as C3
-    String currentWriterInstant = metaClient.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
     // step4: create a requested commit, which has conflict with C3, named it as C4
-    String commitC4 = metaClient.createNewInstantTime();
+    String commitC4 = WriteClientTestUtils.createNewInstantTime();
     createRequestedCommit(commitC4, metaClient);
     // get PendingCommit during write 1 operation
     metaClient.reloadActiveTimeline();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestCommitMetadataResolver.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestCommitMetadataResolver.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.client.utils;
 
 import org.apache.hudi.client.MarkerBasedCommitMetadataResolver;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
@@ -106,7 +107,7 @@ public class TestCommitMetadataResolver extends HoodieCommonTestHarness {
     when(writeConfig.getViewStorageConfig()).thenReturn(FileSystemViewStorageConfig.newBuilder().build());
     when(writeConfig.getMarkersType()).thenReturn(MarkerType.DIRECT);
     when(writeConfig.getBasePath()).thenReturn(basePath);
-    String instantTime = metaClient.createNewInstantTime();
+    String instantTime = WriteClientTestUtils.createNewInstantTime();
 
     // Setup dummy commit metadata
     String p0 = "2020/01/01";

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -543,13 +543,6 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   /**
-   * Returns next instant time in the correct format. Lock is enabled by default.
-   */
-  public String createNewInstantTime() {
-    return createNewInstantTime(true);
-  }
-
-  /**
    * Returns next instant time in the correct format.
    *
    * @param shouldLock whether the lock should be enabled to get the instant time.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -65,12 +65,6 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
   HoodieInstant createRequestedCommitWithReplaceMetadata(String instantTime, String actionType);
 
   /**
-   * Create completion time to assist with wrapping up a commit.
-   * @return newly generated completion time.
-   */
-  String createCompletionTime();
-
-  /**
    * Save Completed instant in active timeline.
    * @param instant Instant to be saved.
    * @param metadata metadata to write into the instant file

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -156,7 +156,7 @@ public class HoodieInstantTimeGenerator {
     return MILLIS_INSTANT_TIME_FORMATTER.format(temporalAccessor);
   }
 
-  public static String getCurrentTimeAsString() {
+  public static String getCurrentInstantTimeStr() {
     return Instant.now().atZone(commitTimeZone.getZoneId()).toLocalDateTime().format(MILLIS_INSTANT_TIME_FORMATTER);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -156,7 +156,7 @@ public class HoodieInstantTimeGenerator {
     return MILLIS_INSTANT_TIME_FORMATTER.format(temporalAccessor);
   }
 
-  public static String getCurrentInstantTimeStr() {
+  public static String getCurrentTimeAsString() {
     return Instant.now().atZone(commitTimeZone.getZoneId()).toLocalDateTime().format(MILLIS_INSTANT_TIME_FORMATTER);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -150,10 +150,6 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
     return instant;
   }
 
-  public String createCompletionTime() {
-    return this.metaClient.createNewInstantTime(false);
-  }
-
   @Override
   public <T> void saveAsComplete(HoodieInstant instant, Option<T> metadata) {
     LOG.info("Marking instant complete {}", instant);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -153,10 +153,6 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     return instant;
   }
 
-  public String createCompletionTime() {
-    return this.metaClient.createNewInstantTime(false);
-  }
-
   @Override
   public <T> void saveAsComplete(HoodieInstant instant, Option<T> metadata) {
     saveAsComplete(true, instant, metadata);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1388,7 +1388,7 @@ public class HoodieTableMetadataUtil {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
-          metaClient.createNewInstantTime(false));
+          HoodieInstantTimeGenerator.getCurrentTimeAsString());
       timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline());
     }
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
@@ -2076,7 +2076,7 @@ public class HoodieTableMetadataUtil {
     }
 
     if (backup) {
-      final StoragePath metadataBackupPath = new StoragePath(metadataTablePath.getParent(), ".metadata_" + dataMetaClient.createNewInstantTime(false));
+      final StoragePath metadataBackupPath = new StoragePath(metadataTablePath.getParent(), ".metadata_" + HoodieInstantTimeGenerator.getCurrentTimeAsString());
       LOG.info("Backing up metadata directory to {} before deletion", metadataBackupPath);
       try {
         if (storage.rename(metadataTablePath, metadataBackupPath)) {
@@ -2133,7 +2133,7 @@ public class HoodieTableMetadataUtil {
 
     if (backup) {
       final StoragePath metadataPartitionBackupPath = new StoragePath(metadataTablePartitionPath.getParent().getParent(),
-          String.format(".metadata_%s_%s", partitionPath, dataMetaClient.createNewInstantTime(false)));
+          String.format(".metadata_%s_%s", partitionPath, HoodieInstantTimeGenerator.getCurrentTimeAsString()));
       LOG.info("Backing up MDT partition {} to {} before deletion", partitionPath, metadataPartitionBackupPath);
       try {
         if (storage.rename(metadataTablePartitionPath, metadataPartitionBackupPath)) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1388,7 +1388,7 @@ public class HoodieTableMetadataUtil {
     TimelineFactory factory = metaClient.getTimelineLayout().getTimelineFactory();
     if (timeline.empty()) {
       final HoodieInstant instant = metaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
-          HoodieInstantTimeGenerator.getCurrentTimeAsString());
+          HoodieInstantTimeGenerator.getCurrentInstantTimeStr());
       timeline = factory.createDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline());
     }
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf());
@@ -2076,7 +2076,7 @@ public class HoodieTableMetadataUtil {
     }
 
     if (backup) {
-      final StoragePath metadataBackupPath = new StoragePath(metadataTablePath.getParent(), ".metadata_" + HoodieInstantTimeGenerator.getCurrentTimeAsString());
+      final StoragePath metadataBackupPath = new StoragePath(metadataTablePath.getParent(), ".metadata_" + HoodieInstantTimeGenerator.getCurrentInstantTimeStr());
       LOG.info("Backing up metadata directory to {} before deletion", metadataBackupPath);
       try {
         if (storage.rename(metadataTablePath, metadataBackupPath)) {
@@ -2133,7 +2133,7 @@ public class HoodieTableMetadataUtil {
 
     if (backup) {
       final StoragePath metadataPartitionBackupPath = new StoragePath(metadataTablePartitionPath.getParent().getParent(),
-          String.format(".metadata_%s_%s", partitionPath, HoodieInstantTimeGenerator.getCurrentTimeAsString()));
+          String.format(".metadata_%s_%s", partitionPath, HoodieInstantTimeGenerator.getCurrentInstantTimeStr()));
       LOG.info("Backing up MDT partition {} to {} before deletion", partitionPath, metadataPartitionBackupPath);
       try {
         if (storage.rename(metadataTablePartitionPath, metadataPartitionBackupPath)) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -192,7 +192,7 @@ public class CompactionUtil {
             instant.getState() == HoodieInstant.State.INFLIGHT).firstInstant();
     if (earliestInflight.isPresent()) {
       HoodieInstant instant = earliestInflight.get();
-      String currentTime = HoodieInstantTimeGenerator.getCurrentInstantTimeStr();
+      String currentTime = HoodieInstantTimeGenerator.getCurrentTimeAsString();
       int timeout = conf.getInteger(FlinkOptions.COMPACTION_TIMEOUT_SECONDS);
       if (StreamerUtil.instantTimeDiffSeconds(currentTime, instant.requestedTime()) >= timeout) {
         LOG.info("Rollback the inflight compaction instant: " + instant + " for timeout(" + timeout + "s)");

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -192,7 +192,7 @@ public class CompactionUtil {
             instant.getState() == HoodieInstant.State.INFLIGHT).firstInstant();
     if (earliestInflight.isPresent()) {
       HoodieInstant instant = earliestInflight.get();
-      String currentTime = HoodieInstantTimeGenerator.getCurrentTimeAsString();
+      String currentTime = HoodieInstantTimeGenerator.getCurrentInstantTimeStr();
       int timeout = conf.getInteger(FlinkOptions.COMPACTION_TIMEOUT_SECONDS);
       if (StreamerUtil.instantTimeDiffSeconds(currentTime, instant.requestedTime()) >= timeout) {
         LOG.info("Rollback the inflight compaction instant: " + instant + " for timeout(" + timeout + "s)");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.bulk;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.table.HoodieFlinkTable;
@@ -66,7 +67,7 @@ public class TestBulkInsertWriteHelper {
   @Test
   void testWrite() throws Exception {
     HoodieFlinkTable<?> table = FlinkTables.createTable(conf);
-    String instant = table.getMetaClient().createNewInstantTime();
+    String instant = WriteClientTestUtils.createNewInstantTime();
     RowType rowType = TestConfigurations.ROW_TYPE;
     BulkInsertWriterHelper writerHelper = new BulkInsertWriterHelper(conf, table, table.getConfig(), instant,
         1, 1, 0, rowType, false);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.avro.model.HoodieClusteringStrategy;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -132,7 +133,7 @@ public class TestClusteringUtil {
         HoodieClusteringStrategy.newBuilder().build(), Collections.emptyMap(), 1, false, null);
     HoodieRequestedReplaceMetadata metadata = new HoodieRequestedReplaceMetadata(WriteOperationType.CLUSTER.name(),
         plan, Collections.emptyMap(), 1);
-    String instantTime = table.getMetaClient().createNewInstantTime();
+    String instantTime = WriteClientTestUtils.createNewInstantTime();
     HoodieInstant clusteringInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, instantTime);
     metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, metadata);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utils;
 import org.apache.hudi.avro.model.HoodieCompactionOperation;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -173,7 +174,7 @@ public class TestCompactionUtil {
   private String generateCompactionPlan() {
     HoodieCompactionOperation operation = new HoodieCompactionOperation();
     HoodieCompactionPlan plan = new HoodieCompactionPlan(Collections.singletonList(operation), Collections.emptyMap(), 1, null, null, null);
-    String instantTime = table.getMetaClient().createNewInstantTime();
+    String instantTime = WriteClientTestUtils.createNewInstantTime();
     HoodieInstant compactionInstant =
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instantTime);
     metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant, plan);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utils;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -149,7 +150,7 @@ public class TestUtils {
 
   public static String amendCompletionTimeToLatest(HoodieTableMetaClient metaClient, java.nio.file.Path sourcePath, String instantTime) throws IOException {
     String fileExt = sourcePath.getFileName().toString().split("\\.")[1];
-    String newCompletionTime = metaClient.createNewInstantTime();
+    String newCompletionTime = WriteClientTestUtils.createNewInstantTime();
     String newFileName = instantTime + "_" + newCompletionTime + "." + fileExt;
 
     java.nio.file.Path newFilePath = sourcePath.getParent().resolve(newFileName);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -613,7 +613,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertEquals(deltaFile1, logFiles.get(1).getFileName(), "Log File Order check");
 
     // schedules a compaction
-    String compactionInstantTime1 = metaClient.createNewInstantTime(); // 60 -> 80
+    String compactionInstantTime1 = WriteClientTestUtils.createNewInstantTime(); // 60 -> 80
     String compactionFile1 = FSUtils.makeBaseFileName(compactionInstantTime1, TEST_WRITE_TOKEN, fileId, BASE_FILE_EXTENSION);
     List<Pair<String, FileSlice>> partitionFileSlicesPairs = new ArrayList<>();
     partitionFileSlicesPairs.add(Pair.of(partitionPath, fileSlices.get(0)));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -614,7 +614,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertEquals(deltaFile1, logFiles.get(1).getFileName(), "Log File Order check");
 
     // schedules a compaction
-    String compactionInstantTime1 = HoodieInstantTimeGenerator.getCurrentTimeAsString(); // 60 -> 80
+    String compactionInstantTime1 = HoodieInstantTimeGenerator.getCurrentInstantTimeStr(); // 60 -> 80
     String compactionFile1 = FSUtils.makeBaseFileName(compactionInstantTime1, TEST_WRITE_TOKEN, fileId, BASE_FILE_EXTENSION);
     List<Pair<String, FileSlice>> partitionFileSlicesPairs = new ArrayList<>();
     partitionFileSlicesPairs.add(Pair.of(partitionPath, fileSlices.get(0)));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -47,6 +47,7 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.table.view.TableFileSystemView.SliceView;
@@ -613,7 +614,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertEquals(deltaFile1, logFiles.get(1).getFileName(), "Log File Order check");
 
     // schedules a compaction
-    String compactionInstantTime1 = WriteClientTestUtils.createNewInstantTime(); // 60 -> 80
+    String compactionInstantTime1 = HoodieInstantTimeGenerator.getCurrentTimeAsString(); // 60 -> 80
     String compactionFile1 = FSUtils.makeBaseFileName(compactionInstantTime1, TEST_WRITE_TOKEN, fileId, BASE_FILE_EXTENSION);
     List<Pair<String, FileSlice>> partitionFileSlicesPairs = new ArrayList<>();
     partitionFileSlicesPairs.add(Pair.of(partitionPath, fileSlices.get(0)));

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGe
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.metadata.HoodieTableMetadata
+
 import org.apache.avro.generic.IndexedRecord
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -36,6 +37,7 @@ import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util
 import java.util.function.Supplier
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -136,14 +136,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
     val metaClient = createMetaClient(jsc, basePath)
 
     val timeline = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
-
-    val maxInstant = HoodieInstantTimeGenerator.getCurrentInstantTimeStr
-    val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
-
-    val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(
-      new java.util.ArrayList[HoodieInstant](instants.toList.asJava).stream(), metaClient.getActiveTimeline.getInstantReader)
-
-    HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, filteredTimeline)
+    HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metaClient, timeline)
   }
 
   override def build: Procedure = new ShowMetadataTableColumnStatsProcedure()

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -25,11 +25,10 @@ import org.apache.hudi.common.data.HoodieData
 import org.apache.hudi.common.engine.HoodieEngineContext
 import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.TableSchemaResolver
-import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.metadata.HoodieTableMetadata
-
 import org.apache.avro.generic.IndexedRecord
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -37,7 +36,6 @@ import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
 import java.util
 import java.util.function.Supplier
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -137,7 +135,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
 
     val timeline = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
 
-    val maxInstant = metaClient.createNewInstantTime()
+    val maxInstant = HoodieInstantTimeGenerator.getCurrentTimeAsString
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableColumnStatsProcedure.scala
@@ -137,7 +137,7 @@ class ShowMetadataTableColumnStatsProcedure extends BaseProcedure with Procedure
 
     val timeline = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
 
-    val maxInstant = HoodieInstantTimeGenerator.getCurrentTimeAsString
+    val maxInstant = HoodieInstantTimeGenerator.getCurrentInstantTimeStr
     val instants = timeline.getInstants.iterator().asScala.filter(_.requestedTime < maxInstant)
 
     val filteredTimeline = metaClient.getTimelineLayout.getTimelineFactory.createDefaultTimeline(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
@@ -20,7 +20,6 @@
 package org.apache.hudi;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
-import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -95,7 +94,7 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
 
     String[] dataset1 = new String[] {"I,id1,Danny,23,1,par1", "I,id2,Tony,20,1,par1"};
     SparkRDDWriteClient client = getHoodieWriteClient(config);
-    String insertTime1 = client.createNewInstantTime();
+    String insertTime1 = client.startCommit();
     List<WriteStatus> writeStatuses1 = writeData(client, insertTime1, dataset1);
     client.commit(insertTime1, jsc().parallelize(writeStatuses1));
 
@@ -104,7 +103,7 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
         "D,id2,Tony,20,2,par1",
         "I,id3,Julian,40,2,par1",
         "D,id4,Stephan,35,2,par1"};
-    String insertTime2 = client.createNewInstantTime();
+    String insertTime2 = client.startCommit();
     List<WriteStatus> writeStatuses2 = writeData(client, insertTime2, dataset2);
     client.commit(insertTime2, jsc().parallelize(writeStatuses2));
 
@@ -156,7 +155,6 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
     List<HoodieRecord> recordList = str2HoodieRecord(records);
     JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(recordList, 2);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    WriteClientTestUtils.startCommitWithTime(client, instant);
     List<WriteStatus> writeStatuses = client.upsert(writeRecords, instant).collect();
     assertNoWriteErrors(writeStatuses);
     metaClient = HoodieTableMetaClient.reload(metaClient);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
@@ -108,7 +109,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends TestHoodieFileGroupR
 
     HoodieReaderContext<InternalRow> ctx = getHoodieReaderContext(getBasePath(), avroSchema, getStorageConf(), metaClient);
     ctx.setTablePath(getBasePath());
-    ctx.setLatestCommitTime(metaClient.createNewInstantTime());
+    ctx.setLatestCommitTime(WriteClientTestUtils.createNewInstantTime());
     ctx.setShouldMergeUseRecordPosition(true);
     ctx.setHasBootstrapBaseFile(false);
     ctx.setHasLogFiles(true);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
@@ -197,8 +197,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
   }
 
   private boolean writeOnMainTable(TestTableContents mainTable, int curr) throws IOException {
-    String commitTime = mainTable.client.createNewInstantTime();
-    WriteClientTestUtils.startCommitWithTime(mainTable.client, commitTime);
+    String commitTime = mainTable.client.startCommit();
 
     int actionType = pickAWriteAction();
     JavaRDD<WriteStatus> result;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -340,7 +340,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     int numRecords = 200;
     //set wrong value for expected number of rows
     HoodieWriteConfig config = getConfigBuilder().withPreCommitValidatorConfig(createPreCommitValidatorConfig(500)).build();
-    String newCommitTime = metaClient.createNewInstantTime();
+    String newCommitTime = WriteClientTestUtils.createNewInstantTime();
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
       Function3<JavaRDD<WriteStatus>, SparkRDDWriteClient, JavaRDD<HoodieRecord>, String> writeFn = (writeClient, recordRDD, instantTime) ->
           writeClient.bulkInsert(recordRDD, instantTime, Option.empty());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstantTimeGenerator.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstantTimeGenerator.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import org.apache.hudi.common.model.HoodieTimelineTimeZone;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.MILLIS_INSTANT_TIME_FORMATTER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestHoodieInstantTimeGenerator {
+
+  @Test
+  void testCreateNewInstantTimes() {
+    List<String> instantTimesSoFar = new ArrayList<>();
+    // explicitly set timezone to UTC and generate timestamps
+    HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.UTC);
+
+    TimeGenerator timeGenerator = mock(TimeGenerator.class);
+    when(timeGenerator.generateTime(anyBoolean())).thenAnswer(invocation -> System.currentTimeMillis());
+    // run for few iterations
+    for (int j = 0; j < 5; j++) {
+      instantTimesSoFar.clear();
+      // Generate an instant time in UTC and validate that all instants generated are within few seconds apart.
+      String newCommitTimeInUTC = getNewInstantTimeInUTC();
+
+      // new instant that we generate below should be within few seconds apart compared to above time we generated. If not, the time zone is not honored
+      for (int i = 0; i < 10; i++) {
+        String newInstantTime = HoodieInstantTimeGenerator.createNewInstantTime(false, timeGenerator, 0);
+        assertTrue(!instantTimesSoFar.contains(newInstantTime));
+        instantTimesSoFar.add(newInstantTime);
+        assertTrue((Long.parseLong(newInstantTime) - Long.parseLong(newCommitTimeInUTC)) < 60000L,
+            String.format("Validation failed on new instant time created: %s, newCommitTimeInUTC=%s",
+                newInstantTime, newCommitTimeInUTC));
+      }
+    }
+    // reset timezone to local
+    HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.LOCAL);
+  }
+
+  @Test
+  void testFormatDate() throws Exception {
+    // Multiple thread test
+    final int numChecks = 100000;
+    final int numThreads = 100;
+    final long milliSecondsInYear = 365 * 24 * 3600 * 1000;
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    List<Future> futures = new ArrayList<>(numThreads);
+    for (int idx = 0; idx < numThreads; ++idx) {
+      futures.add(executorService.submit(() -> {
+        Date date = new Date(System.currentTimeMillis() + (int) (Math.random() * numThreads) * milliSecondsInYear);
+        final String expectedFormat = TimelineUtils.formatDate(date);
+        for (int tidx = 0; tidx < numChecks; ++tidx) {
+          final String curFormat = TimelineUtils.formatDate(date);
+          assertEquals(expectedFormat, curFormat);
+        }
+      }));
+    }
+
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(60, TimeUnit.SECONDS));
+    // required to catch exceptions
+    for (Future f : futures) {
+      f.get();
+    }
+  }
+
+  private String getNewInstantTimeInUTC() {
+    Date d = new Date(System.currentTimeMillis());
+    return d.toInstant().atZone(HoodieTimelineTimeZone.UTC.getZoneId())
+        .toLocalDateTime().format(MILLIS_INSTANT_TIME_FORMATTER);
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
@@ -235,8 +235,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     assertTrue(javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().isEmpty());
 
     // Insert totalRecords records
-    String newCommitTime = writeClient.createNewInstantTime();
-    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
+    String newCommitTime = writeClient.startCommit();
     JavaRDD<WriteStatus> writeStatusRdd = writeClient.upsert(writtenRecords, newCommitTime);
     List<WriteStatus> writeStatuses = writeStatusRdd.collect();
     assertNoWriteErrors(writeStatuses);
@@ -351,8 +350,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
 
     HoodieSparkTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
 
-    String newCommitTime = writeClient.createNewInstantTime();
-    WriteClientTestUtils.startCommitWithTime(writeClient, newCommitTime);
+    String newCommitTime = writeClient.startCommit();
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
     JavaRDD<HoodieRecord> javaRDD1 = tagLocation(index, writeRecords, hoodieTable);
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -571,14 +571,14 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
       String commitActionType = table.getMetaClient().getCommitActionType();
       List<String> instants = new ArrayList<>();
-      String instant0 = metaClient.createNewInstantTime();
+      String instant0 = WriteClientTestUtils.createNewInstantTime();
       HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(State.REQUESTED, commitActionType, instant0);
       activeTimeline.createNewInstant(instant);
       activeTimeline.transitionRequestedToInflight(instant, Option.empty());
       instant = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, commitActionType, instant0);
       activeTimeline.saveAsComplete(instant, Option.empty());
 
-      String instant1 = metaClient.createNewInstantTime();
+      String instant1 = WriteClientTestUtils.createNewInstantTime();
       WriteClientTestUtils.startCommitWithTime(client, instant1);
 
       List<HoodieRecord> records = dataGen.generateInserts(instant1, 200);
@@ -600,7 +600,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       }
       assertEquals(200, inserts);
 
-      String instant2 = metaClient.createNewInstantTime();
+      String instant2 = WriteClientTestUtils.createNewInstantTime();
       WriteClientTestUtils.startCommitWithTime(client, instant2);
       records = dataGen.generateUpdates(instant2, records);
       writeRecords = jsc().parallelize(records, 1);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
@@ -17,6 +17,7 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
 import org.apache.hudi.common.model.HoodieFileFormat
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -26,14 +27,12 @@ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieIOException
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
-
 import org.apache.spark.sql._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue, fail}
 import org.slf4j.LoggerFactory
 
 import java.io.FileNotFoundException
-
 import scala.collection.JavaConverters._
 
 /**
@@ -250,7 +249,7 @@ class TestHoodieActiveTimeline extends HoodieSparkClientTestBase {
     val activeTimeline = metaClient.getActiveTimeline
     try {
       activeTimeline.getInstantContentStream(HoodieTestUtils.INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
-        HoodieTimeline.CLUSTERING_ACTION, metaClient.createNewInstantTime()))
+        HoodieTimeline.CLUSTERING_ACTION, WriteClientTestUtils.createNewInstantTime()))
     } catch {
       // org.apache.hudi.common.util.ClusteringUtils.getRequestedReplaceMetadata depends upon this behaviour
       // where FileNotFoundException is the cause of exception thrown by the API getInstantDetails

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
@@ -17,8 +17,8 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
+import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.common.model.HoodieFileFormat
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
@@ -27,12 +27,14 @@ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieIOException
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
+
 import org.apache.spark.sql._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue, fail}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
 import org.slf4j.LoggerFactory
 
 import java.io.FileNotFoundException
+
 import scala.collection.JavaConverters._
 
 /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
@@ -17,16 +17,16 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieTableType
-import org.apache.hudi.common.table.timeline.{HoodieInstant, InstantComparison}
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, InstantComparison}
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.instantTimeMinusMillis
 import org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
+import java.time.Instant
+import java.util.Date
 import scala.collection.JavaConverters._
 
 class TestIncrementalReadWithFullTableScan extends HoodieSparkClientTestBase {
@@ -114,8 +116,9 @@ class TestIncrementalReadWithFullTableScan extends HoodieSparkClientTestBase {
     val startArchivedCompletionTs = archivedInstants(1).asInstanceOf[HoodieInstant].getCompletionTime //C1 completion
     val endArchivedCompletionTs = archivedInstants(1).asInstanceOf[HoodieInstant].getCompletionTime //C1 completion
 
-    val startOutOfRangeCommitTs = hoodieMetaClient.createNewInstantTime()
-    val endOutOfRangeCommitTs = hoodieMetaClient.createNewInstantTime()
+    val instant = Instant.now()
+    val startOutOfRangeCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(instant))
+    val endOutOfRangeCommitTs = HoodieInstantTimeGenerator.formatDate(Date.from(instant.plusMillis(1)))
 
     assertTrue(compareTimestamps(startOutOfRangeCommitTs, InstantComparison.GREATER_THAN, completedCommits.lastInstant().get().requestedTime))
     assertTrue(compareTimestamps(endOutOfRangeCommitTs, InstantComparison.GREATER_THAN, completedCommits.lastInstant().get().requestedTime))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
@@ -17,7 +17,6 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieTableType
@@ -27,6 +26,7 @@ import org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.EnumSource
 
 import java.time.Instant
 import java.util.Date
+
 import scala.collection.JavaConverters._
 
 class TestIncrementalReadWithFullTableScan extends HoodieSparkClientTestBase {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
@@ -34,6 +34,7 @@ import org.apache.hudi.exception.{HoodieDuplicateKeyException, HoodieException}
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode
 import org.apache.hudi.index.HoodieIndex.IndexType
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
+
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageSubmitted}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.hudi.dml.insert
 
 import org.apache.hudi.{DataSourceWriteOptions, HoodieCLIUtils, HoodieSparkUtils}
 import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.client.WriteClientTestUtils
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
@@ -33,7 +34,6 @@ import org.apache.hudi.exception.{HoodieDuplicateKeyException, HoodieException}
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode
 import org.apache.hudi.index.HoodieIndex.IndexType
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageSubmitted}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
@@ -1257,7 +1257,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
 
           // Simulate a insert overwrite failure
           val metaClient = createMetaClient(spark, tableLocation)
-          val instant = metaClient.createNewInstantTime()
+          val instant = WriteClientTestUtils.createNewInstantTime()
           val timeline = HoodieTestUtils.TIMELINE_FACTORY.createActiveTimeline(metaClient)
           timeline.createNewInstant(metaClient.createNewInstant(
             HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instant))

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities;
 
 import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
@@ -1506,7 +1507,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     for (int i = 0; i < 20; i++) {
       String fileId = UUID.randomUUID().toString();
 
-      String baseInstantTime = metaClient.createNewInstantTime();
+      String baseInstantTime = WriteClientTestUtils.createNewInstantTime();
 
       // Create file slice with base file and log files
       HoodieBaseFile baseFile = new HoodieBaseFile(FSUtils.makeBaseFileName(

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
@@ -520,7 +521,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
         ? new HoodieReplaceCommitMetadata() : new HoodieCommitMetadata();
     commitMetadata.setOperationType(writeOperationType);
     extraMetadata.forEach((k, v) -> commitMetadata.getExtraMetadata().put(k, v));
-    String commitTime = metaClient.createNewInstantTime();
+    String commitTime = WriteClientTestUtils.createNewInstantTime();
     metaClient.getActiveTimeline().createNewInstant(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, commitActiontype, commitTime));
     HoodieInstant inflightInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, commitActiontype, commitTime);
     metaClient.getActiveTimeline().createNewInstant(inflightInstant);


### PR DESCRIPTION
### Change Logs

- Update the test code for creating new instant times to use a specific test utility before further code cleanup. This allows us to limit the number of main codepaths that are creating instant times to ensure they are created in a uniform way.

### Impact

- Cleanup existing code

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
