### PR TITLE
[MINOR] Fix test failures

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.util.Option;
@@ -252,7 +253,8 @@ class TestKeyBasedFileGroupRecordBuffer {
     HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
     when(mockMetaClient.getTableConfig()).thenReturn(tableConfig);
     TypedProperties props = new TypedProperties();
-    return new KeyBasedFileGroupRecordBuffer<>(readerContext, mockMetaClient, recordMergeMode, props, readStats, orderingFieldName, false);
+    return new KeyBasedFileGroupRecordBuffer<>(
+        readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, readStats, orderingFieldName, false);
   }
 
   private static List<IndexedRecord> getActualRecords(FileGroupRecordBuffer<IndexedRecord> fileGroupRecordBuffer) throws IOException {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -77,7 +77,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /**
  * Tests {@link HoodieTableConfig}.
  */
-public class TestHoodieTableConfig extends HoodieCommonTestHarness {
+class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   private HoodieStorage storage;
   private StoragePath metaPath;
@@ -102,7 +102,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testCreate() throws IOException {
+  void testCreate() throws IOException {
     assertTrue(
         storage.exists(new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE)));
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
@@ -110,7 +110,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testUpdate() throws IOException {
+  void testUpdate() throws IOException {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
     updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "new_field");
@@ -125,7 +125,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testDelete() throws IOException {
+  void testDelete() throws IOException {
     Set<String> deletedProps = CollectionUtils.createSet(HoodieTableConfig.TIMELINE_HISTORY_PATH.key(),
         "hoodie.invalid.config");
     HoodieTableConfig.delete(storage, metaPath, deletedProps);
@@ -139,7 +139,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testReadsWhenPropsFileDoesNotExist() throws IOException {
+  void testReadsWhenPropsFileDoesNotExist() throws IOException {
     storage.deleteFile(cfgPath);
     assertThrows(HoodieIOException.class, () -> {
       new HoodieTableConfig(storage, metaPath, null, null, null);
@@ -147,7 +147,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testReadsWithUpdateFailures() throws IOException {
+  void testReadsWithUpdateFailures() throws IOException {
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
     storage.deleteFile(cfgPath);
     try (OutputStream out = storage.create(backupCfgPath)) {
@@ -162,7 +162,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testUpdateRecovery(boolean shouldPropsFileExist) throws IOException {
+  void testUpdateRecovery(boolean shouldPropsFileExist) throws IOException {
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
     if (!shouldPropsFileExist) {
       storage.deleteFile(cfgPath);
@@ -179,7 +179,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testReadRetry() throws IOException {
+  void testReadRetry() throws IOException {
     // When both the hoodie.properties and hoodie.properties.backup do not exist then the read fails
     storage.rename(cfgPath, new StoragePath(cfgPath.toString() + ".bak"));
     assertThrows(HoodieIOException.class, () -> new HoodieTableConfig(storage, metaPath, null, null, null));
@@ -205,7 +205,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
+  void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
     final ExecutorService executor = Executors.newFixedThreadPool(2);
     Future updaterFuture = executor.submit(() -> {
       for (int i = 0; i < 100; i++) {
@@ -230,7 +230,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @EnumSource(value = HoodieTableVersion.class, names = {"SEVEN", "EIGHT"})
-  public void testPartitionFields(HoodieTableVersion version) {
+  void testPartitionFields(HoodieTableVersion version) {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), version.greaterThan(HoodieTableVersion.SEVEN) ? "p1:simple,p2:timestamp" : "p1,p2");
     updatedProps.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
@@ -245,7 +245,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @ValueSource(strings = {"p1:simple,p2:timestamp", "p1,p2"})
-  public void testPartitionFieldAPIs(String partitionFields) {
+  void testPartitionFieldAPIs(String partitionFields) {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), partitionFields);
     HoodieTableConfig.update(storage, metaPath, updatedProps);
@@ -259,7 +259,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testValidateConfigVersion() {
+  void testValidateConfigVersion() {
     assertTrue(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.EIGHT));
     assertTrue(HoodieTableConfig.validateConfigVersion(ConfigProperty.key("").noDefaultValue().withDocumentation(""),
         HoodieTableVersion.SIX));
@@ -267,7 +267,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testDropInvalidConfigs() {
+  void testDropInvalidConfigs() {
     // test invalid configs are dropped
     HoodieConfig config = new HoodieConfig();
     config.setValue(HoodieTableConfig.VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
@@ -288,9 +288,9 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testDefinedTableConfigs() {
+  void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(39, configProperties.size());
+    assertEquals(41, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -77,7 +77,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /**
  * Tests {@link HoodieTableConfig}.
  */
-class TestHoodieTableConfig extends HoodieCommonTestHarness {
+public class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   private HoodieStorage storage;
   private StoragePath metaPath;
@@ -102,7 +102,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testCreate() throws IOException {
+  public void testCreate() throws IOException {
     assertTrue(
         storage.exists(new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE)));
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
@@ -110,7 +110,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testUpdate() throws IOException {
+  public void testUpdate() throws IOException {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
     updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "new_field");
@@ -125,7 +125,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testDelete() throws IOException {
+  public void testDelete() throws IOException {
     Set<String> deletedProps = CollectionUtils.createSet(HoodieTableConfig.TIMELINE_HISTORY_PATH.key(),
         "hoodie.invalid.config");
     HoodieTableConfig.delete(storage, metaPath, deletedProps);
@@ -139,7 +139,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testReadsWhenPropsFileDoesNotExist() throws IOException {
+  public void testReadsWhenPropsFileDoesNotExist() throws IOException {
     storage.deleteFile(cfgPath);
     assertThrows(HoodieIOException.class, () -> {
       new HoodieTableConfig(storage, metaPath, null, null, null);
@@ -147,7 +147,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testReadsWithUpdateFailures() throws IOException {
+  public void testReadsWithUpdateFailures() throws IOException {
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
     storage.deleteFile(cfgPath);
     try (OutputStream out = storage.create(backupCfgPath)) {
@@ -162,7 +162,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testUpdateRecovery(boolean shouldPropsFileExist) throws IOException {
+  public void testUpdateRecovery(boolean shouldPropsFileExist) throws IOException {
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
     if (!shouldPropsFileExist) {
       storage.deleteFile(cfgPath);
@@ -179,7 +179,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testReadRetry() throws IOException {
+  public void testReadRetry() throws IOException {
     // When both the hoodie.properties and hoodie.properties.backup do not exist then the read fails
     storage.rename(cfgPath, new StoragePath(cfgPath.toString() + ".bak"));
     assertThrows(HoodieIOException.class, () -> new HoodieTableConfig(storage, metaPath, null, null, null));
@@ -205,7 +205,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
+  public void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
     final ExecutorService executor = Executors.newFixedThreadPool(2);
     Future updaterFuture = executor.submit(() -> {
       for (int i = 0; i < 100; i++) {
@@ -230,7 +230,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @EnumSource(value = HoodieTableVersion.class, names = {"SEVEN", "EIGHT"})
-  void testPartitionFields(HoodieTableVersion version) {
+  public void testPartitionFields(HoodieTableVersion version) {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), version.greaterThan(HoodieTableVersion.SEVEN) ? "p1:simple,p2:timestamp" : "p1,p2");
     updatedProps.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
@@ -245,7 +245,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
 
   @ParameterizedTest
   @ValueSource(strings = {"p1:simple,p2:timestamp", "p1,p2"})
-  void testPartitionFieldAPIs(String partitionFields) {
+  public void testPartitionFieldAPIs(String partitionFields) {
     Properties updatedProps = new Properties();
     updatedProps.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), partitionFields);
     HoodieTableConfig.update(storage, metaPath, updatedProps);
@@ -259,7 +259,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testValidateConfigVersion() {
+  public void testValidateConfigVersion() {
     assertTrue(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.EIGHT));
     assertTrue(HoodieTableConfig.validateConfigVersion(ConfigProperty.key("").noDefaultValue().withDocumentation(""),
         HoodieTableVersion.SIX));
@@ -267,7 +267,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testDropInvalidConfigs() {
+  public void testDropInvalidConfigs() {
     // test invalid configs are dropped
     HoodieConfig config = new HoodieConfig();
     config.setValue(HoodieTableConfig.VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
@@ -288,7 +288,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testDefinedTableConfigs() {
+  public void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
     assertEquals(41, configProperties.size());
     configProperties.forEach(c -> {


### PR DESCRIPTION
### Change Logs

Fixed two issues:
1. Azure CI test failed due to table configuration # changed from 39 to 41.
2. GH CI test failed due to signature change of KeyBasedFileGroupRecordBuffer. 

### Impact

Make CI test passed.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
