### PR TITLE
[HUDI-9570] Flink AsyncInstant may lost data when trigger recommit

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -360,6 +360,10 @@ public class StreamWriteOperatorCoordinator
   @Override
   public CompletableFuture<CoordinationResponse> handleCoordinationRequest(CoordinationRequest request) {
     CompletableFuture<CoordinationResponse> response = new CompletableFuture<>();
+    if (request instanceof Correspondent.PendingCheckpointsRequest) {
+      response.complete(CoordinationResponseSerDe.wrap(Correspondent.PendingCheckpointsResponse.getInstance(this.eventBuffers.getPendingCheckpoints())));
+      return response;
+    }
     instantRequestExecutor.execute(() -> {
       Correspondent.InstantTimeRequest instantTimeRequest = (Correspondent.InstantTimeRequest) request;
       long checkpointId = instantTimeRequest.getCheckpointId();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -131,5 +132,9 @@ public class EventBuffers implements Serializable {
 
   public String getPendingInstants() {
     return this.eventBuffers.values().stream().map(Pair::getKey).collect(Collectors.joining(","));
+  }
+
+  public Set<Long> getPendingCheckpoints() {
+    return this.eventBuffers.keySet();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondent.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondent.java
@@ -22,6 +22,8 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.event.Correspondent;
 
+import java.util.Set;
+
 /**
  * A mock {@link Correspondent} that always return the latest instant.
  */
@@ -38,6 +40,16 @@ public class MockCorrespondent extends Correspondent {
       return response.getInstant();
     } catch (Exception e) {
       throw new HoodieException("Error requesting the instant time from the coordinator", e);
+    }
+  }
+
+  @Override
+  public Set<Long> requestPendingCheckpoints() {
+    try {
+      PendingCheckpointsResponse response = CoordinationResponseSerDe.unwrap(this.coordinator.handleCoordinationRequest(PendingCheckpointsRequest.getInstance()).get());
+      return response.getCkpIds();
+    } catch (Exception e) {
+      throw new HoodieException("Error requesting the pending checkpoint ids from the coordinator", e);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondentWithTimeout.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondentWithTimeout.java
@@ -26,6 +26,7 @@ import org.apache.hudi.sink.event.Correspondent;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,16 @@ public class MockCorrespondentWithTimeout extends Correspondent {
       return response.getInstant();
     } catch (Exception e) {
       throw new HoodieException("Error requesting the instant time from the coordinator", e);
+    }
+  }
+
+  @Override
+  public Set<Long> requestPendingCheckpoints() {
+    try {
+      PendingCheckpointsResponse response = CoordinationResponseSerDe.unwrap(this.coordinator.handleCoordinationRequest(PendingCheckpointsRequest.getInstance()).get());
+      return response.getCkpIds();
+    } catch (Exception e) {
+      throw new HoodieException("Error requesting the pending checkpoint ids from the coordinator", e);
     }
   }
 }


### PR DESCRIPTION
### Change Logs

1. TM crashed after snapshot state but before notify checkpoint complete.
2. Job restarted automatically with `attemptId++`
3. Not Trigger re-commit
4. Data lost because Kafka source has commit offset during snapshot state.
### Impact

flink write

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
