### PR TITLE
[HUDI-9535] Prevent Unnecessary data transfer b/w driver and executor in Spark Partitioner

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -85,13 +85,21 @@ public class BucketIdentifier implements Serializable {
   }
 
   public static String newBucketFileIdPrefix(int bucketId) {
-    return FSUtils.createNewFileIdPfx().replaceFirst(".{8}", bucketIdStr(bucketId));
+    return newBucketFileIdPrefix(bucketIdStr(bucketId));
+  }
+
+  public static String newBucketFileIdPrefix(String bucketIdStr) {
+    return FSUtils.createNewFileIdPfx().replaceFirst(".{8}", bucketIdStr);
+  }
+
+  public static String newBucketFileIdForNBCC(int bucketId) {
+    return newBucketFileIdForNBCC(bucketIdStr(bucketId));
   }
 
   /**
    * Generate a new file id for NBCC mode, file id is fixed for each bucket with format: "{bucket_id}-0000-0000-0000-000000000000-0"
    */
-  public static String newBucketFileIdForNBCC(int bucketId) {
-    return FSUtils.createNewFileId(bucketIdStr(bucketId) + CONSTANT_FILE_ID_SUFFIX, 0);
+  public static String newBucketFileIdForNBCC(String bucketIdStr) {
+    return FSUtils.createNewFileId(bucketIdStr + CONSTANT_FILE_ID_SUFFIX, 0);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkBucketIndexBucketInfoGetter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class BaseSparkBucketIndexBucketInfoGetter implements SparkBucketInfoGetter {
+
+  private final Map<String, Set<String>> updatePartitionPathFileIds;
+  private final boolean isOverwrite;
+  private final boolean isNonBlockingConcurrencyControl;
+
+  public BaseSparkBucketIndexBucketInfoGetter(Map<String, Set<String>> updatePartitionPathFileIds,
+                                              boolean isOverwrite,
+                                              boolean isNonBlockingConcurrencyControl) {
+    if (isOverwrite) {
+      ValidationUtils.checkArgument(!isNonBlockingConcurrencyControl,
+          "Insert overwrite is not supported with non-blocking concurrency control");
+    }
+    this.updatePartitionPathFileIds = updatePartitionPathFileIds;
+    this.isOverwrite = isOverwrite;
+    this.isNonBlockingConcurrencyControl = isNonBlockingConcurrencyControl;
+  }
+
+  protected BucketInfo getBucketInfo(int bucketId, String partitionPath) {
+    String bucketIdStr = BucketIdentifier.bucketIdStr(bucketId);
+    // Insert overwrite always generates new bucket file id
+    if (isOverwrite) {
+      return new BucketInfo(BucketType.INSERT, BucketIdentifier.newBucketFileIdPrefix(bucketIdStr), partitionPath);
+    }
+    Option<String> fileIdOption = Option.fromJavaOptional(updatePartitionPathFileIds
+        .getOrDefault(partitionPath, Collections.emptySet()).stream()
+        .filter(e -> e.startsWith(bucketIdStr))
+        .findFirst());
+    if (fileIdOption.isPresent()) {
+      return new BucketInfo(BucketType.UPDATE, fileIdOption.get(), partitionPath);
+    } else {
+      // Always write into log file instead of base file if using NB-CC
+      if (isNonBlockingConcurrencyControl) {
+        return new BucketInfo(BucketType.UPDATE, BucketIdentifier.newBucketFileIdForNBCC(bucketIdStr), partitionPath);
+      }
+      return new BucketInfo(BucketType.INSERT, BucketIdentifier.newBucketFileIdPrefix(bucketIdStr), partitionPath);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/InsertOverwriteBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/InsertOverwriteBucketInfoGetter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.common.fs.FSUtils;
+
+import java.util.Map;
+
+/**
+ * Companion class to SparkInsertOverwritePartitioner
+ */
+public class InsertOverwriteBucketInfoGetter extends MapBasedSparkBucketInfoGetter {
+  public InsertOverwriteBucketInfoGetter(Map<Integer, BucketInfo> bucketInfoMap) {
+    super(bucketInfoMap);
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    BucketInfo bucketInfo = super.getBucketInfo(bucketNumber);
+    switch (bucketInfo.bucketType) {
+      case INSERT:
+        return bucketInfo;
+      case UPDATE:
+        // Insert overwrite always generates new bucket file id
+        return new BucketInfo(BucketType.INSERT, FSUtils.createNewFileIdPfx(), bucketInfo.partitionPath);
+      default:
+        throw new AssertionError();
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/ListBasedSparkBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/ListBasedSparkBucketInfoGetter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import java.util.List;
+
+public class ListBasedSparkBucketInfoGetter implements SparkBucketInfoGetter {
+  private final List<BucketInfo> bucketInfoList;
+
+  public ListBasedSparkBucketInfoGetter(List<BucketInfo> bucketInfoList) {
+    this.bucketInfoList = bucketInfoList;
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return bucketInfoList.get(bucketNumber);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/MapBasedSparkBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/MapBasedSparkBucketInfoGetter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import java.util.Map;
+
+public class MapBasedSparkBucketInfoGetter implements SparkBucketInfoGetter {
+
+  private final Map<Integer, BucketInfo> bucketInfoMap;
+
+  public MapBasedSparkBucketInfoGetter(Map<Integer, BucketInfo> bucketInfoMap) {
+    this.bucketInfoMap = bucketInfoMap;
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return bucketInfoMap.get(bucketNumber);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexBucketInfoGetter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Companion class to SparkBucketIndexPartitioner
+ */
+public class SparkBucketIndexBucketInfoGetter extends BaseSparkBucketIndexBucketInfoGetter {
+  private final int numBucketsPerPartition;
+  private final List<String> partitionPaths;
+
+  public SparkBucketIndexBucketInfoGetter(int numBucketsPerPartition,
+                                          List<String> partitionPaths,
+                                          Map<String, Set<String>> updatePartitionPathFileIds,
+                                          boolean isOverwrite,
+                                          boolean isNonBlockingConcurrencyControl) {
+    super(updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl);
+    this.numBucketsPerPartition = numBucketsPerPartition;
+    this.partitionPaths = partitionPaths;
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return getBucketInfo(bucketNumber % numBucketsPerPartition, partitionPaths.get(bucketNumber / numBucketsPerPartition));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketInfoGetter.java
@@ -19,14 +19,20 @@
 
 package org.apache.hudi.table.action.commit;
 
+import java.io.Serializable;
+
 /**
  * Some SparkHoodiePartitioner classes can store a lot of data. To prevent
  * unnecessary serialization and transmission of data, SparkBucketInfoGetter
  * was created to store the minimal data needed for getBucketInfo.
  * getBucketInfo is invoked on the executor
  */
-public interface SparkBucketInfoGetter {
+public interface SparkBucketInfoGetter extends Serializable {
 
+  /**
+   * @param bucketNumber spark partition id
+   * @return bucket info for that spark partition
+   */
   BucketInfo getBucketInfo(int bucketNumber);
 
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketInfoGetter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+/**
+ * Some SparkHoodiePartitioner classes can store a lot of data. To prevent
+ * unnecessary serialization and transmission of data, SparkBucketInfoGetter
+ * was created to store the minimal data needed for getBucketInfo.
+ * getBucketInfo is invoked on the executor
+ */
+public interface SparkBucketInfoGetter {
+
+  BucketInfo getBucketInfo(int bucketNumber);
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkHoodiePartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkHoodiePartitioner.java
@@ -46,13 +46,5 @@ public abstract class SparkHoodiePartitioner<T> extends Partitioner
     return numPartitions();
   }
 
-  /**
-   * You should probably not override this method.
-   * Make sure you have a good understanding of what you are doing.
-   */
-  public BucketInfo getBucketInfo(int bucketNumber) {
-    return getSparkBucketInfoGetter().getBucketInfo(bucketNumber);
-  }
-
   public abstract SparkBucketInfoGetter getSparkBucketInfoGetter();
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkHoodiePartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkHoodiePartitioner.java
@@ -46,5 +46,13 @@ public abstract class SparkHoodiePartitioner<T> extends Partitioner
     return numPartitions();
   }
 
-  public abstract BucketInfo getBucketInfo(int bucketNumber);
+  /**
+   * You should probably not override this method.
+   * Make sure you have a good understanding of what you are doing.
+   */
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return getSparkBucketInfoGetter().getBucketInfo(bucketNumber);
+  }
+
+  public abstract SparkBucketInfoGetter getSparkBucketInfoGetter();
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwritePartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwritePartitioner.java
@@ -19,14 +19,10 @@
 package org.apache.hudi.table.action.commit;
 
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.WorkloadProfile;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,25 +32,14 @@ import java.util.List;
  */
 public class SparkInsertOverwritePartitioner extends UpsertPartitioner {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SparkInsertOverwritePartitioner.class);
-
   public SparkInsertOverwritePartitioner(WorkloadProfile profile, HoodieEngineContext context, HoodieTable table,
                                          HoodieWriteConfig config, WriteOperationType operationType) {
     super(profile, context, table, config, operationType);
   }
 
   @Override
-  public BucketInfo getBucketInfo(int bucketNumber) {
-    BucketInfo bucketInfo = super.getBucketInfo(bucketNumber);
-    switch (bucketInfo.bucketType) {
-      case INSERT:
-        return bucketInfo;
-      case UPDATE:
-        // Insert overwrite always generates new bucket file id
-        return new BucketInfo(BucketType.INSERT, FSUtils.createNewFileIdPfx(), bucketInfo.partitionPath);
-      default:
-        throw new AssertionError();
-    }
+  public SparkBucketInfoGetter getSparkBucketInfoGetter() {
+    return new InsertOverwriteBucketInfoGetter(bucketInfoMap);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPartitioner.java
@@ -60,7 +60,7 @@ public class SparkMetadataTableUpsertPartitioner<T> extends SparkHoodiePartition
   }
 
   @Override
-  public BucketInfo getBucketInfo(int bucketNumber) {
-    return bucketInfoList.get(bucketNumber);
+  public SparkBucketInfoGetter getSparkBucketInfoGetter() {
+    return new ListBasedSparkBucketInfoGetter(bucketInfoList);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexBucketInfoGetter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Companion class to SparkPartitionBucketIndexPartitioner
+ */
+public class SparkPartitionBucketIndexBucketInfoGetter extends BaseSparkBucketIndexBucketInfoGetter {
+
+  private final Integer[] partitionNumberToLocalBucketId;
+  private final String[] partitionNumberToPath;
+
+  public SparkPartitionBucketIndexBucketInfoGetter(Integer[] partitionNumberToLocalBucketId,
+                                                   String[] partitionNumberToPath,
+                                                   Map<String, Set<String>> updatePartitionPathFileIds,
+                                                   boolean isOverwrite,
+                                                   boolean isNonBlockingConcurrencyControl) {
+    super(updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl);
+    this.partitionNumberToLocalBucketId = partitionNumberToLocalBucketId;
+    this.partitionNumberToPath = partitionNumberToPath;
+  }
+
+  @Override
+  public BucketInfo getBucketInfo(int bucketNumber) {
+    return getBucketInfo(partitionNumberToLocalBucketId[bucketNumber], partitionNumberToPath[bucketNumber]);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexPartitioner.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -35,7 +34,6 @@ import org.apache.hudi.table.WorkloadProfile;
 import org.apache.hudi.table.WorkloadStat;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -145,40 +143,9 @@ public class SparkPartitionBucketIndexPartitioner<T> extends SparkHoodiePartitio
   }
 
   @Override
-  public BucketInfo getBucketInfo(int bucketNumber) {
-    Pair<Integer, String> res = computeBucketAndPartitionPath(bucketNumber);
-    int bucket = res.getLeft();
-    String partitionPath = res.getRight();
-    // Insert overwrite always generates new bucket file id
-    if (isOverwrite) {
-      ValidationUtils.checkArgument(!isNonBlockingConcurrencyControl,
-          "Insert overwrite is not supported with non-blocking concurrency control");
-      return new BucketInfo(BucketType.INSERT, BucketIdentifier.newBucketFileIdPrefix(bucket), partitionPath);
-    }
-    Option<String> fileIdOption = Option.fromJavaOptional(updatePartitionPathFileIds
-        .getOrDefault(partitionPath, Collections.emptySet()).stream()
-        .filter(e -> e.startsWith(BucketIdentifier.bucketIdStr(bucket)))
-        .findFirst());
-    if (fileIdOption.isPresent()) {
-      return new BucketInfo(BucketType.UPDATE, fileIdOption.get(), partitionPath);
-    } else {
-      // Always write into log file instead of base file if using NB-CC
-      if (isNonBlockingConcurrencyControl) {
-        String fileId = BucketIdentifier.newBucketFileIdForNBCC(bucket);
-        return new BucketInfo(BucketType.UPDATE, fileId, partitionPath);
-      }
-      String fileIdPrefix = BucketIdentifier.newBucketFileIdPrefix(bucket);
-      return new BucketInfo(BucketType.INSERT, fileIdPrefix, partitionPath);
-    }
-  }
-
-  private Pair<Integer, String> computeBucketAndPartitionPath(int bucketNumber) {
-    Integer bucket;
-    String partitionPath;
-    bucket = partitionNumberToLocalBucketId[bucketNumber];
-    partitionPath = partitionNumberToPath[bucketNumber];
-    ValidationUtils.checkArgument(bucket != null && partitionPath != null);
-    return Pair.of(bucket, partitionPath);
+  public SparkBucketInfoGetter getSparkBucketInfoGetter() {
+    return new SparkPartitionBucketIndexBucketInfoGetter(partitionNumberToLocalBucketId, partitionNumberToPath,
+        updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
@@ -83,7 +83,7 @@ public class UpsertPartitioner<T> extends SparkHoodiePartitioner<T> {
   /**
    * Remembers what type each bucket is for later.
    */
-  private final HashMap<Integer, BucketInfo> bucketInfoMap;
+  protected final HashMap<Integer, BucketInfo> bucketInfoMap;
 
   protected final HoodieWriteConfig config;
   private final WriteOperationType operationType;
@@ -323,8 +323,9 @@ public class UpsertPartitioner<T> extends SparkHoodiePartitioner<T> {
     return Collections.unmodifiableList(new ArrayList<>(bucketInfoMap.values()));
   }
 
-  public BucketInfo getBucketInfo(int bucketNumber) {
-    return bucketInfoMap.get(bucketNumber);
+  @Override
+  public SparkBucketInfoGetter getSparkBucketInfoGetter() {
+    return new MapBasedSparkBucketInfoGetter(bucketInfoMap);
   }
 
   public List<InsertBucketCumulativeWeightPair> getInsertBuckets(String partitionPath) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPartitioner.java
@@ -82,9 +82,10 @@ public class TestSparkMetadataTableUpsertPartitioner extends HoodieClientTestBas
     }).collect(Collectors.toList());
 
     SparkHoodiePartitioner partitioner = new SparkMetadataTableUpsertPartitioner(bucketInfoList, fileIdToSparkPartitionIndexMap);
+    SparkBucketInfoGetter bucketInfoGetter = partitioner.getSparkBucketInfoGetter();
     keysToProbe.stream().forEach(keyToProbe -> {
       int sparkPartitionIndex = partitioner.getPartition(keyToProbe);
-      BucketInfo bucketInfo = partitioner.getBucketInfo(sparkPartitionIndex);
+      BucketInfo bucketInfo = bucketInfoGetter.getBucketInfo(sparkPartitionIndex);
       // validate expected values.
       assertEquals(expectedBucketInfoForRecordKey.get(keyToProbe._1.getRecordKey()), bucketInfo);
       assertEquals(bucketInfoList.get(sparkPartitionIndex), bucketInfo);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -196,11 +196,12 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     List<InsertBucketCumulativeWeightPair> insertBuckets = partitioner.getInsertBuckets(testPartitionPath);
 
     assertEquals(3, partitioner.numPartitions(), "Should have 3 partitions");
-    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+    SparkBucketInfoGetter bucketInfoGetter = partitioner.getSparkBucketInfoGetter();
+    assertEquals(BucketType.UPDATE, bucketInfoGetter.getBucketInfo(0).bucketType,
         "Bucket 0 is UPDATE");
-    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(1).bucketType,
+    assertEquals(BucketType.INSERT, bucketInfoGetter.getBucketInfo(1).bucketType,
         "Bucket 1 is INSERT");
-    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(2).bucketType,
+    assertEquals(BucketType.INSERT, bucketInfoGetter.getBucketInfo(2).bucketType,
         "Bucket 2 is INSERT");
     assertEquals(3, insertBuckets.size(), "Total of 3 insert buckets");
 
@@ -213,13 +214,14 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     insertBuckets = partitioner.getInsertBuckets(testPartitionPath);
 
     assertEquals(4, partitioner.numPartitions(), "Should have 4 partitions");
-    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+    bucketInfoGetter = partitioner.getSparkBucketInfoGetter();
+    assertEquals(BucketType.UPDATE, bucketInfoGetter.getBucketInfo(0).bucketType,
         "Bucket 0 is UPDATE");
-    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(1).bucketType,
+    assertEquals(BucketType.INSERT, bucketInfoGetter.getBucketInfo(1).bucketType,
         "Bucket 1 is INSERT");
-    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(2).bucketType,
+    assertEquals(BucketType.INSERT, bucketInfoGetter.getBucketInfo(2).bucketType,
         "Bucket 2 is INSERT");
-    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(3).bucketType,
+    assertEquals(BucketType.INSERT, bucketInfoGetter.getBucketInfo(3).bucketType,
         "Bucket 3 is INSERT");
     assertEquals(4, insertBuckets.size(), "Total of 4 insert buckets");
 
@@ -257,9 +259,10 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     SparkUpsertDeltaCommitPartitioner partitioner = new SparkUpsertDeltaCommitPartitioner(profile, context, table, config, WriteOperationType.UPSERT);
 
     assertEquals(1, partitioner.numPartitions(), "Should have 1 partitions");
-    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+    SparkBucketInfoGetter bucketInfoGetter = partitioner.getSparkBucketInfoGetter();
+    assertEquals(BucketType.UPDATE, bucketInfoGetter.getBucketInfo(0).bucketType,
             "Bucket 0 is UPDATE");
-    assertEquals("2", partitioner.getBucketInfo(0).fileIdPrefix,
+    assertEquals("2", bucketInfoGetter.getBucketInfo(0).fileIdPrefix,
             "Should be assigned to only file id not pending compaction which is 2");
   }
 
@@ -334,9 +337,10 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
     SparkUpsertDeltaCommitPartitioner partitioner = new SparkUpsertDeltaCommitPartitioner(profile, context, table, config, WriteOperationType.UPSERT);
 
     assertEquals(1, partitioner.numPartitions(), "Should have 1 partitions");
-    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+    SparkBucketInfoGetter bucketInfoGetter = partitioner.getSparkBucketInfoGetter();
+    assertEquals(BucketType.UPDATE, bucketInfoGetter.getBucketInfo(0).bucketType,
             "Bucket 0 should be UPDATE");
-    assertEquals("fg1", partitioner.getBucketInfo(0).fileIdPrefix,
+    assertEquals("fg1", bucketInfoGetter.getBucketInfo(0).fileIdPrefix,
             "Insert should be assigned to fg1");
   }
 


### PR DESCRIPTION
### Change Logs

For large tables, the broadcast of some of the partitioners can be a performance issue. Most of the data is not used, so SparkBucketInfoGetter abstraction is added to be a lightweight holder of only the data needed for getBucketInfo().

### Impact

Performance improvement

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
