### PR TITLE
[HUDI-9628] Add bloom filtering to prune keys prior to lookup in Metadata HFiles

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -170,10 +170,10 @@ public class HoodieMetadataWriteUtils {
             // Keeping the log blocks as large as the log files themselves reduces the number of HFile blocks to be checked for
             // presence of keys
             .logFileDataBlockMaxSize(maxLogFileSizeBytes)
-                               .withBloomFilterType(writeConfig.getBloomFilterType())
-                               .withBloomFilterNumEntries(writeConfig.getBloomFilterNumEntries())
-                               .withBloomFilterFpp(writeConfig.getBloomFilterFPP())
-                               .withBloomFilterDynamicMaxEntries(writeConfig.getDynamicBloomFilterMaxNumEntries())
+                               .withBloomFilterType(writeConfig.getMetadataConfig().getBloomFilterType())
+                               .withBloomFilterNumEntries(writeConfig.getMetadataConfig().getBloomFilterNumEntries())
+                               .withBloomFilterFpp(writeConfig.getMetadataConfig().getBloomFilterFPP())
+                               .withBloomFilterDynamicMaxEntries(writeConfig.getMetadataConfig().getDynamicBloomFilterMaxNumEntries())
                                .build())
         .withRollbackParallelism(MDT_DEFAULT_PARALLELISM)
         .withFinalizeWriteParallelism(MDT_DEFAULT_PARALLELISM)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -172,7 +172,7 @@ public class HoodieMetadataWriteUtils {
             .logFileDataBlockMaxSize(maxLogFileSizeBytes)
                                .withBloomFilterType(writeConfig.getMetadataConfig().getBloomFilterType())
                                .withBloomFilterNumEntries(writeConfig.getMetadataConfig().getBloomFilterNumEntries())
-                               .withBloomFilterFpp(writeConfig.getMetadataConfig().getBloomFilterFPP())
+                               .withBloomFilterFpp(writeConfig.getMetadataConfig().getBloomFilterFpp())
                                .withBloomFilterDynamicMaxEntries(writeConfig.getMetadataConfig().getDynamicBloomFilterMaxNumEntries())
                                .build())
         .withRollbackParallelism(MDT_DEFAULT_PARALLELISM)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -169,7 +169,12 @@ public class HoodieMetadataWriteUtils {
             .logFileMaxSize(maxLogFileSizeBytes)
             // Keeping the log blocks as large as the log files themselves reduces the number of HFile blocks to be checked for
             // presence of keys
-            .logFileDataBlockMaxSize(maxLogFileSizeBytes).build())
+            .logFileDataBlockMaxSize(maxLogFileSizeBytes)
+                               .withBloomFilterType(writeConfig.getBloomFilterType())
+                               .withBloomFilterNumEntries(writeConfig.getBloomFilterNumEntries())
+                               .withBloomFilterFpp(writeConfig.getBloomFilterFPP())
+                               .withBloomFilterDynamicMaxEntries(writeConfig.getDynamicBloomFilterMaxNumEntries())
+                               .build())
         .withRollbackParallelism(MDT_DEFAULT_PARALLELISM)
         .withFinalizeWriteParallelism(MDT_DEFAULT_PARALLELISM)
         .withKeyGenerator(HoodieTableMetadataKeyGenerator.class.getCanonicalName())

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -529,7 +529,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("This is the number of entries stored in a bloom filter for the files in the metadata table. "
           + "The rationale for the default: 10000 is chosen to be a good tradeoff between false positive rate and "
           + "storage size. Warning: Setting this very low generates a lot of false positives and the metadata "
-          + "table reading have to scan a lot more files than it has to and setting this to a very high number "
+          + "table reading has to scan a lot more files than it has to and setting this to a very high number "
           + "increases the size every base file linearly (roughly 4KB for every 50000 entries). "
           + "This config is also used with DYNAMIC bloom filter which determines the initial size for the bloom.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -516,11 +516,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> BLOOM_FILTER_NUM_ENTRIES_VALUE = ConfigProperty
       .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.num.entries"))
-      .defaultValue("100000")
+      .defaultValue("10000")
       .markAdvanced()
       .sinceVersion("1.1.0")
       .withDocumentation("This is the number of entries stored in a bloom filter in the metadata table. "
-          + "The rationale for the default: 100000 is chosen to be a good tradeoff between false positive rate and "
+          + "The rationale for the default: 10000 is chosen to be a good tradeoff between false positive rate and "
           + "storage size. Warning: Setting this very low generates a lot of false positives and the metadata "
           + "table reading have to scan a lot more files than it has to and setting this to a very high number "
           + "increases the size every base file linearly (roughly 4KB for every 50000 entries). "
@@ -540,8 +540,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> BLOOM_FILTER_DYNAMIC_MAX_ENTRIES = ConfigProperty
       .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.dynamic.max.entries"))
-      .defaultValue("500000")
+      .defaultValue("100000")
       .markAdvanced()
+      .sinceVersion("1.1.0")
       .withDocumentation("The threshold for the maximum number of keys to record in a dynamic bloom filter row. "
           + "Only applies if the filter type (" + BLOOM_FILTER_TYPE.key() + " ) is BloomFilterTypeCode.DYNAMIC_V0.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -505,46 +505,54 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("Max size in MB below which metadata file (HFile) will be downloaded "
           + "and cached entirely for the HFileReader.");
 
+  public static final ConfigProperty<Boolean> BLOOM_FILTER_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom.filter.enable")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Whether to use bloom filter in the files for lookup in the metadata table.");
+
   // Configs that control the bloom filter that is written to the file footer
   public static final ConfigProperty<String> BLOOM_FILTER_TYPE = ConfigProperty
-      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.type"))
+      .key(METADATA_PREFIX + ".bloom.filter.type")
       .defaultValue(BloomFilterTypeCode.DYNAMIC_V0.name())
       .withValidValues(BloomFilterTypeCode.SIMPLE.name(), BloomFilterTypeCode.DYNAMIC_V0.name())
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation(BloomFilterTypeCode.class, "Bloom filter type used by the metadata table");
+      .withDocumentation(BloomFilterTypeCode.class, "Bloom filter type for the files in the metadata table");
 
-  public static final ConfigProperty<String> BLOOM_FILTER_NUM_ENTRIES_VALUE = ConfigProperty
-      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.num.entries"))
+  public static final ConfigProperty<String> BLOOM_FILTER_NUM_ENTRIES = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom.filter.num.entries")
       .defaultValue("10000")
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("This is the number of entries stored in a bloom filter in the metadata table. "
+      .withDocumentation("This is the number of entries stored in a bloom filter for the files in the metadata table. "
           + "The rationale for the default: 10000 is chosen to be a good tradeoff between false positive rate and "
           + "storage size. Warning: Setting this very low generates a lot of false positives and the metadata "
           + "table reading have to scan a lot more files than it has to and setting this to a very high number "
           + "increases the size every base file linearly (roughly 4KB for every 50000 entries). "
           + "This config is also used with DYNAMIC bloom filter which determines the initial size for the bloom.");
 
-  public static final ConfigProperty<String> BLOOM_FILTER_FPP_VALUE = ConfigProperty
-      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.fpp"))
+  public static final ConfigProperty<String> BLOOM_FILTER_FPP = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom.filter.fpp")
       .defaultValue("0.000000001")
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("Expected probability a false positive in a bloom filter in the metadata table. "
-          + "This is used to calculate how many bits should be assigned for the bloom filter "
+      .withDocumentation("Expected probability a false positive in a bloom filter for the files in the "
+          + "metadata table. This is used to calculate how many bits should be assigned for the bloom filter "
           + "and the number of hash functions. This is usually set very low (default: 0.000000001), "
           + "we like to tradeoff disk space for lower false positives. If the number of entries "
           + "added to bloom filter exceeds the configured value (hoodie.metadata.bloom.num_entries), "
           + "then this fpp may not be honored.");
 
   public static final ConfigProperty<String> BLOOM_FILTER_DYNAMIC_MAX_ENTRIES = ConfigProperty
-      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.filter.dynamic.max.entries"))
+      .key(METADATA_PREFIX + ".bloom.filter.dynamic.max.entries")
       .defaultValue("100000")
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("The threshold for the maximum number of keys to record in a dynamic bloom filter row. "
-          + "Only applies if the filter type (" + BLOOM_FILTER_TYPE.key() + " ) is BloomFilterTypeCode.DYNAMIC_V0.");
+      .withDocumentation("The threshold for the maximum number of keys to record in a dynamic "
+          + "bloom filter row for the files in the metadata table. Only applies if the filter "
+          + "type (" + BLOOM_FILTER_TYPE.key() + " ) is BloomFilterTypeCode.DYNAMIC_V0.");
 
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
@@ -706,16 +714,20 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getExpressionIndexOptions(getString(EXPRESSION_INDEX_OPTIONS));
   }
 
+  public boolean enableBloomFilter() {
+    return getBooleanOrDefault(BLOOM_FILTER_ENABLE);
+  }
+
   public String getBloomFilterType() {
     return getStringOrDefault(BLOOM_FILTER_TYPE);
   }
 
   public int getBloomFilterNumEntries() {
-    return getIntOrDefault(BLOOM_FILTER_NUM_ENTRIES_VALUE);
+    return getIntOrDefault(BLOOM_FILTER_NUM_ENTRIES);
   }
 
   public double getBloomFilterFpp() {
-    return getDoubleOrDefault(BLOOM_FILTER_FPP_VALUE);
+    return getDoubleOrDefault(BLOOM_FILTER_FPP);
   }
 
   public int getDynamicBloomFilterMaxNumEntries() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.config;
 
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.Option;
@@ -504,6 +505,45 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("Max size in MB below which metadata file (HFile) will be downloaded "
           + "and cached entirely for the HFileReader.");
 
+  // Configs that control the bloom filter that is written to the file footer
+  public static final ConfigProperty<String> BLOOM_FILTER_TYPE = ConfigProperty
+      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.index.filter.type"))
+      .defaultValue(BloomFilterTypeCode.DYNAMIC_V0.name())
+      .withValidValues(BloomFilterTypeCode.SIMPLE.name(), BloomFilterTypeCode.DYNAMIC_V0.name())
+      .markAdvanced()
+      .withDocumentation(BloomFilterTypeCode.class);
+
+  public static final ConfigProperty<String> BLOOM_FILTER_NUM_ENTRIES_VALUE = ConfigProperty
+      .key(String.format("%s.%s", METADATA_PREFIX, "index.bloom.num_entries"))
+      .defaultValue("60000")
+      .markAdvanced()
+      .withDocumentation("Only applies if index type is BLOOM. "
+                             + "This is the number of entries to be stored in the bloom filter. "
+                             + "The rationale for the default: Assume the maxParquetFileSize is 128MB and averageRecordSize is 1kb and "
+                             + "hence we approx a total of 130K records in a file. The default (60000) is roughly half of this approximation. "
+                             + "Warning: Setting this very low, will generate a lot of false positives and index lookup "
+                             + "will have to scan a lot more files than it has to and setting this to a very high number will "
+                             + "increase the size every base file linearly (roughly 4KB for every 50000 entries). "
+                             + "This config is also used with DYNAMIC bloom filter which determines the initial size for the bloom.");
+
+  public static final ConfigProperty<String> BLOOM_FILTER_FPP_VALUE = ConfigProperty
+      .key(String.format("%s.%s", METADATA_PREFIX, "index.bloom.fpp"))
+      .defaultValue("0.000000001")
+      .markAdvanced()
+      .withDocumentation("Only applies if index type is BLOOM. "
+                             + "Error rate allowed given the number of entries. This is used to calculate how many bits should be "
+                             + "assigned for the bloom filter and the number of hash functions. This is usually set very low (default: 0.000000001), "
+                             + "we like to tradeoff disk space for lower false positives. "
+                             + "If the number of entries added to bloom filter exceeds the configured value (hoodie.index.bloom.num_entries), "
+                             + "then this fpp may not be honored.");
+
+  public static final ConfigProperty<String> BLOOM_FILTER_DYNAMIC_MAX_ENTRIES = ConfigProperty
+      .key(String.format("%s.%s", METADATA_PREFIX, "bloom.index.filter.dynamic.max.entries"))
+      .defaultValue("100000")
+      .markAdvanced()
+      .withDocumentation("The threshold for the maximum number of keys to record in a dynamic Bloom filter row. "
+                             + "Only applies if filter type is BloomFilterTypeCode.DYNAMIC_V0.");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -662,6 +702,22 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public Map<String, String> getExpressionIndexOptions() {
     return getExpressionIndexOptions(getString(EXPRESSION_INDEX_OPTIONS));
+  }
+
+  public String getBloomFilterType() {
+    return getStringOrDefault(BLOOM_FILTER_TYPE);
+  }
+
+  public int getBloomFilterNumEntries() {
+    return getIntOrDefault(BLOOM_FILTER_NUM_ENTRIES_VALUE);
+  }
+
+  public double getBloomFilterFPP() {
+    return getDoubleOrDefault(BLOOM_FILTER_FPP_VALUE);
+  }
+
+  public int getDynamicBloomFilterMaxNumEntries() {
+    return getIntOrDefault(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES);
   }
 
   private Map<String, String> getExpressionIndexOptions(String configValue) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -524,6 +524,50 @@ public class HoodieStorageConfig extends HoodieConfig {
       return this;
     }
 
+    /**
+     * Sets the bloom filter type for the configuration.
+     *
+     * @param bloomFilterType The bloom filter type (SIMPLE or DYNAMIC_V0)
+     * @return this builder instance for method chaining
+     */
+    public Builder withBloomFilterType(String bloomFilterType) {
+      storageConfig.setValue(BLOOM_FILTER_TYPE, bloomFilterType);
+      return this;
+    }
+
+    /**
+     * Sets the number of entries to be stored in the bloom filter.
+     *
+     * @param numEntries The number of entries for the bloom filter
+     * @return this builder instance for method chaining
+     */
+    public Builder withBloomFilterNumEntries(int numEntries) {
+      storageConfig.setValue(BLOOM_FILTER_NUM_ENTRIES_VALUE, String.valueOf(numEntries));
+      return this;
+    }
+
+    /**
+     * Sets the false positive probability (FPP) for the bloom filter.
+     *
+     * @param fpp The false positive probability as a double
+     * @return this builder instance for method chaining
+     */
+    public Builder withBloomFilterFpp(double fpp) {
+      storageConfig.setValue(BLOOM_FILTER_FPP_VALUE, String.valueOf(fpp));
+      return this;
+    }
+
+    /**
+     * Sets the maximum number of entries for dynamic bloom filter.
+     *
+     * @param maxEntries The maximum number of entries for dynamic bloom filter
+     * @return this builder instance for method chaining
+     */
+    public Builder withBloomFilterDynamicMaxEntries(int maxEntries) {
+      storageConfig.setValue(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES, String.valueOf(maxEntries));
+      return this;
+    }
+
     public HoodieStorageConfig build() {
       storageConfig.setDefaults(HoodieStorageConfig.class.getName());
       return storageConfig;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -313,14 +313,14 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   private Option<BloomFilter> getBloomFilter() {
     Option<BloomFilter> bloomFilter = Option.empty();
-    if (config.enabled()) {
-      try {
-        bloomFilter = Option.of(readBloomFilter());
-        LOG.info("Successfully read the bloom filter to look up RLI keys");
-      } catch (Throwable ignore) {
-        LOG.error("Exception while reading the bloom filter to look up RLI keys");
-      }
+    //if (config.enabled()) {
+    try {
+      bloomFilter = Option.of(readBloomFilter());
+      LOG.info("Successfully read the bloom filter to look up RLI keys");
+    } catch (Throwable ignore) {
+      LOG.error("Exception while reading the bloom filter to look up RLI keys");
     }
+    //}
     return bloomFilter;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -647,8 +647,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
       return this;
     }
 
-    public Builder schema(Schema schema) {
-      this.schemaOption = Option.of(schema);
+    public Builder schema(Option<Schema> schemaOption) {
+      this.schemaOption = schemaOption;
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -438,7 +438,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
         }
 
         while (sortedKeyIterator.hasNext()) {
-          // First check if the key is present in the file using bloom filter, skip checking hfile if not present.
+          // First check if the key is present in the file using bloom filter;
+          // skip seekTo in HFile if the key is not present.
           String rawKey = sortedKeyIterator.next();
           if (bloomFilterOption.isPresent() && !bloomFilterOption.get().mightContain(rawKey)) {
             continue;

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
@@ -38,7 +38,7 @@ public class TestHoodieStorageConfig {
   void testHoodieStorageConfig() {
     String bloomFilterType = BloomFilterTypeCode.SIMPLE.name();
     assertNotEquals(BLOOM_FILTER_TYPE.defaultValue().toUpperCase(),
-                    bloomFilterType.toUpperCase());
+        bloomFilterType.toUpperCase());
     Properties props = new Properties();
     props.put(BLOOM_FILTER_TYPE.key(), bloomFilterType);
     HoodieStorageConfig config = HoodieStorageConfig.newBuilder()

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
@@ -25,19 +25,54 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_DYNAMIC_MAX_ENTRIES;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_FPP_VALUE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_NUM_ENTRIES_VALUE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class TestHoodieStorageConfig {
+
   @Test
   void testHoodieStorageConfig() {
     String bloomFilterType = BloomFilterTypeCode.SIMPLE.name();
-    assertNotEquals(HoodieStorageConfig.BLOOM_FILTER_TYPE.defaultValue().toUpperCase(),
-        bloomFilterType.toUpperCase());
+    assertNotEquals(BLOOM_FILTER_TYPE.defaultValue().toUpperCase(),
+                    bloomFilterType.toUpperCase());
     Properties props = new Properties();
-    props.put(HoodieStorageConfig.BLOOM_FILTER_TYPE.key(), bloomFilterType);
+    props.put(BLOOM_FILTER_TYPE.key(), bloomFilterType);
     HoodieStorageConfig config = HoodieStorageConfig.newBuilder()
         .fromProperties(props).build();
     assertEquals(bloomFilterType, config.getBloomFilterType());
+  }
+
+  @Test
+  void testBloomFilterBuilderWithAllValues() {
+    String expectedFilterType = BloomFilterTypeCode.SIMPLE.name();
+    int expectedNumEntries = 80000;
+    double expectedFpp = 0.000000005;
+    int expectedDynamicMaxEntries = 150000;
+
+    HoodieStorageConfig storageConfig = HoodieStorageConfig.newBuilder()
+        .withBloomFilterType(expectedFilterType)
+        .withBloomFilterNumEntries(expectedNumEntries)
+        .withBloomFilterFpp(expectedFpp)
+        .withBloomFilterDynamicMaxEntries(expectedDynamicMaxEntries).build();
+
+    // Verify values are set correctly
+    assertEquals(expectedFilterType, storageConfig.getString(BLOOM_FILTER_TYPE));
+    assertEquals(expectedNumEntries, storageConfig.getInt(BLOOM_FILTER_NUM_ENTRIES_VALUE));
+    assertEquals(expectedFpp, storageConfig.getDouble(BLOOM_FILTER_FPP_VALUE));
+    assertEquals(expectedDynamicMaxEntries, storageConfig.getInt(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES));
+  }
+
+  @Test
+  void testBloomFilterBuilderWithDefaultValues() {
+    HoodieStorageConfig storageConfig = HoodieStorageConfig.newBuilder().build();
+    // Verify values are set correctly
+    assertEquals(BLOOM_FILTER_TYPE.defaultValue(), storageConfig.getString(BLOOM_FILTER_TYPE));
+    assertEquals(BLOOM_FILTER_NUM_ENTRIES_VALUE.defaultValue(), storageConfig.getString(BLOOM_FILTER_NUM_ENTRIES_VALUE));
+    assertEquals(BLOOM_FILTER_FPP_VALUE.defaultValue(), storageConfig.getString(BLOOM_FILTER_FPP_VALUE));
+    assertEquals(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES.defaultValue(), storageConfig.getString(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class TestHoodieStorageConfig {
-
   @Test
   void testHoodieStorageConfig() {
     String bloomFilterType = BloomFilterTypeCode.SIMPLE.name();

--- a/hudi-common/src/test/java/org/apache/hudi/io/storage/TestHoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/test/java/org/apache/hudi/io/storage/TestHoodieNativeAvroHFileReader.java
@@ -49,7 +49,8 @@ class TestHoodieNativeAvroHFileReader {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(DEFAULT_PROPS)
         .withPath(path).build();
-    reader = new HoodieNativeAvroHFileReader(readerFactory, path, Option.empty());
+    reader = HoodieNativeAvroHFileReader.builder()
+        .readerFactory(readerFactory).path(path).build();
   }
 
   @Test

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieAvroFileReaderFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieAvroFileReaderFactory.java
@@ -51,7 +51,8 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(hoodieConfig.getProps())
         .withPath(path).build();
-    return new HoodieNativeAvroHFileReader(readerFactory, path, schemaOption);
+    return HoodieNativeAvroHFileReader.builder()
+        .readerFactory(readerFactory).path(path).schema(schemaOption).build();
   }
 
   @Override
@@ -63,7 +64,8 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(hoodieConfig.getProps())
         .withContent(content).build();
-    return new HoodieNativeAvroHFileReader(readerFactory, path, schemaOption);
+    return HoodieNativeAvroHFileReader.builder()
+        .readerFactory(readerFactory).path(path).schema(schemaOption).build();
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
@@ -260,7 +260,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     try (HoodieAvroHFileReaderImplBase hfileReader = (HoodieAvroHFileReaderImplBase)
         createReader(HoodieTestUtils.getStorage(getFilePath()))) {
       List<String> keys =
-          IntStream.concat(IntStream.range(40, NUM_RECORDS * 2), IntStream.range(10, 20))
+          IntStream.concat(IntStream.range(10, 20), IntStream.range(40, NUM_RECORDS * 2))
               .mapToObj(i -> "key" + String.format("%02d", i)).collect(Collectors.toList());
       Schema avroSchema =
           getSchemaFromResource(TestHoodieReaderWriterBase.class, "/exampleSchema.avsc");
@@ -268,7 +268,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
           hfileReader.getRecordsByKeysIterator(keys, avroSchema);
 
       List<Integer> expectedIds =
-          IntStream.concat(IntStream.range(40, NUM_RECORDS), IntStream.range(10, 20))
+          IntStream.concat(IntStream.range(10, 20), IntStream.range(40, NUM_RECORDS))
               .boxed().collect(Collectors.toList());
       int index = 0;
       while (iterator.hasNext()) {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.FileIOUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.storage.HFileReaderFactory;
@@ -106,7 +105,8 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(DEFAULT_PROPS)
         .withPath(getFilePath()).build();
-    return new HoodieNativeAvroHFileReader(readerFactory, getFilePath(), Option.empty());
+    return HoodieNativeAvroHFileReader.builder()
+        .readerFactory(readerFactory).path(getFilePath()).build();
   }
 
   protected HoodieAvroHFileReaderImplBase createHFileReader(HoodieStorage storage,
@@ -114,7 +114,8 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(DEFAULT_PROPS)
         .withContent(content).build();
-    return new HoodieNativeAvroHFileReader(readerFactory, getFilePath(), Option.empty());
+    return HoodieNativeAvroHFileReader.builder()
+        .readerFactory(readerFactory).path(getFilePath()).build();
   }
 
   protected void verifyHFileReader(byte[] content,

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
@@ -304,6 +304,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     try (HoodieNativeAvroHFileReader reader = HoodieNativeAvroHFileReader.builder()
         .readerFactory(readerFactory).path(new StoragePath("dummy")).useBloomFilter(useBloomFilter)
         .build()) {
+      // These iterators should not use bloom filters in any case
       reader.getRecordIterator();
       verify(hfileReader, never()).getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK);
 
@@ -328,6 +329,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
       reader.getIndexedRecordsByKeyPrefixIterator(filterKeys, schema);
       verify(hfileReader, never()).getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK);
 
+      // Only iterators filtering full keys should use bloom filters for filtering
       reader.getRecordsByKeysIterator(filterKeys);
       verify(hfileReader, useBloomFilter ? times(1) : never())
           .getMetaBlock(KEY_BLOOM_FILTER_META_BLOCK);


### PR DESCRIPTION
### Change Logs

This PR adds the support of bloom filter of keys prior to HFile lookup to avoid download and deserialization of the relevant Hfile blocks when possible. For instance, in RLI with insert heavy workloads, we can achieve significant speedup by pruning most of the keys prior to HFile lookup.

The following configs are added:
- `hoodie.metadata.bloom.filter.enable`: whether to use bloom filter in the files for lookup in the metadata table
- `hoodie.metadata.bloom.filter.type`: bloom filter type to use for files in the metadata table
- `hoodie.metadata.bloom.filter.num.entries`: number of entries to store in a bloom filter for files in the metadata table
- `hoodie.metadata.bloom.filter.fpp`: expected probability a false positive in a bloom filter for files in the metadata table
- `hoodie.metadata.bloom.filter.dynamic.max.entries`: The threshold for the maximum number of keys to store in a dynamic bloom filter for files in the metadata table

### Impact

Performance improvement on index lookup in the metadata table which uses HFile as the file format.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
