### PR TITLE
[MINOR] The build is interrupted due to jars conflict on hudi 0.15.0 and spark3.5 

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -201,6 +201,12 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>hudi-gcp</artifactId>
+          <groupId>org.apache.hudi</groupId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>

--- a/hudi-examples/hudi-examples-spark/pom.xml
+++ b/hudi-examples/hudi-examples-spark/pom.xml
@@ -161,6 +161,12 @@
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hudi-gcp</artifactId>
+                    <groupId>org.apache.hudi</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -101,6 +101,12 @@
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hudi-gcp</artifactId>
+                    <groupId>org.apache.hudi</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hudi</groupId>

--- a/packaging/hudi-cli-bundle/pom.xml
+++ b/packaging/hudi-cli-bundle/pom.xml
@@ -188,6 +188,12 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>hudi-gcp</artifactId>
+          <groupId>org.apache.hudi</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Kryo -->

--- a/packaging/hudi-kafka-connect-bundle/pom.xml
+++ b/packaging/hudi-kafka-connect-bundle/pom.xml
@@ -231,6 +231,12 @@
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hudi-gcp</artifactId>
+                    <groupId>org.apache.hudi</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hudi</groupId>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -298,6 +298,12 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-utilities_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>hudi-gcp</artifactId>
+          <groupId>org.apache.hudi</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Parquet -->


### PR DESCRIPTION
Change Logs
 **The build is interrupted due to jars conflict on hudi 0.15.0 and spark3.5. The following modules report error messages **with the same cause:****


hudi-cli/pom.xml
hudi-examples/hudi-examples-spark/pom.xml
hudi-kafka-connect/pom.xml
packaging/hudi-cli-bundle/pom.xml
packaging/hudi-kafka-connect-bundle/pom.xml
packaging/hudi-utilities-bundle/pom.xml 

**error info:**

[INFO] hudi-utilities-bundle_2.12 ......................... FAILURE [  0.064 s]
[INFO] hudi-cli ........................................... SKIPPED
[INFO] hudi-flink-client .................................. SKIPPED
[INFO] hudi-datahub-sync .................................. SKIPPED
[INFO] hudi-adb-sync ...................................... SKIPPED
[INFO] hudi-sync .......................................... SKIPPED
[INFO] hudi-hadoop-mr-bundle .............................. SKIPPED
[INFO] hudi-datahub-sync-bundle ........................... SKIPPED
[INFO] hudi-hive-sync-bundle .............................. SKIPPED
[INFO] hudi-aws-bundle .................................... SKIPPED
[INFO] hudi-gcp-bundle .................................... SKIPPED
[INFO] hudi-spark3.5-bundle_2.12 .......................... SKIPPED
[INFO] hudi-presto-bundle ................................. SKIPPED
[INFO] hudi-utilities-slim-bundle_2.12 .................... SKIPPED
[INFO] hudi-timeline-server-bundle ........................ SKIPPED
[INFO] hudi-trino-bundle .................................. SKIPPED
[INFO] hudi-examples ...................................... SKIPPED
[INFO] hudi-examples-common ............................... SKIPPED
[INFO] hudi-examples-spark ................................ SKIPPED
[INFO] hudi-flink-datasource .............................. SKIPPED
[INFO] hudi-flink1.18.x ................................... SKIPPED
[INFO] hudi-flink ......................................... SKIPPED
[INFO] hudi-examples-flink ................................ SKIPPED
[INFO] hudi-examples-java ................................. SKIPPED
[INFO] hudi-flink1.14.x ................................... SKIPPED
[INFO] hudi-flink1.15.x ................................... SKIPPED
[INFO] hudi-flink1.16.x ................................... SKIPPED
[INFO] hudi-flink1.17.x ................................... SKIPPED
[INFO] hudi-kafka-connect ................................. SKIPPED
[INFO] hudi-flink1.18-bundle .............................. SKIPPED
[INFO] hudi-kafka-connect-bundle .......................... SKIPPED
[INFO] hudi-cli-bundle_2.12 ............................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:30 min
[INFO] Finished at: 2025-06-13T09:50:13+08:00
[INFO] ------------------------------------------------------------------------

[ERROR] Failed to execute goal on project hudi-utilities-bundle_2.12: Could not resolve dependencies for project org.apache.hudi:hudi-utilities-bundle_2.12:jar:0.15.0: Failed to collect dependencies for org.apache.hudi:hudi-utilities-bundle_2.12:
jar:0.15.0: Could not resolve version conflict among [org.apache.hudi:hudi-utilities_2.12:jar:0.15.0 -> org.apache.hudi:hudi-gcp:jar:0.15.0 -> com.google.cloud:google-cloud-bigquery:jar:2.26.0 -> io.grpc:grpc-api:jar:1.54.0, org.apache.hudi:hudi-
utilities_2.12:jar:0.15.0 -> org.apache.hudi:hudi-gcp:jar:0.15.0 -> com.google.cloud:google-cloud-pubsub:jar:1.123.12 -> io.grpc:grpc-api:jar:1.54.0, org.apache.hudi:hudi-utilities_2.12:jar:0.15.0 -> org.apache.hudi:hudi-gcp:jar:0.15.0 -> com.goo
gle.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.2.7 -> com.google.cloud.bigdataoss:gcsio:jar:2.2.7 -> io.grpc:grpc-api:jar:1.43.2, org.apache.hudi:hudi-utilities_2.12:jar:0.15.0 -> org.apache.hudi:hudi-gcp:jar:0.15.0 -> com.google.cloud.bigdatao
ss:gcs-connector:jar:hadoop2-2.2.7 -> com.google.cloud.bigdataoss:gcsio:jar:2.2.7 -> io.grpc:grpc-census:jar:1.43.2 -> io.grpc:grpc-api:jar:[1.43.2,1.43.2], org.apache.hudi:hudi-utilities_2.12:jar:0.15.0 -> org.apache.hudi:hudi-gcp:jar:0.15.0 -> 
com.google.cloud.bigdataoss:gcs-connector:jar:hadoop2-2.2.7 -> com.google.cloud.bigdataoss:gcsio:jar:2.2.7 -> com.google.api.grpc:grpc-google-cloud-storage-v2:jar:2.2.2-alpha -> io.grpc:grpc-api:jar:1.42.1, org.apache.parquet:parquet-avro:jar:1.1
3.1 -> org.apache.parquet:parquet-hadoop:jar:1.13.1 -> io.grpc:grpc-netty-shaded:jar:1.31.1 -> io.grpc:grpc-core:jar:[1.31.1,1.31.1] -> io.grpc:grpc-api:jar:[1.31.1,1.31.1], org.apache.parquet:parquet-avro:jar:1.13.1 -> org.apache.parquet:parquet
-hadoop:jar:1.13.1 -> io.grpc:grpc-protobuf:jar:1.31.1 -> io.grpc:grpc-api:jar:1.31.1, org.apache.parquet:parquet-avro:jar:1.13.1 -> org.apache.parquet:parquet-hadoop:jar:1.13.1 -> io.grpc:grpc-stub:jar:1.31.1 -> io.grpc:grpc-api:jar:1.31.1] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :hudi-utilities-bundle_2.12


**Impact**
compile

**Risk level (write none, low medium or high below)**
low

**Documentation Update**
none

**Contributor's checklist**
 Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
 Change Logs and Impact were stated clearly
 Adequate tests were added if applicable
 CI passed