### PR TITLE
[HUDI-8635] Fix stats for total records written and num inserts in FileGroupReader based compaction

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedAppendHandle.java
@@ -91,7 +91,6 @@ public class FileGroupReaderBasedAppendHandle<T, I, K, O> extends HoodieAppendHa
       this.insertRecordsWritten = readStats.getNumInserts();
       this.updatedRecordsWritten = readStats.getNumUpdates();
       this.recordsDeleted = readStats.getNumDeletes();
-      this.recordsWritten = readStats.getNumInserts() + readStats.getNumUpdates();
     } catch (IOException e) {
       throw new HoodieIOException("Failed to initialize file group reader for " + fileSlice, e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
@@ -26,8 +26,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.CompactionOperation;
-import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
@@ -60,6 +59,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.MERGE_USE_RECORD_POSITIONS;
 import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
@@ -76,7 +76,6 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
   private static final Logger LOG = LoggerFactory.getLogger(FileGroupReaderBasedMergeHandle.class);
 
   private final HoodieReaderContext<T> readerContext;
-  private final FileSlice fileSlice;
   private final CompactionOperation operation;
   private final String maxInstantTime;
   private HoodieReadStats readStats;
@@ -84,14 +83,13 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
   private final Option<HoodieCDCLogger> cdcLogger;
 
   public FileGroupReaderBasedMergeHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                                         FileSlice fileSlice, CompactionOperation operation, TaskContextSupplier taskContextSupplier,
+                                         CompactionOperation operation, TaskContextSupplier taskContextSupplier,
                                          HoodieReaderContext<T> readerContext, String maxInstantTime,
                                          HoodieRecord.HoodieRecordType enginRecordType) {
     super(config, instantTime, operation.getPartitionPath(), operation.getFileId(), hoodieTable, taskContextSupplier);
     this.maxInstantTime = maxInstantTime;
     this.keyToNewRecords = Collections.emptyMap();
     this.readerContext = readerContext;
-    this.fileSlice = fileSlice;
     this.operation = operation;
     // If the table is a metadata table or the base file is an HFile, we use AVRO record type, otherwise we use the engine record type.
     this.recordType = hoodieTable.isMetadataTable() || HFILE.getFileExtension().equals(hoodieTable.getBaseFileExtension()) ? HoodieRecord.HoodieRecordType.AVRO : enginRecordType;
@@ -108,21 +106,21 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
     } else {
       this.cdcLogger = Option.empty();
     }
-    init(operation, this.partitionPath, fileSlice.getBaseFile());
+    init(operation, this.partitionPath);
   }
 
