### PR TITLE
[HUDI-9555] Fixing Streaming dag writes to metadata table to create inflight once across multiple upsertPrepped calls

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -173,7 +173,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   public JavaRDD<WriteStatus> secondaryWriteToMetadataTablePartitions(JavaRDD<HoodieRecord> preppedRecords, String instantTime) {
     engineContext.setJobStatus(this.getClass().getSimpleName(), String.format("Upserting at %s into metadata table %s", instantTime, metadataWriteConfig.getTableName()));
-    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getWriteClient().upsertPreppedRecords(preppedRecords, instantTime);
+    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getSparkWriteClient(Option.empty()).upsertPreppedRecords(preppedRecords, instantTime, false);
     return partialMetadataWriteStatuses;
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -165,7 +165,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   public JavaRDD<WriteStatus> streamWriteToMetadataTable(Pair<List<HoodieFileGroupId>, HoodieData<HoodieRecord>> fileGroupIdToTaggedRecords, String instantTime) {
     JavaRDD<HoodieRecord> mdtRecords = HoodieJavaRDD.getJavaRDD(fileGroupIdToTaggedRecords.getValue());
     engineContext.setJobStatus(this.getClass().getSimpleName(), String.format("Upserting with instant %s into metadata table %s", instantTime, metadataWriteConfig.getTableName()));
-    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getSparkWriteClient(Option.empty()).upsertPreppedRecords(mdtRecords, instantTime, Option.of(
+    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getSparkWriteClient(Option.empty()).streamUpsertPreppedRecords(mdtRecords, instantTime, Option.of(
         fileGroupIdToTaggedRecords.getKey()));
     return partialMetadataWriteStatuses;
   }
@@ -173,7 +173,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   public JavaRDD<WriteStatus> secondaryWriteToMetadataTablePartitions(JavaRDD<HoodieRecord> preppedRecords, String instantTime) {
     engineContext.setJobStatus(this.getClass().getSimpleName(), String.format("Upserting at %s into metadata table %s", instantTime, metadataWriteConfig.getTableName()));
-    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getSparkWriteClient(Option.empty()).upsertPreppedRecords(preppedRecords, instantTime, false);
+    JavaRDD<WriteStatus> partialMetadataWriteStatuses = getSparkWriteClient(Option.empty()).streamUpsertPreppedRecords(preppedRecords, instantTime);
     return partialMetadataWriteStatuses;
   }
 
@@ -197,7 +197,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                  String instantTime,
                                  JavaRDD<HoodieRecord> preppedRecordInputs,
                                  List<HoodieFileGroupId> fileGroupsIdsToUpdate) {
-    JavaRDD<WriteStatus> writeStatusJavaRDD = getSparkWriteClient(Option.of(writeClient)).upsertPreppedRecords(preppedRecordInputs, instantTime, Option.of(fileGroupsIdsToUpdate));
+    JavaRDD<WriteStatus> writeStatusJavaRDD = getSparkWriteClient(Option.of(writeClient)).streamUpsertPreppedRecords(preppedRecordInputs, instantTime, Option.of(fileGroupsIdsToUpdate));
     writeClient.commit(instantTime, writeStatusJavaRDD, Option.empty(), DELTA_COMMIT_ACTION, Collections.emptyMap());
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadMetadataTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadMetadataTable.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.commit.SparkMetadataTableUpsertCommitActionExecutor;
+import org.apache.hudi.table.action.commit.SparkMetadataTableUpsertPreppedCommitActionExecutor;
 
 import java.util.List;
 
@@ -48,7 +49,12 @@ public class HoodieSparkMergeOnReadMetadataTable<T> extends HoodieSparkMergeOnRe
                                                                     Option<List<HoodieFileGroupId>> hoodieFileGroupIdListOpt,
                                                                     boolean initialCall) {
     // upsert partitioner for metadata table when all records are upsert and locations are known upfront
-    return new SparkMetadataTableUpsertCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime, preppedRecords,
+    return new SparkMetadataTableUpsertPreppedCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime, preppedRecords,
         hoodieFileGroupIdListOpt.get(), initialCall).execute();
+  }
+
+  public HoodieWriteMetadata<HoodieData<WriteStatus>> upsertPrepped(HoodieEngineContext context, String instantTime,
+                                                                    HoodieData<HoodieRecord<T>> preppedRecords, boolean initialCall) {
+    return new SparkMetadataTableUpsertCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime, preppedRecords, initialCall).execute();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadMetadataTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadMetadataTable.java
@@ -48,13 +48,17 @@ public class HoodieSparkMergeOnReadMetadataTable<T> extends HoodieSparkMergeOnRe
                                                                     HoodieData<HoodieRecord<T>> preppedRecords,
                                                                     Option<List<HoodieFileGroupId>> hoodieFileGroupIdListOpt,
                                                                     boolean initialCall) {
-    // upsert partitioner for metadata table when all records are upsert and locations are known upfront
-    return new SparkMetadataTableUpsertPreppedCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime, preppedRecords,
-        hoodieFileGroupIdListOpt.get(), initialCall).execute();
+    // upsert partitioner for metadata table when all records are upsert and locations are known upfront.
+    // this is expected to be invoked first during streaming writes to metadata table.
+    return new SparkMetadataTableUpsertPreppedCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime,
+        preppedRecords, hoodieFileGroupIdListOpt.get(), initialCall).execute();
   }
 
   public HoodieWriteMetadata<HoodieData<WriteStatus>> upsertPrepped(HoodieEngineContext context, String instantTime,
                                                                     HoodieData<HoodieRecord<T>> preppedRecords, boolean initialCall) {
-    return new SparkMetadataTableUpsertCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime, preppedRecords, initialCall).execute();
+    // upsert partitioner for metadata table when all records are upsert and locations are known upfront.
+    // this is expected to be invoked second during streaming writes to metadata table.
+    return new SparkMetadataTableUpsertCommitActionExecutor<>((HoodieSparkEngineContext) context, config, this, instantTime,
+        preppedRecords, initialCall).execute();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertCommitActionExecutor.java
@@ -20,57 +20,25 @@ package org.apache.hudi.table.action.commit;
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieCommitException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.WorkloadProfile;
-import org.apache.hudi.table.WorkloadStat;
 import org.apache.hudi.table.action.deltacommit.SparkUpsertPreppedDeltaCommitActionExecutor;
 
