### PR TITLE
[HUDI-9569] Add support for multiple ordering fields

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
@@ -58,7 +58,7 @@ public class HoodiePayloadConfig extends HoodieConfig {
 
   /** @deprecated Use {@link HoodieWriteConfig#PRECOMBINE_FIELD_NAME} and its methods instead */
   @Deprecated
-  public static final ConfigProperty<String> ORDERING_FIELD = ConfigProperty
+  public static final ConfigProperty<String> ORDERING_FIELDS = ConfigProperty
       .key(PAYLOAD_ORDERING_FIELD_PROP_KEY)
       .noDefaultValue()
       .markAdvanced()
@@ -93,8 +93,8 @@ public class HoodiePayloadConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withPayloadOrderingField(String payloadOrderingField) {
-      payloadConfig.setValue(ORDERING_FIELD, String.valueOf(payloadOrderingField));
+    public Builder withPayloadOrderingFields(String payloadOrderingFields) {
+      payloadConfig.setValue(ORDERING_FIELDS, String.valueOf(payloadOrderingFields));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -101,6 +101,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -172,8 +173,10 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
       .key("hoodie.datasource.write.precombine.field")
       .noDefaultValue()
-      .withDocumentation("Field used in preCombining before actual write. When two records have the same key value, "
-          + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..)");
+      .withDocumentation("Comma separated list of fields used in preCombining before actual write. When two records have the same key value, "
+          + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..). "
+          + "For multiple fields if first key comparison is same, second key comparison is made and so on. This config is used for combining records "
+          + "within the same batch and also for merging using event time merge mode");
 
   public static final ConfigProperty<String> WRITE_PAYLOAD_CLASS_NAME = ConfigProperty
       .key("hoodie.datasource.write.payload.class")
@@ -1401,8 +1404,13 @@ public class HoodieWriteConfig extends HoodieConfig {
         HoodieTableConfig.TYPE, HoodieTableConfig.TYPE.defaultValue().name()).toUpperCase());
   }
 
-  public String getPreCombineField() {
-    return getString(PRECOMBINE_FIELD_NAME);
+  public List<String> getPreCombineFields() {
+    return Option.ofNullable(getString(PRECOMBINE_FIELD_NAME))
+        .map(preCombine -> Arrays.asList(preCombine.split(",")))
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(StringUtils::nonEmpty)
+        .collect(Collectors.toList());
   }
 
   public String getKeyGeneratorClass() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -175,7 +175,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
 
   static void upgradeMergeMode(HoodieTableConfig tableConfig, Map<ConfigProperty, String> tablePropsToAdd) {
     String payloadClass = tableConfig.getPayloadClass();
-    String preCombineField = tableConfig.getPreCombineField();
+    String preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
     if (isCustomPayloadClass(payloadClass)) {
       // This contains a special case: HoodieMetadataPayload.
       tablePropsToAdd.put(
@@ -190,7 +190,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     } else if (tableConfig.getTableType() == HoodieTableType.COPY_ON_WRITE) {
       setEventTimeOrCommitTimeBasedOnPayload(payloadClass, tablePropsToAdd);
     } else { // MOR table
-      if (StringUtils.nonEmpty(preCombineField)) {
+      if (StringUtils.nonEmpty(preCombineFields)) {
         // This contains a special case: OverwriteWithLatestPayload with preCombine field.
         tablePropsToAdd.put(
             HoodieTableConfig.PAYLOAD_CLASS_NAME,

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
@@ -96,6 +97,7 @@ class TestSevenToEightUpgradeHandler {
     // Mock record merge mode configuration for merging behavior
     when(tableConfig.contains(isA(ConfigProperty.class))).thenAnswer(i -> i.getArguments()[0].equals(PAYLOAD_CLASS_NAME));
     when(tableConfig.getPayloadClass()).thenReturn(OverwriteWithLatestAvroPayload.class.getName());
+    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
     assertTrue(tablePropsToAdd.containsKey(RECORD_MERGE_MODE));
     assertNotNull(tablePropsToAdd.get(RECORD_MERGE_MODE));
@@ -138,7 +140,7 @@ class TestSevenToEightUpgradeHandler {
     Map<ConfigProperty, String> tablePropsToAdd = new HashMap<>();
 
     when(tableConfig.getPayloadClass()).thenReturn(payloadClass);
-    when(tableConfig.getPreCombineField()).thenReturn(preCombineField);
+    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.ofNullable(preCombineField));
 
     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
@@ -88,7 +88,7 @@ public abstract class HoodieFileGroupReaderOnJavaTestBase<T> extends TestHoodieF
             .setKeyGeneratorType(KeyGeneratorType.SIMPLE.name())
             .setRecordKeyFields(writeConfigs.get(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()))
             .setPartitionFields(writeConfigs.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()))
-            .setPreCombineField(writeConfigs.get("hoodie.datasource.write.precombine.field"))
+            .setPreCombineFields(writeConfigs.get("hoodie.datasource.write.precombine.field"))
             .set(initConfigs);
         if (writeConfigs.containsKey("hoodie.datasource.write.payload.class")) {
           builder = builder.setPayloadClassName(writeConfigs.get("hoodie.datasource.write.payload.class"));

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
@@ -17,40 +17,41 @@
 
 package org.apache.hudi
 
+import org.apache.avro.Schema
 import org.apache.hudi.HoodieSparkUtils.injectSQLConf
 import org.apache.hudi.client.WriteStatus
 import org.apache.hudi.client.model.HoodieInternalRow
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.data.HoodieData
 import org.apache.hudi.common.engine.TaskContextSupplier
-import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
-import org.apache.hudi.common.util.ReflectionUtils
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.util.{OrderingValues, ReflectionUtils}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.data.HoodieJavaRDD
 import org.apache.hudi.exception.HoodieException
-import org.apache.hudi.index.{HoodieIndex, SparkHoodieIndexFactory}
 import org.apache.hudi.index.HoodieIndex.BucketIndexEngineType
-import org.apache.hudi.keygen.{AutoRecordGenWrapperKeyGenerator, BuiltinKeyGenerator, KeyGenUtils}
+import org.apache.hudi.index.{HoodieIndex, SparkHoodieIndexFactory}
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
-import org.apache.hudi.table.{BulkInsertPartitioner, HoodieTable}
+import org.apache.hudi.keygen.{AutoRecordGenWrapperKeyGenerator, BuiltinKeyGenerator, KeyGenUtils}
 import org.apache.hudi.table.action.commit.{BucketBulkInsertDataInternalWriterHelper, BulkInsertDataInternalWriterHelper, ConsistentBucketBulkInsertDataInternalWriterHelper, ParallelismHelper}
+import org.apache.hudi.table.{BulkInsertPartitioner, HoodieTable}
 import org.apache.hudi.util.JFunction.toJavaSerializableFunctionUnchecked
-import org.apache.avro.Schema
+
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Dataset, HoodieUnsafeUtils, Row}
-import org.apache.spark.sql.HoodieUnsafeRowUtils.{composeNestedFieldPath, getNestedInternalRowValue}
+import org.apache.spark.sql.HoodieUnsafeRowUtils.{NestedFieldPath, composeNestedFieldPath, getNestedInternalRowValue}
 import org.apache.spark.sql.HoodieUnsafeUtils.getNumPartitions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset, HoodieUnsafeUtils, Row}
 import org.apache.spark.unsafe.types.UTF8String
 
 import scala.collection.JavaConverters.asScalaBufferConverter
-import scala.collection.mutable
+import scala.collection.{JavaConverters, mutable}
 
 object HoodieDatasetBulkInsertHelper
   extends ParallelismHelper[DataFrame](toJavaSerializableFunctionUnchecked(df => getNumPartitions(df))) with Logging {
@@ -120,7 +121,7 @@ object HoodieDatasetBulkInsertHelper
       }
 
       val dedupedRdd = if (config.shouldCombineBeforeInsert) {
-        dedupeRows(prependedRdd, updatedSchema, config.getPreCombineField, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
+        dedupeRows(prependedRdd, updatedSchema, config.getPreCombineFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
       } else {
         prependedRdd
       }
@@ -213,12 +214,12 @@ object HoodieDatasetBulkInsertHelper
       }), SQLConf.get).toJavaRDD())
   }
 
-  private def dedupeRows(rdd: RDD[InternalRow], schema: StructType, preCombineFieldRef: String, isGlobalIndex: Boolean, targetParallelism: Int): RDD[InternalRow] = {
+  private def dedupeRows(rdd: RDD[InternalRow], schema: StructType, preCombineFields: List[String], isGlobalIndex: Boolean, targetParallelism: Int): RDD[InternalRow] = {
     val recordKeyMetaFieldOrd = schema.fieldIndex(HoodieRecord.RECORD_KEY_METADATA_FIELD)
     val partitionPathMetaFieldOrd = schema.fieldIndex(HoodieRecord.PARTITION_PATH_METADATA_FIELD)
     // NOTE: Pre-combine field could be a nested field
-    val preCombineFieldPath = composeNestedFieldPath(schema, preCombineFieldRef)
-      .getOrElse(throw new HoodieException(s"Pre-combine field $preCombineFieldRef is missing in $schema"))
+    val preCombineFieldPaths = preCombineFields.map(preCombineField => composeNestedFieldPath(schema, preCombineField)
+      .getOrElse(throw new HoodieException(s"Pre-combine field $preCombineField is missing in $schema")))
 
     rdd.map { row =>
         val rowKey = if (isGlobalIndex) {
@@ -233,13 +234,14 @@ object HoodieDatasetBulkInsertHelper
         (rowKey, row.copy())
       }
       .reduceByKey ((oneRow, otherRow) => {
-        val onePreCombineVal = getNestedInternalRowValue(oneRow, preCombineFieldPath).asInstanceOf[Comparable[AnyRef]]
-        val otherPreCombineVal = getNestedInternalRowValue(otherRow, preCombineFieldPath).asInstanceOf[Comparable[AnyRef]]
-        if (onePreCombineVal.compareTo(otherPreCombineVal.asInstanceOf[AnyRef]) >= 0) {
+        val onePreCombineVal = getOrderingValue(preCombineFieldPaths, oneRow).asInstanceOf[Comparable[AnyRef]]
+        val otherPreCombineVal = getOrderingValue(preCombineFieldPaths, otherRow)
+        val selectedRow: InternalRow = if (onePreCombineVal.compareTo(otherPreCombineVal.asInstanceOf[AnyRef]) >= 0) {
           oneRow
         } else {
           otherRow
         }
+        selectedRow
       }, targetParallelism)
       .values
   }
@@ -253,6 +255,11 @@ object HoodieDatasetBulkInsertHelper
     } else {
       input.sparkSession.sparkContext.defaultParallelism
     }
+  }
+
+  private def getOrderingValue(nestedFieldPaths: List[NestedFieldPath], r: InternalRow): Comparable[_] = {
+    OrderingValues.create(
+      nestedFieldPaths.map(nestedFieldPath => getNestedInternalRowValue(r, nestedFieldPath).asInstanceOf[Comparable[_]]).toArray)
   }
 
   private def getPartitionPathFields(config: HoodieWriteConfig): mutable.Seq[String] = {

--- a/hudi-common/src/main/avro/HoodieDeleteRecordList.avsc
+++ b/hudi-common/src/main/avro/HoodieDeleteRecordList.avsc
@@ -64,7 +64,8 @@
                 "org.apache.hudi.avro.model.DateWrapper",
                 "org.apache.hudi.avro.model.DecimalWrapper",
                 "org.apache.hudi.avro.model.TimeMicrosWrapper",
-                "org.apache.hudi.avro.model.TimestampMicrosWrapper"
+                "org.apache.hudi.avro.model.TimestampMicrosWrapper",
+                "org.apache.hudi.avro.model.ArrayWrapper"
               ],
               "default": null
             }

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -302,6 +302,40 @@
                                             "name": "value"
                                         }
                                     ]
+                                },
+                                {
+                                    "namespace": "org.apache.hudi.avro.model",
+                                    "type": "record",
+                                    "name": "ArrayWrapper",
+                                    "doc": "A record containing a list of wrapped values.",
+                                    "fields": [
+                                        {
+                                            "name": "wrappedValues",
+                                            "doc": "An array where each element is one of the supported wrapper types.",
+                                            "type": [
+                                                "null",
+                                                {
+                                                    "type": "array",
+                                                    "items": [
+                                                        "null",
+                                                        "org.apache.hudi.avro.model.BooleanWrapper",
+                                                        "org.apache.hudi.avro.model.IntWrapper",
+                                                        "org.apache.hudi.avro.model.LongWrapper",
+                                                        "org.apache.hudi.avro.model.FloatWrapper",
+                                                        "org.apache.hudi.avro.model.DoubleWrapper",
+                                                        "org.apache.hudi.avro.model.BytesWrapper",
+                                                        "org.apache.hudi.avro.model.StringWrapper",
+                                                        "org.apache.hudi.avro.model.DateWrapper",
+                                                        "org.apache.hudi.avro.model.DecimalWrapper",
+                                                        "org.apache.hudi.avro.model.TimeMicrosWrapper",
+                                                        "org.apache.hudi.avro.model.TimestampMicrosWrapper",
+                                                        "org.apache.hudi.avro.model.LocalDateWrapper"
+                                                    ]
+                                                }
+                                            ],
+                                            "default": null
+                                        }
+                                    ]
                                 }
                             ],
                             "default": null

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.avro;
 
+import org.apache.hudi.avro.model.ArrayWrapper;
 import org.apache.hudi.avro.model.BooleanWrapper;
 import org.apache.hudi.avro.model.BytesWrapper;
 import org.apache.hudi.avro.model.DateWrapper;
@@ -32,7 +33,9 @@ import org.apache.hudi.avro.model.TimestampMicrosWrapper;
 import org.apache.hudi.common.config.SerializableSchema;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.collection.ArrayComparable;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.SpillableMapUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -153,6 +156,7 @@ public class HoodieAvroUtils {
   private static final Lazy<DecimalWrapper.Builder> DECIMAL_WRAPPER_BUILDER_STUB = Lazy.lazily(DecimalWrapper::newBuilder);
   private static final Lazy<DateWrapper.Builder> DATE_WRAPPER_BUILDER_STUB = Lazy.lazily(DateWrapper::newBuilder);
   private static final Lazy<LocalDateWrapper.Builder> LOCAL_DATE_WRAPPER_BUILDER_STUB = Lazy.lazily(LocalDateWrapper::newBuilder);
+  private static final Lazy<ArrayWrapper.Builder> ARRAY_WRAPPER_BUILDER_STUB = Lazy.lazily(ArrayWrapper::newBuilder);
 
   private static final long MILLIS_PER_DAY = 86400000L;
 
@@ -1499,7 +1503,7 @@ public class HoodieAvroUtils {
   public static HoodieRecord createHoodieRecordFromAvro(
       IndexedRecord data,
       String payloadClass,
-      String preCombineField,
+      String[] preCombineFields,
       Option<Pair<String, String>> simpleKeyGenFieldsOpt,
       Boolean withOperation,
       Option<String> partitionNameOp,
@@ -1507,13 +1511,13 @@ public class HoodieAvroUtils {
       Option<Schema> schemaWithoutMetaFields) {
     if (populateMetaFields) {
       return SpillableMapUtils.convertToHoodieRecordPayload((GenericRecord) data,
-          payloadClass, preCombineField, withOperation);
+          payloadClass, preCombineFields, withOperation);
     } else if (simpleKeyGenFieldsOpt.isPresent()) {
       return SpillableMapUtils.convertToHoodieRecordPayload((GenericRecord) data,
-          payloadClass, preCombineField, simpleKeyGenFieldsOpt.get(), withOperation, partitionNameOp, schemaWithoutMetaFields);
+          payloadClass, preCombineFields, simpleKeyGenFieldsOpt.get(), withOperation, partitionNameOp, schemaWithoutMetaFields);
     } else {
       return SpillableMapUtils.convertToHoodieRecordPayload((GenericRecord) data,
-          payloadClass, preCombineField, withOperation, partitionNameOp, schemaWithoutMetaFields);
+          payloadClass, preCombineFields, withOperation, partitionNameOp, schemaWithoutMetaFields);
     }
   }
 
