### PR TITLE
[MINOR] Fix typo in import

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/engine/TestReaderContextTypeConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/engine/TestReaderContextTypeConverter.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.AssertionsKt.assertNull;
 
 class TestReaderContextTypeConverter {
   private final ReaderContextTypeConverter typeHandler = new ReaderContextTypeConverter();


### PR DESCRIPTION
### Change Logs

Fix typo in `assertNull` import in a test class, which has been added recently.

### Impact

No

### Risk level (write none, low medium or high below)

No

### Documentation Update

No need

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
