### PR TITLE
[HUDI-8286] Add special handling for ordering fields when building FileGroupReader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -178,8 +178,10 @@ public abstract class AbstractHoodieLogRecordScanner {
     this.preCombineField = tableConfig.getPreCombineField();
     // Log scanner merge log with precombine
     TypedProperties props = new TypedProperties();
-    if (this.preCombineField != null) {
-      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, this.preCombineField);
+    if (preCombineField != null) {
+      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, preCombineField);
+      props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), preCombineField);
+      props.setProperty("hoodie.datasource.write.precombine.field", preCombineField);
     }
     this.tableVersion = tableConfig.getTableVersion();
     this.payloadProps = props;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -28,9 +28,11 @@ import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.KeySpec;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
@@ -110,7 +112,13 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
       this.payloadClass = Option.empty();
     }
     this.orderingFieldName = orderingFieldName;
+    // Ensure that ordering field is populated for mergers and legacy payloads
+    orderingFieldName.ifPresent(orderingField -> {
+      props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, hoodieTableMetaClient.getTableConfig().getPreCombineField());
+      props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELD.key(), hoodieTableMetaClient.getTableConfig().getPreCombineField());
+    });
     this.props = props;
+
     this.internalSchema = readerContext.getSchemaHandler().getInternalSchema();
     this.hoodieTableMetaClient = hoodieTableMetaClient;
     long maxMemorySizeInBytes = props.getLong(MAX_MEMORY_FOR_MERGE.key(), MAX_MEMORY_FOR_MERGE.defaultValue());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -116,6 +116,7 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
     orderingFieldName.ifPresent(orderingField -> {
       props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
       props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELD.key(), orderingField);
+      props.putIfAbsent("hoodie.datasource.write.precombine.field", orderingField);
     });
     this.props = props;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -114,8 +114,8 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
     this.orderingFieldName = orderingFieldName;
     // Ensure that ordering field is populated for mergers and legacy payloads
     orderingFieldName.ifPresent(orderingField -> {
-      props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, hoodieTableMetaClient.getTableConfig().getPreCombineField());
-      props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELD.key(), hoodieTableMetaClient.getTableConfig().getPreCombineField());
+      props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
+      props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELD.key(), orderingField);
     });
     this.props = props;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -533,7 +534,11 @@ public final class HoodieFileGroupReader<T> implements Closeable {
       ValidationUtils.checkArgument(dataSchema != null, "Data schema is required");
       ValidationUtils.checkArgument(requestedSchema != null, "Requested schema is required");
       ValidationUtils.checkArgument(props != null, "Props is required");
-
+      // Ensure that ordering field is populated for mergers and legacy payloads
+      if (hoodieTableMetaClient.getTableConfig().getPreCombineField() != null) {
+        props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, hoodieTableMetaClient.getTableConfig().getPreCombineField());
+        props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELD.key(), hoodieTableMetaClient.getTableConfig().getPreCombineField());
+      }
 
       return new HoodieFileGroupReader<>(
           readerContext, storage, tablePath, latestCommitTime, fileSlice,

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -79,12 +79,12 @@ public class ConfigUtils {
    */
   public static String getOrderingField(Properties properties) {
     String orderField = null;
-    if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
-      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
-    } else if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
+    if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
       orderField = properties.getProperty("hoodie.datasource.write.precombine.field");
     } else if (properties.containsKey(HoodieTableConfig.PRECOMBINE_FIELD.key())) {
       orderField = properties.getProperty(HoodieTableConfig.PRECOMBINE_FIELD.key());
+    } else if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
+      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
     }
     return orderField;
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomMerger.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
 import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.AVRO;
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
@@ -66,6 +67,7 @@ public class TestCustomMerger extends HoodieFileGroupReaderTestHarness {
     Properties metaProps = super.getMetaProps();
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name());
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), CustomAvroMerger.KEEP_CERTAIN_TIMESTAMP_VALUE_ONLY);
+    metaProps.setProperty(PRECOMBINE_FIELD.key(), "timestamp");
     return metaProps;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
@@ -57,6 +58,7 @@ public class TestEventTimeMerging extends HoodieFileGroupReaderTestHarness {
   protected Properties getMetaProps() {
     Properties metaProps =  super.getMetaProps();
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.EVENT_TIME_ORDERING.name());
+    metaProps.setProperty(PRECOMBINE_FIELD.key(), "timestamp");
     return metaProps;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
@@ -65,18 +65,10 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
   protected List<Boolean> shouldWritePositions;
 
   // Environmental variables.
-  protected static StorageConfiguration<?> storageConf;
+  protected static StorageConfiguration<?> storageConf = getDefaultStorageConf();
   protected static HoodieTestTable testTable;
-  protected static TypedProperties properties;
+  protected static TypedProperties properties = new TypedProperties();
   protected HoodieReaderContext<IndexedRecord> readerContext;
-
-  static {
-    // Note: Make `timestamp` as ordering field.
-    properties = new TypedProperties();
-    properties.setProperty(
-        "hoodie.datasource.write.precombine.field", "timestamp");
-    storageConf = getDefaultStorageConf();
-  }
 
   @AfterAll
   public static void tearDown() throws IOException {


### PR DESCRIPTION
### Change Logs

- Ensure that the ordering field options are properly set for payload and merger classes when constructing the FileGroupRecordBuffer
- Simplify the HoodieFileGroupReader to set the ordering field based off of the table config instead of allowing the user to override this value and cause inconsistent behavior
- Update tests to execute this path where the fields are read from the table config

### Impact

- Moving the code to a common location helps prevent future bugs

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
