### PR TITLE
feat: [HUDI-9553] Add equals and hashCode override to Predicate inner classes

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/expression/BinaryExpression.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/BinaryExpression.java
@@ -20,6 +20,7 @@ package org.apache.hudi.expression;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import java.util.List;
  */
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
+@EqualsAndHashCode
 public abstract class BinaryExpression implements Expression {
 
   private final Expression left;

--- a/hudi-common/src/main/java/org/apache/hudi/expression/Literal.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/Literal.java
@@ -22,6 +22,7 @@ import org.apache.hudi.internal.schema.Type;
 import org.apache.hudi.internal.schema.Types;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.xml.bind.DatatypeConverter;
@@ -32,6 +33,7 @@ import java.util.UUID;
 
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class Literal<T> extends LeafExpression {
 
   public static <V> Literal from(V value) {

--- a/hudi-common/src/main/java/org/apache/hudi/expression/NameReference.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/NameReference.java
@@ -21,10 +21,12 @@ package org.apache.hudi.expression;
 import org.apache.hudi.internal.schema.Type;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class NameReference extends LeafExpression {
 
   private final String name;

--- a/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -122,6 +123,19 @@ public class Predicates {
     public String toString() {
       return "TRUE";
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
   }
 
   public static class FalseExpression extends LeafExpression implements Predicate {
@@ -150,6 +164,19 @@ public class Predicates {
     @Override
     public String toString() {
       return "FALSE";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
     }
   }
 
@@ -185,6 +212,23 @@ public class Predicates {
     @Override
     public String toString() {
       return "(" + getLeft() + " " + getOperator().symbol + " " + getRight() + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      And and = (And) o;
+      return Objects.equals(getLeft(), and.getLeft()) && Objects.equals(getRight(), and.getRight());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getLeft(), getRight(), getOperator());
     }
   }
 
@@ -223,6 +267,23 @@ public class Predicates {
     public String toString() {
       return "(" + getLeft() + " " + getOperator().symbol + " " + getRight() + ")";
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Or or = (Or) o;
+      return Objects.equals(getLeft(), or.getLeft()) && Objects.equals(getRight(), or.getRight());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getLeft(), getRight(), getOperator());
+    }
   }
 
   public static class StringStartsWith extends BinaryExpression implements Predicate {
@@ -240,6 +301,24 @@ public class Predicates {
     public Object eval(StructLike data) {
       return getLeft().eval(data).toString().startsWith(getRight().eval(data).toString());
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StringStartsWith that = (StringStartsWith) o;
+      return Objects.equals(getLeft(), that.getLeft()) && Objects.equals(getRight(),
+          that.getRight());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getLeft(), getRight(), getOperator());
+    }
   }
 
   public static class StringContains extends BinaryExpression implements Predicate {
@@ -256,6 +335,24 @@ public class Predicates {
     @Override
     public Object eval(StructLike data) {
       return getLeft().eval(data).toString().contains(getRight().eval(data).toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StringContains that = (StringContains) o;
+      return Objects.equals(getLeft(), that.getLeft()) && Objects.equals(getRight(),
+          that.getRight());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getLeft(), getRight(), getOperator());
     }
   }
 
@@ -299,6 +396,23 @@ public class Predicates {
     public List<Expression> getRightChildren() {
       return validValues;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      In in = (In) o;
+      return Objects.equals(value, in.value) && Objects.equals(validValues, in.validValues);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, validValues);
+    }
   }
 
   public static class IsNull implements Predicate {
@@ -327,6 +441,23 @@ public class Predicates {
     @Override
     public String toString() {
       return child.toString() + " IS NULL";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      IsNull isNull = (IsNull) o;
+      return Objects.equals(child, isNull.child);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(child);
     }
   }
 
@@ -357,6 +488,23 @@ public class Predicates {
     public String toString() {
       return child.toString() + " IS NOT NULL";
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      IsNotNull isNotNull = (IsNotNull) o;
+      return Objects.equals(child, isNotNull.child);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(child);
+    }
   }
 
   public static class Not implements Predicate {
@@ -374,7 +522,7 @@ public class Predicates {
 
     @Override
     public Boolean eval(StructLike data) {
-      return ! (Boolean) child.eval(data);
+      return !(Boolean) child.eval(data);
     }
 
     @Override
@@ -385,6 +533,23 @@ public class Predicates {
     @Override
     public String toString() {
       return "NOT " + child;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Not not = (Not) o;
+      return Objects.equals(child, not.child);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(child);
     }
   }
 
@@ -414,6 +579,24 @@ public class Predicates {
         default:
           throw new IllegalArgumentException("The operation " + getOperator() + " doesn't support binary comparison");
       }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BinaryComparison that = (BinaryComparison) o;
+      return getOperator() == that.getOperator() && Objects.equals(getLeft(), that.getLeft())
+          && Objects.equals(getRight(), that.getRight());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getLeft(), getRight(), getOperator());
     }
   }
 
@@ -449,8 +632,26 @@ public class Predicates {
       return false;
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StringStartsWithAny that = (StringStartsWithAny) o;
+      return operator == that.operator && Objects.equals(left, that.left)
+          && Objects.equals(right, that.right);
+    }
+
     public List<Expression> getRightChildren() {
       return right;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(operator, left, right);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
+++ b/hudi-common/src/main/java/org/apache/hudi/expression/Predicates.java
@@ -20,13 +20,13 @@ package org.apache.hudi.expression;
 
 import org.apache.hudi.internal.schema.Type;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -180,6 +180,7 @@ public class Predicates {
     }
   }
 
+  @EqualsAndHashCode(callSuper = true)
   public static class And extends BinaryExpression implements Predicate {
 
     public And(Expression left, Expression right) {
@@ -213,25 +214,9 @@ public class Predicates {
     public String toString() {
       return "(" + getLeft() + " " + getOperator().symbol + " " + getRight() + ")";
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      And and = (And) o;
-      return Objects.equals(getLeft(), and.getLeft()) && Objects.equals(getRight(), and.getRight());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getLeft(), getRight(), getOperator());
-    }
   }
 
+  @EqualsAndHashCode(callSuper = true)
   public static class Or extends BinaryExpression implements Predicate {
 
     public Or(Expression left, Expression right) {
@@ -267,25 +252,9 @@ public class Predicates {
     public String toString() {
       return "(" + getLeft() + " " + getOperator().symbol + " " + getRight() + ")";
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      Or or = (Or) o;
-      return Objects.equals(getLeft(), or.getLeft()) && Objects.equals(getRight(), or.getRight());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getLeft(), getRight(), getOperator());
-    }
   }
 
+  @EqualsAndHashCode(callSuper = true)
   public static class StringStartsWith extends BinaryExpression implements Predicate {
 
     StringStartsWith(Expression left, Expression right) {
@@ -301,26 +270,9 @@ public class Predicates {
     public Object eval(StructLike data) {
       return getLeft().eval(data).toString().startsWith(getRight().eval(data).toString());
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      StringStartsWith that = (StringStartsWith) o;
-      return Objects.equals(getLeft(), that.getLeft()) && Objects.equals(getRight(),
-          that.getRight());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getLeft(), getRight(), getOperator());
-    }
   }
 
+  @EqualsAndHashCode(callSuper = true)
   public static class StringContains extends BinaryExpression implements Predicate {
 
     StringContains(Expression left, Expression right) {
@@ -336,26 +288,9 @@ public class Predicates {
     public Object eval(StructLike data) {
       return getLeft().eval(data).toString().contains(getRight().eval(data).toString());
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      StringContains that = (StringContains) o;
-      return Objects.equals(getLeft(), that.getLeft()) && Objects.equals(getRight(),
-          that.getRight());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getLeft(), getRight(), getOperator());
-    }
   }
 
+  @EqualsAndHashCode
   public static class In implements Predicate {
 
     protected final Expression value;
@@ -396,25 +331,9 @@ public class Predicates {
     public List<Expression> getRightChildren() {
       return validValues;
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      In in = (In) o;
-      return Objects.equals(value, in.value) && Objects.equals(validValues, in.validValues);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(value, validValues);
-    }
   }
 
+  @EqualsAndHashCode
   public static class IsNull implements Predicate {
 
     protected final Expression child;
@@ -442,25 +361,9 @@ public class Predicates {
     public String toString() {
       return child.toString() + " IS NULL";
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      IsNull isNull = (IsNull) o;
-      return Objects.equals(child, isNull.child);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(child);
-    }
   }
 
+  @EqualsAndHashCode
   public static class IsNotNull implements Predicate {
 
     protected final Expression child;
@@ -488,25 +391,9 @@ public class Predicates {
     public String toString() {
       return child.toString() + " IS NOT NULL";
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      IsNotNull isNotNull = (IsNotNull) o;
-      return Objects.equals(child, isNotNull.child);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(child);
-    }
   }
 
+  @EqualsAndHashCode
   public static class Not implements Predicate {
 
     Expression child;
@@ -534,25 +421,9 @@ public class Predicates {
     public String toString() {
       return "NOT " + child;
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      Not not = (Not) o;
-      return Objects.equals(child, not.child);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(child);
-    }
   }
 
+  @EqualsAndHashCode(callSuper = true)
   public static class BinaryComparison extends BinaryExpression implements Predicate {
 
     public BinaryComparison(Expression left, Operator operator, Expression right) {
@@ -580,26 +451,9 @@ public class Predicates {
           throw new IllegalArgumentException("The operation " + getOperator() + " doesn't support binary comparison");
       }
     }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      BinaryComparison that = (BinaryComparison) o;
-      return getOperator() == that.getOperator() && Objects.equals(getLeft(), that.getLeft())
-          && Objects.equals(getRight(), that.getRight());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getLeft(), getRight(), getOperator());
-    }
   }
 
+  @EqualsAndHashCode
   public static class StringStartsWithAny implements Predicate {
 
     @Getter
@@ -632,26 +486,8 @@ public class Predicates {
       return false;
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      StringStartsWithAny that = (StringStartsWithAny) o;
-      return operator == that.operator && Objects.equals(left, that.left)
-          && Objects.equals(right, that.right);
-    }
-
     public List<Expression> getRightChildren() {
       return right;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(operator, left, right);
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
+++ b/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.expression;
+
+import static org.apache.hudi.expression.Predicates.alwaysFalse;
+import static org.apache.hudi.expression.Predicates.alwaysTrue;
+import static org.apache.hudi.expression.Predicates.and;
+import static org.apache.hudi.expression.Predicates.contains;
+import static org.apache.hudi.expression.Predicates.eq;
+import static org.apache.hudi.expression.Predicates.gt;
+import static org.apache.hudi.expression.Predicates.gteq;
+import static org.apache.hudi.expression.Predicates.in;
+import static org.apache.hudi.expression.Predicates.isNotNull;
+import static org.apache.hudi.expression.Predicates.isNull;
+import static org.apache.hudi.expression.Predicates.lteq;
+import static org.apache.hudi.expression.Predicates.not;
+import static org.apache.hudi.expression.Predicates.or;
+import static org.apache.hudi.expression.Predicates.startsWith;
+import static org.apache.hudi.expression.Predicates.startsWithAny;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hudi.expression.Predicates.And;
+import org.apache.hudi.expression.Predicates.BinaryComparison;
+import org.apache.hudi.expression.Predicates.In;
+import org.apache.hudi.expression.Predicates.IsNotNull;
+import org.apache.hudi.expression.Predicates.IsNull;
+import org.apache.hudi.expression.Predicates.Not;
+import org.apache.hudi.expression.Predicates.Or;
+import org.apache.hudi.expression.Predicates.StringContains;
+import org.apache.hudi.expression.Predicates.StringStartsWith;
+import org.apache.hudi.expression.Predicates.StringStartsWithAny;
+import org.apache.hudi.internal.schema.Types;
+import org.junit.jupiter.api.Test;
+
+class PredicatesTest {
+
+  // Define some common literal expressions for use in tests
+  private final Expression a = new Literal<>("a", Types.StringType.get());
+  private final Expression b = new Literal<>(10, Types.IntType.get());
+  private final Expression c = new Literal<>("c", Types.StringType.get());
+
+  @Test
+  void testSingletonPredicates() {
+    // Test alwaysTrue
+    assertEquals(alwaysTrue(), alwaysTrue(), "alwaysTrue() should be equal to itself");
+    assertNotEquals(alwaysTrue(), alwaysFalse(), "alwaysTrue() should not be equal to alwaysFalse()");
+    assertNotEquals(alwaysTrue(), null, "Predicate should not be equal to null");
+    assertNotEquals(alwaysTrue(), new Object(), "Predicate should not be equal to a different type");
+    assertEquals(alwaysTrue().hashCode(), alwaysTrue().hashCode(), "Hash code for alwaysTrue() should be consistent");
+
+    // Test alwaysFalse
+    assertEquals(alwaysFalse(), alwaysFalse(), "alwaysFalse() should be equal to itself");
+    assertEquals(alwaysFalse().hashCode(), alwaysFalse().hashCode(), "Hash code for alwaysFalse() should be consistent");
+
+    // Cross-check hash codes
+    assertNotEquals(alwaysTrue().hashCode(), alwaysFalse().hashCode(), "Hash codes of singletons should differ");
+  }
+
+  @Test
+  void testAnd() {
+    And p1 = and(a, b);
+    And p2 = and(a, b);
+    And p3 = and(b, a);
+    And p4 = and(a, c);
+
+    // Standard checks
+    assertEquals(p1, p1);
+    assertNotEquals(null, p1);
+    assertNotEquals(new Object(), p1);
+
+    // Equality
+    assertEquals(p1, p2, "And predicates with the same children should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal And predicates should be the same");
+
+    // Inequality
+    assertNotEquals(p1, p3, "And predicates with swapped children should not be equal");
+    assertNotEquals(p1, p4, "And predicates with different children should not be equal");
+  }
+
+  @Test
+  void testOr() {
+    Or p1 = or(a, b);
+    Or p2 = or(a, b);
+    Or p3 = or(b, a);
+    Or p4 = or(a, c);
+
+    assertEquals(p1, p2, "Or predicates with the same children should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal Or predicates should be the same");
+
+    assertNotEquals(p1, p3, "Or predicates with swapped children should not be equal");
+    assertNotEquals(p1, p4, "Or predicates with different children should not be equal");
+  }
+
+  @Test
+  void testNot() {
+    Not p1 = not(a);
+    Not p2 = not(a);
+    Not p3 = not(b);
+
+    assertEquals(p1, p2, "Not predicates with the same child should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal Not predicates should be the same");
+    assertNotEquals(p1, p3, "Not predicates with different children should not be equal");
+  }
+
+  @Test
+  void testIsNull() {
+    IsNull p1 = isNull(a);
+    IsNull p2 = isNull(a);
+    IsNull p3 = isNull(b);
+
+    assertEquals(p1, p2, "IsNull predicates with the same child should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal IsNull predicates should be the same");
+    assertNotEquals(p1, p3, "IsNull predicates with different children should not be equal");
+  }
+
+  @Test
+  void testIsNotNull() {
+    IsNotNull p1 = isNotNull(a);
+    IsNotNull p2 = isNotNull(a);
+    IsNotNull p3 = isNotNull(b);
+
+    assertEquals(p1, p2, "IsNotNull predicates with the same child should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal IsNotNull predicates should be the same");
+    assertNotEquals(p1, p3, "IsNotNull predicates with different children should not be equal");
+  }
+
+  @Test
+  void testBinaryComparison() {
+    BinaryComparison p1 = gteq(a, b); // a >= b
+    BinaryComparison p2 = gteq(a, b); // a >= b (should be equal)
+    BinaryComparison p3 = gt(a, b);   // a > b (not equal, different operator)
+    BinaryComparison p4 = gteq(b, a); // b >= a (not equal, different children)
+    BinaryComparison p5 = lteq(a, b); // a <= b (not equal, different operator)
+
+    assertEquals(p1, p2, "BinaryComparisons with same children and operator should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal BinaryComparisons should be the same");
+
+    assertNotEquals(p1, p3, "BinaryComparisons with different operators should not be equal");
+    assertNotEquals(p1, p4, "BinaryComparisons with different children should not be equal");
+    assertNotEquals(p1, p5, "BinaryComparisons with different operators should not be equal");
+
+    // Test another operator
+    BinaryComparison eq1 = eq(a, b);
+    BinaryComparison eq2 = eq(a, b);
+    assertEquals(eq1, eq2);
+    assertEquals(eq1.hashCode(), eq2.hashCode());
+    assertNotEquals(p1, eq1);
+  }
+
+  @Test
+  void testStringStartsWith() {
+    StringStartsWith p1 = startsWith(a, b);
+    StringStartsWith p2 = startsWith(a, b);
+    StringStartsWith p3 = startsWith(b, a);
+    StringStartsWith p4 = startsWith(a, c);
+
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p4);
+  }
+
+  @Test
+  void testStringContains() {
+    StringContains p1 = contains(a, b);
+    StringContains p2 = contains(a, b);
+    StringContains p3 = contains(b, a);
+    StringContains p4 = contains(a, c);
+
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p4);
+  }
+
+  @Test
+  void testIn() {
+    List<Expression> list1 = Arrays.asList(b, c);
+    List<Expression> list2 = Arrays.asList(b, c);
+    List<Expression> list3 = Arrays.asList(c, b); // different order
+    List<Expression> list4 = Collections.singletonList(b); // different content
+
+    In p1 = in(a, list1);
+    In p2 = in(a, list2); // equal
+    In p3 = in(b, list1); // different value expression
+    In p4 = in(a, list3); // different list order
+    In p5 = in(a, list4); // different list content
+
+    assertEquals(p1, p2, "In predicates with same value and list should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal In predicates should be the same");
+
+    assertNotEquals(p1, p3, "In predicates with different value expressions should not be equal");
+    assertNotEquals(p1, p4, "In predicates with different list order should not be equal");
+    assertNotEquals(p1, p5, "In predicates with different list content should not be equal");
+  }
+
+  @Test
+  void testStringStartsWithAny() {
+    List<Expression> list1 = Arrays.asList(b, c);
+    List<Expression> list2 = Arrays.asList(b, c);
+    List<Expression> list3 = Arrays.asList(c, b); // different order
+    List<Expression> list4 = Collections.singletonList(b); // different content
+
+    StringStartsWithAny p1 = startsWithAny(a, list1);
+    StringStartsWithAny p2 = startsWithAny(a, list2); // equal
+    StringStartsWithAny p3 = startsWithAny(b, list1); // different left value
+    StringStartsWithAny p4 = startsWithAny(a, list3); // different list order
+    StringStartsWithAny p5 = startsWithAny(a, list4); // different list content
+
+    assertEquals(p1, p2, "StringStartsWithAny predicates with same children should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Hash codes for equal StringStartsWithAny predicates should be the same");
+
+    assertNotEquals(p1, p3, "StringStartsWithAny with different left expressions should not be equal");
+    assertNotEquals(p1, p4, "StringStartsWithAny with different list order should not be equal");
+    assertNotEquals(p1, p5, "StringStartsWithAny with different list content should not be equal");
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
+++ b/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
@@ -236,4 +236,30 @@ class PredicatesTest {
     assertNotEquals(p1, p4, "StringStartsWithAny with different list order should not be equal");
     assertNotEquals(p1, p5, "StringStartsWithAny with different list content should not be equal");
   }
+
+  @Test
+  void testEqualsWithDistinctButEqualOperands() {
+    // Operands are built independently (distinct instances) but are value-equal. This is the
+    // independently-built-tree case the Trino Expression Index comparison relies on: it only holds
+    // if the leaf operands (Literal, NameReference) compare by value rather than by identity.
+    Expression lit1 = new Literal<>("a", Types.StringType.get());
+    Expression lit2 = new Literal<>("a", Types.StringType.get());
+    Expression col1 = new NameReference("col");
+    Expression col2 = new NameReference("col");
+
+    // Leaf predicate over distinct-but-equal literals.
+    assertEquals(isNull(lit1), isNull(lit2), "IsNull over value-equal literals should be equal");
+    assertEquals(isNull(lit1).hashCode(), isNull(lit2).hashCode());
+
+    // Nested tree built from distinct-but-equal Literal and NameReference operands.
+    assertEquals(and(eq(col1, lit1), isNotNull(col1)), and(eq(col2, lit2), isNotNull(col2)),
+        "Independently built predicate trees with value-equal operands should be equal");
+    assertEquals(and(eq(col1, lit1), isNotNull(col1)).hashCode(),
+        and(eq(col2, lit2), isNotNull(col2)).hashCode());
+
+    // Value still distinguishes: a different literal value or column name is not equal.
+    assertNotEquals(isNull(new Literal<>("a", Types.StringType.get())),
+        isNull(new Literal<>("b", Types.StringType.get())));
+    assertNotEquals(isNull(new NameReference("col")), isNull(new NameReference("other")));
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
+++ b/hudi-common/src/test/java/org/apache/hudi/expression/PredicatesTest.java
@@ -18,6 +18,24 @@
 
 package org.apache.hudi.expression;
 
+import org.apache.hudi.expression.Predicates.And;
+import org.apache.hudi.expression.Predicates.BinaryComparison;
+import org.apache.hudi.expression.Predicates.In;
+import org.apache.hudi.expression.Predicates.IsNotNull;
+import org.apache.hudi.expression.Predicates.IsNull;
+import org.apache.hudi.expression.Predicates.Not;
+import org.apache.hudi.expression.Predicates.Or;
+import org.apache.hudi.expression.Predicates.StringContains;
+import org.apache.hudi.expression.Predicates.StringStartsWith;
+import org.apache.hudi.expression.Predicates.StringStartsWithAny;
+import org.apache.hudi.internal.schema.Types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.hudi.expression.Predicates.alwaysFalse;
 import static org.apache.hudi.expression.Predicates.alwaysTrue;
 import static org.apache.hudi.expression.Predicates.and;
@@ -35,22 +53,6 @@ import static org.apache.hudi.expression.Predicates.startsWith;
 import static org.apache.hudi.expression.Predicates.startsWithAny;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import org.apache.hudi.expression.Predicates.And;
-import org.apache.hudi.expression.Predicates.BinaryComparison;
-import org.apache.hudi.expression.Predicates.In;
-import org.apache.hudi.expression.Predicates.IsNotNull;
-import org.apache.hudi.expression.Predicates.IsNull;
-import org.apache.hudi.expression.Predicates.Not;
-import org.apache.hudi.expression.Predicates.Or;
-import org.apache.hudi.expression.Predicates.StringContains;
-import org.apache.hudi.expression.Predicates.StringStartsWith;
-import org.apache.hudi.expression.Predicates.StringStartsWithAny;
-import org.apache.hudi.internal.schema.Types;
-import org.junit.jupiter.api.Test;
 
 class PredicatesTest {
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: #17072

The `Predicate` inner classes in `Predicates` did not override `equals`/`hashCode`, so equivalent predicates compared by identity and were never equal (e.g. in unit tests).

### Summary and Changelog

Add value-based `equals`/`hashCode` to the `Predicate` inner classes. Per review feedback, these are generated via Lombok's `@EqualsAndHashCode` instead of hand-written boilerplate:

- `BinaryExpression` is annotated with `@EqualsAndHashCode`; its subclasses (`And`, `Or`, `StringStartsWith`, `StringContains`, `BinaryComparison`) use `@EqualsAndHashCode(callSuper = true)` to compare the shared `left`/`operator`/`right`.
- `In`, `IsNull`, `IsNotNull`, `Not`, `StringStartsWithAny` use `@EqualsAndHashCode`.
- `TrueExpression`/`FalseExpression` keep manual overrides: as field-less singletons, Lombok would emit a constant `hashCode` and collide the two classes.

### Impact

No functional impact. Users can now compare `Predicate` inner classes with `equals` (e.g. in unit tests).

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
