### PR TITLE
Clustering parallelism based on write io metric , executors count and disk space available

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -153,6 +153,34 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .sinceVersion("0.9.0")
       .withDocumentation("Config to control frequency of async clustering");
 
+  public static final ConfigProperty<Double> CLUSTERING_DISK_USAGE_FRACTION = ConfigProperty
+      .key("hoodie.clustering.disk.usage.fraction")
+      .defaultValue(0.3)
+      .markAdvanced()
+      .sinceVersion("0.14.0")
+      .withDocumentation("Usage fraction of cluster total disk memory  and is used to estimate clustering batch operation.");
+
+  public static final ConfigProperty<Double> CLUSTERING_MAX_DISK_USAGE_FRACTION = ConfigProperty
+      .key("hoodie.clustering.disk.usage.max.fraction")
+      .defaultValue(0.9)
+      .markAdvanced()
+      .sinceVersion("0.14.0")
+      .withDocumentation("Max usage fraction of cluster total disk memory and is used to estimate clustering batch operation.");
+
+  public static final ConfigProperty<Double> CLUSTERING_MIN_DISK_USAGE_FRACTION = ConfigProperty
+      .key("hoodie.clustering.disk.usage.min.fraction")
+      .defaultValue(0.1)
+      .markAdvanced()
+      .sinceVersion("0.14.0")
+      .withDocumentation("Min usage fraction of cluster total disk memory and is used to estimate clustering batch operation.");
+
+  public static final ConfigProperty<Integer> CLUSTERING_EXECUTOR_DISK_SIZE_GB = ConfigProperty
+      .key("hoodie.clustering.executor.disk.size.gb")
+      .defaultValue(200)
+      .markAdvanced()
+      .sinceVersion("0.14.0")
+      .withDocumentation("Disk size per executor in GB and is used to estimate clustering batch operation.");
+
   public static final ConfigProperty<Integer> CLUSTERING_MAX_PARALLELISM = ConfigProperty
       .key("hoodie.clustering.max.parallelism")
       .defaultValue(15)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1824,6 +1824,22 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.CLUSTERING_MAX_PARALLELISM);
   }
 
+  public double getClusteringMaxDiskUsageFraction() {
+    return getDouble(HoodieClusteringConfig.CLUSTERING_MAX_DISK_USAGE_FRACTION);
+  }
+
+  public double getClusteringMinDiskUsageFraction() {
+    return getDouble(HoodieClusteringConfig.CLUSTERING_MIN_DISK_USAGE_FRACTION);
+  }
+
+  public double getClusteringDiskUsageFraction() {
+    return getDouble(HoodieClusteringConfig.CLUSTERING_DISK_USAGE_FRACTION);
+  }
+
+  public int getClusteringExecutorDiskSizeGB() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_EXECUTOR_DISK_SIZE_GB);
+  }
+
   public ClusteringPlanPartitionFilterMode getClusteringPlanPartitionFilterMode() {
     String mode = getString(HoodieClusteringConfig.PLAN_PARTITION_FILTER_MODE_NAME);
     return ClusteringPlanPartitionFilterMode.valueOf(mode);


### PR DESCRIPTION
### Change Logs

Configure clustering batch parallelism based on configurable disk size per executor, executor count and total write io of clustering groups.


### Documentation Update

```
hoodie.clustering.disk.usage.max.fraction: 0.9
hoodie.clustering.disk.usage.min.fraction: 0.1
hoodie.clustering.disk.usage.fraction: 0.3
hoodie.clustering.executor.disk.size.gb: 200
```

### Tests
- added unit tests for corner cases of `getClusteringMaxParallelismByDiskIO` and `performClustering`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