@@ -1615,6 +1619,9 @@ public class HoodieAvroUtils {
       return BytesWrapper.newBuilder(BYTES_WRAPPER_BUILDER_STUB.get()).setValue((ByteBuffer) value).build();
     } else if (value instanceof String || value instanceof Utf8) {
       return StringWrapper.newBuilder(STRING_WRAPPER_BUILDER_STUB.get()).setValue(value.toString()).build();
+    } else if (value instanceof ArrayComparable) {
+      List<Object> avroValues = OrderingValues.getValues((ArrayComparable) value).stream().map(HoodieAvroUtils::wrapValueIntoAvro).collect(Collectors.toList());
+      return ArrayWrapper.newBuilder(ARRAY_WRAPPER_BUILDER_STUB.get()).setWrappedValues(avroValues).build();
     } else {
       throw new UnsupportedOperationException(String.format("Unsupported type of the value (%s)", value.getClass()));
     }
@@ -1659,6 +1666,11 @@ public class HoodieAvroUtils {
       return ((BytesWrapper) avroValueWrapper).getValue();
     } else if (avroValueWrapper instanceof StringWrapper) {
       return ((StringWrapper) avroValueWrapper).getValue();
+    } else if (avroValueWrapper instanceof ArrayWrapper) {
+      ArrayWrapper arrayWrapper = (ArrayWrapper) avroValueWrapper;
+      return OrderingValues.create(arrayWrapper.getWrappedValues().stream()
+          .map(HoodieAvroUtils::unwrapAvroValueWrapper)
+          .toArray(Comparable[]::new));
     } else if (avroValueWrapper instanceof GenericRecord) {
       // NOTE: This branch could be hit b/c Avro records could be reconstructed
       //       as {@code GenericRecord)

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -26,8 +27,6 @@ import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Properties;
-
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * Provides support for seamlessly applying changes captured via Amazon Database Migration Service onto S3.
@@ -52,7 +51,7 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public AWSDmsAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, OrderingValues.getDefault()); // natural order
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -29,7 +30,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro;
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * The only difference with {@link DefaultHoodieRecordPayload} is that is does not
@@ -42,7 +42,7 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
   }
 
   public EventTimeAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, OrderingValues.getDefault()); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -41,7 +42,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
 /**
  * This only use by reader returning.
@@ -181,8 +181,8 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
       Boolean populateMetaFields,
       Option<Schema> schemaWithoutMetaFields) {
     String payloadClass = ConfigUtils.getPayloadClass(props);
-    String preCombineField = ConfigUtils.getOrderingField(props);
-    return HoodieAvroUtils.createHoodieRecordFromAvro(data, payloadClass, preCombineField, simpleKeyGenFieldsOpt, withOperation, partitionNameOp, populateMetaFields, schemaWithoutMetaFields);
+    String[] orderingFields = ConfigUtils.getOrderingFields(props);
+    return HoodieAvroUtils.createHoodieRecordFromAvro(data, payloadClass, orderingFields, simpleKeyGenFieldsOpt, withOperation, partitionNameOp, populateMetaFields, schemaWithoutMetaFields);
   }
 
   @Override
@@ -211,15 +211,16 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public Comparable<?> doGetOrderingValue(Schema recordSchema, Properties props) {
-    String orderingField = ConfigUtils.getOrderingField(props);
-    if (isNullOrEmpty(orderingField)) {
-      return DEFAULT_ORDERING_VALUE;
+    String[] orderingFields = ConfigUtils.getOrderingFields(props);
+    if (orderingFields == null) {
+      return OrderingValues.getDefault();
     }
     boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(props.getProperty(
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
-    return (Comparable<?>) HoodieAvroUtils.getNestedFieldVal((GenericRecord) data,
-        orderingField, true, consistentLogicalTimestampEnabled);
+    return OrderingValues.create(
+        orderingFields,
+        field -> (Comparable<?>) HoodieAvroUtils.getNestedFieldVal((GenericRecord) data, field, true, consistentLogicalTimestampEnabled));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -227,8 +227,9 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
       Option<Schema> schemaWithoutMetaFields) throws IOException {
     IndexedRecord indexedRecord = (IndexedRecord) data.getInsertValue(recordSchema, props).get();
     String payloadClass = ConfigUtils.getPayloadClass(props);
-    String preCombineField = ConfigUtils.getOrderingField(props);
-    return HoodieAvroUtils.createHoodieRecordFromAvro(indexedRecord, payloadClass, preCombineField, simpleKeyGenFieldsOpt, withOperation, partitionNameOp, populateMetaFields, schemaWithoutMetaFields);
+    String[] orderingFields = ConfigUtils.getOrderingFields(props);
+    return HoodieAvroUtils.createHoodieRecordFromAvro(indexedRecord, payloadClass, orderingFields, simpleKeyGenFieldsOpt,
+        withOperation, partitionNameOp, populateMetaFields, schemaWithoutMetaFields);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -173,10 +172,8 @@ public interface HoodieRecordMerger extends Serializable {
       }
     }
 
-    String preCombine = cfg.getPreCombineField();
-    if (!StringUtils.isNullOrEmpty(preCombine)) {
-      requiredFields.add(preCombine);
-    }
+    List<String> preCombineFields = cfg.getPreCombineFields();
+    requiredFields.addAll(preCombineFields);
     return requiredFields.toArray(new String[0]);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.model;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
@@ -28,8 +29,6 @@ import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * <ol>
@@ -45,7 +44,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   public OverwriteWithLatestAvroPayload(Option<GenericRecord> record) {
-    this(record.isPresent() ? record.get() : null, DEFAULT_ORDERING_VALUE); // natural order
+    this(record.isPresent() ? record.get() : null, OrderingValues.getDefault()); // natural order
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1069,7 +1069,7 @@ public class HoodieTableMetaClient implements Serializable {
     private String timelinePath;
     private String timelineHistoryPath;
     private String baseFileFormat;
-    private String preCombineField;
+    private String preCombineFields;
     private String partitionFields;
     private Boolean cdcEnabled;
     private String cdcSupplementalLoggingMode;
@@ -1190,8 +1190,12 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
-    public TableBuilder setPreCombineField(String preCombineField) {
-      this.preCombineField = preCombineField;
+    /**
+     * Sets preCombine fields as a comma separated string in the table
+     * @param preCombineFieldsAsString - Comma separated preCombine fields which need to be set for the table
+     */
+    public TableBuilder setPreCombineFields(String preCombineFieldsAsString) {
+      this.preCombineFields = preCombineFieldsAsString;
       return this;
     }
 
@@ -1394,8 +1398,8 @@ public class HoodieTableMetaClient implements Serializable {
         setBootstrapIndexEnable(hoodieConfig.getBoolean(HoodieTableConfig.BOOTSTRAP_INDEX_ENABLE));
       }
 
-      if (hoodieConfig.contains(HoodieTableConfig.PRECOMBINE_FIELD)) {
-        setPreCombineField(hoodieConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD));
+      if (hoodieConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)) {
+        setPreCombineFields(hoodieConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
       }
       if (hoodieConfig.contains(HoodieTableConfig.PARTITION_FIELDS)) {
         setPartitionFields(
@@ -1478,7 +1482,7 @@ public class HoodieTableMetaClient implements Serializable {
 
       Triple<RecordMergeMode, String, String> mergeConfigs =
           HoodieTableConfig.inferCorrectMergingBehavior(
-              recordMergeMode, payloadClassName, recordMergerStrategyId, preCombineField,
+              recordMergeMode, payloadClassName, recordMergerStrategyId, preCombineFields,
               tableVersion);
       tableConfig.setValue(RECORD_MERGE_MODE, mergeConfigs.getLeft().name());
       tableConfig.setValue(PAYLOAD_CLASS_NAME.key(), mergeConfigs.getMiddle());
@@ -1527,8 +1531,8 @@ public class HoodieTableMetaClient implements Serializable {
         tableConfig.setValue(HoodieTableConfig.BOOTSTRAP_BASE_PATH, bootstrapBasePath);
       }
 
-      if (StringUtils.nonEmpty(preCombineField)) {
-        tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELD, preCombineField);
+      if (StringUtils.nonEmpty(preCombineFields)) {
+        tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELDS, preCombineFields);
       }
 
       if (null != partitionFields) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -105,7 +105,7 @@ public abstract class AbstractHoodieLogRecordScanner {
   // Partition name override
   private final Option<String> partitionNameOverrideOpt;
   // Pre-combining field
-  protected final String preCombineField;
+  protected final String preCombineFields;
   // Stateless component for merging records
   protected final HoodieRecordMerger recordMerger;
   private final TypedProperties payloadProps;
@@ -175,13 +175,13 @@ public abstract class AbstractHoodieLogRecordScanner {
     // load class from the payload fully qualified class name
     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
     this.payloadClassFQN = tableConfig.getPayloadClass();
-    this.preCombineField = tableConfig.getPreCombineField();
+    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
     // Log scanner merge log with precombine
     TypedProperties props = new TypedProperties();
-    if (preCombineField != null) {
-      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, preCombineField);
-      props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), preCombineField);
-      props.setProperty("hoodie.datasource.write.precombine.field", preCombineField);
+    if (preCombineFields != null) {
+      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, preCombineFields);
+      props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), preCombineFields);
+      props.setProperty("hoodie.datasource.write.precombine.field", preCombineFields);
     }
     this.tableVersion = tableConfig.getTableVersion();
     this.payloadProps = props;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -95,7 +95,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
   // Partition name override
   private final Option<String> partitionNameOverrideOpt;
   // Pre-combining field
-  protected final String preCombineField;
+  protected final String preCombineFields;
   private final TypedProperties payloadProps;
   // Log File Paths
   protected final List<String> logFilePaths;
@@ -151,11 +151,11 @@ public abstract class BaseHoodieLogRecordReader<T> {
     // load class from the payload fully qualified class name
     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
     this.payloadClassFQN = tableConfig.getPayloadClass();
-    this.preCombineField = tableConfig.getPreCombineField();
+    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
     // Log scanner merge log with precombine
     TypedProperties props = new TypedProperties();
-    if (this.preCombineField != null) {
-      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, this.preCombineField);
+    if (this.preCombineFields != null) {
+      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, this.preCombineFields);
     }
     this.payloadProps = props;
     this.totalLogFiles.addAndGet(logFilePaths.size());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -32,7 +32,7 @@ import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.SpillableMapUtils;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.exception.HoodieIOException;
@@ -279,8 +279,8 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
       Comparable deleteOrderingVal = deleteRecord.getOrderingValue();
       // Checks the ordering value does not equal to 0
       // because we use 0 as the default value which means natural order
