### PR TITLE
[MINOR] Fix getColumnValueAsJava for HoodieHiveRecord

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -203,6 +203,10 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
 
   @Override
   public Object getValue(ArrayWritable record, Schema schema, String fieldName) {
+    return getFieldValueFromArrayWritable(record, schema, fieldName, objectInspectorCache);
+  }
+
+  public static Object getFieldValueFromArrayWritable(ArrayWritable record, Schema schema, String fieldName, ObjectInspectorCache objectInspectorCache) {
     return StringUtils.isNullOrEmpty(fieldName) ? null : objectInspectorCache.getValue(record, schema, fieldName);
   }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
@@ -146,7 +146,7 @@ public class HoodieHiveRecord extends HoodieRecord<ArrayWritable> {
 
   @Override
   public Object getColumnValueAsJava(Schema recordSchema, String column, Properties props) {
-    throw new UnsupportedOperationException("Unsupported yet for " + this.getClass().getSimpleName());
+    return HiveHoodieReaderContext.getFieldValueFromArrayWritable(data, schema, column, objectInspectorCache);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Fixes getColumnValueAsJava for HoodieHiveRecord. The other record implementations were fixed as part of HUDI-9340. Only HoodieHiveRecord implementation needs to be fixed here.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
