### PR TITLE
[HUDI-9578] Reuse FG readers in MDT

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -64,8 +64,9 @@ import static org.apache.spark.sql.HoodieInternalRowUtils.getCachedSchema;
 public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderContext<InternalRow> {
 
   protected BaseSparkInternalRowReaderContext(StorageConfiguration<?> storageConfig,
-                                              HoodieTableConfig tableConfig) {
-    super(storageConfig, tableConfig, Option.empty(), Option.empty());
+                                              HoodieTableConfig tableConfig,
+                                              boolean reuseBuffer) {
+    super(storageConfig, tableConfig, Option.empty(), Option.empty(), reuseBuffer);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -66,7 +66,7 @@ class SparkFileFormatInternalRowReaderContext(parquetFileReader: SparkParquetRea
                                               requiredFilters: Seq[Filter],
                                               storageConfiguration: StorageConfiguration[_],
                                               tableConfig: HoodieTableConfig)
-  extends BaseSparkInternalRowReaderContext(storageConfiguration, tableConfig) {
+  extends BaseSparkInternalRowReaderContext(storageConfiguration, tableConfig, false) {
   lazy val sparkAdapter: SparkAdapter = SparkAdapterSupport.sparkAdapter
   private lazy val bootstrapSafeFilters: Seq[Filter] = filters.filter(filterIsSafeForBootstrap) ++ requiredFilters
   private val deserializerMap: mutable.Map[Schema, HoodieAvroDeserializer] = mutable.Map()

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroReaderContext.java
@@ -75,7 +75,16 @@ public class HoodieAvroReaderContext extends HoodieReaderContext<IndexedRecord> 
       HoodieTableConfig tableConfig,
       Option<InstantRange> instantRangeOpt,
       Option<Predicate> filterOpt) {
-    super(storageConfiguration, tableConfig, instantRangeOpt, filterOpt);
+    this(storageConfiguration, tableConfig, instantRangeOpt, filterOpt, false);
+  }
+
+  public HoodieAvroReaderContext(
+      StorageConfiguration<?> storageConfiguration,
+      HoodieTableConfig tableConfig,
+      Option<InstantRange> instantRangeOpt,
+      Option<Predicate> filterOpt,
+      boolean reuseBuffer) {
+    super(storageConfiguration, tableConfig, instantRangeOpt, filterOpt, reuseBuffer);
     this.payloadClass = tableConfig.getPayloadClass();
     this.typeConverter = new AvroReaderContextTypeConverter();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
@@ -45,6 +45,10 @@ public class BufferedRecord<T> implements Serializable {
   private T record;
   private final Integer schemaId;
   private final boolean isDelete;
+  // Note that it is set to true only when
+  // 1. flag `reuseBuffer` is set for record buffer, and
+  // 2. the record has been merged with a base record.
+  private boolean merged = false;
 
   public BufferedRecord(String recordKey, Comparable orderingValue, T record, Integer schemaId, boolean isDelete) {
     this.recordKey = recordKey;
@@ -107,6 +111,18 @@ public class BufferedRecord<T> implements Serializable {
       record = readerContext.seal(readerContext.toBinaryRow(readerContext.getSchemaFromBufferRecord(this), record));
     }
     return this;
+  }
+
+  public void setMerged() {
+    merged = true;
+  }
+
+  public void unsetMerged() {
+    merged = false;
+  }
+
+  public boolean isMerged() {
+    return merged;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupRecordBuffer.java
@@ -228,6 +228,12 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
     records.close();
   }
 
+  public void clearVisitedFlag() {
+    for(BufferedRecord<T> record : records.values()) {
+      record.unsetMerged();
+    }
+  }
+
   /**
    * Merge two log data records if needed.
    *
@@ -352,6 +358,11 @@ public abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordB
 
     while (logRecordIterator.hasNext()) {
       BufferedRecord<T> nextRecordInfo = logRecordIterator.next();
+      // When reuseBuffer is true, all log records are kept into the buffer.
+      // We should skip records that have been merged with base records.
+      if (readerContext.getReuseBuffer() && nextRecordInfo.isMerged()) {
+        continue;
+      }
       if (!nextRecordInfo.isDelete()) {
         nextRecord = nextRecordInfo.getRecord();
         readStats.incrementNumInserts();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/KeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/KeyBasedFileGroupRecordBuffer.java
@@ -133,7 +133,13 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
 
   protected boolean hasNextBaseRecord(T baseRecord) throws IOException {
     String recordKey = readerContext.getRecordKey(baseRecord, readerSchema);
-    BufferedRecord<T> logRecordInfo = records.remove(recordKey);
+    BufferedRecord<T> logRecordInfo;
+    if (readerContext.getReuseBuffer()) {
+      logRecordInfo = records.get(recordKey);
+      logRecordInfo.setMerged();
+    } else {
+      logRecordInfo = records.remove(recordKey);
+    }
     return hasNextBaseRecord(baseRecord, logRecordInfo);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRowDataReaderContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRowDataReaderContext.java
@@ -99,7 +99,7 @@ public class FlinkRowDataReaderContext extends HoodieReaderContext<RowData> {
       List<ExpressionPredicates.Predicate> predicates,
       HoodieTableConfig tableConfig,
       Option<InstantRange> instantRangeOpt) {
-    super(storageConfiguration, tableConfig, instantRangeOpt, Option.empty());
+    super(storageConfiguration, tableConfig, instantRangeOpt, Option.empty(), false);
     this.tableConfig = tableConfig;
     this.internalSchemaManager = internalSchemaManager;
     this.predicates = predicates;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -98,7 +98,7 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
                                     ObjectInspectorCache objectInspectorCache,
                                     StorageConfiguration<?> storageConfiguration,
                                     HoodieTableConfig tableConfig) {
-    super(storageConfiguration, tableConfig, Option.empty(), Option.empty());
+    super(storageConfiguration, tableConfig, Option.empty(), Option.empty(), false);
     this.readerCreator = readerCreator;
     this.partitionCols = partitionCols;
     this.partitionColSet = new HashSet<>(this.partitionCols);


### PR DESCRIPTION
### Change Logs

MDT support `reuse` feature, that is to reuse the same file readers if specified. However, this feature was not support by FG readers since the underlying RecordBuffer is recreated during recreation.

This PR re-enable `reuse` feature in MDT, which should cache FG readers, and make sure the internal RecordBuffer is not recreated when recreating the underlying readers for base and log files.

### Impact

Make the repetitive queries to MDT efficiently.

### Risk level (write none, low medium or high below)

Medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