-  private void init(CompactionOperation operation, String partitionPath, Option<HoodieBaseFile> baseFileToMerge) {
+  private void init(CompactionOperation operation, String partitionPath) {
     LOG.info("partitionPath:{}, fileId to be merged:{}", partitionPath, fileId);
-    this.baseFileToMerge = baseFileToMerge.orElse(null);
+    this.baseFileToMerge = operation.getBaseFile(config.getBasePath(), operation.getPartitionPath()).orElse(null);
     this.writtenRecordKeys = new HashSet<>();
     writeStatus.setStat(new HoodieWriteStat());
     writeStatus.getStat().setTotalLogSizeCompacted(
         operation.getMetrics().get(CompactionStrategy.TOTAL_LOG_FILE_SIZE).longValue());
     try {
       Option<String> latestValidFilePath = Option.empty();
-      if (baseFileToMerge.isPresent()) {
-        latestValidFilePath = Option.of(baseFileToMerge.get().getFileName());
-        writeStatus.getStat().setPrevCommit(baseFileToMerge.get().getCommitTime());
+      if (baseFileToMerge != null) {
+        latestValidFilePath = Option.of(baseFileToMerge.getFileName());
+        writeStatus.getStat().setPrevCommit(baseFileToMerge.getCommitTime());
         // At the moment, we only support SI for overwrite with latest payload. So, we don't need to embed entire file slice here.
         // HUDI-8518 will be taken up to fix it for any payload during which we might require entire file slice to be set here.
         // Already AppendHandle adds all logs file from current file slice to HoodieDeltaWriteStat.
@@ -176,10 +174,14 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
     TypedProperties props = TypedProperties.copy(config.getProps());
     long maxMemoryPerCompaction = IOUtils.getMaxMemoryPerCompaction(taskContextSupplier, config);
     props.put(HoodieMemoryConfig.MAX_MEMORY_FOR_MERGE.key(), String.valueOf(maxMemoryPerCompaction));
+    Stream<HoodieLogFile> logFiles = operation.getDeltaFileNames().stream().map(logFileName ->
+        new HoodieLogFile(new StoragePath(FSUtils.constructAbsolutePath(
+            config.getBasePath(), operation.getPartitionPath()), logFileName)));
     // Initializes file group reader
     try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder().withReaderContext(readerContext).withHoodieTableMetaClient(hoodieTable.getMetaClient())
-        .withLatestCommitTime(maxInstantTime).withFileSlice(fileSlice).withDataSchema(writeSchemaWithMetaFields).withRequestedSchema(writeSchemaWithMetaFields)
-        .withInternalSchema(internalSchemaOption).withProps(props).withShouldUseRecordPosition(usePosition).withSortOutput(hoodieTable.requireSortedRecords())
+        .withLatestCommitTime(maxInstantTime).withPartitionPath(partitionPath).withBaseFileOption(Option.ofNullable(baseFileToMerge)).withLogFiles(logFiles)
+        .withDataSchema(writeSchemaWithMetaFields).withRequestedSchema(writeSchemaWithMetaFields).withInternalSchema(internalSchemaOption).withProps(props)
+        .withShouldUseRecordPosition(usePosition).withSortOutput(hoodieTable.requireSortedRecords())
         .withFileGroupUpdateCallback(cdcLogger.map(logger -> new CDCCallback(logger, readerContext))).build()) {
       // Reads the records from the file slice
       try (ClosableIterator<HoodieRecord<T>> recordIterator = fileGroupReader.getClosableHoodieRecordIterator()) {
@@ -214,7 +216,7 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
         this.recordsDeleted = readStats.getNumDeletes();
       }
     } catch (IOException e) {
-      throw new HoodieUpsertException("Failed to compact file slice: " + fileSlice, e);
+      throw new HoodieUpsertException("Failed to compact file group: " + fileId, e);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
@@ -199,6 +199,7 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
             writeToFile(record.getKey(), record, writeSchemaWithMetaFields,
                 config.getPayloadConfig().getProps(), preserveMetadata);
             writeStatus.markSuccess(record, recordMetadata);
+            recordsWritten++;
           } catch (Exception e) {
             LOG.error("Error writing record {}", record, e);
             writeStatus.markFailure(record, e, recordMetadata);
@@ -211,7 +212,6 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
         this.insertRecordsWritten = readStats.getNumInserts();
         this.updatedRecordsWritten = readStats.getNumUpdates();
         this.recordsDeleted = readStats.getNumDeletes();
-        this.recordsWritten = readStats.getNumInserts() + readStats.getNumUpdates();
       }
     } catch (IOException e) {
       throw new HoodieUpsertException("Failed to compact file slice: " + fileSlice, e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -68,6 +68,7 @@ import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -529,6 +530,9 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       markClosed();
       // flush any remaining records to disk
       appendDataAndDeleteBlocks(header, true);
+      if (recordItr instanceof Closeable) {
+        ((Closeable) recordItr).close();
+      }
       recordItr = null;
 
       if (writer != null) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
@@ -123,7 +123,8 @@ public class HoodieMergeHandleFactory {
     boolean isFallbackEnabled = config.isMergeHandleFallbackEnabled();
 
     String mergeHandleClass = config.getCompactionMergeHandleClassName();
-    LOG.info("Create HoodieMergeHandle implementation {} for fileId {} and partitionPath {} at commit {}", mergeHandleClass, operation.getFileId(), operation.getPartitionPath(), instantTime);
+    String logContext = String.format("for fileId %s and partitionPath %s at commit %s", operation.getFileId(), operation.getPartitionPath(), instantTime);
+    LOG.info("Create HoodieMergeHandle implementation {} {}", mergeHandleClass, logContext);
 
     Class<?>[] constructorParamTypes = new Class<?>[] {
         HoodieWriteConfig.class, String.class, HoodieTable.class, FileSlice.class, CompactionOperation.class,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
@@ -21,7 +21,6 @@ package org.apache.hudi.io;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.CompactionOperation;
-import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -127,7 +126,7 @@ public class HoodieMergeHandleFactory {
     LOG.info("Create HoodieMergeHandle implementation {} {}", mergeHandleClass, logContext);
 
     Class<?>[] constructorParamTypes = new Class<?>[] {
-        HoodieWriteConfig.class, String.class, HoodieTable.class, FileSlice.class, CompactionOperation.class,
+        HoodieWriteConfig.class, String.class, HoodieTable.class, CompactionOperation.class,
         TaskContextSupplier.class, HoodieReaderContext.class, String.class, HoodieRecord.HoodieRecordType.class
     };
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
@@ -114,7 +114,6 @@ public class HoodieMergeHandleFactory {
       HoodieWriteConfig config,
       String instantTime,
       HoodieTable<T, I, K, O> hoodieTable,
-      FileSlice fileSlice,
       CompactionOperation operation,
       TaskContextSupplier taskContextSupplier,
       HoodieReaderContext<T> readerContext,
@@ -124,8 +123,7 @@ public class HoodieMergeHandleFactory {
     boolean isFallbackEnabled = config.isMergeHandleFallbackEnabled();
 
     String mergeHandleClass = config.getCompactionMergeHandleClassName();
-    String logContext = String.format("for fileId %s and partitionPath %s at commit %s", operation.getFileId(), operation.getPartitionPath(), instantTime);
-    LOG.info("Create HoodieMergeHandle implementation {} {}", mergeHandleClass, logContext);
+    LOG.info("Create HoodieMergeHandle implementation {} for fileId {} and partitionPath {} at commit {}", mergeHandleClass, operation.getFileId(), operation.getPartitionPath(), instantTime);
 
     Class<?>[] constructorParamTypes = new Class<?>[] {
         HoodieWriteConfig.class, String.class, HoodieTable.class, FileSlice.class, CompactionOperation.class,
@@ -134,7 +132,7 @@ public class HoodieMergeHandleFactory {
 
     return instantiateMergeHandle(
         isFallbackEnabled, mergeHandleClass, COMPACT_MERGE_HANDLE_CLASS_NAME.defaultValue(), logContext, constructorParamTypes,
-        config, instantTime, hoodieTable, fileSlice, operation, taskContextSupplier, readerContext, maxInstantTime, recordType);
+        config, instantTime, hoodieTable, operation, taskContextSupplier, readerContext, maxInstantTime, recordType);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -26,11 +26,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.engine.TaskContextSupplier;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.CompactionOperation;
-import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.HoodieBaseFile;
-import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -46,7 +42,6 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.io.FileGroupReaderBasedAppendHandle;
 import org.apache.hudi.io.HoodieMergeHandle;
 import org.apache.hudi.io.HoodieMergeHandleFactory;
-import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.Schema;
@@ -57,7 +52,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -698,7 +698,9 @@ public abstract class BaseHoodieLogRecordReader<T> {
       }
       // Done
       progress = 1.0f;
-      totalLogRecords.set(recordBuffer.getTotalLogRecords());
+      if (recordBuffer != null) {
+        totalLogRecords.set(recordBuffer.getTotalLogRecords());
+      }
     } catch (IOException e) {
       LOG.error("Got IOException when reading log file", e);
       throw new HoodieIOException("IOException when reading log file ", e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -698,6 +698,7 @@ public abstract class BaseHoodieLogRecordReader<T> {
       }
       // Done
       progress = 1.0f;
+      totalLogRecords.set(recordBuffer.getTotalLogRecords());
     } catch (IOException e) {
       LOG.error("Got IOException when reading log file", e);
       throw new HoodieIOException("IOException when reading log file ", e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -73,7 +73,6 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
   protected final Option<String> payloadClass;
   protected final TypedProperties props;
   protected final ExternalSpillableMap<Serializable, BufferedRecord<T>> records;
-  protected final HoodieReadStats readStats;
   protected final boolean shouldCheckCustomDeleteMarker;
   protected final boolean shouldCheckBuiltInDeleteMarker;
   protected ClosableIterator<T> baseFileIterator;
@@ -91,7 +90,6 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
                                   RecordMergeMode recordMergeMode,
                                   PartialUpdateMode partialUpdateMode,
                                   TypedProperties props,
-                                  HoodieReadStats readStats,
                                   Option<String> orderingFieldName,
                                   UpdateProcessor<T> updateProcessor) {
     this.readerContext = readerContext;
@@ -122,7 +120,6 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
         SPILLABLE_DISK_MAP_TYPE.defaultValue().name()).toUpperCase(Locale.ROOT));
     boolean isBitCaskDiskMapCompressionEnabled = props.getBoolean(DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(),
         DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue());
-    this.readStats = readStats;
     try {
       // Store merged records for all versions for this log file, set the in-memory footprint to maxInMemoryMapSize
       this.records = new ExternalSpillableMap<>(maxMemorySizeInBytes, spillableMapBasePath, new DefaultSizeEstimator<>(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -328,7 +328,7 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
   }
 
   protected void initializeLogRecordIterator() {
-    logRecordIterator = records.values().iterator();
+    logRecordIterator = records.iterator();
   }
 
   protected boolean hasNextLogRecord() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -324,7 +324,6 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
 
     // Inserts
     nextRecord = readerContext.seal(baseRecord);
-    readStats.incrementNumInserts();
     return true;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -180,13 +180,13 @@ public final class HoodieFileGroupReader<T> implements Closeable {
           readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats);
     } else if (sortOutput) {
       return new SortedKeyBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
     } else if (shouldUseRecordPosition && inputSplit.baseFileOption.isPresent()) {
       return new PositionBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, inputSplit.baseFileOption.get().getCommitTime(), props, readStats, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, inputSplit.baseFileOption.get().getCommitTime(), props, orderingFieldName, updateProcessor);
     } else {
       return new KeyBasedFileGroupRecordBuffer<>(
-          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, orderingFieldName, updateProcessor);
+          readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -390,6 +390,11 @@ public final class HoodieFileGroupReader<T> implements Closeable {
         nextRecord -> readerContext.getRecordKey(nextRecord, readerContext.getSchemaHandler().getRequestedSchema()));
   }
 
+  public ClosableIterator<BufferedRecord<T>> getLogRecordsOnly() throws IOException {
+    initRecordIterators();
+    return recordBuffer.getLogRecordIterator();
+  }
+
   public static class HoodieFileGroupReaderIterator<T> implements ClosableIterator<T> {
     private HoodieFileGroupReader<T> reader;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/KeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/KeyBasedFileGroupRecordBuffer.java
@@ -54,10 +54,9 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
                                        RecordMergeMode recordMergeMode,
                                        PartialUpdateMode partialUpdateMode,
                                        TypedProperties props,
-                                       HoodieReadStats readStats,
                                        Option<String> orderingFieldName,
                                        UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PositionBasedFileGroupRecordBuffer.java
@@ -72,10 +72,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
                                             PartialUpdateMode partialUpdateMode,
                                             String baseFileInstantTime,
                                             TypedProperties props,
-                                            HoodieReadStats readStats,
                                             Option<String> orderingFieldName,
                                             UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
     this.baseFileInstantTime = baseFileInstantTime;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/SortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/SortedKeyBasedFileGroupRecordBuffer.java
@@ -48,10 +48,9 @@ public class SortedKeyBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupRec
                                              RecordMergeMode recordMergeMode,
                                              PartialUpdateMode partialUpdateMode,
                                              TypedProperties props,
-                                             HoodieReadStats readStats,
                                              Option<String> orderingFieldName,
                                              UpdateProcessor<T> updateProcessor) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, orderingFieldName, updateProcessor);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, orderingFieldName, updateProcessor);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UnmergedFileGroupRecordBuffer.java
@@ -43,6 +43,7 @@ import java.util.Deque;
 public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
 
   private final Deque<HoodieLogBlock> currentInstantLogBlocks;
+  private final HoodieReadStats readStats;
   private ClosableIterator<T> recordIterator;
 
   public UnmergedFileGroupRecordBuffer(
@@ -52,7 +53,8 @@ public class UnmergedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
       PartialUpdateMode partialUpdateMode,
       TypedProperties props,
       HoodieReadStats readStats) {
-    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, readStats, Option.empty(), null);
+    super(readerContext, hoodieTableMetaClient, recordMergeMode, partialUpdateMode, props, Option.empty(), null);
+    this.readStats = readStats;
     this.currentInstantLogBlocks = new ArrayDeque<>();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1033,7 +1033,7 @@ public class HoodieTableMetadataUtil {
       readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(readerContext, writerSchemaOpt.get(), writerSchemaOpt.get(), Option.empty(), tableConfig, properties));
       HoodieReadStats readStats = new HoodieReadStats();
       KeyBasedFileGroupRecordBuffer<T> recordBuffer = new KeyBasedFileGroupRecordBuffer<>(readerContext, datasetMetaClient,
-          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, readStats, Option.ofNullable(tableConfig.getPreCombineField()),
+          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, Option.ofNullable(tableConfig.getPreCombineField()),
           UpdateProcessor.create(readStats, readerContext, true, Option.empty()));
 
       // CRITICAL: Ensure allowInflightInstants is set to true

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupRecordBuffer.java
@@ -297,7 +297,6 @@ class TestFileGroupRecordBuffer {
             RecordMergeMode.COMMIT_TIME_ORDERING,
             PartialUpdateMode.NONE,
             props,
-            readStats,
             Option.empty(),
             updateProcessor
         );
@@ -312,7 +311,6 @@ class TestFileGroupRecordBuffer {
             RecordMergeMode.COMMIT_TIME_ORDERING,
             PartialUpdateMode.NONE,
             props,
-            readStats,
             Option.empty(),
             updateProcessor
     );
@@ -336,7 +334,6 @@ class TestFileGroupRecordBuffer {
             RecordMergeMode.COMMIT_TIME_ORDERING,
             PartialUpdateMode.NONE,
             props,
-            readStats,
             Option.empty(),
             updateProcessor
         );

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
@@ -272,7 +272,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     TypedProperties props = new TypedProperties();
     UpdateProcessor<IndexedRecord> updateProcessor = UpdateProcessor.create(readStats, readerContext, false, Option.empty());
     return new KeyBasedFileGroupRecordBuffer<>(
-        readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, readStats, orderingFieldName, updateProcessor);
+        readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, orderingFieldName, updateProcessor);
   }
 
   private static List<IndexedRecord> getActualRecords(FileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
@@ -100,6 +100,9 @@ class TestKeyBasedFileGroupRecordBuffer {
     List<IndexedRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     // delete for record3 is ignored due to event time ordering
     assertEquals(Arrays.asList(testRecord1UpdateWithSameTime, testRecord2Update, testRecord3Update), actualRecords);
+    assertEquals(0, readStats.getNumInserts());
+    assertEquals(0, readStats.getNumDeletes());
+    assertEquals(3, readStats.getNumUpdates());
   }
 
   @Test
@@ -132,6 +135,9 @@ class TestKeyBasedFileGroupRecordBuffer {
 
     List<IndexedRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     assertEquals(Arrays.asList(testRecord2Update, testRecord3Update), actualRecords);
+    assertEquals(0, readStats.getNumInserts());
+    assertEquals(1, readStats.getNumDeletes());
+    assertEquals(2, readStats.getNumUpdates());
   }
 
   @Test
@@ -159,6 +165,9 @@ class TestKeyBasedFileGroupRecordBuffer {
 
     List<IndexedRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     assertEquals(Arrays.asList(testRecord1UpdateWithSameTime, testRecord2EarlierUpdate), actualRecords);
+    assertEquals(0, readStats.getNumInserts());
+    assertEquals(1, readStats.getNumDeletes());
+    assertEquals(2, readStats.getNumUpdates());
   }
 
   @Test
@@ -192,6 +201,10 @@ class TestKeyBasedFileGroupRecordBuffer {
 
     List<IndexedRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     assertEquals(Collections.singletonList(testRecord1), actualRecords);
+
+    assertEquals(0, readStats.getNumInserts());
+    assertEquals(3, readStats.getNumDeletes());
+    assertEquals(0, readStats.getNumUpdates());
   }
 
   @Test
@@ -225,6 +238,10 @@ class TestKeyBasedFileGroupRecordBuffer {
 
     List<IndexedRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     assertEquals(Collections.singletonList(testRecord1), actualRecords);
+
+    assertEquals(0, readStats.getNumInserts());
+    assertEquals(3, readStats.getNumDeletes());
+    assertEquals(0, readStats.getNumUpdates());
   }
 
   private static GenericRecord createTestRecord(String recordKey, int counter, long ts) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
@@ -77,7 +77,7 @@ class TestSortedKeyBasedFileGroupRecordBuffer {
 
     List<TestRecord> actualRecords = getActualRecords(fileGroupRecordBuffer);
     assertEquals(Arrays.asList(testRecord1, testRecord2Update, testRecord4, testRecord5, testRecord6Update), actualRecords);
-    assertEquals(4, readStats.getNumInserts());
+    assertEquals(3, readStats.getNumInserts());
     assertEquals(1, readStats.getNumUpdates());
     assertEquals(1, readStats.getNumDeletes());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
@@ -129,7 +129,7 @@ class TestSortedKeyBasedFileGroupRecordBuffer {
     TypedProperties props = new TypedProperties();
     UpdateProcessor<TestRecord> updateProcessor = UpdateProcessor.create(readStats, mockReaderContext, false, Option.empty());
     return new SortedKeyBasedFileGroupRecordBuffer<>(
-        mockReaderContext, mockMetaClient, recordMergeMode, partialUpdateMode, props, readStats, Option.empty(), updateProcessor);
+        mockReaderContext, mockMetaClient, recordMergeMode, partialUpdateMode, props, Option.empty(), updateProcessor);
   }
 
   private static List<TestRecord> getActualRecords(SortedKeyBasedFileGroupRecordBuffer<TestRecord> fileGroupRecordBuffer) throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -85,6 +85,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -913,7 +914,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
 
   public HoodieRecord generateDeleteRecord(HoodieKey key) throws IOException {
     RawTripTestPayload payload =
-        new RawTripTestPayload(Option.empty(), key.getRecordKey(), key.getPartitionPath(), null, true, 0L);
+        new RawTripTestPayload(Option.empty(), key.getRecordKey(), key.getPartitionPath(), null, true, DEFAULT_ORDERING_VALUE);
     return new HoodieAvroRecord(key, payload);
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
@@ -52,6 +52,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.createHoodieRecordFromAvro;
+import static org.apache.hudi.common.model.HoodieRecord.DEFAULT_ORDERING_VALUE;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
@@ -190,7 +191,7 @@ public class RawTripTestPayload implements HoodieRecordPayload<RawTripTestPayloa
 
   @Override
   public RawTripTestPayload preCombine(RawTripTestPayload oldValue) {
-    if (oldValue.orderingVal.compareTo(orderingVal) > 0) {
+    if (!orderingVal.equals(DEFAULT_ORDERING_VALUE) && oldValue.orderingVal.compareTo(orderingVal) > 0) {
       // pick the payload with greatest ordering value
       return oldValue;
     } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -501,7 +501,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
         Option.empty(), metaClient.getTableConfig, readerProperties))
     val stats = new HoodieReadStats
     val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient,
-      readerContext.getMergeMode, metaClient.getTableConfig.getPartialUpdateMode, readerProperties, stats,
+      readerContext.getMergeMode, metaClient.getTableConfig.getPartialUpdateMode, readerProperties,
       Option.ofNullable(metaClient.getTableConfig.getPreCombineField),
       UpdateProcessor.create(stats, readerContext, true, Option.empty()))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -35,12 +35,11 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
-import org.apache.hudi.common.table.read.UpdateProcessor;
 import org.apache.hudi.common.table.read.CustomPayloadForTesting;
 import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
-import org.apache.hudi.common.table.read.HoodieReadStats;
-import org.apache.hudi.common.table.read.PositionBasedFileGroupRecordBuffer;
 import org.apache.hudi.common.table.read.ParquetRowIndexBasedSchemaHandler;
+import org.apache.hudi.common.table.read.PositionBasedFileGroupRecordBuffer;
+import org.apache.hudi.common.table.read.UpdateProcessor;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.RawTripTestPayload;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -152,7 +151,6 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
       writeConfigs.put(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), CustomPayloadForTesting.class.getName());
       writeConfigs.put(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID);
     }
-    HoodieReadStats readStats = new HoodieReadStats();
     buffer = new PositionBasedFileGroupRecordBuffer<>(
         ctx,
         metaClient,
@@ -160,7 +158,6 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
         metaClient.getTableConfig().getPartialUpdateMode(),
         baseFileInstantTime,
         props,
-        readStats,
         Option.of("timestamp"),
         updateProcessor);
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -449,7 +449,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
         Dataset<Row> actual = HoodieClientTestUtils.read(
             jsc(), basePath(), sqlContext(), hoodieStorage(), fullPartitionPaths);
         List<Row> rows = actual.collectAsList();
-        assertEquals(100, rows.size());
+        assertEquals(90, rows.size());
         int updatedCount = 0;
         for (Row row : rows) {
           if (row.getAs(HoodieRecord.COMMIT_TIME_METADATA_FIELD).equals(newCommitTime)) {
@@ -461,8 +461,8 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
           // check that file names metadata is updated
           assertTrue(row.getString(HoodieRecord.FILENAME_META_FIELD_ORD).contains(compactionInstantTime));
         }
-        // check that all 90 records are updated
-        assertEquals(90, updatedCount);
+        // check that 80 records are updated
+        assertEquals(80, updatedCount);
       }
     }
   }


### PR DESCRIPTION
### Change Logs

- Fixes discrepancy on "inserts" for compaction between old and new code. Inserts are only meant to count new records (records in log files only) whereas the FileGroupReader based compaction is counting any record without an update as an insert.
- Once this is updated, the total records written must also be updated since it was the sum of inserts and updates previously
- Update test case to prevent regressions

### Impact

- Fixes stats generated by compaction

### Risk level (write none, low medium or high below)

- Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
