### PR TITLE
[HUDI-9567] BaseHoodieLogRecordReader should skip checking inflight i…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
@@ -135,6 +136,8 @@ public abstract class BaseHoodieLogRecordReader<T> {
   protected FileGroupRecordBuffer<T> recordBuffer;
   // Allows to consider inflight instants while merging log records
   protected boolean allowInflightInstants;
+  // table version for compatibility
+  private final HoodieTableVersion tableVersion;
 
   protected BaseHoodieLogRecordReader(HoodieReaderContext<T> readerContext, HoodieTableMetaClient hoodieTableMetaClient, HoodieStorage storage, List<String> logFilePaths,
                                       boolean reverseReader, int bufferSize, Option<InstantRange> instantRange,
@@ -185,6 +188,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
     this.recordBuffer = recordBuffer;
     // When the allowInflightInstants flag is enabled, records written by inflight instants are also read
     this.allowInflightInstants = allowInflightInstants;
+    this.tableVersion = tableConfig.getTableVersion();
   }
 
   /**
@@ -213,9 +217,6 @@ public abstract class BaseHoodieLogRecordReader<T> {
     totalLogBlocks = new AtomicLong(0);
     totalLogRecords = new AtomicLong(0);
     HoodieLogFormatReader logFormatReaderWrapper = null;
-    HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
-    HoodieTimeline completedInstantsTimeline = commitsTimeline.filterCompletedInstants();
-    HoodieTimeline inflightInstantsTimeline = commitsTimeline.filterInflights();
     try {
       // Iterate over the paths
       logFormatReaderWrapper = new HoodieLogFormatReader(storage,
@@ -241,13 +242,16 @@ public abstract class BaseHoodieLogRecordReader<T> {
         }
         totalLogBlocks.incrementAndGet();
         if (logBlock.isDataOrDeleteBlock()) {
+          if (this.tableVersion.lesserThan(HoodieTableVersion.EIGHT) && !allowInflightInstants) {
+            HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
+            if (commitsTimeline.filterInflights().containsInstant(instantTime)
+                || !commitsTimeline.filterCompletedInstants().containsOrBeforeTimelineStarts(instantTime)) {
+              // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
+              continue;
+            }
+          }
           if (compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), GREATER_THAN, this.latestInstantTime)) {
             // Skip processing a data or delete block with the instant time greater than the latest instant time used by this log record reader
-            continue;
-          }
-          if (!allowInflightInstants
-              && (inflightInstantsTimeline.containsInstant(instantTime) || !completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime))) {
-            // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
             continue;
           }
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
@@ -505,9 +509,6 @@ public abstract class BaseHoodieLogRecordReader<T> {
     totalLogBlocks = new AtomicLong(0);
     totalLogRecords = new AtomicLong(0);
     HoodieLogFormatReader logFormatReaderWrapper = null;
-    HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
-    HoodieTimeline completedInstantsTimeline = commitsTimeline.filterCompletedInstants();
-    HoodieTimeline inflightInstantsTimeline = commitsTimeline.filterInflights();
     try {
       // Iterate over the paths
       logFormatReaderWrapper = new HoodieLogFormatReader(storage,
@@ -578,10 +579,13 @@ public abstract class BaseHoodieLogRecordReader<T> {
           continue;
         }
         if (logBlock.getBlockType() != COMMAND_BLOCK) {
-          if (!allowInflightInstants
-              && (inflightInstantsTimeline.containsInstant(instantTime)) || !completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)) {
-            // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
-            continue;
+          if (this.tableVersion.lesserThan(HoodieTableVersion.EIGHT) && !allowInflightInstants) {
+            HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
+            if (commitsTimeline.filterInflights().containsInstant(instantTime)
+                || !commitsTimeline.filterCompletedInstants().containsOrBeforeTimelineStarts(instantTime)) {
+              // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
+              continue;
+            }
           }
           if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
             // filter the log block by instant range


### PR DESCRIPTION
…nstant for table version EIGHT

### Change Logs

BaseHoodieLogRecordReader should skip checking inflight instant for table version EIGHT.

### Impact

Improve FileGroup reader performance by avoiding unnecessary timeline scanning.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
