### PR TITLE
[HUDI-9591] Introduce input based file group record buffer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/InputBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/InputBasedFileGroupRecordBuffer.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.KeySpec;
+import org.apache.hudi.common.table.log.block.HoodieDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class InputBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupRecordBuffer<T> {
+  private final ClosableIterator<T> inputRecordIterator;
+
+  public InputBasedFileGroupRecordBuffer(HoodieReaderContext readerContext,
+                                         HoodieTableMetaClient hoodieTableMetaClient,
+                                         RecordMergeMode recordMergeMode,
+                                         TypedProperties props,
+                                         HoodieReadStats readStats,
+                                         Option<String> orderingFieldName,
+                                         boolean emitDelete,
+                                         ClosableIterator<T> inputRecordIterator) {
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, props, readStats, orderingFieldName, emitDelete);
+    this.inputRecordIterator = inputRecordIterator;
+
+    // Read input records into the buffer.
+    populateRecordBuffer();
+  }
+
+  private void populateRecordBuffer() {
+    if (null == inputRecordIterator) {
+      throw new IllegalArgumentException("InputRecordIterator can not be null");
+    }
+
+    while (inputRecordIterator.hasNext()) {
+      T engineRecord = inputRecordIterator.next();
+      String recordKey = readerContext.getRecordKey(nextRecord, readerSchema);
+      boolean isDelete =
+          isBuiltInDeleteRecord(engineRecord)
+          || isCustomDeleteRecord(engineRecord)
+          || isDeleteHoodieOperation(engineRecord);
+      BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(
+          engineRecord, readerSchema, readerContext, orderingFieldName, isDelete);
+      records.put(recordKey, bufferedRecord);
+    }
+  }
+
+  @Override
+  public void processDataBlock(HoodieDataBlock dataBlock, Option<KeySpec> keySpecOpt) throws IOException {
+    throw new HoodieNotSupportedException("Method 'processDataBlock' is not supported");
+  }
+
+  @Override
+  public void processNextDataRecord(BufferedRecord<T> record, Serializable recordKey) throws IOException {
+    throw new HoodieNotSupportedException("Method 'processNextDataRecord' is not supported");
+  }
+
+  @Override
+  public void processDeleteBlock(HoodieDeleteBlock deleteBlock) throws IOException {
+    throw new HoodieNotSupportedException("Method 'processDeleteBlock' is not supported");
+  }
+
+  @Override
+  public void processNextDeletedRecord(DeleteRecord deleteRecord, Serializable recordKey) {
+    throw new HoodieNotSupportedException("Method 'processNextDeletedRecord' is not supported");
+  }
+}


### PR DESCRIPTION
### Change Logs

Create FG reader based on a base file and the input records.

### Impact

This is a preliminary step to support FG reader for mergeHandle.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
