### PR TITLE
[MINOR] Use scala-test throughout TestExpressionIndex.scala

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -32,7 +32,6 @@ import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
-import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.hudi.storage.{HoodieStorage, StoragePath}
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
@@ -886,7 +886,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
 
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
-
+        setCompactionConfigs(tableType)
         spark.sql(
           s"""
            CREATE TABLE $tableName (
@@ -985,7 +985,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_partition_pruning_with_unpartitioned_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        setCompactionConfigs(tableType)
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
 
         spark.sql(
@@ -1079,7 +1079,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_partition_pruning_with_partition_stats_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        setCompactionConfigs(tableType)
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
 
         spark.sql(
@@ -1175,7 +1175,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
         val isTableMOR = tableType.equals("mor")
         val tableName = generateTableName + s"_partition_pruning_after_update_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        spark.sql("set hoodie.compact.inline=false") // initially disable compaction to avoid merging log files
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
 
         spark.sql(
@@ -1289,10 +1289,6 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
           Seq(riderCalifornia, "RIDER-A", "RIDER-C"),
           Seq(riderTexas, "RIDER-E", "RIDER-H")
         )
-
-        if (isTableMOR) {
-          spark.sql("set hoodie.compact.inline=false")
-        }
         spark.sql(s"drop index idx_rider on $tableName")
       }
     }
@@ -1304,7 +1300,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
         val isTableMOR = tableType.equals("mor")
         val tableName = generateTableName + s"_partition_pruning_after_delete_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        spark.sql("set hoodie.compact.inline=false") // initially disable compaction to avoid merging log files
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
 
         spark.sql(
@@ -1420,9 +1416,6 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
           Seq(riderTexas, "RIDER-F", "RIDER-F")
         )
 
-        if (isTableMOR) {
-          spark.sql("set hoodie.compact.inline=false")
-        }
         spark.sql(s"drop index idx_rider on $tableName")
       }
     }
@@ -1436,7 +1429,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_stats_pruning_date_expr_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        setCompactionConfigs(tableType)
         spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
 
         spark.sql(
@@ -1586,7 +1579,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_stats_pruning_string_expr_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        setCompactionConfigs(tableType)
         spark.sql(
           s"""
            CREATE TABLE $tableName (
@@ -1711,7 +1704,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_bloom_pruning_$tableType"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"
-
+        setCompactionConfigs(tableType)
         spark.sql(
           s"""
            CREATE TABLE $tableName (
@@ -1765,7 +1758,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
           .filterCompletedInstants().lastInstant().get().requestedTime
         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(s"expr_index_idx_bloom_$tableName"))
         assertTrue(metaClient.getIndexMetadata.isPresent)
-        assertEquals(2, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
+        assertEquals(1, metaClient.getIndexMetadata.get.getIndexDefinitions.size())
         val indexDefinition: HoodieIndexDefinition = metaClient.getIndexMetadata.get.getIndexDefinitions.get(s"expr_index_idx_bloom_$tableName")
         // validate index options
         assertEquals("0.01", indexDefinition.getIndexOptions.get(HoodieExpressionIndex.FALSE_POSITIVE_RATE))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
@@ -58,7 +58,6 @@ import org.apache.spark.sql.hudi.command.{CreateIndexCommand, ShowIndexesCommand
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
-import org.junit.jupiter.api.Test
 
 import java.util.stream.Collectors
 
@@ -880,8 +879,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  @Test
-  def testPrunePartitions(): Unit = {
+  test("Test Prune Partitions") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_prune_partitions_$tableType"
@@ -982,11 +980,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  /**
-   * Test expression index partition pruning with unpartitioned table.
-   */
-  @Test
-  def testExpressionIndexPartitionStatsWithUnpartitionedTable(): Unit = {
+  test("Test expression index partition pruning with unpartitioned table") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_partition_pruning_with_unpartitioned_$tableType"
@@ -1080,11 +1074,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  /**
-   * Test expression index partition pruning with partition stats.
-   */
-  @Test
-  def testPartitionPruningWithPartitionStats(): Unit = {
+  test("Test expression index partition pruning with partition stats") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_partition_pruning_with_partition_stats_$tableType"
@@ -1179,11 +1169,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  /**
-   * Test expression index pruning after update with partition stats.
-   */
-  @Test
-  def testPartitionPruningAfterUpdateWithPartitionStats(): Unit = {
+  test("Test expression index pruning after update with partition stats") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val isTableMOR = tableType.equals("mor")
@@ -1312,11 +1298,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  /**
-   * Test expression index pruning after update with partition stats.
-   */
-  @Test
-  def testPartitionPruningAfterDeleteWithPartitionStats(): Unit = {
+  test("Test expression index pruning after delete with partition stats") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val isTableMOR = tableType.equals("mor")
@@ -1724,8 +1706,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
     }
   }
 
-  @Test
-  def testBloomFiltersIndexPruning(): Unit = {
+  test("Test bloom filters index pruning") {
     withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         val tableName = generateTableName + s"_bloom_pruning_$tableType"


### PR DESCRIPTION
### Change Logs

- Current TestExpressionIndex uses a mix of scalatest and junit testing code which could be causing the spark session to not close properly so I am updating all tests in this class to use scalatest.

### Impact

- Fix CI issues

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
