### PR TITLE
[HUDI-9591]  FG reader based merge handle for COW merge

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleFactory.java
@@ -124,10 +124,12 @@ public class HoodieMergeHandleFactory {
     String mergeHandleClass = config.getCompactionMergeHandleClassName();
     String logContext = String.format("for fileId %s and partitionPath %s at commit %s", operation.getFileId(), operation.getPartitionPath(), instantTime);
     LOG.info("Create HoodieMergeHandle implementation {} {}", mergeHandleClass, logContext);
+
     Class<?>[] constructorParamTypes = new Class<?>[] {
         HoodieWriteConfig.class, String.class, HoodieTable.class, CompactionOperation.class,
         TaskContextSupplier.class, HoodieReaderContext.class, String.class, HoodieRecord.HoodieRecordType.class
     };
+
     return instantiateMergeHandle(
         isFallbackEnabled, mergeHandleClass, COMPACT_MERGE_HANDLE_CLASS_NAME.defaultValue(), logContext, constructorParamTypes,
         config, instantTime, hoodieTable, operation, taskContextSupplier, readerContext, maxInstantTime, recordType);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BaseFileUpdateCallback.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BaseFileUpdateCallback.java
@@ -44,9 +44,4 @@ public interface BaseFileUpdateCallback<T> {
    * @param previousRecord the record in the base file before deletion
    */
   void onDelete(String recordKey, T previousRecord);
-
-  /**
-   * Callback method to return the name of the callback.
-   */
-  String getName();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/InputBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/InputBasedFileGroupRecordBuffer.java
@@ -30,7 +30,6 @@ import org.apache.hudi.common.table.log.KeySpec;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 
 import java.io.IOException;
@@ -66,18 +65,13 @@ public class InputBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupRecordB
 
     while (inputRecordIterator.hasNext()) {
       HoodieRecord<T> hoodieRecord = inputRecordIterator.next();
-      try {
-        BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(
-            hoodieRecord.getRecordKey(),
-            hoodieRecord.getData(),
-            readerContext.getSchemaHandler().tableSchema,
-            readerContext,
-            orderingFieldName,
-            hoodieRecord.isDelete(readerContext.getSchemaHandler().tableSchema, props));
-        records.put(hoodieRecord.getRecordKey(), bufferedRecord);
-      } catch (IOException e) {
-        throw new HoodieException("Failed to populate data into the record buffer", e);
-      }
+      BufferedRecord<T> bufferedRecord = BufferedRecord.forRecordWithContext(
+          hoodieRecord,
+          readerContext.getSchemaHandler().tableSchema,
+          readerContext,
+          orderingFieldName,
+          props);
+      records.put(hoodieRecord.getRecordKey(), bufferedRecord);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1034,7 +1034,7 @@ public class HoodieTableMetadataUtil {
       HoodieReadStats readStats = new HoodieReadStats();
       KeyBasedFileGroupRecordBuffer<T> recordBuffer = new KeyBasedFileGroupRecordBuffer<>(readerContext, datasetMetaClient,
           readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, Option.ofNullable(tableConfig.getPreCombineField()),
-          UpdateProcessor.create(readStats, readerContext, true, Collections.emptyList()));
+          UpdateProcessor.create(readStats, readerContext, true, Option.empty()));
 
       // CRITICAL: Ensure allowInflightInstants is set to true
       try (HoodieMergedLogRecordReader<T> mergedLogRecordReader = HoodieMergedLogRecordReader.<T>newBuilder()

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestKeyBasedFileGroupRecordBuffer.java
@@ -270,7 +270,7 @@ class TestKeyBasedFileGroupRecordBuffer {
     HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
     when(mockMetaClient.getTableConfig()).thenReturn(tableConfig);
     TypedProperties props = new TypedProperties();
-    UpdateProcessor<IndexedRecord> updateProcessor = UpdateProcessor.create(readStats, readerContext, false, Collections.emptyList());
+    UpdateProcessor<IndexedRecord> updateProcessor = UpdateProcessor.create(readStats, readerContext, false, Option.empty());
     return new KeyBasedFileGroupRecordBuffer<>(
         readerContext, mockMetaClient, recordMergeMode, PartialUpdateMode.NONE, props, orderingFieldName, updateProcessor);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestSortedKeyBasedFileGroupRecordBuffer.java
@@ -127,7 +127,7 @@ class TestSortedKeyBasedFileGroupRecordBuffer {
     RecordMergeMode recordMergeMode = RecordMergeMode.COMMIT_TIME_ORDERING;
     PartialUpdateMode partialUpdateMode = PartialUpdateMode.NONE;
     TypedProperties props = new TypedProperties();
-    UpdateProcessor<TestRecord> updateProcessor = UpdateProcessor.create(readStats, mockReaderContext, false, Collections.emptyList());
+    UpdateProcessor<TestRecord> updateProcessor = UpdateProcessor.create(readStats, mockReaderContext, false, Option.empty());
     return new SortedKeyBasedFileGroupRecordBuffer<>(
         mockReaderContext, mockMetaClient, recordMergeMode, partialUpdateMode, props, Option.empty(), updateProcessor);
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -503,7 +503,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
     val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient,
       readerContext.getMergeMode, metaClient.getTableConfig.getPartialUpdateMode, readerProperties,
       Option.ofNullable(metaClient.getTableConfig.getPreCombineField),
-      UpdateProcessor.create(stats, readerContext, true, Collections.emptyList()))
+      UpdateProcessor.create(stats, readerContext, true, Option.empty()))
 
     HoodieMergedLogRecordReader.newBuilder[InternalRow]
       .withStorage(metaClient.getStorage)


### PR DESCRIPTION
### Change Logs

This PR introduces:

1. Input record based on record buffer that merely creates the internal buffer based on the record iterator.
2. create constructor in HoodieFileGroupReader to use the above record buffer.
3. enable above FileGroupReaderBasedMergeHandle to use such FG reader api.
4. add SI support FileGroupReaderBasedMergeHandle through callbacks.

### Impact

Unify COW write path using FG reader.

### Risk level (write none, low medium or high below)

Medium.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
