### PR TITLE
[HUDI-9559] Account for failed deletion with rollback execution

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
@@ -216,6 +216,13 @@ public class RollbackHelper implements Serializable {
             isDeleted = true;
           }
         }
+        if (!isDeleted) {
+          if (metaClient.getStorage().exists(fullDeletePath)) {
+            LOG.warn("Deleting file during rollback execution failed for {} ", fullDeletePath);
+            throw new HoodieIOException("Failing to delete file during rollback execution failed : " + fullDeletePath);
+          }
+          isDeleted = true;
+        }
         return HoodieRollbackStat.newBuilder()
             .withPartitionPath(partitionPath)
             .withDeletedFileResult(fullDeletePath.toString(), isDeleted)

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -21,9 +21,12 @@ package org.apache.hudi.table.action.rollback;
 
 import org.apache.hudi.avro.model.HoodieRollbackRequest;
 import org.apache.hudi.common.HoodieRollbackStat;
+import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -32,13 +35,22 @@ import org.apache.hudi.common.testutils.FileCreateUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.collection.Triple;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,10 +66,13 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class TestRollbackHelper extends HoodieRollbackTestBase {
   private static final int ROLLBACK_LOG_VERSION = 20;
+  private static final Logger LOG = LoggerFactory.getLogger(TestRollbackHelper.class);
 
   @Override
   @BeforeEach
@@ -240,6 +255,99 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
               .build()));
     }
     assertRollbackStatsEquals(expected, rollbackStats);
+  }
+
+  @Test
+  public void testFailedDeletionsWithRollbackExecution() throws IOException {
+    HoodieTableMetaClient mockedMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTable<?, ?, ?, ?> mockHoodieTable = mock(HoodieTable.class);
+    when(mockHoodieTable.getMetaClient()).thenReturn(mockedMetaClient);
+    when(mockedMetaClient.getBasePath()).thenReturn(basePath);
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    when(mockedMetaClient.getTableConfig()).thenReturn(tableConfig);
+    HoodieStorage mockedStorage = mock(HoodieStorage.class);
+    when(mockedMetaClient.getStorage()).thenReturn(mockedStorage);
+    StorageConfiguration storageConfiguration = storage.getConf();
+    when(mockedStorage.getConf()).thenReturn(storageConfiguration);
+    HoodieEngineContext context = new HoodieLocalEngineContext(storageConfiguration);
+
+    String rollbackInstantTime = "003";
+    String instantToRollback = "002";
+    RollbackHelper rollbackHelper = new RollbackHelper(mockHoodieTable, config);
+
+    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    String partition1 = "partition1";
+    String baseFileId1 = UUID.randomUUID().toString();
+    String baseFileId2 = UUID.randomUUID().toString();
+    String baseFileId3 = UUID.randomUUID().toString();
+
+    // Base files to roll back
+    StoragePath baseFilePath1 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId1, instantToRollback);
+    StoragePath baseFilePath2 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId2, instantToRollback);
+    StoragePath baseFilePath3 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId3, instantToRollback);
+
+    // test all diff combinations where rollback execution will succeed
+    // deletion succeeds
+    when(mockedStorage.deleteFile(baseFilePath1)).thenReturn(true);
+    // fs.delete -> false, fs.exists -> false
+    when(mockedStorage.deleteFile(baseFilePath2)).thenReturn(false);
+    when(mockedStorage.exists(baseFilePath2)).thenReturn(false);
+    // fs.delete throws FileNotFoundException
+    when(mockedStorage.deleteFile(baseFilePath3)).thenThrow(new FileNotFoundException("File does not exist"));
+
+    when(timeline.lastInstant()).thenReturn(
+        Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstantTime)));
+
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
+        context,
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+        rollbackRequests, true, 5);
+
+    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
+    expected.add(Pair.of(partition1,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition1)
+            .withDeletedFileResult(baseFilePath1.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition1,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition1)
+            .withDeletedFileResult(baseFilePath2.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition1,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition1)
+            .withDeletedFileResult(baseFilePath3.toString(), true)
+            .build()));
+    assertRollbackStatsEquals(expected, rollbackStats);
+
+    // error case, where fs.delete returned false and fs.exists returned true
+    rollbackRequests.clear();
+    String baseFileId4 = UUID.randomUUID().toString();
+    StoragePath baseFilePath4 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId4, instantToRollback);
+
+    // fs.delete -> false, fs.exists -> true
+    when(mockedStorage.deleteFile(baseFilePath4)).thenReturn(false);
+    when(mockedStorage.exists(baseFilePath4)).thenReturn(true);
+    // execute and assert failure
+    assertFailedDeletion(rollbackHelper, context, rollbackInstantTime, instantToRollback, rollbackRequests, baseFilePath4.toString());
+  }
+
+  private void assertFailedDeletion(RollbackHelper rollbackHelper, HoodieEngineContext context, String rollbackInstantTime, String instantToRollback,
+                                    List<SerializableHoodieRollbackRequest> rollbackRequests, String expectedFileToFailOnDeletion) {
+    try {
+      rollbackHelper.maybeDeleteAndCollectStats(
+          context,
+          INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+          rollbackRequests, true, 5);
+      fail("Should not have reached here");
+    } catch (HoodieException e) {
+      if (!(e.getCause() instanceof HoodieIOException)) {
+        LOG.error("Expected HoodieIOException to be thrown, but found " + e.getCause() + ", w/ error msg " + e.getCause().getMessage());
+      }
+      assertTrue(e.getCause() instanceof HoodieIOException);
+      assertTrue(e.getCause().getMessage().contains("Failing to delete file during rollback execution failed : " + expectedFileToFailOnDeletion));
+    }
   }
 
   private void assertRollbackStatsEquals(List<Pair<String, HoodieRollbackStat>> expected,


### PR DESCRIPTION
### Change Logs

- Account for failed deletion with rollback execution. If not, we could end up exposing uncommitted data to queries down the line. 

### Impact

- Robust data consistency w/ failures and rollback. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