-      boolean choosePrev = !deleteOrderingVal.equals(0)
-          && ReflectionUtils.isSameClass(curOrderingVal, deleteOrderingVal)
+      boolean choosePrev = !OrderingValues.isDefault(deleteOrderingVal)
+          && OrderingValues.isSameClass(curOrderingVal, deleteOrderingVal)
           && curOrderingVal.compareTo(deleteOrderingVal) > 0;
       if (choosePrev) {
         // The DELETE message is obsolete if the old message has greater orderingVal.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.log.block;
 
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieDeleteRecord;
 import org.apache.hudi.avro.model.HoodieDeleteRecordList;
 import org.apache.hudi.common.fs.SizeAwareDataInputStream;
@@ -55,7 +56,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.unwrapAvroValueWrapper;
-import static org.apache.hudi.avro.HoodieAvroUtils.wrapValueIntoAvro;
 
 /**
  * Delete block contains a list of keys to be deleted from scanning the blocks so far.
@@ -143,10 +143,10 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
     HoodieDeleteRecord.Builder recordBuilder = HOODIE_DELETE_RECORD_BUILDER_STUB.get();
     List<HoodieDeleteRecord> deleteRecordList = Arrays.stream(getRecordsToDelete())
         .map(record -> HoodieDeleteRecord.newBuilder(recordBuilder)
-            .setRecordKey(record.getRecordKey())
-            .setPartitionPath(record.getPartitionPath())
-            .setOrderingVal(wrapValueIntoAvro(record.getOrderingValue()))
-            .build())
+          .setRecordKey(record.getRecordKey())
+          .setPartitionPath(record.getPartitionPath())
+          .setOrderingVal(HoodieAvroUtils.wrapValueIntoAvro(record.getOrderingValue()))
+          .build())
         .collect(Collectors.toList());
     writer.write(HoodieDeleteRecordList.newBuilder(recordListBuilder)
         .setDeleteRecordList(deleteRecordList)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
@@ -22,17 +22,16 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.exception.HoodieException;
 
 import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 
 /**
  * Buffered Record used by file group reader.
@@ -67,10 +66,10 @@ public class BufferedRecord<T> implements Serializable {
     return new BufferedRecord<>(recordKey, record.getOrderingValue(schema, props), record.getData(), schemaId, isDelete);
   }
 
-  public static <T> BufferedRecord<T> forRecordWithContext(T record, Schema schema, HoodieReaderContext<T> readerContext, Option<String> orderingFieldName, boolean isDelete) {
+  public static <T> BufferedRecord<T> forRecordWithContext(T record, Schema schema, HoodieReaderContext<T> readerContext, List<String> orderingFieldNames, boolean isDelete) {
     String recordKey = readerContext.getRecordKey(record, schema);
     Integer schemaId = readerContext.encodeAvroSchema(schema);
-    Comparable orderingValue = readerContext.getOrderingValue(record, schema, orderingFieldName);
+    Comparable orderingValue = readerContext.getOrderingValue(record, schema, orderingFieldNames);
     return new BufferedRecord<>(recordKey, orderingValue, record, schemaId, isDelete);
   }
 
@@ -99,7 +98,7 @@ public class BufferedRecord<T> implements Serializable {
   }
 
   public boolean isCommitTimeOrderingDelete() {
-    return isDelete && getOrderingValue().equals(DEFAULT_ORDERING_VALUE);
+    return isDelete && OrderingValues.isDefault(orderingValue);
   }
 
   public BufferedRecord<T> toBinary(HoodieReaderContext<T> readerContext) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
@@ -208,7 +208,7 @@ public class FileGroupReaderSchemaHandler<T> {
         cfg.getRecordMergeMode(),
         cfg.getPayloadClass(),
         cfg.getRecordMergeStrategyId(),
-        cfg.getPreCombineField(),
+        cfg.getPreCombineFieldsStr().orElse(null),
         cfg.getTableVersion());
 
     if (mergingConfigs.getLeft() == RecordMergeMode.CUSTOM) {
@@ -233,10 +233,8 @@ public class FileGroupReaderSchemaHandler<T> {
     }
     // Add precombine field for event time ordering merge mode.
     if (mergingConfigs.getLeft() == RecordMergeMode.EVENT_TIME_ORDERING) {
-      String preCombine = cfg.getPreCombineField();
-      if (!StringUtils.isNullOrEmpty(preCombine)) {
-        requiredFields.add(preCombine);
-      }
+      List<String> preCombineFields = cfg.getPreCombineFields();
+      requiredFields.addAll(preCombineFields);
     }
     // Add `HOODIE_IS_DELETED_FIELD` field if exists.
     if (hasBuiltInDelete) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/DefaultFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/DefaultFileGroupRecordBufferLoader.java
@@ -53,7 +53,7 @@ class DefaultFileGroupRecordBufferLoader<T> extends LogScanningRecordBufferLoade
   public Pair<HoodieFileGroupRecordBuffer<T>, List<String>> getRecordBuffer(HoodieReaderContext<T> readerContext,
                                                                             HoodieStorage storage,
                                                                             InputSplit inputSplit,
-                                                                            Option<String> orderingFieldName,
+                                                                            List<String> orderingFieldNames,
                                                                             HoodieTableMetaClient hoodieTableMetaClient,
                                                                             TypedProperties props,
                                                                             ReaderParameters readerParameters,
@@ -69,14 +69,14 @@ class DefaultFileGroupRecordBufferLoader<T> extends LogScanningRecordBufferLoade
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, readStats);
     } else if (readerParameters.sortOutputs()) {
       recordBuffer = new SortedKeyBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldNames, updateProcessor);
     } else if (readerParameters.useRecordPosition() && inputSplit.getBaseFileOption().isPresent()) {
       recordBuffer = new PositionBasedFileGroupRecordBuffer<>(
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, inputSplit.getBaseFileOption().get().getCommitTime(), props,
-          orderingFieldName, updateProcessor);
+          orderingFieldNames, updateProcessor);
     } else {
       recordBuffer = new KeyBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldNames, updateProcessor);
     }
     return Pair.of(recordBuffer, scanLogFiles(readerContext, storage, inputSplit, hoodieTableMetaClient, props, readerParameters, readStats, recordBuffer));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBufferLoader.java
@@ -41,7 +41,7 @@ public interface FileGroupRecordBufferLoader<T> {
   Pair<HoodieFileGroupRecordBuffer<T>, List<String>> getRecordBuffer(HoodieReaderContext<T> readerContext,
                                                                      HoodieStorage storage,
                                                                      InputSplit inputSplit,
-                                                                     Option<String> orderingFieldName,
+                                                                     List<String> orderingFieldNames,
                                                                      HoodieTableMetaClient hoodieTableMetaClient,
                                                                      TypedProperties props,
                                                                      ReaderParameters readerParameters,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A buffer that is used to store log records by {@link org.apache.hudi.common.table.log.HoodieMergedLogRecordReader}
@@ -57,9 +58,9 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
                                        RecordMergeMode recordMergeMode,
                                        PartialUpdateMode partialUpdateMode,
                                        TypedProperties props,
-                                       Option<String> orderingFieldName,
+                                       List<String> orderingFieldNames,
                                        UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldNames, updateProcessor);
   }
 
   @Override
@@ -80,7 +81,7 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
           recordMergeMode,
           true,
           recordMerger,
-          orderingFieldName,
+          orderingFieldNames,
           payloadClass,
           readerSchema,
           props,
@@ -93,7 +94,7 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       while (recordIterator.hasNext()) {
         T nextRecord = recordIterator.next();
         boolean isDelete = isBuiltInDeleteRecord(nextRecord) || isCustomDeleteRecord(nextRecord) || isDeleteHoodieOperation(nextRecord);
-        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(nextRecord, schema, readerContext, orderingFieldName, isDelete);
+        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(nextRecord, schema, readerContext, orderingFieldNames, isDelete);
         processNextDataRecord(bufferedRecord, bufferedRecord.getRecordKey());
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
@@ -75,9 +75,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
                                             PartialUpdateMode partialUpdateMode,
                                             String baseFileInstantTime,
                                             TypedProperties props,
-                                            Option<String> orderingFieldName,
+                                            List<String> orderingFieldNames,
                                             UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldNames, updateProcessor);
     this.baseFileInstantTime = baseFileInstantTime;
   }
 
@@ -119,7 +119,7 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
           recordMergeMode,
           true,
           recordMerger,
-          orderingFieldName,
+          orderingFieldNames,
           payloadClass,
           readerSchema,
           props,
@@ -146,7 +146,7 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
         long recordPosition = recordPositions.get(recordIndex++);
         T evolvedNextRecord = schemaTransformerWithEvolvedSchema.getLeft().apply(nextRecord);
         boolean isDelete = isBuiltInDeleteRecord(evolvedNextRecord) || isCustomDeleteRecord(evolvedNextRecord) || isDeleteHoodieOperation(evolvedNextRecord);
-        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(evolvedNextRecord, schema, readerContext, orderingFieldName, isDelete);
+        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(evolvedNextRecord, schema, readerContext, orderingFieldNames, isDelete);
         processNextDataRecord(bufferedRecord, recordPosition);
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableFileGroupRecordBufferLoader.java
@@ -52,7 +52,7 @@ public class ReusableFileGroupRecordBufferLoader<T> extends LogScanningRecordBuf
   public synchronized Pair<HoodieFileGroupRecordBuffer<T>, List<String>> getRecordBuffer(HoodieReaderContext<T> readerContext,
                                                                                          HoodieStorage storage,
                                                                                          InputSplit inputSplit,
-                                                                                         Option<String> orderingFieldName,
+                                                                                         List<String> orderingFieldNames,
                                                                                          HoodieTableMetaClient hoodieTableMetaClient,
                                                                                          TypedProperties props,
                                                                                          ReaderParameters readerParameters,
@@ -63,13 +63,13 @@ public class ReusableFileGroupRecordBufferLoader<T> extends LogScanningRecordBuf
     if (cachedResults == null) {
       // Create an initial buffer to process the log files
       KeyBasedFileGroupRecordBuffer<T> initialBuffer = new KeyBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldNames, updateProcessor);
       List<String> validInstants = scanLogFiles(readerContextWithoutFilters, storage, inputSplit, hoodieTableMetaClient, props, readerParameters, readStats, initialBuffer);
       cachedResults = Pair.of(initialBuffer, validInstants);
     }
     // Create a reusable buffer with the results from the initial scan
     ReusableKeyBasedRecordBuffer<T> reusableBuffer = new ReusableKeyBasedRecordBuffer<>(
-        readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldName, updateProcessor, cachedResults.getLeft().getLogRecords());
+        readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateMode, props, orderingFieldNames, updateProcessor, cachedResults.getLeft().getLogRecords());
     return Pair.of(reusableBuffer, cachedResults.getRight());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableKeyBasedRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableKeyBasedRecordBuffer.java
@@ -56,9 +56,9 @@ public class ReusableKeyBasedRecordBuffer<T> extends FileGroupRecordBuffer<T> {
 
   ReusableKeyBasedRecordBuffer(HoodieReaderContext<T> readerContext, HoodieTableMetaClient hoodieTableMetaClient,
                                RecordMergeMode recordMergeMode, PartialUpdateMode partialUpdateMode,
-                               TypedProperties props, Option<String> orderingFieldName,
+                               TypedProperties props, List<String> orderingFieldNames,
                                UpdateProcessor<T> updateProcessor, Map<Serializable, BufferedRecord<T>> records) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldNames, updateProcessor);
     this.existingRecords = records;
     ValidationUtils.checkArgument(readerContext.getKeyFilterOpt().orElse(null) instanceof Predicates.In,
         () -> "Key filter should be of type Predicates.In, but found: " + readerContext.getKeyFilterOpt().map(filter -> filter.getClass().getSimpleName()).orElse("NULL"));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/SortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/SortedKeyBasedFileGroupRecordBuffer.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.stream.Collectors;
@@ -50,9 +51,9 @@ class SortedKeyBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupRecordBuff
                                              RecordMergeMode recordMergeMode,
                                              PartialUpdateMode partialUpdateMode,
                                              TypedProperties props,
-                                             Option<String> orderingFieldName,
+                                             List<String> orderingFieldNames,
                                              UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldNames, updateProcessor);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/UnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/UnmergedFileGroupRecordBuffer.java
@@ -40,6 +40,7 @@ import org.apache.avro.Schema;
 
 import java.io.Serializable;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 
 class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
@@ -55,7 +56,7 @@ class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       PartialUpdateMode partialUpdateMode,
       TypedProperties props,
       HoodieReadStats readStats) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, Option.empty(), null);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, Collections.emptyList(), null);
     this.readStats = readStats;
     this.currentInstantLogBlocks = new ArrayDeque<>();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrderingValues.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrderingValues.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.util.collection.ArrayComparable;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Factory class for ordering values.
+ */
+public class OrderingValues {
+  private static final Comparable<?> DEFAULT_VALUE = org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
+
+  /**
+   * Creates an {@code OrderingValue} with given values.
+   *
+   * <p>CAUTION: if the values are fetched through ordering fields,
+   * please use {@link #create(List, Function)} or {@link #create(String[], Function)}
+   * as much as possible to avoid streaming on the ordering fields in row level.</p>
+   */
+  public static Comparable create(Comparable[] orderingValues) {
+    if (orderingValues.length == 1) {
+      return orderingValues[0];
+    } else {
+      return new ArrayComparable(orderingValues);
+    }
+  }
+
+  /**
+   * Applies the input mapping function on the input ordering fields and returns a new {@code OrderingValue} with
+   * the mapped ordering field values.
+   */
+  public static Comparable create(List<String> orderingFields, Function<String, Comparable> fieldMappingFunction) {
+    if (orderingFields.isEmpty()) {
+      return DEFAULT_VALUE;
+    } else if (orderingFields.size() == 1) {
+      return fieldMappingFunction.apply(orderingFields.get(0));
+    } else {
+      Comparable[] orderingValues = new Comparable[orderingFields.size()];
+      for (int i = 0; i < orderingFields.size(); i++) {
+        orderingValues[i] = fieldMappingFunction.apply(orderingFields.get(i));
+      }
+      return new ArrayComparable(orderingValues);
+    }
+  }
+
+  /**
+   * Applies the input mapping function on the input ordering fields and returns a new {@code OrderingValue} with
+   * the mapped ordering field values.
+   */
+  public static Comparable create(String[] orderingFields, Function<String, Comparable> fieldMappingFunction) {
+    if (orderingFields.length == 0) {
+      return DEFAULT_VALUE;
+    } else if (orderingFields.length == 1) {
+      return fieldMappingFunction.apply(orderingFields[0]);
+    } else {
+      Comparable[] orderingValues = new Comparable[orderingFields.length];
+      for (int i = 0; i < orderingFields.length; i++) {
+        orderingValues[i] = fieldMappingFunction.apply(orderingFields[i]);
+      }
+      return new ArrayComparable(orderingValues);
+    }
+  }
+
+  /**
+   * Returns the default {@code OrderingValue} value.
+   */
+  public static Comparable getDefault() {
+    return DEFAULT_VALUE;
+  }
+
+  /**
+   * Returns whether the given {@code orderingValue} is default.
+   */
+  public static boolean isDefault(Comparable orderingValue) {
+    return DEFAULT_VALUE.equals(orderingValue);
+  }
+
+  /**
+   * Returns whether the given two ordering values belong to the same class.
+   */
+  public static boolean isSameClass(Comparable val1, Comparable val2) {
+    if (val1.getClass() != val2.getClass()) {
+      return false;
+    } else if (val1 instanceof ArrayComparable) {
+      return ((ArrayComparable) val1).isValueSameClass((ArrayComparable) val2);
+    }
+    return true;
+  }
+
+  /**
+   * Returns the ordering values as a list.
+   */
+  public static List<Comparable> getValues(ArrayComparable orderingValue) {
+    return orderingValue.getValues();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/SpillableMapUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/SpillableMapUtils.java
@@ -33,13 +33,13 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.getNullableValAsString;
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.util.BinaryUtil.generateChecksum;
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
 /**
  * A utility class supports spillable map.
@@ -110,18 +110,18 @@ public class SpillableMapUtils {
   /**
    * Utility method to convert bytes to HoodieRecord using schema and payload class.
    */
-  public static <R> HoodieRecord<R> convertToHoodieRecordPayload(GenericRecord rec, String payloadClazz, String preCombineField, boolean withOperationField) {
-    return convertToHoodieRecordPayload(rec, payloadClazz, preCombineField,
+  public static <R> HoodieRecord<R> convertToHoodieRecordPayload(GenericRecord rec, String payloadClazz, String[] preCombineFields, boolean withOperationField) {
+    return convertToHoodieRecordPayload(rec, payloadClazz, preCombineFields,
         Pair.of(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD),
         withOperationField, Option.empty(), Option.empty());
   }
 
   public static <R> HoodieRecord<R> convertToHoodieRecordPayload(GenericRecord record, String payloadClazz,
-                                                                 String preCombineField,
+                                                                 String[] preCombineFields,
                                                                  boolean withOperationField,
                                                                  Option<String> partitionName,
                                                                  Option<Schema> schemaWithoutMetaFields) {
-    return convertToHoodieRecordPayload(record, payloadClazz, preCombineField,
+    return convertToHoodieRecordPayload(record, payloadClazz, preCombineFields,
         Pair.of(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD),
         withOperationField, partitionName, schemaWithoutMetaFields);
   }
@@ -130,7 +130,7 @@ public class SpillableMapUtils {
    * Utility method to convert bytes to HoodieRecord using schema and payload class.
    */
   public static <R> HoodieRecord<R> convertToHoodieRecordPayload(GenericRecord record, String payloadClazz,
-                                                                 String preCombineField,
+                                                                 String[] preCombineFields,
                                                                  Pair<String, String> recordKeyPartitionPathFieldPair,
                                                                  boolean withOperationField,
                                                                  Option<String> partitionName,
@@ -139,7 +139,7 @@ public class SpillableMapUtils {
     final String partitionPath = (partitionName.isPresent() ? partitionName.get() :
         record.get(recordKeyPartitionPathFieldPair.getRight()).toString());
 
-    Comparable preCombineVal = getPreCombineVal(record, preCombineField);
+    Comparable preCombineVal = getPreCombineVal(record, preCombineFields);
     HoodieOperation operation = withOperationField
         ? HoodieOperation.fromName(getNullableValAsString(record, HoodieRecord.OPERATION_METADATA_FIELD)) : null;
 
@@ -162,16 +162,20 @@ public class SpillableMapUtils {
    * Returns the preCombine value with given field name.
    *
    * @param rec The avro record
-   * @param preCombineField The preCombine field name
+   * @param preCombineFields The preCombine field names
    * @return the preCombine field value or 0 if the field does not exist in the avro schema
    */
-  private static Comparable getPreCombineVal(GenericRecord rec, String preCombineField) {
-    if (isNullOrEmpty(preCombineField)) {
-      return DEFAULT_ORDERING_VALUE;
+  private static Comparable getPreCombineVal(GenericRecord rec, @Nullable String[] preCombineFields) {
+    if (preCombineFields == null) {
+      return OrderingValues.getDefault();
     }
     // keep consistent with writer side, using Java type for ordering value, see `DefaultHoodieRecordPayload`.
-    Object orderingValue = HoodieAvroUtils.getNestedFieldVal(rec, preCombineField, true, false);
-    return orderingValue == null ? DEFAULT_ORDERING_VALUE : (Comparable) orderingValue;
+    return OrderingValues.create(
+        preCombineFields,
+        field -> {
+          Object orderingValue = HoodieAvroUtils.getNestedFieldVal(rec, field, true, false);
+          return orderingValue == null ? OrderingValues.getDefault() : (Comparable) orderingValue;
+        });
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ArrayComparable.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ArrayComparable.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.apache.hudi.common.util.ValidationUtils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A wrapper class to manage multiple ordering fields across Hudi.
+ *
+ * <p>Currently only multiple fields ordering value utilizes this abstraction,
+ * for single field ordering value, {@link Comparable} is used directly instead.</p>
+ *
+ * @see org.apache.hudi.common.util.OrderingValues
+ */
+public class ArrayComparable implements Comparable<ArrayComparable>, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final Comparable[] values;
+
+  public ArrayComparable(Comparable[] values) {
+    this.values = values;
+  }
+
+  public List<Comparable> getValues() {
+    return Arrays.asList(values);
+  }
+
+  public ArrayComparable apply(Function<Comparable, Comparable> mappingFunction) {
+    return new ArrayComparable(Arrays.stream(values).map(mappingFunction).toArray(Comparable[]::new));
+  }
+
+  public boolean isValueSameClass(ArrayComparable other) {
+    for (int i = 0; i < this.values.length; i++) {
+      if (this.values[i].getClass() != other.values[i].getClass()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int compareTo(ArrayComparable otherOrderingValue) {
+    ValidationUtils.checkArgument(values.length == otherOrderingValue.values.length, "The values should be of the same size");
+    for (int i = 0; i < values.length; i++) {
+      int comparingValue = values[i].compareTo(otherOrderingValue.values[i]);
+      if (comparingValue != 0) {
+        return comparingValue;
+      }
+    }
+    return 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArrayComparable that = (ArrayComparable) o;
+    if (values.length != that.values.length) {
+      return false;
+    }
+    for (int i = 0; i < values.length; i++) {
+      Comparable objComparable = values[i];
+      Comparable otherObjComparable = that.values[i];
+      if (objComparable == null && otherObjComparable == null) {
+        // if both are null continue
+        continue;
+      } else if (objComparable == null || otherObjComparable == null) {
+        // One comparable is null while other is not null
+        return false;
+      } else if (!objComparable.equals(otherObjComparable)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values);
+  }
+
+  @Override
+  public String toString() {
+    return Arrays.toString(values);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1036,7 +1036,7 @@ public class HoodieTableMetadataUtil {
       readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(readerContext, writerSchemaOpt.get(), writerSchemaOpt.get(), Option.empty(), tableConfig, properties));
       HoodieReadStats readStats = new HoodieReadStats();
       KeyBasedFileGroupRecordBuffer<T> recordBuffer = new KeyBasedFileGroupRecordBuffer<>(readerContext, datasetMetaClient,
-          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, Option.ofNullable(tableConfig.getPreCombineField()),
+          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, tableConfig.getPreCombineFields(),
           UpdateProcessor.create(readStats, readerContext, true, Option.empty()));
 
       // CRITICAL: Ensure allowInflightInstants is set to true

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -248,9 +249,11 @@ public abstract class SchemaHandlerTestBase {
     when(hoodieTableConfig.populateMetaFields()).thenReturn(true);
     when(hoodieTableConfig.getRecordMergeMode()).thenReturn(mergeMode);
     if (hasPrecombine) {
-      when(hoodieTableConfig.getPreCombineField()).thenReturn("timestamp");
+      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.of("timestamp"));
+      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.singletonList("timestamp"));
     } else {
-      when(hoodieTableConfig.getPreCombineField()).thenReturn(null);
+      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
+      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.emptyList());
     }
     if (mergeMode == CUSTOM) {
       when(hoodieTableConfig.getRecordMergeStrategyId()).thenReturn("asdf");

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
@@ -192,7 +192,8 @@ public class TestFileGroupReaderSchemaHandler extends SchemaHandlerTestBase {
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
     when(tableConfig.getRecordMergeMode()).thenReturn(mergeMode);
     when(tableConfig.populateMetaFields()).thenReturn(true);
-    when(tableConfig.getPreCombineField()).thenReturn(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING);
+    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.of(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING));
+    when(tableConfig.getPreCombineFields()).thenReturn(setPrecombine ? Collections.singletonList(preCombineField) : Collections.emptyList());
     when(tableConfig.getTableVersion()).thenReturn(tableVersion);
     if (tableConfig.getTableVersion() == HoodieTableVersion.SIX) {
       if (mergeMode == RecordMergeMode.EVENT_TIME_ORDERING) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -33,8 +33,10 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.serialization.DefaultSerializer;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -49,6 +51,7 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
@@ -76,6 +79,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -175,6 +179,48 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
 
       // Three commits; reading one file group containing a base file and two log files
       List<HoodieRecord> updates2 = dataGen.generateUniqueUpdates("003", 100);
+      List<HoodieRecord> finalRecords = mergeRecordLists(updates2, allRecords);
+      commitToTable(updates2, UPSERT.value(), false, writeConfigs);
+      validateOutputFromFileGroupReader(
+          getStorageConf(), getBasePath(), true, 2, recordMergeMode,
+          finalRecords, CollectionUtils.combine(unmergedRecords, updates2));
+    }
+  }
+
+  @Test
+  public void testReadFileGroupWithMultipleOrderingFields() throws Exception {
+    RecordMergeMode recordMergeMode = RecordMergeMode.EVENT_TIME_ORDERING;
+    Map<String, String> writeConfigs = new HashMap<>(getCommonConfigs(recordMergeMode, true));
+    writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "avro");
+    writeConfigs.put("hoodie.datasource.write.table.type", HoodieTableType.MERGE_ON_READ.name());
+    // Use two precombine values - combination of timestamp and rider
+    String orderingValues = "timestamp,rider";
+    writeConfigs.put("hoodie.datasource.write.precombine.field", orderingValues);
+    writeConfigs.put("hoodie.payload.ordering.field", orderingValues);
+
+    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
+      // Initial commit. rider column gets value of rider-002
+      List<HoodieRecord> initialRecords = dataGen.generateInserts("002", 100);
+      commitToTable(initialRecords, INSERT.value(), true, writeConfigs);
+      validateOutputFromFileGroupReader(
+          getStorageConf(), getBasePath(), true, 0, recordMergeMode,
+          initialRecords, initialRecords);
+
+      // The updates have rider values as rider-001 and the existing records have rider values as rider-002
+      // timestamp is 0 for all records so will not be considered
+      // All updates in this batch will be ignored as rider values are smaller and timestamp value is same
+      List<HoodieRecord> updates = dataGen.generateUniqueUpdates("001", 5);
+      List<HoodieRecord> allRecords = initialRecords;
+      List<HoodieRecord> unmergedRecords = CollectionUtils.combine(updates, allRecords);
+      commitToTable(updates, UPSERT.value(), false, writeConfigs);
+      validateOutputFromFileGroupReader(
+          getStorageConf(), getBasePath(), true, 1, recordMergeMode,
+          allRecords, unmergedRecords);
+
+      // The updates have rider values as rider-003 and the existing records have rider values as rider-002
+      // timestamp is 0 for all records so will not be considered
+      // All updates in this batch will reflect in the final records
+      List<HoodieRecord> updates2 = dataGen.generateUniqueUpdates("003", 10);
       List<HoodieRecord> finalRecords = mergeRecordLists(updates2, allRecords);
       commitToTable(updates2, UPSERT.value(), false, writeConfigs);
       validateOutputFromFileGroupReader(
@@ -466,6 +512,12 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     List<HoodieTestDataGenerator.RecordIdentifier> expectedUnMergedRecords = new ArrayList<>();
     objectMapper.reader().forType(HoodieTestDataGenerator.RecordIdentifier.class).<HoodieTestDataGenerator.RecordIdentifier>readValues(basePath.resolve("unmerged_records.json").toFile())
         .forEachRemaining(expectedUnMergedRecords::add);
+    expectedRecords = expectedRecords.stream()
+        .map(recordIdentifier -> HoodieTestDataGenerator.RecordIdentifier.clone(recordIdentifier, recordIdentifier.getOrderingVal()))
+        .collect(Collectors.toList());
+    expectedUnMergedRecords = expectedUnMergedRecords.stream()
+        .map(recordIdentifier -> HoodieTestDataGenerator.RecordIdentifier.clone(recordIdentifier, recordIdentifier.getOrderingVal()))
+        .collect(Collectors.toList());
     validateOutputFromFileGroupReaderWithExistingRecords(getStorageConf(), basePath.toString(), true, 1, RecordMergeMode.EVENT_TIME_ORDERING,
         expectedRecords, expectedUnMergedRecords);
   }
@@ -491,7 +543,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
           for (T record : records) {
             String recordKey = readerContext.getRecordKey(record, avroSchema);
             //test key based
-            BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(record, avroSchema, readerContext, Option.of("timestamp"), false);
+            BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(record, avroSchema, readerContext, Collections.singletonList("timestamp"), false);
             spillableMap.put(recordKey, bufferedRecord.toBinary(readerContext));
 
             //test position based
@@ -596,11 +648,28 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
                                                  List<HoodieRecord> expectedHoodieUnmergedRecords) throws Exception {
     HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storageConf, tablePath);
     Schema avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    expectedHoodieRecords = getExpectedHoodieRecordsWithOrderingValue(expectedHoodieRecords, metaClient, avroSchema);
+    expectedHoodieUnmergedRecords = getExpectedHoodieRecordsWithOrderingValue(expectedHoodieUnmergedRecords, metaClient, avroSchema);
     List<HoodieTestDataGenerator.RecordIdentifier> expectedRecords = convertHoodieRecords(expectedHoodieRecords, avroSchema);
     List<HoodieTestDataGenerator.RecordIdentifier> expectedUnmergedRecords = convertHoodieRecords(expectedHoodieUnmergedRecords, avroSchema);
     validateOutputFromFileGroupReaderWithExistingRecords(
         storageConf, tablePath, containsBaseFile, expectedLogFileNum, recordMergeMode,
         expectedRecords, expectedUnmergedRecords);
+  }
+
+  private static List<HoodieRecord> getExpectedHoodieRecordsWithOrderingValue(List<HoodieRecord> expectedHoodieRecords, HoodieTableMetaClient metaClient, Schema avroSchema) {
+    return expectedHoodieRecords.stream().map(rec -> {
+      RawTripTestPayload oldPayload = (RawTripTestPayload) rec.getData();
+      try {
+        List<String> orderingFields = metaClient.getTableConfig().getPreCombineFields();
+        HoodieAvroRecord avroRecord = ((HoodieAvroRecord) rec);
+        Comparable orderingValue = OrderingValues.create(orderingFields, field -> (Comparable) avroRecord.getColumnValueAsJava(avroSchema, field, new TypedProperties()));
+        RawTripTestPayload newPayload = new RawTripTestPayload(Option.ofNullable(oldPayload.getJsonData()), oldPayload.getRowKey(), oldPayload.getPartitionPath(), null, false, orderingValue);
+        return new HoodieAvroRecord<>(rec.getKey(), newPayload);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toList());
   }
 
   private void validateOutputFromFileGroupReaderWithExistingRecords(StorageConfiguration<?> storageConf,
@@ -618,20 +687,20 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     boolean sortOutput = !containsBaseFile;
     List<HoodieTestDataGenerator.RecordIdentifier> actualRecordList = convertEngineRecords(
         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, false, sortOutput),
-        avroSchema, readerContext);
+        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
     // validate size is equivalent to ensure no duplicates are returned
     assertEquals(expectedRecords.size(), actualRecordList.size());
     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
     // validate records can be read from file group as HoodieRecords
     actualRecordList = convertHoodieRecords(
         readHoodieRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode),
-        avroSchema, readerContext);
+        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
     assertEquals(expectedRecords.size(), actualRecordList.size());
     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
     // validate unmerged records
     actualRecordList = convertEngineRecords(
         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, true, false),
-        avroSchema, readerContext);
+        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
     assertEquals(expectedUnmergedRecords.size(), actualRecordList.size());
     assertEquals(new HashSet<>(expectedUnmergedRecords), new HashSet<>(actualRecordList));
   }
@@ -767,8 +836,8 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
 
   private TypedProperties buildProperties(HoodieTableMetaClient metaClient, RecordMergeMode recordMergeMode) {
     TypedProperties props = new TypedProperties();
-    props.setProperty("hoodie.datasource.write.precombine.field", PRECOMBINE_FIELD_NAME);
-    props.setProperty("hoodie.payload.ordering.field", PRECOMBINE_FIELD_NAME);
+    props.setProperty("hoodie.datasource.write.precombine.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
+    props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
     props.setProperty(RECORD_MERGE_MODE.key(), recordMergeMode.name());
     if (recordMergeMode.equals(RecordMergeMode.CUSTOM)) {
       props.setProperty(RECORD_MERGE_STRATEGY_ID.key(), PAYLOAD_BASED_MERGE_STRATEGY_UUID);
@@ -815,22 +884,27 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     }).collect(Collectors.toList());
   }
 
-  private List<HoodieTestDataGenerator.RecordIdentifier> convertEngineRecords(List<T> records, Schema schema, HoodieReaderContext<T> readerContext) {
+  private List<HoodieTestDataGenerator.RecordIdentifier> convertEngineRecords(List<T> records, Schema schema, HoodieReaderContext<T> readerContext, List<String> preCombineFields) {
     return records.stream()
         .map(record -> new HoodieTestDataGenerator.RecordIdentifier(
             readerContext.getValue(record, schema, KEY_FIELD_NAME).toString(),
             readerContext.getValue(record, schema, PARTITION_FIELD_NAME).toString(),
-            readerContext.getValue(record, schema, PRECOMBINE_FIELD_NAME).toString(),
+            OrderingValues.create(preCombineFields,
+                    field -> (Comparable) readerContext.getValue(record, schema, field))
+                .toString(),
             readerContext.getValue(record, schema, RIDER_FIELD_NAME).toString()))
         .collect(Collectors.toList());
   }
 
-  private List<HoodieTestDataGenerator.RecordIdentifier> convertHoodieRecords(List<HoodieRecord<T>> records, Schema schema, HoodieReaderContext<T> readerContext) {
+  private List<HoodieTestDataGenerator.RecordIdentifier> convertHoodieRecords(List<HoodieRecord<T>> records, Schema schema, HoodieReaderContext<T> readerContext,
+                                                                              List<String> preCombineFields) {
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.datasource.write.precombine.field", String.join(",", preCombineFields));
     return records.stream()
         .map(record -> new HoodieTestDataGenerator.RecordIdentifier(
             record.getRecordKey(),
             removeHiveStylePartition(record.getPartitionPath()),
-            record.getOrderingValue(schema, new TypedProperties()).toString(),
+            record.getOrderingValue(schema, props).toString(),
             readerContext.getValue(record.getData(), schema, RIDER_FIELD_NAME).toString()))
         .collect(Collectors.toList());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
@@ -89,7 +89,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
     KeyBasedFileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer = buildKeyBasedFileGroupRecordBuffer(readerContext, tableConfig, readStats, null,
-        RecordMergeMode.EVENT_TIME_ORDERING, Option.of("ts"), Option.of(Pair.of("counter", "3")));
+        RecordMergeMode.EVENT_TIME_ORDERING, Collections.singletonList("ts"), Option.of(Pair.of("counter", "3")));
 
     fileGroupRecordBuffer.setBaseFileIterator(ClosableIterator.wrap(Arrays.asList(testRecord1, testRecord2, testRecord3).iterator()));
 
@@ -116,7 +116,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
     KeyBasedFileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer = buildKeyBasedFileGroupRecordBuffer(readerContext, tableConfig, readStats, null,
-        RecordMergeMode.EVENT_TIME_ORDERING, Option.of("ts"), Option.of(Pair.of("counter", "3")));
+        RecordMergeMode.EVENT_TIME_ORDERING, Collections.singletonList("ts"), Option.of(Pair.of("counter", "3")));
 
     fileGroupRecordBuffer.setBaseFileIterator(ClosableIterator.wrap(Arrays.asList(testRecord1, testRecord2, testRecord3).iterator()));
 
@@ -151,7 +151,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
     KeyBasedFileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer = buildKeyBasedFileGroupRecordBuffer(readerContext, tableConfig, readStats, null,
-        RecordMergeMode.COMMIT_TIME_ORDERING, Option.empty(), Option.of(Pair.of("counter", "3")));
+        RecordMergeMode.COMMIT_TIME_ORDERING, Collections.emptyList(), Option.of(Pair.of("counter", "3")));
 
     fileGroupRecordBuffer.setBaseFileIterator(ClosableIterator.wrap(Arrays.asList(testRecord1, testRecord2, testRecord3).iterator()));
 
@@ -182,7 +182,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
     KeyBasedFileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer = buildKeyBasedFileGroupRecordBuffer(readerContext, tableConfig, readStats, new HoodieAvroRecordMerger(),
-        RecordMergeMode.CUSTOM, Option.empty(), Option.empty());
+        RecordMergeMode.CUSTOM, Collections.emptyList(), Option.empty());
 
     fileGroupRecordBuffer.setBaseFileIterator(ClosableIterator.wrap(Arrays.asList(testRecord1, testRecord2, testRecord3, testRecord4).iterator()));
 
@@ -219,7 +219,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
     KeyBasedFileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer = buildKeyBasedFileGroupRecordBuffer(readerContext, tableConfig, readStats, new CustomMerger(),
-        RecordMergeMode.CUSTOM, Option.empty(), Option.empty());
+        RecordMergeMode.CUSTOM, Collections.emptyList(), Option.empty());
 
     fileGroupRecordBuffer.setBaseFileIterator(ClosableIterator.wrap(Arrays.asList(testRecord1, testRecord2, testRecord3, testRecord4).iterator()));
 
@@ -260,7 +260,7 @@ class TestKeyBasedFileGroupRecordBuffer {
                                                                                                  HoodieReadStats readStats,
                                                                                                  HoodieRecordMerger recordMerger,
                                                                                                  RecordMergeMode recordMergeMode,
-                                                                                                 Option<String> orderingFieldName,
+                                                                                                 List<String> orderingFieldNames,
                                                                                                  Option<Pair<String, String>> deleteMarkerKeyValue) {
 
     readerContext.setRecordMerger(Option.ofNullable(recordMerger));
@@ -275,7 +275,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     TypedProperties props = new TypedProperties();
     UpdateProcessor<IndexedRecord> updateProcessor = UpdateProcessor.create(readStats, readerContext, false, Option.empty());
     return new KeyBasedFileGroupRecordBuffer<>(
-        readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, orderingFieldName, updateProcessor);
+        readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, orderingFieldNames, updateProcessor);
   }
 
   private static List<IndexedRecord> getActualRecords(FileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestReusableKeyBasedRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestReusableKeyBasedRecordBuffer.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ class TestReusableKeyBasedRecordBuffer {
     when(mockReaderContext.seal(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     ReusableKeyBasedRecordBuffer<TestRecord> buffer = new ReusableKeyBasedRecordBuffer<>(mockReaderContext, metaClient,
-        RecordMergeMode.EVENT_TIME_ORDERING, PartialUpdateMode.NONE, new TypedProperties(), Option.of("value"), updateProcessor, preMergedLogRecords);
+        RecordMergeMode.EVENT_TIME_ORDERING, PartialUpdateMode.NONE, new TypedProperties(), Collections.singletonList("value"), updateProcessor, preMergedLogRecords);
 
     List<TestRecord> baseFileRecords = Arrays.asList(new TestRecord("1", 10), new TestRecord("3", 30));
     buffer.setBaseFileIterator(ClosableIterator.wrap(baseFileRecords.iterator()));

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
@@ -130,7 +130,7 @@ class TestSortedKeyBasedFileGroupRecordBuffer {
     TypedProperties props = new TypedProperties();
     UpdateProcessor<TestRecord> updateProcessor = UpdateProcessor.create(readStats, mockReaderContext, false, Option.empty());
     return new SortedKeyBasedFileGroupRecordBuffer<>(
-        mockReaderContext, mockMetaClient, recordMergeMode, partialUpdateMode, props, Option.empty(), updateProcessor);
+        mockReaderContext, mockMetaClient, recordMergeMode, partialUpdateMode, props, Collections.emptyList(), updateProcessor);
   }
 
   private static List<TestRecord> getActualRecords(SortedKeyBasedFileGroupRecordBuffer<TestRecord> fileGroupRecordBuffer) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
@@ -68,7 +68,7 @@ public class HoodieAdaptablePayloadDataGenerator {
     props.put("hoodie.datasource.write.precombine.field", orderingField);
     props.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id");
     props.put(HoodieTableConfig.PARTITION_FIELDS.key(), "pt");
-    props.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), orderingField);
+    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), orderingField);
     return props;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -1247,13 +1247,18 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
       this.riderValue = riderValue;
     }
 
+    public static RecordIdentifier clone(RecordIdentifier toClone, String orderingVal) {
+      return new RecordIdentifier(toClone.recordKey, toClone.partitionPath, orderingVal, toClone.riderValue);
+    }
+
     public static RecordIdentifier fromTripTestPayload(RawTripTestPayload payload) {
       try {
         String recordKey = payload.getRowKey();
         String partitionPath = payload.getPartitionPath();
-        String orderingVal = payload.getOrderingValue().toString();
+        Comparable orderingValue = payload.getOrderingValue();
+        String orderingValStr = orderingValue.toString();
         String riderValue = payload.getJsonDataAsMap().getOrDefault("rider", "").toString();
-        return new RecordIdentifier(recordKey, partitionPath, orderingVal, riderValue);
+        return new RecordIdentifier(recordKey, partitionPath, orderingValStr, riderValue);
       } catch (IOException ex) {
         throw new HoodieIOException("Failed to parse payload", ex);
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 
 public class PreCombineTestUtils {
   private static String[] preCombineConfigs = new String[] {
-      HoodieTableConfig.PRECOMBINE_FIELD.key(),
+      HoodieTableConfig.PRECOMBINE_FIELDS.key(),
       "hoodie.datasource.write.precombine.field",
       HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY
   };

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
@@ -179,7 +179,7 @@ public class RawTripTestPayload implements HoodieRecordPayload<RawTripTestPayloa
       avroData.put("_hoodie_is_deleted", isDeleted);
       convertedRecords.add(
           createHoodieRecordFromAvro(avroData, DefaultHoodieRecordPayload.class.getName(),
-              "timestamp", Option.of(Pair.of("_row_key", "partition_path")),
+              new String[] {"timestamp"}, Option.of(Pair.of("_row_key", "partition_path")),
               false, Option.empty(), false, Option.of(AVRO_SCHEMA)));
     }
     return convertedRecords;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -115,9 +115,9 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .defaultValue("ts")
       .withFallbackKeys("write.precombine.field", HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key())
-      .withDescription("Field used in preCombining before actual write. When two records have the same\n"
+      .withDescription("Comma separated list of fields used in preCombining before actual write. When two records have the same\n"
           + "key value, we will pick the one with the largest value for the precombine field,\n"
-          + "determined by Object.compareTo(..)");
+          + "determined by Object.compareTo(..). For multiple fields if first key comparison is same, second key comparison is made and so on");
 
   @AdvancedConfig
   public static final ConfigOption<String> PAYLOAD_CLASS_NAME = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -117,9 +117,9 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
               && !conf.contains(FlinkOptions.RECORD_KEY_FIELD)) {
             conf.set(FlinkOptions.RECORD_KEY_FIELD, tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
           }
-          if (tableConfig.contains(HoodieTableConfig.PRECOMBINE_FIELD)
+          if (tableConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)
               && !conf.contains(FlinkOptions.PRECOMBINE_FIELD)) {
-            conf.set(FlinkOptions.PRECOMBINE_FIELD, tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD));
+            conf.set(FlinkOptions.PRECOMBINE_FIELD, tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
           }
           if (tableConfig.contains(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE)
               && !conf.contains(FlinkOptions.HIVE_STYLE_PARTITIONING)) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -101,7 +101,7 @@ public class CompactionUtil {
    * @param conf The configuration
    */
   public static void setPreCombineField(Configuration conf, HoodieTableMetaClient metaClient) {
-    String preCombineField = metaClient.getTableConfig().getPreCombineField();
+    String preCombineField = metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null);
     if (preCombineField != null) {
       conf.set(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -175,7 +175,7 @@ public class StreamerUtil {
   public static HoodiePayloadConfig getPayloadConfig(Configuration conf) {
     return HoodiePayloadConfig.newBuilder()
         .withPayloadClass(conf.get(FlinkOptions.PAYLOAD_CLASS_NAME))
-        .withPayloadOrderingField(conf.get(FlinkOptions.PRECOMBINE_FIELD))
+        .withPayloadOrderingFields(conf.get(FlinkOptions.PRECOMBINE_FIELD))
         .withPayloadEventTimeField(conf.get(FlinkOptions.PRECOMBINE_FIELD))
         .build();
   }
@@ -296,7 +296,7 @@ public class StreamerUtil {
           .setPayloadClassName(getPayloadClass(conf))
           .setDatabaseName(conf.get(FlinkOptions.DATABASE_NAME))
           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD.key(), null))
-          .setPreCombineField(OptionsResolver.getPreCombineField(conf))
+          .setPreCombineFields(OptionsResolver.getPreCombineField(conf))
           .setArchiveLogFolder(TIMELINE_HISTORY_PATH.defaultValue())
           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD.key(), null))
           .setKeyGeneratorClassProp(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -68,7 +69,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
@@ -140,6 +140,7 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
   @Override
   public void commitToTable(List<HoodieRecord> recordList, String operation, boolean firstCommit, Map<String, String> writeConfigs, String schemaStr) {
     writeConfigs.forEach((key, value) -> conf.setString(key, value));
+    conf.set(FlinkOptions.PRECOMBINE_FIELD, writeConfigs.get("hoodie.datasource.write.precombine.field"));
     conf.set(FlinkOptions.OPERATION, operation);
     Schema localSchema = getRecordAvroSchema(schemaStr);
     conf.set(FlinkOptions.SOURCE_AVRO_SCHEMA, localSchema.toString());
@@ -210,8 +211,8 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
         .optionalLong("ts")
         .endRecord();
     GenericRowData rowData = GenericRowData.of(StringData.fromString("f1"), StringData.fromString("f2"), 1000L);
-    assertEquals(1000L, readerContext.getOrderingValue(rowData, schema, Option.of("ts")));
-    assertEquals(DEFAULT_ORDERING_VALUE, readerContext.getOrderingValue(rowData, schema, Option.of("non_existent_col")));
+    assertEquals(1000L, readerContext.getOrderingValue(rowData, schema, Collections.singletonList("ts")));
+    assertEquals(OrderingValues.getDefault(), readerContext.getOrderingValue(rowData, schema, Collections.singletonList("non_existent_col")));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -86,7 +86,7 @@ class TestStreamerUtil {
     assertTrue(metaClient1.getTableConfig().getPartitionFields().isPresent(),
         "Missing partition columns in the hoodie.properties.");
     assertArrayEquals(metaClient1.getTableConfig().getPartitionFields().get(), new String[] {"p0", "p1"});
-    assertEquals(metaClient1.getTableConfig().getPreCombineField(), "ts");
+    assertEquals(metaClient1.getTableConfig().getPreCombineFieldsStr().get(), "ts");
     assertEquals(metaClient1.getTableConfig().getKeyGeneratorClassName(), SimpleAvroKeyGenerator.class.getName());
     assertEquals(HoodieTableVersion.current(), metaClient1.getTableConfig().getTableVersion());
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -45,6 +46,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -113,7 +115,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   void testUpdate() throws IOException {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
-    updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "new_field");
+    updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field");
     HoodieTableConfig.update(storage, metaPath, updatedProps);
 
     assertTrue(storage.exists(cfgPath));
@@ -121,7 +123,8 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
     assertEquals(8, config.getProps().size());
     assertEquals("test-table2", config.getTableName());
-    assertEquals("new_field", config.getPreCombineField());
+    assertEquals(Collections.singletonList("new_field"), config.getPreCombineFields());
+    assertEquals(Option.of("new_field"), config.getPreCombineFieldsStr());
   }
 
   @Test
@@ -211,7 +214,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
       for (int i = 0; i < 100; i++) {
         Properties updatedProps = new Properties();
         updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table" + i);
-        updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "new_field" + i);
+        updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field" + i);
         HoodieTableConfig.update(storage, metaPath, updatedProps);
       }
     });

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -204,7 +204,7 @@ class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     Properties props = new Properties();
     props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
     props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
 
     HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
         .fromProperties(props)
@@ -218,7 +218,7 @@ class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
     // test table name and type and precombine field also match
     assertEquals(metaClient1.getTableConfig().getTableName(), metaClient2.getTableConfig().getTableName());
     assertEquals(metaClient1.getTableConfig().getTableType(), metaClient2.getTableConfig().getTableType());
-    assertEquals(metaClient1.getTableConfig().getPreCombineField(), metaClient2.getTableConfig().getPreCombineField());
+    assertEquals(metaClient1.getTableConfig().getPreCombineFields(), metaClient2.getTableConfig().getPreCombineFields());
     // default table version should be current version
     assertEquals(HoodieTableVersion.current(), metaClient2.getTableConfig().getTableVersion());
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomBufferedRecordMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomBufferedRecordMerger.java
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
 import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.AVRO;
-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
@@ -67,7 +67,7 @@ public class TestCustomBufferedRecordMerger extends HoodieFileGroupReaderTestHar
     Properties metaProps = super.getMetaProps();
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name());
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), CustomAvroMerger.KEEP_CERTAIN_TIMESTAMP_VALUE_ONLY);
-    metaProps.setProperty(PRECOMBINE_FIELD.key(), "timestamp");
+    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
     return metaProps;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
 import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
@@ -58,7 +58,7 @@ public class TestEventTimeMerging extends HoodieFileGroupReaderTestHarness {
   protected Properties getMetaProps() {
     Properties metaProps =  super.getMetaProps();
     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.EVENT_TIME_ORDERING.name());
-    metaProps.setProperty(PRECOMBINE_FIELD.key(), "timestamp");
+    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
     return metaProps;
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestArrayComparables.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestArrayComparables.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.apache.hudi.common.util.OrderingValues;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ArrayComparable}.
+ */
+public class TestArrayComparables {
+
+  @Test
+  void testApply() {
+    ArrayComparable original = new ArrayComparable(new Comparable[] {1, 2, 3});
+    ArrayComparable transformed = original.apply(val -> (Integer) val * 2);
+
+    ArrayComparable expected = new ArrayComparable(new Comparable[] {2, 4, 6});
+    assertEquals(expected, transformed, "The new instance should have the transformed values.");
+    assertNotEquals(original, transformed, "The original instance should not be mutated.");
+  }
+
+  @Test
+  void testIsValueSameClass() {
+    ArrayComparable a = new ArrayComparable(new Comparable[] {1, "a"});
+    ArrayComparable b = new ArrayComparable(new Comparable[] {2, "b"});
+    assertTrue(a.isValueSameClass(b));
+  }
+
+  @Test
+  void testCompareTo() {
+    ArrayComparable arrayComparable = new ArrayComparable(new Comparable[] {"a", 1, 3.0});
+    ArrayComparable arrayComparableCopy = new ArrayComparable(new Comparable[] {"a", 1, 3.0});
+
+    // Identical objects should compare to 0
+    assertEquals(0, arrayComparable.compareTo(arrayComparableCopy));
+
+    // First element is smaller
+    assertTrue(arrayComparable.compareTo(new ArrayComparable(new Comparable[] {"b", 2, 4.0})) < 0);
+    // Third element is smaller
+    assertTrue(arrayComparable.compareTo(new ArrayComparable(new Comparable[] {"a", 1, 5.0})) < 0);
+    // Second element is larger
+    assertTrue(arrayComparable.compareTo(new ArrayComparable(new Comparable[] {"a", 0, 3.0})) > 0);
+  }
+
+  @Test
+  void testEquals() {
+    ArrayComparable arrayComparable = new ArrayComparable(new Comparable[] {"a", null, 3.0});
+    ArrayComparable arrayComparableCopy = new ArrayComparable(new Comparable[] {"a", null, 3.0});
+
+    // Identical objects should be equal
+    assertEquals(arrayComparable, arrayComparableCopy);
+
+    // Different length
+    assertNotEquals(arrayComparable, new ArrayComparable(new Comparable[] {"a", null}));
+
+    // Different class so can not be equal
+    assertNotEquals(OrderingValues.create(new Comparable[] {1}), new ArrayComparable(new Comparable[] {1}));
+    // Second element is null in original ArrayComparable object
+    assertNotEquals(new ArrayComparable(new Comparable[] {"a", 1, 3.0}), arrayComparable);
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.MetadataValues;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.hadoop.utils.HoodieArrayWritableAvroUtils;
 import org.apache.hudi.hadoop.utils.ObjectInspectorCache;
@@ -46,8 +47,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
-
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
 /**
  * {@link HoodieRecord} implementation for Hive records of {@link ArrayWritable}.
@@ -103,11 +102,12 @@ public class HoodieHiveRecord extends HoodieRecord<ArrayWritable> {
 
   @Override
   public Comparable<?> doGetOrderingValue(Schema recordSchema, Properties props) {
-    String orderingField = ConfigUtils.getOrderingField(props);
-    if (isNullOrEmpty(orderingField)) {
-      return DEFAULT_ORDERING_VALUE;
+    String[] orderingFields = ConfigUtils.getOrderingFields(props);
+    if (orderingFields == null) {
+      return OrderingValues.getDefault();
+    } else {
+      return OrderingValues.create(orderingFields, field -> (Comparable<?>) getValue(field));
     }
-    return (Comparable<?>) getValue(orderingField);
   }
 
   @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -90,8 +90,8 @@ public abstract class AbstractRealtimeRecordReader {
       metaClient = HoodieTableMetaClient.builder()
           .setConf(HadoopFSUtils.getStorageConfWithCopy(jobConf)).setBasePath(split.getBasePath()).build();
       payloadProps.putAll(metaClient.getTableConfig().getProps(true));
-      if (metaClient.getTableConfig().getPreCombineField() != null) {
-        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineField());
+      if (metaClient.getTableConfig().getPreCombineFieldsStr().isPresent()) {
+        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null));
       }
       this.usesCustomPayload = usesCustomPayload(metaClient);
       LOG.info("usesCustomPayload ==> " + this.usesCustomPayload);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
@@ -21,7 +21,6 @@ package org.apache.hudi.hadoop.realtime;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.UseFileSplitsFromInputFormat;
@@ -115,10 +114,7 @@ public class HoodieParquetRealtimeInputFormat extends HoodieParquetInputFormat {
           List<String> fieldsToAdd = new ArrayList<>();
           if (!realtimeSplit.getDeltaLogPaths().isEmpty()) {
             HoodieRealtimeInputFormatUtils.addVirtualKeysProjection(jobConf, realtimeSplit.getVirtualKeyInfo());
-            String preCombineKey = tableConfig.getPreCombineField();
-            if (!StringUtils.isNullOrEmpty(preCombineKey)) {
-              fieldsToAdd.add(preCombineKey);
-            }
+            fieldsToAdd.addAll(tableConfig.getPreCombineFields());
           }
 
           Option<String[]> partitions = tableConfig.getPartitionFields();

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieMultiWriterTestSuiteJob.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieMultiWriterTestSuiteJob.java
@@ -203,7 +203,7 @@ public class HoodieMultiWriterTestSuiteJob {
     tableConfig.enableHiveSync = globalConfig.enableHiveSync;
     tableConfig.enableMetaSync = globalConfig.enableMetaSync;
     tableConfig.schemaProviderClassName = globalConfig.schemaProviderClassName;
-    tableConfig.sourceOrderingField = globalConfig.sourceOrderingField;
+    tableConfig.sourceOrderingFields = globalConfig.sourceOrderingFields;
     tableConfig.sourceClassName = globalConfig.sourceClassName;
     tableConfig.tableType = globalConfig.tableType;
     tableConfig.targetTableName = globalConfig.targetTableName;

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteWriter.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieTestSuiteWriter.java
@@ -95,7 +95,7 @@ public abstract class HoodieTestSuiteWriter implements Serializable {
     HoodieWriteConfig.Builder builder =
         HoodieWriteConfig.newBuilder().combineInput(true, true).withPath(cfg.targetBasePath)
             .withPayloadConfig(HoodiePayloadConfig.newBuilder()
-                .withPayloadOrderingField(cfg.sourceOrderingField)
+                .withPayloadOrderingFields(cfg.sourceOrderingFields)
                 .withPayloadClass(cfg.payloadClassName)
                 .build())
             .forTable(cfg.targetTableName)

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/job/TestHoodieTestSuiteJob.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/job/TestHoodieTestSuiteJob.java
@@ -306,7 +306,7 @@ public class TestHoodieTestSuiteJob extends UtilitiesTestBase {
     cfg.targetTableName = "table1";
     cfg.tableType = tableType;
     cfg.sourceClassName = AvroDFSSource.class.getName();
-    cfg.sourceOrderingField = SchemaUtils.SOURCE_ORDERING_FIELD;
+    cfg.sourceOrderingFields = SchemaUtils.SOURCE_ORDERING_FIELD;
     cfg.propsFilePath = basePath + "/test-source.properties";
     cfg.outputTypeName = DeltaOutputMode.DFS.name();
     cfg.inputFormatName = DeltaInputType.AVRO.name();

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -180,13 +180,6 @@ public class ReflectionUtils {
   }
 
   /**
-   * Returns whether the given two comparable values come from the same runtime class.
-   */
-  public static boolean isSameClass(Comparable<?> v, Comparable<?> o) {
-    return v.getClass() == o.getClass();
-  }
-
-  /**
    * Invoke a static method of a class.
    * @param clazz
    * @param methodName

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -205,8 +205,8 @@ public class DataSourceUtils {
             // to realize the SQL functionality, so the write config needs to be fetched first.
             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
-            .withPayloadOrderingField(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
-                parameters.get(HoodieTableConfig.PRECOMBINE_FIELD)))
+            .withPayloadOrderingFields(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
+                parameters.get(HoodieTableConfig.PRECOMBINE_FIELDS)))
             .build())
         // override above with Hoodie configs specified as options.
         .withProps(parameters).build();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -135,8 +135,8 @@ class DefaultSource extends RelationProvider
       .setBasePath(tablePath).build()
 
     // Add preCombineField to options for buildReaderWithPartitionValues properly
-    val options = if (metaClient.getTableConfig.getPreCombineField != null) {
-      parameters ++ Map(HoodieTableConfig.PRECOMBINE_FIELD.key -> metaClient.getTableConfig.getPreCombineField)
+    val options = if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent) {
+      parameters ++ Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> metaClient.getTableConfig.getPreCombineFieldsStr.orElse(null))
     } else {
       parameters
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -81,7 +81,7 @@ case class HoodieTableSchema(structTypeSchema: StructType, avroSchemaStr: String
 case class HoodieTableState(tablePath: String,
                             latestCommitTimestamp: Option[String],
                             recordKeyField: String,
-                            preCombineFieldOpt: Option[String],
+                            preCombineFields: List[String],
                             usesVirtualKeys: Boolean,
                             recordPayloadClassName: String,
                             metadataConfig: HoodieMetadataConfig,
@@ -135,15 +135,16 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
       keyFields.head
     }
 
-  protected lazy val preCombineFieldOpt: Option[String] =
-    Option(tableConfig.getPreCombineField)
-      .orElse(optParams.get(DataSourceWriteOptions.PRECOMBINE_FIELD.key)) match {
-      // NOTE: This is required to compensate for cases when empty string is used to stub
-      //       property value to avoid it being set with the default value
-      // TODO(HUDI-3456) cleanup
-      case Some(f) if !StringUtils.isNullOrEmpty(f) => Some(f)
-      case _ => None
+  protected lazy val preCombineFields: List[String] = {
+    val tablePrecombineFields = tableConfig.getPreCombineFields
+    if (tablePrecombineFields.isEmpty) {
+      DataSourceOptionsHelper.getPreCombineFields(optParams)
+        .orElse(java.util.Collections.emptyList[String])
+        .asScala.toList
+    } else {
+      tablePrecombineFields.asScala.toList
     }
+  }
 
   protected lazy val specifiedQueryTimestamp: Option[String] =
     optParams.get(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT.key)
@@ -264,11 +265,10 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
   lazy val tableState: HoodieTableState = {
     val recordMergerImpls = optParams.get(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key()).map(impls => ConfigUtils.split2List(impls).asScala.toList).getOrElse(List.empty)
     // Subset of the state of table's configuration as of at the time of the query
-    HoodieTableState(
-      tablePath = basePath.toString,
+    HoodieTableState(tablePath = basePath.toString,
       latestCommitTimestamp = queryTimestamp,
       recordKeyField = recordKeyField,
-      preCombineFieldOpt = preCombineFieldOpt,
+      preCombineFields = preCombineFields,
       usesVirtualKeys = !tableConfig.populateMetaFields(),
       recordPayloadClassName = tableConfig.getPayloadClass,
       metadataConfig = fileIndex.metadataConfig,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapMORRelation.scala
@@ -64,7 +64,7 @@ case class HoodieBootstrapMORRelation(override val sqlContext: SQLContext,
   override type Relation = HoodieBootstrapMORRelation
 
   protected lazy val mandatoryFieldsForMerging: Seq[String] =
-    Seq(recordKeyField) ++ preCombineFieldOpt.map(Seq(_)).getOrElse(Seq())
+    Seq(recordKeyField) ++ preCombineFields
 
   override lazy val mandatoryFields: Seq[String] = mandatoryFieldsForMerging
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -529,7 +529,7 @@ object HoodieFileIndex extends Logging {
 
     if (tableConfig != null) {
       properties.setProperty(RECORDKEY_FIELD.key, tableConfig.getRecordKeyFields.orElse(Array.empty).mkString(","))
-      properties.setProperty(PRECOMBINE_FIELD.key, Option(tableConfig.getPreCombineField).getOrElse(""))
+      properties.setProperty(PRECOMBINE_FIELD.key, tableConfig.getPreCombineFieldsStr.orElse(""))
       properties.setProperty(PARTITIONPATH_FIELD.key, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(tableConfig).orElse(""))
 
       // for simple bucket index, we need to set the INDEX_TYPE, BUCKET_INDEX_HASH_FIELD, BUCKET_INDEX_NUM_BUCKETS

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -310,7 +310,7 @@ class HoodieSparkSqlWriterInternal {
           .setArchiveLogFolder(archiveLogFolder)
           // we can't fetch preCombine field from hoodieConfig object, since it falls back to "ts" as default value,
           // but we are interested in what user has set, hence fetching from optParams.
-          .setPreCombineField(optParams.getOrElse(PRECOMBINE_FIELD.key(), null))
+          .setPreCombineFields(optParams.getOrElse(PRECOMBINE_FIELD.key(), null))
           .setPartitionFields(partitionColumnsForKeyGenerator)
           .setPopulateMetaFields(populateMetaFields)
           .setRecordKeyFields(hoodieConfig.getString(RECORDKEY_FIELD))
@@ -772,7 +772,7 @@ class HoodieSparkSqlWriterInternal {
           .setPayloadClassName(payloadClass)
           .setRecordMergeMode(RecordMergeMode.getValue(hoodieConfig.getString(HoodieWriteConfig.RECORD_MERGE_MODE)))
           .setRecordMergeStrategyId(recordMergerStrategy)
-          .setPreCombineField(hoodieConfig.getStringOrDefault(PRECOMBINE_FIELD, null))
+          .setPreCombineFields(hoodieConfig.getStringOrDefault(PRECOMBINE_FIELD, null))
           .setBootstrapIndexClass(bootstrapIndexClass)
           .setBaseFileFormat(baseFileFormat)
           .setBootstrapBasePath(bootstrapBasePath)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -248,7 +248,7 @@ object HoodieWriterUtils {
         }
 
         val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
-        val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD)
+        val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS)
         if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey && datasourcePreCombineKey != tableConfigPreCombineKey) {
           diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
         }
@@ -340,7 +340,7 @@ object HoodieWriterUtils {
   private val sparkDatasourceConfigsToTableConfigsMap = Map(
     TABLE_NAME -> HoodieTableConfig.NAME,
     TABLE_TYPE -> HoodieTableConfig.TYPE,
-    PRECOMBINE_FIELD -> HoodieTableConfig.PRECOMBINE_FIELD,
+    PRECOMBINE_FIELD -> HoodieTableConfig.PRECOMBINE_FIELDS,
     PARTITIONPATH_FIELD -> HoodieTableConfig.PARTITION_FIELDS,
     RECORDKEY_FIELD -> HoodieTableConfig.RECORDKEY_FIELDS,
     PAYLOAD_CLASS_NAME -> HoodieTableConfig.PAYLOAD_CLASS_NAME,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
@@ -86,14 +86,14 @@ class LogFileIterator(logFiles: List[HoodieLogFile],
   }
   private val maxCompactionMemoryInBytes: Long = getMaxCompactionMemoryInBytes(new JobConf(config))
 
-  protected val payloadProps: TypedProperties = tableState.preCombineFieldOpt
-    .map { preCombineField =>
-      HoodiePayloadConfig.newBuilder
-        .withPayloadOrderingField(preCombineField)
-        .build
-        .getProps
-    }
-    .getOrElse(new TypedProperties())
+  protected val payloadProps: TypedProperties = if (tableState.preCombineFields.nonEmpty) {
+    HoodiePayloadConfig.newBuilder
+      .withPayloadOrderingFields(String.join(",", tableState.preCombineFields: _*))
+      .build
+      .getProps
+  } else {
+    new TypedProperties()
+  }
 
   protected override val avroSchema: Schema = requiredAvroSchema
   protected override val structTypeSchema: StructType = requiredStructTypeSchema

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
@@ -250,8 +250,7 @@ trait HoodieIncrementalRelationV1Trait extends HoodieBaseRelation {
   override lazy val mandatoryFields: Seq[String] = {
     // NOTE: This columns are required for Incremental flow to be able to handle the rows properly, even in
     //       cases when no columns are requested to be fetched (for ex, when using {@code count()} API)
-    Seq(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD) ++
-      preCombineFieldOpt.map(Seq(_)).getOrElse(Seq())
+    Seq(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD) ++ preCombineFields
   }
 
   protected def validate(): Unit = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
@@ -246,8 +246,7 @@ trait HoodieIncrementalRelationV2Trait extends HoodieBaseRelation {
   override lazy val mandatoryFields: Seq[String] = {
     // NOTE: These columns are required for Incremental flow to be able to handle the rows properly, even in
     //       cases when no columns are requested to be fetched (for ex, when using {@code count()} API)
-    Seq(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD) ++
-      preCombineFieldOpt.map(Seq(_)).getOrElse(Seq())
+    Seq(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD) ++ preCombineFields
   }
 
   protected def validate(): Unit = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -92,7 +92,7 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
    *       by the query), therefore saving on throughput
    */
   protected lazy val mandatoryFieldsForMerging: Seq[String] =
-    Seq(recordKeyField) ++ preCombineFieldOpt.map(Seq(_)).getOrElse(Seq())
+    Seq(recordKeyField) ++ preCombineFields
 
   override lazy val mandatoryFields: Seq[String] = mandatoryFieldsForMerging
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -501,9 +501,8 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
       new FileGroupReaderSchemaHandler[InternalRow](readerContext, avroSchema, avroSchema,
         Option.empty(), metaClient.getTableConfig, readerProperties))
     val stats = new HoodieReadStats
-    val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient,
-      readerContext.getMergeMode, metaClient.getTableConfig.getPartialUpdateMode, readerProperties,
-      Option.ofNullable(metaClient.getTableConfig.getPreCombineField),
+    val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient, readerContext.getMergeMode,
+      metaClient.getTableConfig.getPartialUpdateMode, readerProperties, metaClient.getTableConfig.getPreCombineFields,
       UpdateProcessor.create(stats, readerContext, true, Option.empty()))
 
     HoodieMergedLogRecordReader.newBuilder[InternalRow]

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.hudi.{AvroConversionUtils, DataSourceOptionsHelper}
 import org.apache.hudi.DataSourceWriteOptions.OPERATION
+import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.HoodieWriterUtils._
 import org.apache.hudi.avro.AvroSchemaUtils
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, TypedProperties}
@@ -127,9 +128,9 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
   lazy val primaryKeys: Array[String] = tableConfig.getRecordKeyFields.orElse(Array.empty)
 
   /**
-   * PreCombine Field
+   * Comparables Field
    */
-  lazy val preCombineKey: Option[String] = Option(tableConfig.getPreCombineField)
+  lazy val preCombineKeys: java.util.List[String] = tableConfig.getPreCombineFields
 
   /**
    * Partition Fields

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -61,7 +61,7 @@ object HoodieOptionConfig {
   val SQL_KEY_PRECOMBINE_FIELD: HoodieSQLOption[String] = buildConf()
     .withSqlKey("preCombineField")
     .withHoodieKey(DataSourceWriteOptions.PRECOMBINE_FIELD.key)
-    .withTableConfigKey(HoodieTableConfig.PRECOMBINE_FIELD.key)
+    .withTableConfigKey(HoodieTableConfig.PRECOMBINE_FIELDS.key)
     .build()
 
   val SQL_PAYLOAD_CLASS: HoodieSQLOption[String] = buildConf()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -125,7 +125,7 @@ object CreateHoodieTableCommand {
       val originTableConfig = hoodieCatalogTable.tableConfig.getProps.asScala.toMap
       val tableOptions = hoodieCatalogTable.catalogProperties
 
-      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PRECOMBINE_FIELD.key)
+      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PRECOMBINE_FIELDS.key)
       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PARTITION_FIELDS.key)
       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.RECORDKEY_FIELDS.key)
       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
@@ -94,7 +94,7 @@ class TestProvidesHoodieConfig {
     // catalogProperties won't be passed in correctly, because they were not synced properly
     when(mockCatalog.catalogProperties).thenReturn(Map.empty[String, String])
     when(mockCatalog.partitionFields).thenReturn(Array("partition"))
-    when(mockCatalog.preCombineKey).thenCallRealMethod()
+    when(mockCatalog.preCombineKeys).thenCallRealMethod()
     when(mockCatalog.partitionSchema).thenReturn(StructType(Nil))
     when(mockCatalog.primaryKeys).thenReturn(Array("key"))
     when(mockCatalog.table).thenReturn(CatalogTable.apply(
@@ -103,7 +103,7 @@ class TestProvidesHoodieConfig {
       CatalogStorageFormat.empty,
       StructType(Nil)))
     val props = new TypedProperties()
-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key, "segment")
+    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key, "segment")
     val mockTableConfig = spy(classOf[HoodieTableConfig])
     when(mockTableConfig.getProps).thenReturn(props)
     when(mockCatalog.tableConfig).thenReturn(mockTableConfig)
@@ -140,7 +140,7 @@ class TestProvidesHoodieConfig {
 
     assertEquals(
       "segment",
-      combinedConfig.getOrElse(HoodieTableConfig.PRECOMBINE_FIELD.key, "")
+      combinedConfig.getOrElse(HoodieTableConfig.PRECOMBINE_FIELDS.key, "")
     )
 
     // write config precombine field should be inferred from table config

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -237,7 +237,7 @@ public class BootstrapExecutorUtils implements Serializable {
         .setTableName(cfg.tableName)
         .setTableVersion(bootstrapConfig.getWriteVersion())
         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
-        .setPreCombineField(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
+        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
         .setPopulateMetaFields(props.getBoolean(
             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
         .setArchiveLogFolder(props.getString(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.SPARK;
-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELD;
+import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -100,7 +100,7 @@ class TestDefaultSparkRecordMerger {
 
     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
     TypedProperties props = new TypedProperties();
-    props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
+    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
     Option<Pair<HoodieRecord, Schema>> merged =
@@ -127,7 +127,7 @@ class TestDefaultSparkRecordMerger {
 
     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
     TypedProperties props = new TypedProperties();
-    props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
+    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
     Option<Pair<HoodieRecord, Schema>> r =
@@ -151,7 +151,7 @@ class TestDefaultSparkRecordMerger {
 
     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
     TypedProperties props = new TypedProperties();
-    props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
+    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
     Option<Pair<HoodieRecord, Schema>> r =
@@ -172,7 +172,7 @@ class TestDefaultSparkRecordMerger {
 
     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
     TypedProperties props = new TypedProperties();
-    props.setProperty(PRECOMBINE_FIELD.key(), INT_COLUMN_NAME);
+    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
     Option<Pair<HoodieRecord, Schema>> r =

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
@@ -86,7 +86,7 @@ public class TestHoodieMergeHandleWithSparkMerger extends SparkClientFunctionalT
     properties.setProperty(
         HoodieTableConfig.BASE_FILE_FORMAT.key(),
         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "record_key");
+    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "record_key");
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(),"partition_path");
     properties.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "partition_path");
     metaClient = getHoodieMetaClient(storageConf(), basePath(), HoodieTableType.MERGE_ON_READ, properties);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -158,7 +158,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
         metaClient.getTableConfig().getPartialUpdateMode(),
         baseFileInstantTime,
         props,
-        Option.of("timestamp"),
+        Collections.singletonList("timestamp"),
         updateProcessor);
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -209,7 +209,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
     cleanupClients();
     Properties props = new Properties();
-    props.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
     initMetaClient(tableType, props);
     cleanupTimelineService();
     initTimelineService();
@@ -307,7 +307,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
     cleanupClients();
     Properties props = new Properties();
-    props.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
     initMetaClient(tableType, props);
     cleanupTimelineService();
     initTimelineService();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
@@ -220,7 +220,7 @@ public class TestColStatsRecordWithMetadataRecord extends HoodieSparkClientTestH
     while (itr.hasNext()) {
       GenericRecord genericRecord = (GenericRecord) ((HoodieRecord) itr.next()).getData();
       HoodieRecord<HoodieMetadataPayload> mdtRec = SpillableMapUtils.convertToHoodieRecordPayload(genericRecord,
-          mdtWriteConfig.getPayloadClass(), mdtWriteConfig.getPreCombineField(),
+          mdtWriteConfig.getPayloadClass(), mdtWriteConfig.getPreCombineFields().toArray(new String[0]),
           Pair.of(mdtMetaClient.getTableConfig().getRecordKeyFieldProp(), mdtMetaClient.getTableConfig().getPartitionFieldProp()),
           false, Option.of(COLUMN_STATS.getPartitionPath()), Option.empty());
       allRecords.add(mdtRec);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -435,7 +435,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     Triple<RecordMergeMode, String, String> inferredMergeConfs =
         HoodieTableConfig.inferCorrectMergingBehavior(
             writeConfig.getRecordMergeMode(), writeConfig.getPayloadClass(),
-            writeConfig.getRecordMergeStrategyId(), writeConfig.getPreCombineField(),
+            writeConfig.getRecordMergeStrategyId(), String.join(",", writeConfig.getPreCombineFields()),
             metaClient.getTableConfig().getTableVersion());
     HoodieTableConfig hoodieTableConfig =
         new HoodieTableConfig(this.storage, metaClient.getMetaPath(), inferredMergeConfs.getLeft(), inferredMergeConfs.getMiddle(), inferredMergeConfs.getRight());
@@ -458,7 +458,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     Triple<RecordMergeMode, String, String> inferredMergeConfs2 =
         HoodieTableConfig.inferCorrectMergingBehavior(
             writeConfig2.getRecordMergeMode(), writeConfig2.getPayloadClass(),
-            writeConfig2.getRecordMergeStrategyId(), writeConfig2.getPreCombineField(),
+            writeConfig2.getRecordMergeStrategyId(), String.join(",", writeConfig2.getPreCombineFields()),
             metaClient.getTableConfig().getTableVersion());
     HoodieTableConfig hoodieTableConfig2 =
         new HoodieTableConfig(this.storage, metaClient.getMetaPath(),

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
@@ -152,7 +152,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
         .withSchema(RawTripTestPayload.JSON_DATA_SCHEMA_STR)
         .withPayloadConfig(HoodiePayloadConfig.newBuilder()
             .withPayloadClass(RawTripTestPayload.class.getName())
-            .withPayloadOrderingField("number").build())
+            .withPayloadOrderingFields("number").build())
         .withRollbackUsingMarkers(rollbackUsingMarkers)
         .withIndexConfig(indexBuilder.build())
         .withMetadataConfig(metadataConfigBuilder.build())
@@ -180,7 +180,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
       properties.put("hoodie.datasource.write.partitionpath.field", "time");
       properties.put("hoodie.datasource.write.precombine.field", "number");
       properties.put(HoodieTableConfig.PARTITION_FIELDS.key(), "time");
-      properties.put(HoodieTableConfig.PRECOMBINE_FIELD.key(), "number");
+      properties.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "number");
     }
     return properties;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -270,7 +270,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
   @ValueSource(booleans = {true, false})
   public void testSimpleInsertUpdateAndDelete(boolean populateMetaFields) throws Exception {
     Properties properties = populateMetaFields ? new Properties() : getPropertiesForKeyGen();
-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "timestamp");
+    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
     HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
@@ -617,7 +617,7 @@ public class TestSparkNonBlockingConcurrencyControl extends SparkClientFunctiona
     props.put(ENABLE_SCHEMA_CONFLICT_RESOLUTION.key(), "false");
     String basePath = basePath();
     return HoodieWriteConfig.newBuilder()
-        .withProps(Collections.singletonMap(HoodieTableConfig.PRECOMBINE_FIELD.key(), "ts"))
+        .withProps(Collections.singletonMap(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts"))
         .forTable("test")
         .withPath(basePath)
         .withSchema(jsonSchema)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSourceDefaults.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSourceDefaults.scala
@@ -579,7 +579,7 @@ class TestDataSourceDefaults extends ScalaAssertionSupport {
   @Test def testDefaultHoodieRecordPayloadCombineAndGetUpdateValue(): Unit = {
     val fieldSchema: Schema = baseRecord.getSchema().getField("favoriteIntNumber").schema()
     val props = HoodiePayloadConfig.newBuilder()
-      .withPayloadOrderingField("favoriteIntNumber").build().getProps;
+      .withPayloadOrderingFields("favoriteIntNumber").build().getProps;
 
     val laterRecord = SchemaTestUtil
       .generateAvroRecordFromJson(schema, 2, "001", "f1")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -614,7 +614,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
-      .setPreCombineField(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
+      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieIndexConfig, HoodieWriteConfig}
-import org.apache.hudi.exception.{HoodieException, SchemaCompatibilityException}
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode
 import org.apache.hudi.functional.TestBootstrap
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -36,7 +36,6 @@ import org.apache.avro.Schema
 import org.apache.commons.io.FileUtils
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
-import org.apache.spark.sql.functions.{expr, lit}
 import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
@@ -486,7 +485,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
-      .setPreCombineField(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
+      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -29,7 +29,7 @@ import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderOnSpark.getFileCount
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
-import org.apache.hudi.common.util.{CollectionUtils, Option => HOption}
+import org.apache.hudi.common.util.{CollectionUtils, Option => HOption, OrderingValues}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.storage.{StorageConfiguration, StoragePath}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
@@ -53,6 +53,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.when
 
 import java.util
+import java.util.Collections
 
 import scala.collection.JavaConverters._
 
@@ -187,7 +188,7 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     testGetOrderingValue(
       sparkReaderContext, row, avroSchema, "col3", UTF8String.fromString("blue"))
     testGetOrderingValue(
-      sparkReaderContext, row, avroSchema, "non_existent_col", HoodieRecord.DEFAULT_ORDERING_VALUE)
+      sparkReaderContext, row, avroSchema, "non_existent_col", OrderingValues.getDefault)
   }
 
   val expectedEventTimeBased: Seq[(Int, String, String, String, Double, String)] = Seq(
@@ -300,8 +301,7 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
                                    avroSchema: Schema,
                                    orderingColumn: String,
                                    expectedOrderingValue: Comparable[_]): Unit = {
-    assertEquals(expectedOrderingValue, sparkReaderContext.getOrderingValue(
-      row, avroSchema, HOption.of(orderingColumn)))
+    assertEquals(expectedOrderingValue, sparkReaderContext.getOrderingValue(row, avroSchema, Collections.singletonList(orderingColumn)))
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -200,14 +200,14 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
         Map(HoodieTableConfig.VERSION.key -> HoodieTableVersion.SIX.versionCode().toString)
       } ++
       (if (hasPreCombineField && !isNullOrEmpty(precombineField)) {
-        Map(HoodieTableConfig.PRECOMBINE_FIELD.key -> precombineField)
+        Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> precombineField)
       } else {
         Map()
       })).asJava
     val nonExistentConfigs: java.util.List[String] = (if (hasPreCombineField) {
       Seq[String]()
     } else {
-      Seq(HoodieTableConfig.PRECOMBINE_FIELD.key)
+      Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
     }).asJava
     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
     val commit1CompletionTime = if (
@@ -1719,5 +1719,58 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertTrue(metadataPartitionExists(basePath, context, PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
     assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_NAME_SECONDARY_INDEX_PREFIX + secondaryIndexName2))
+  }
+
+  @Test
+  def testMultipleOrderingFields() {
+    val (writeOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.AVRO)
+
+    // Insert Operation
+    var records = recordsToStrings(dataGen.generateInserts("003", 100)).asScala.toList
+    var inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+
+    val commonOptsWithMultipleOrderingFields = writeOpts ++ Map(
+      DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp,rider",
+      DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.EVENT_TIME_ORDERING.name(),
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+    )
+    inputDF.write.format("hudi")
+      .options(commonOptsWithMultipleOrderingFields)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    records = recordsToStrings(dataGen.generateUniqueUpdates("002", 10)).asScala.toList
+    inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(commonOptsWithMultipleOrderingFields)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+    assertEquals(0, spark.read.format("org.apache.hudi").load(basePath).filter("rider = 'rider-002'").count())
+
+    records = recordsToStrings(dataGen.generateUniqueUpdates("004", 10)).asScala.toList
+    inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(commonOptsWithMultipleOrderingFields)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+    assertEquals(10, spark.read.format("org.apache.hudi").load(basePath).filter("rider = 'rider-004'").count())
+
+    records = recordsToStrings(dataGen.generateUniqueUpdates("001", 10)).asScala.toList
+    inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF = inputDF.withColumn("timestamp", lit(1))
+    inputDF.write.format("hudi")
+      .options(commonOptsWithMultipleOrderingFields)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+    assertEquals(10, spark.read.format("org.apache.hudi").load(basePath).filter("rider = 'rider-001'").count())
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
@@ -146,7 +146,7 @@ class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
         val properties = metaClient.getTableConfig.getProps.asScala.toMap
         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELD.key))
+        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
         assertResult(tableName)(metaClient.getTableConfig.getTableName)
         // Validate partition_stats index exists
         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_STATS.getPartitionPath))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.client.transaction.PreferWriterConflictResolutionStrategy
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model._
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, InProcessTimeGenerator}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
@@ -107,7 +107,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
       assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
       assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
     } else {
-      if (StringUtils.isNullOrEmpty(metaClient.getTableConfig.getPreCombineField)) {
+      if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent && StringUtils.isNullOrEmpty(metaClient.getTableConfig.getPreCombineFieldsStr.get())) {
         assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
         assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
         assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -42,7 +42,7 @@ class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
         HoodieTableMetaClient.newTableBuilder()
           .setTableType(tableType)
           .setTableName(s"test_stream_${tableType.name()}")
-          .setPreCombineField("timestamp")
+          .setPreCombineFields("timestamp")
           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
         val writeConfig = HoodieWriteConfig.newBuilder()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -60,7 +60,7 @@ class TestStreamingSource extends StreamTest {
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
-        .setPreCombineField("ts")
+        .setPreCombineFields("ts")
         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
       addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -111,7 +111,7 @@ class TestStreamingSource extends StreamTest {
         .setTableType(MERGE_ON_READ)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
-        .setPreCombineField("ts")
+        .setPreCombineFields("ts")
         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
       addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -156,7 +156,7 @@ class TestStreamingSource extends StreamTest {
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
-        .setPreCombineField("ts")
+        .setPreCombineFields("ts")
         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
       addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -187,7 +187,7 @@ class TestStreamingSource extends StreamTest {
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
-        .setPreCombineField("ts")
+        .setPreCombineFields("ts")
         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
       addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -220,7 +220,7 @@ class TestStreamingSource extends StreamTest {
           .setTableType(MERGE_ON_READ)
           .setTableName(getTableName(tablePath))
           .setRecordKeyFields("id")
-          .setPreCombineField("ts")
+          .setPreCombineFields("ts")
           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
         addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -265,7 +265,7 @@ class TestStreamingSource extends StreamTest {
           .setTableType(MERGE_ON_READ)
           .setTableName(getTableName(tablePath))
           .setRecordKeyFields("id")
-          .setPreCombineField("ts")
+          .setPreCombineFields("ts")
           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
         addData(tablePath, Seq(("1", "a1", "10", "000")))
@@ -304,7 +304,7 @@ class TestStreamingSource extends StreamTest {
         .setTableType(COPY_ON_WRITE)
         .setTableName(getTableName(tablePath))
         .setRecordKeyFields("id")
-        .setPreCombineField("ts")
+        .setPreCombineFields("ts")
         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
       addData(tablePath, Seq(("1", "a1", "10", "000")))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -28,6 +28,7 @@ import org.apache.hudi.common.table.log.HoodieLogFileReader
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock
 import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig, SyncableFileSystemView}
 import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.common.util.OrderingValues
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -438,7 +439,7 @@ object HoodieSparkSqlTestBase {
       val logBlock = logReader.next()
       if (logBlock.isInstanceOf[HoodieDeleteBlock]) {
         val deleteLogBlock = logBlock.asInstanceOf[HoodieDeleteBlock]
-        assertTrue(deleteLogBlock.getRecordsToDelete.forall(i => i.getOrderingValue() == 0 || i.getOrderingValue() == null))
+        assertTrue(deleteLogBlock.getRecordsToDelete.forall(i => i.getOrderingValue().equals(OrderingValues.getDefault) || i.getOrderingValue() == null))
         deleteLogBlockFound = true
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
@@ -59,7 +59,7 @@ class TestHoodieOptionConfig extends SparkClientFunctionalTestHarness {
 
     assertTrue(tableConfigs.size == 5)
     assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
-    assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELD.key) == "timestamp")
+    assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELDS.key) == "timestamp")
     assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
     assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
     assertTrue(tableConfigs("hoodie.compact.inline") == "true")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -139,7 +139,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
     assertResult(true)(tableConfig.contains(HoodieTableConfig.CREATE_SCHEMA.key))
     assertResult("dt")(tableConfig(HoodieTableConfig.PARTITION_FIELDS.key))
     assertResult("id")(tableConfig(HoodieTableConfig.RECORDKEY_FIELDS.key))
-    assertResult("ts")(tableConfig(HoodieTableConfig.PRECOMBINE_FIELD.key))
+    assertResult("ts")(tableConfig(HoodieTableConfig.PRECOMBINE_FIELDS.key))
     assertResult(KeyGeneratorType.SIMPLE.name())(tableConfig(HoodieTableConfig.KEY_GENERATOR_TYPE.key))
     assertResult("default")(tableConfig(HoodieTableConfig.DATABASE_NAME.key()))
     assertResult(tableName)(tableConfig(HoodieTableConfig.NAME.key()))
@@ -907,7 +907,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
         val properties = metaClient.getTableConfig.getProps.asScala.toMap
         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELD.key))
+        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
         assertResult("hudi_database")(metaClient.getTableConfig.getDatabaseName)
         assertResult(s"original_$tableName")(metaClient.getTableConfig.getTableName)
 
@@ -978,7 +978,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
         val properties = metaClient.getTableConfig.getProps.asScala.toMap
         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
         assertResult("day,hh")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELD.key))
+        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
 
         val escapedPathPart = escapePathName(day)
 
@@ -1045,7 +1045,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       val metaClient = createMetaClient(spark, tmp.getCanonicalPath)
       val properties = metaClient.getTableConfig.getProps.asScala.toMap
       assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
-      assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELD.key))
+      assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
 
       // Test insert into
       spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000)")
@@ -1454,7 +1454,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
         val hoodieCatalogTable = HoodieCatalogTable(spark, TableIdentifier(tableName))
         assertResult(Array("id"))(hoodieCatalogTable.primaryKeys)
         assertResult(tableType)(hoodieCatalogTable.tableTypeName)
-        assertResult("ts")(hoodieCatalogTable.preCombineKey.get)
+        assertResult(java.util.Collections.singletonList[String]("ts"))(hoodieCatalogTable.preCombineKeys)
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
@@ -75,12 +75,12 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> COMMIT_TIME_BASED_MERGE_STRATEGY_UUID)
     }
     val nonExistentConfigs = if (tableVersion.toInt == 6) {
-      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.PRECOMBINE_FIELD.key)
+      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.PRECOMBINE_FIELDS.key)
     } else {
       if (setRecordMergeConfigs) {
         Seq()
       } else {
-        Seq(HoodieTableConfig.PRECOMBINE_FIELD.key)
+        Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
       }
     }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
@@ -71,12 +71,12 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
       Map(
         HoodieTableConfig.VERSION.key -> "6",
         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
-        HoodieTableConfig.PRECOMBINE_FIELD.key -> "ts"
+        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts"
       )
     } else {
       Map(
         HoodieTableConfig.VERSION.key -> String.valueOf(HoodieTableVersion.current().versionCode()),
-        HoodieTableConfig.PRECOMBINE_FIELD.key -> "ts",
+        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts",
         HoodieTableConfig.RECORD_MERGE_MODE.key -> EVENT_TIME_ORDERING.name(),
         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> EVENT_TIME_BASED_MERGE_STRATEGY_UUID)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -207,7 +207,7 @@ public class BootstrapExecutor implements Serializable {
         .setTableType(cfg.tableType)
         .setTableName(cfg.targetTableName)
         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
-        .setPreCombineField(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
+        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
         .setTableVersion(ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION))
         .setTableFormat(props.getString(HoodieTableConfig.TABLE_FORMAT.key(), HoodieTableConfig.TABLE_FORMAT.defaultValue()))
         .setPopulateMetaFields(props.getBoolean(

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieMultiTableStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieMultiTableStreamer.java
@@ -234,7 +234,7 @@ public class HoodieMultiTableStreamer {
       tableConfig.enableMetaSync = globalConfig.enableMetaSync;
       tableConfig.syncClientToolClassNames = globalConfig.syncClientToolClassNames;
       tableConfig.schemaProviderClassName = globalConfig.schemaProviderClassName;
-      tableConfig.sourceOrderingField = globalConfig.sourceOrderingField;
+      tableConfig.sourceOrderingFields = globalConfig.sourceOrderingField;
       tableConfig.sourceClassName = globalConfig.sourceClassName;
       tableConfig.tableType = globalConfig.tableType;
       tableConfig.targetTableName = globalConfig.targetTableName;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -158,7 +158,7 @@ public class HoodieStreamer implements Serializable {
     this.properties = combineProperties(cfg, propsOverride, jssc.hadoopConfiguration());
     Triple<RecordMergeMode, String, String> mergingConfigs =
         HoodieTableConfig.inferCorrectMergingBehavior(
-            cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingField,
+            cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingFields,
             HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(this.properties, HoodieWriteConfig.WRITE_TABLE_VERSION)));
     cfg.recordMergeMode = mergingConfigs.getLeft();
     cfg.payloadClassName = mergingConfigs.getMiddle();
@@ -272,9 +272,9 @@ public class HoodieStreamer implements Serializable {
             + "JsonKafkaSource, AvroKafkaSource, HiveIncrPullSource}")
     public String sourceClassName = JsonDFSSource.class.getName();
 
-    @Parameter(names = {"--source-ordering-field"}, description = "Field within source record to decide how"
+    @Parameter(names = {"--source-ordering-field"}, description = "Comma separated list of fields within source record to decide how"
         + " to break ties between records with same key in input data.")
-    public String sourceOrderingField = null;
+    public String sourceOrderingFields = null;
 
     @Parameter(names = {"--payload-class"}, description = "Deprecated. "
         + "Use --merge-mode for commit time or event time merging. "
@@ -505,7 +505,7 @@ public class HoodieStreamer implements Serializable {
           && Objects.equals(propsFilePath, config.propsFilePath)
           && Objects.equals(configs, config.configs)
           && Objects.equals(sourceClassName, config.sourceClassName)
-          && Objects.equals(sourceOrderingField, config.sourceOrderingField)
+          && Objects.equals(sourceOrderingFields, config.sourceOrderingFields)
           && Objects.equals(payloadClassName, config.payloadClassName)
           && Objects.equals(schemaProviderClassName, config.schemaProviderClassName)
           && Objects.equals(transformerClassNames, config.transformerClassNames)
@@ -538,7 +538,7 @@ public class HoodieStreamer implements Serializable {
     public int hashCode() {
       return Objects.hash(targetBasePath, targetTableName, tableType,
           baseFileFormat, propsFilePath, configs, sourceClassName,
-          sourceOrderingField, payloadClassName, schemaProviderClassName,
+          sourceOrderingFields, payloadClassName, schemaProviderClassName,
           transformerClassNames, sourceLimit, operation, filterDupes,
           enableHiveSync, enableMetaSync, forceEmptyMetaSync, syncClientToolClassNames, maxPendingCompactions, maxPendingClustering,
           continuousMode, minSyncIntervalSeconds, sparkMaster, commitOnErrors,
@@ -557,7 +557,7 @@ public class HoodieStreamer implements Serializable {
           + ", propsFilePath='" + propsFilePath + '\''
           + ", configs=" + configs
           + ", sourceClassName='" + sourceClassName + '\''
-          + ", sourceOrderingField='" + sourceOrderingField + '\''
+          + ", sourceOrderingField='" + sourceOrderingFields + '\''
           + ", payloadClassName='" + payloadClassName + '\''
           + ", schemaProviderClassName='" + schemaProviderClassName + '\''
           + ", transformerClassNames=" + transformerClassNames

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
@@ -33,7 +33,9 @@ import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Either;
+import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
@@ -83,7 +85,7 @@ public class HoodieStreamerUtils {
                                                                   SchemaProvider schemaProvider, HoodieRecord.HoodieRecordType recordType, boolean autoGenerateRecordKeys,
                                                                   String instantTime, Option<BaseErrorTableWriter> errorTableWriter) {
     boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
-    boolean shouldUseOrderingField = shouldCombine && !StringUtils.isNullOrEmpty(cfg.sourceOrderingField);
+    boolean shouldUseOrderingField = shouldCombine && !StringUtils.isNullOrEmpty(cfg.sourceOrderingFields);
     boolean shouldErrorTable = errorTableWriter.isPresent() && props.getBoolean(ERROR_ENABLE_VALIDATE_RECORD_CREATION.key(), ERROR_ENABLE_VALIDATE_RECORD_CREATION.defaultValue());
     boolean useConsistentLogicalTimestamp = ConfigUtils.getBooleanWithAltKeys(
         props, KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED);
@@ -111,8 +113,11 @@ public class HoodieStreamerUtils {
                 try {
                   HoodieKey hoodieKey = new HoodieKey(builtinKeyGenerator.getRecordKey(genRec), builtinKeyGenerator.getPartitionPath(genRec));
                   GenericRecord gr = isDropPartitionColumns(props) ? HoodieAvroUtils.removeFields(genRec, partitionColumns) : genRec;
-                  HoodieRecordPayload payload = shouldUseOrderingField ? DataSourceUtils.createPayload(payloadClassName, gr,
-                      (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, cfg.sourceOrderingField, false, useConsistentLogicalTimestamp))
+                  Comparable orderingValue = shouldUseOrderingField
+                      ? OrderingValues.create(cfg.sourceOrderingFields.split(","),
+                         field -> (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, field, false, useConsistentLogicalTimestamp))
+                      : null;
+                  HoodieRecordPayload payload = shouldUseOrderingField ? HoodieRecordUtils.loadPayload(payloadClassName, gr, orderingValue)
                       : DataSourceUtils.createPayload(payloadClassName, gr);
                   return Either.left(new HoodieAvroRecord<>(hoodieKey, payload));
                 } catch (Exception e) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -444,7 +444,7 @@ public class StreamSync implements Serializable, Closeable {
         .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
             HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
         .setKeyGeneratorClassProp(keyGenClassName)
-        .setPreCombineField(cfg.sourceOrderingField)
+        .setPreCombineFields(cfg.sourceOrderingFields)
         .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
             HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
         .setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),
@@ -1104,7 +1104,7 @@ public class StreamSync implements Serializable, Closeable {
             .withPayloadConfig(
                 HoodiePayloadConfig.newBuilder()
                     .withPayloadClass(cfg.payloadClassName)
-                    .withPayloadOrderingField(cfg.sourceOrderingField)
+                    .withPayloadOrderingFields(cfg.sourceOrderingFields)
                     .build())
             .withRecordMergeMode(cfg.recordMergeMode)
             .withRecordMergeStrategyId(cfg.recordMergeStrategyId)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -151,6 +151,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     testUtils.setup();
     topicName = "topic" + testNum;
     prepareInitialConfigs(storage, basePath, testUtils.brokerAddress());
+    // reset TestDataSource recordInstantTime which may be set by any other test
+    TestDataSource.recordInstantTime = Option.empty();
   }
 
   @AfterEach
@@ -636,7 +638,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       cfg.transformerClassNames = transformerClassNames;
       cfg.operation = op;
       cfg.enableHiveSync = enableHiveSync;
-      cfg.sourceOrderingField = sourceOrderingField;
+      cfg.sourceOrderingFields = sourceOrderingField;
       cfg.propsFilePath = UtilitiesTestBase.basePath + "/" + propsFilename;
       cfg.sourceLimit = sourceLimit;
       cfg.checkpoint = checkpoint;
@@ -649,7 +651,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       cfg.allowCommitOnNoCheckpointChange = allowCommitOnNoCheckpointChange;
       Triple<RecordMergeMode, String, String> mergeCfgs =
           HoodieTableConfig.inferCorrectMergingBehavior(
-              cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingField,
+              cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingFields,
               HoodieTableVersion.current());
       cfg.recordMergeMode = mergeCfgs.getLeft();
       cfg.payloadClassName = mergeCfgs.getMiddle();
@@ -665,7 +667,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       cfg.tableType = "COPY_ON_WRITE";
       cfg.sourceClassName = HoodieIncrSource.class.getName();
       cfg.operation = op;
-      cfg.sourceOrderingField = "timestamp";
+      cfg.sourceOrderingFields = "timestamp";
       cfg.propsFilePath = UtilitiesTestBase.basePath + "/test-downstream-source.properties";
       cfg.sourceLimit = 1000;
       if (null != schemaProviderClassName) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -372,7 +372,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     cfg.transformerClassNames = transformerClassNames;
     cfg.operation = op;
     cfg.enableHiveSync = false;
-    cfg.sourceOrderingField = "timestamp";
+    cfg.sourceOrderingFields = "timestamp";
     cfg.propsFilePath = propsFilePath;
     cfg.sourceLimit = 1000;
     cfg.schemaProviderClassName = defaultSchemaProviderClassName;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
@@ -91,7 +91,7 @@ public class TestMultipleMetaSync extends HoodieDeltaStreamerTestBase {
     cfg.syncClientToolClassNames = syncClassNames;
     cfg.operation = WriteOperationType.BULK_INSERT;
     cfg.enableHiveSync = true;
-    cfg.sourceOrderingField = "timestamp";
+    cfg.sourceOrderingFields = "timestamp";
     cfg.propsFilePath = UtilitiesTestBase.basePath + "/test-source.properties";
     cfg.configs.add("hoodie.datasource.hive_sync.partition_fields=year,month,day");
     cfg.sourceLimit =  1000;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
@@ -41,6 +41,7 @@ public class TestDataSource extends AbstractBaseTestSource {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestDataSource.class);
   public static boolean returnEmptyBatch = false;
+  public static Option<String> recordInstantTime = Option.empty();
   private static int counter = 0;
 
   public TestDataSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
@@ -67,7 +68,7 @@ public class TestDataSource extends AbstractBaseTestSource {
     counter++;
 
     List<GenericRecord> records =
-        fetchNextBatch(props, (int) sourceLimit, instantTime, DEFAULT_PARTITION_NUM).collect(Collectors.toList());
+        fetchNextBatch(props, (int) sourceLimit, recordInstantTime.orElse(instantTime), DEFAULT_PARTITION_NUM).collect(Collectors.toList());
     JavaRDD<GenericRecord> avroRDD = sparkContext.<GenericRecord>parallelize(records, 4);
     return new InputBatch<>(Option.of(avroRDD), instantTime);
   }


### PR DESCRIPTION
### Change Logs

Currently we only support one ordering field to be configured. The Jira aims to add support for multiple ordering fields such that records will be ordered by the first ordering field and then by the second ordering field (if first ordering field is same) and so on.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