-import org.apache.spark.Partitioner;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.storage.StorageLevel;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-/**
- * Upsert commit action executor for Metadata table.
- *
- * @param <T>
- */
 public class SparkMetadataTableUpsertCommitActionExecutor<T> extends SparkUpsertPreppedDeltaCommitActionExecutor<T> {
-
-  private static final WorkloadStat PLACEHOLDER_GLOBAL_STAT = new WorkloadStat();
-  private final List<HoodieFileGroupId> mdtFileGroupIdList;
   private final boolean initialCall;
 
-  public SparkMetadataTableUpsertCommitActionExecutor(HoodieSparkEngineContext context, HoodieWriteConfig config, HoodieTable table, String instantTime,
-                                                      HoodieData<HoodieRecord<T>> preppedRecords, List<HoodieFileGroupId> mdtFileGroupIdList,
+  public SparkMetadataTableUpsertCommitActionExecutor(HoodieSparkEngineContext context, HoodieWriteConfig config,
+                                                      HoodieTable table, String instantTime,
+                                                      HoodieData<HoodieRecord<T>> preppedRecords,
                                                       boolean initialCall) {
     super(context, config, table, instantTime, preppedRecords);
-    this.mdtFileGroupIdList = mdtFileGroupIdList;
     this.initialCall = initialCall;
   }
 
   @Override
-  protected boolean shouldPersistInputRecords(JavaRDD<HoodieRecord<T>> inputRDD) {
-    return inputRDD.getStorageLevel() == StorageLevel.NONE();
-  }
-
-  @Override
-  protected WorkloadProfile prepareWorkloadProfile(HoodieData<HoodieRecord<T>> inputRecordsWithClusteringUpdate) {
-    // create workload profile only when we are writing to FILES partition in Metadata table.
-    WorkloadProfile workloadProfile = new WorkloadProfile(Pair.of(Collections.emptyMap(), PLACEHOLDER_GLOBAL_STAT));
-    return workloadProfile;
-  }
-
   protected void saveWorkloadProfileMetadataToInflight(WorkloadProfile profile, String instantTime)
       throws HoodieCommitException {
     // with streaming writes support, we might write to metadata table multiple times for the same instant times.
@@ -80,24 +48,4 @@ public class SparkMetadataTableUpsertCommitActionExecutor<T> extends SparkUpsert
       super.saveWorkloadProfileMetadataToInflight(profile, instantTime);
     }
   }
-
-  @Override
-  protected Partitioner getPartitioner(WorkloadProfile profile) {
-    List<BucketInfo> bucketInfoList = new ArrayList<>();
-    Map<String, Integer> fileIdToSparkPartitionIndexMap = new HashMap<>();
-    int counter = 0;
-    while (counter < mdtFileGroupIdList.size()) {
-      HoodieFileGroupId fileGroupId = mdtFileGroupIdList.get(counter);
-      fileIdToSparkPartitionIndexMap.put(fileGroupId.getFileId(), counter);
-      bucketInfoList.add(new BucketInfo(BucketType.UPDATE, fileGroupId.getFileId(), fileGroupId.getPartitionPath()));
-      counter++;
-    }
-    return new SparkMetadataTableUpsertPartitioner<>(bucketInfoList, fileIdToSparkPartitionIndexMap);
-  }
-
-  @Override
-  protected HoodieData<HoodieRecord<T>> clusteringHandleUpdate(HoodieData<HoodieRecord<T>> inputRecords) {
-    return inputRecords;
-  }
-
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertCommitActionExecutor.java
@@ -27,6 +27,13 @@ import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.WorkloadProfile;
 import org.apache.hudi.table.action.deltacommit.SparkUpsertPreppedDeltaCommitActionExecutor;
 
+/**
+ * Upsert commit action executor for Metadata table. This CommitActionExecutor is expected to be used during second write
+ * to metadata table when streaming writes are enabled. This avoids adding inflight commit file to the timeline more than once
+ * for the metadata table.
+ *
+ * @param <T>
+ */
 public class SparkMetadataTableUpsertCommitActionExecutor<T> extends SparkUpsertPreppedDeltaCommitActionExecutor<T> {
   private final boolean initialCall;
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPreppedCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPreppedCommitActionExecutor.java
@@ -41,7 +41,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Upsert commit action executor for Metadata table.
+ * Upsert commit action executor for Metadata table. This commit action executor is meticulously designed to avoid
+ * de-referencing the incoming records compared to regular upsert commit action executor. This CommitActionExecutor
+ * is expected to be used during first write to metadata table when streaming writes are enabled.
  *
  * @param <T>
  */

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPreppedCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMetadataTableUpsertPreppedCommitActionExecutor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieCommitException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.WorkloadProfile;
+import org.apache.hudi.table.WorkloadStat;
+import org.apache.hudi.table.action.deltacommit.SparkUpsertPreppedDeltaCommitActionExecutor;
+
+import org.apache.spark.Partitioner;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.storage.StorageLevel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Upsert commit action executor for Metadata table.
+ *
+ * @param <T>
+ */
+public class SparkMetadataTableUpsertPreppedCommitActionExecutor<T> extends SparkUpsertPreppedDeltaCommitActionExecutor<T> {
+
+  private static final WorkloadStat PLACEHOLDER_GLOBAL_STAT = new WorkloadStat();
+  private final List<HoodieFileGroupId> mdtFileGroupIdList;
+  private final boolean initialCall;
+
+  public SparkMetadataTableUpsertPreppedCommitActionExecutor(HoodieSparkEngineContext context, HoodieWriteConfig config, HoodieTable table, String instantTime,
+                                                             HoodieData<HoodieRecord<T>> preppedRecords, List<HoodieFileGroupId> mdtFileGroupIdList,
+                                                             boolean initialCall) {
+    super(context, config, table, instantTime, preppedRecords);
+    this.mdtFileGroupIdList = mdtFileGroupIdList;
+    this.initialCall = initialCall;
+  }
+
+  @Override
+  protected boolean shouldPersistInputRecords(JavaRDD<HoodieRecord<T>> inputRDD) {
+    return inputRDD.getStorageLevel() == StorageLevel.NONE();
+  }
+
+  @Override
+  protected WorkloadProfile prepareWorkloadProfile(HoodieData<HoodieRecord<T>> inputRecordsWithClusteringUpdate) {
+    // create workload profile only when we are writing to FILES partition in Metadata table.
+    WorkloadProfile workloadProfile = new WorkloadProfile(Pair.of(Collections.emptyMap(), PLACEHOLDER_GLOBAL_STAT));
+    return workloadProfile;
+  }
+
+  @Override
+  protected void saveWorkloadProfileMetadataToInflight(WorkloadProfile profile, String instantTime)
+      throws HoodieCommitException {
+    // with streaming writes support, we might write to metadata table multiple times for the same instant times.
+    // ie. writeClient.startCommit(t1), writeClient.upsert(batch1, t1), writeClient.upsert(batch2, t1), writeClient.commit(t1, ...)
+    // So, here we are generating inflight file only in the last known writes, which we know will only have FILES partition.
+    if (initialCall) {
+      super.saveWorkloadProfileMetadataToInflight(profile, instantTime);
+    }
+  }
+
+  @Override
+  protected Partitioner getPartitioner(WorkloadProfile profile) {
+    List<BucketInfo> bucketInfoList = new ArrayList<>();
+    Map<String, Integer> fileIdToSparkPartitionIndexMap = new HashMap<>();
+    int counter = 0;
+    while (counter < mdtFileGroupIdList.size()) {
+      HoodieFileGroupId fileGroupId = mdtFileGroupIdList.get(counter);
+      fileIdToSparkPartitionIndexMap.put(fileGroupId.getFileId(), counter);
+      bucketInfoList.add(new BucketInfo(BucketType.UPDATE, fileGroupId.getFileId(), fileGroupId.getPartitionPath()));
+      counter++;
+    }
+    return new SparkMetadataTableUpsertPartitioner<>(bucketInfoList, fileIdToSparkPartitionIndexMap);
+  }
+
+  @Override
+  protected HoodieData<HoodieRecord<T>> clusteringHandleUpdate(HoodieData<HoodieRecord<T>> inputRecords) {
+    return inputRecords;
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDMetadataWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDMetadataWriteClient.java
@@ -128,7 +128,7 @@ public class TestSparkRDDMetadataWriteClient extends HoodieClientTestBase {
 
       // ingest RLI records to metadata table.
       client.startCommitForMetadataTable(metadataMetaClient, commitTimeOfInterest, DELTA_COMMIT_ACTION);
-      JavaRDD<WriteStatus> partialWriteStatusesRDD = client.upsertPreppedRecords(jsc.parallelize(rliRecords), commitTimeOfInterest, Option.of(nonFilesPartitionFileGroupIdList));
+      JavaRDD<WriteStatus> partialWriteStatusesRDD = client.streamUpsertPreppedRecords(jsc.parallelize(rliRecords), commitTimeOfInterest, Option.of(nonFilesPartitionFileGroupIdList));
       List<WriteStatus> partialWriteStatuses = partialWriteStatusesRDD.collect();
       // assert that isMetadataTable is rightly set
       partialWriteStatuses.forEach(writeStatus -> assertTrue(writeStatus.isMetadataTable()));
@@ -140,7 +140,7 @@ public class TestSparkRDDMetadataWriteClient extends HoodieClientTestBase {
       assertTrue(reloadedMdtActiveTimeline.filterInflightsAndRequested().getInstants().stream().anyMatch(instant -> instant.requestedTime().equals(finalCommitTimeOfInterest)));
 
       // write to FILES partition
-      JavaRDD<WriteStatus> filePartitionWriteStatusesRDD = client.upsertPreppedRecords(jsc.parallelize(filesPartitionExpectedRecords), commitTimeOfInterest, Option.of(filesPartitionFileGroupIdList));
+      JavaRDD<WriteStatus> filePartitionWriteStatusesRDD = client.streamUpsertPreppedRecords(jsc.parallelize(filesPartitionExpectedRecords), commitTimeOfInterest);
       List<WriteStatus> filesPartitionWriteStatus = filePartitionWriteStatusesRDD.collect();
       // assert that isMetadataTable is rightly set
       filesPartitionWriteStatus.forEach(writeStatus -> assertTrue(writeStatus.isMetadataTable()));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPreppedCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkMetadataTableUpsertPreppedCommitActionExecutor.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests SparkMetadataTableUpsertCommitActionExecutor.
  */
-public class TestSparkMetadataTableUpsertCommitActionExecutor extends SparkClientFunctionalTestHarness {
+public class TestSparkMetadataTableUpsertPreppedCommitActionExecutor extends SparkClientFunctionalTestHarness {
 
   @Test
   public void testMetadataTableUpsertCommitActionExecutor() throws IOException {
@@ -71,7 +71,7 @@ public class TestSparkMetadataTableUpsertCommitActionExecutor extends SparkClien
     metaClient.getActiveTimeline().createNewInstant(metaClient.createNewInstant(HoodieInstant.State.REQUESTED, DELTA_COMMIT_ACTION,
         "0001"));
 
-    SparkMetadataTableUpsertCommitActionExecutor commitActionExecutor = new MockSparkMetadataTableUpsertCommitActionExecutor(context(),
+    SparkMetadataTableUpsertPreppedCommitActionExecutor commitActionExecutor = new MockSparkMetadataTableUpsertPreppedCommitActionExecutor(context(),
         writeConfig, table, "0001", recordHoodieData, hoodieFileGroupIdList, statusHoodieData, true);
     commitActionExecutor.execute(recordHoodieData);
     // since this is initial call, inflight instant should be added.
@@ -80,7 +80,7 @@ public class TestSparkMetadataTableUpsertCommitActionExecutor extends SparkClien
     hoodieFileGroupIdList.clear();
     hoodieFileGroupIdList.add(new HoodieFileGroupId(MetadataPartitionType.FILES.getPartitionPath(), "files-00001"));
 
-    commitActionExecutor = new MockSparkMetadataTableUpsertCommitActionExecutor(context(),
+    commitActionExecutor = new MockSparkMetadataTableUpsertPreppedCommitActionExecutor(context(),
         writeConfig, table, "0001", recordHoodieData, hoodieFileGroupIdList, statusHoodieData, false);
     commitActionExecutor.execute(recordHoodieData);
     // ensure inflight is still intact and is not complete yet unless we commit
@@ -89,13 +89,13 @@ public class TestSparkMetadataTableUpsertCommitActionExecutor extends SparkClien
     assertFalse(reloadedActiveTimeline.getWriteTimeline().filterCompletedInstants().containsInstant("0001"));
   }
 
-  static class MockSparkMetadataTableUpsertCommitActionExecutor<T> extends SparkMetadataTableUpsertCommitActionExecutor<T> {
+  static class MockSparkMetadataTableUpsertPreppedCommitActionExecutor<T> extends SparkMetadataTableUpsertPreppedCommitActionExecutor<T> {
     private final HoodieData<WriteStatus> writeStatusHoodieData;
-    public MockSparkMetadataTableUpsertCommitActionExecutor(HoodieSparkEngineContext context, HoodieWriteConfig config, HoodieTable table,
-                                                            String instantTime, HoodieData<HoodieRecord<T>> preppedRecords,
-                                                            List<HoodieFileGroupId> hoodieFileGroupIdList,
-                                                            HoodieData<WriteStatus> writeStatusHoodieData,
-                                                            boolean initialCall) {
+    public MockSparkMetadataTableUpsertPreppedCommitActionExecutor(HoodieSparkEngineContext context, HoodieWriteConfig config, HoodieTable table,
+                                                                   String instantTime, HoodieData<HoodieRecord<T>> preppedRecords,
+                                                                   List<HoodieFileGroupId> hoodieFileGroupIdList,
+                                                                   HoodieData<WriteStatus> writeStatusHoodieData,
+                                                                   boolean initialCall) {
       super(context, config, table, instantTime, preppedRecords, hoodieFileGroupIdList, initialCall);
       this.writeStatusHoodieData = writeStatusHoodieData;
     }


### PR DESCRIPTION
### Change Logs

When streaming writes to metadata table is enabled, we call upsertPrepped twice to metadata table before finally completing the commit. 

First one is meant for streaming writes and the second one is for batch write including FILES partition.  

Some coordination is required for these writes so that we create inflight commit meta file in metadata table timeline only once. 

When streaming dag patch was first put out, we did ensure this was taken care, but along the way while addressing feedback, we refactored the second api to re-use legacy apis. So, this lead to creating inflight commit file twice for a given delta commit in metadata table. 

In local FS, this is not an issue, but in AWS env, this led to failures. 

Changes added as part of this patch: 
- Renamed upsertPreppedRecords -> streamUpsertPreppedRecords for the metadata writer api in SparkRDDMetadataWriteClient.java
- Added a new api to SparkRDDMetadataWriteClient for the secondary call. 
```
/**
   * Upserts the given prepared records into the Hoodie table, at the supplied instantTime.
   * This is the secondary api to be invoked when streaming writes to metadata table is enabled. After this invocation, the commit is expected to be wrapped up.
   *
   * <p>This implementation requires that the input records are already tagged, and de-duped if needed.
   *
   * @param preppedRecords Prepared HoodieRecords to upsert
   * @param instantTime    Instant time of the commit
   * @return Collection of WriteStatus to inspect errors and counts
   */
  public JavaRDD<WriteStatus> streamUpsertPreppedRecords(JavaRDD<HoodieRecord<T>> preppedRecords, String instantTime) {
```
- Renamed existing SparkMetadataTableUpsertCommitActionExecutor to SparkMetadataTableUpsertPreppedCommitActionExecutor. This will be used for the first write to metadata table.
- Added SparkMetadataTableUpsertCommitActionExecutor which extends from SparkUpsertPreppedDeltaCommitActionExecutor. Only additional logic this overrides compared to SparkUpsertPreppedDeltaCommitActionExecutor is to avoid creating inflight more than once. This will be used for second write to metadata table. 
- Fixed tests to test the changes. 

### Impact

Fixing Streaming dag writes to metadata table to create inflight once across multiple upsertPrepped calls.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
