### PR TITLE
[HUDI-9611] Metadata writer tries to initialize invalid partitions

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -145,7 +145,7 @@ public abstract class HoodieWriteHandle<T, I, K, O> extends HoodieIOHandle<T, I,
   private void initSecondaryIndexStats(boolean preserveMetadata) {
     // Secondary index should not be updated for clustering and compaction
     // Since for clustering and compaction preserveMetadata is true, we are checking for it before enabling secondary index update
-    if (config.isSecondaryIndexEnabled() && !preserveMetadata) {
+    if (!preserveMetadata) {
       secondaryIndexDefns = hoodieTable.getMetaClient().getIndexMetadata()
           .map(indexMetadata -> indexMetadata.getIndexDefinitions().values())
           .orElse(Collections.emptyList())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1490,13 +1490,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   private void updateSecondaryIndexIfPresent(HoodieCommitMetadata commitMetadata, Map<String, HoodieData<HoodieRecord>> partitionToRecordMap,
                                              String instantTime) {
-    if (!dataWriteConfig.isSecondaryIndexEnabled()) {
+    boolean secondaryIndexMetadataPartitionAvailable = SECONDARY_INDEX.isMetadataPartitionAvailable(dataMetaClient);
+    if (!secondaryIndexMetadataPartitionAvailable) {
       return;
     }
     // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
     // because these operations do not change the secondary key - record key mapping.
     WriteOperationType operationType = commitMetadata.getOperationType();
-    if (operationType.isInsertOverwriteOrDeletePartition() && MetadataPartitionType.SECONDARY_INDEX.isMetadataPartitionAvailable(dataMetaClient)) {
+    if (operationType.isInsertOverwriteOrDeletePartition()) {
       throw new HoodieIndexException(String.format("Can not perform operation %s on secondary index", operationType));
     } else if (operationType == WriteOperationType.COMPACT || operationType == WriteOperationType.CLUSTER) {
       return;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -417,12 +417,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     // Already initialized partitions can be ignored
-    partitionsToInit.removeIf(metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable((metadataPartition))
-        || (metadataPartition == PARTITION_STATS && !dataMetaClient.getTableConfig().isTablePartitioned()));
+    partitionsToInit.removeIf(metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable((metadataPartition)));
 
-    if (partitionsToInit.isEmpty()) {
-      return true;
-    }
     // Get a complete list of files and partitions from the file system or from already initialized FILES partition of MDT
     List<DirectoryInfo> partitionInfoList;
     if (filesPartitionAvailable) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -417,8 +417,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     // Already initialized partitions can be ignored
-    partitionsToInit.removeIf(metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable((metadataPartition)));
+    partitionsToInit.removeIf(metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable((metadataPartition))
+        || (metadataPartition == PARTITION_STATS && !dataMetaClient.getTableConfig().isTablePartitioned()));
 
+    if (partitionsToInit.isEmpty()) {
+      return true;
+    }
     // Get a complete list of files and partitions from the file system or from already initialized FILES partition of MDT
     List<DirectoryInfo> partitionInfoList;
     if (filesPartitionAvailable) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -811,8 +811,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isSecondaryIndexEnabled() {
     // Secondary index is enabled only iff record index (primary key index) is also enabled and a secondary index column is specified.
-    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && getString(SECONDARY_INDEX_COLUMN) != null
-        && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
+    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
   }
 
   public int getSecondaryIndexParallelism() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -810,8 +810,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   }
 
   public boolean isSecondaryIndexEnabled() {
-    // Secondary index is enabled only iff record index (primary key index) is also enabled
-    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
+    // Secondary index is enabled only iff record index (primary key index) is also enabled and a secondary index column is specified.
+    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && getString(SECONDARY_INDEX_COLUMN) != null
+        && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
   }
 
   public int getSecondaryIndexParallelism() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -811,7 +811,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isSecondaryIndexEnabled() {
     // Secondary index is enabled only iff record index (primary key index) is also enabled and a secondary index column is specified.
-    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
+    return isRecordIndexEnabled() && getBoolean(SECONDARY_INDEX_ENABLE_PROP) && StringUtils.nonEmpty(getSecondaryIndexColumn())
+        && !isDropMetadataIndex(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath());
   }
 
   public int getSecondaryIndexParallelism() {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -204,7 +204,7 @@ public enum MetadataPartitionType {
   SECONDARY_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX, "secondary-index-", 7) {
     @Override
     public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
-      return metadataConfig.isSecondaryIndexEnabled();
+      return metadataConfig.isSecondaryIndexEnabled() && StringUtils.nonEmpty(metadataConfig.getSecondaryIndexColumn());
     }
 
     @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -26,6 +26,7 @@ import org.apache.hudi.avro.model.HoodieSecondaryIndexInfo;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -89,7 +90,7 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.mergeColumnStatsR
 public enum MetadataPartitionType {
   FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 2) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isEnabled();
     }
 
@@ -105,7 +106,7 @@ public enum MetadataPartitionType {
   },
   COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 3) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isColumnStatsIndexEnabled();
     }
 
@@ -127,7 +128,7 @@ public enum MetadataPartitionType {
   },
   BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 4) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isBloomFilterIndexEnabled();
     }
 
@@ -158,7 +159,7 @@ public enum MetadataPartitionType {
   },
   RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-", 5) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isRecordIndexEnabled() || metadataConfig.isPartitionedRecordIndexEnabled();
     }
 
@@ -181,7 +182,7 @@ public enum MetadataPartitionType {
   },
   EXPRESSION_INDEX(PARTITION_NAME_EXPRESSION_INDEX_PREFIX, "expr-index-", -1) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isExpressionIndexEnabled();
     }
 
@@ -203,8 +204,8 @@ public enum MetadataPartitionType {
   },
   SECONDARY_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX, "secondary-index-", 7) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
-      return metadataConfig.isSecondaryIndexEnabled() && StringUtils.nonEmpty(metadataConfig.getSecondaryIndexColumn());
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
+      return metadataConfig.isSecondaryIndexEnabled();
     }
 
     @Override
@@ -237,8 +238,8 @@ public enum MetadataPartitionType {
   },
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
-      return metadataConfig.isPartitionStatsIndexEnabled();
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
+      return tableConfig.isTablePartitioned() && metadataConfig.isPartitionStatsIndexEnabled();
     }
 
     @Override
@@ -260,7 +261,7 @@ public enum MetadataPartitionType {
   // ALL_PARTITIONS is just another record type in FILES partition
   ALL_PARTITIONS(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 1) {
     @Override
-    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig) {
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
       return metadataConfig.isEnabled();
     }
 
@@ -355,7 +356,7 @@ public enum MetadataPartitionType {
   /**
    * Check if the metadata partition is enabled based on the metadata config.
    */
-  public abstract boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig);
+  public abstract boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig);
 
   /**
    * Check if the metadata partition is available based on the table config.
@@ -470,8 +471,7 @@ public enum MetadataPartitionType {
       return Collections.emptyList();
     }
     return Arrays.stream(getValidValues())
-        .filter(partitionType -> partitionType.isMetadataPartitionEnabled(dataMetadataConfig) || partitionType.isMetadataPartitionAvailable(metaClient))
-        .filter(partitionType -> partitionType != PARTITION_STATS  || metaClient.getTableConfig().isTablePartitioned())
+        .filter(partitionType -> partitionType.isMetadataPartitionEnabled(dataMetadataConfig, metaClient.getTableConfig()) || partitionType.isMetadataPartitionAvailable(metaClient))
         .collect(Collectors.toList());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -471,6 +471,7 @@ public enum MetadataPartitionType {
     }
     return Arrays.stream(getValidValues())
         .filter(partitionType -> partitionType.isMetadataPartitionEnabled(dataMetadataConfig) || partitionType.isMetadataPartitionAvailable(metaClient))
+        .filter(partitionType -> partitionType != PARTITION_STATS  || metaClient.getTableConfig().isTablePartitioned())
         .collect(Collectors.toList());
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -30,13 +30,17 @@ import org.apache.hudi.common.util.StringUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -50,13 +54,25 @@ import static org.mockito.Mockito.when;
  */
 public class TestMetadataPartitionType {
 
+  private static Stream<Arguments> partitionTypeAndPartitionPairs() {
+    return Arrays.stream(MetadataPartitionType.values())
+        .flatMap(type -> {
+          if (type == MetadataPartitionType.PARTITION_STATS) {
+            // PARTITION_STATS can only be enabled if the table is partitioned
+            return Stream.of(Arguments.of(type, true));
+          }
+          return Stream.of(Arguments.of(type, true), Arguments.of(type, false));
+        });
+  }
+
   @ParameterizedTest
-  @EnumSource(MetadataPartitionType.class)
-  public void testPartitionEnabledByConfigOnly(MetadataPartitionType partitionType) {
+  @MethodSource("partitionTypeAndPartitionPairs")
+  public void testPartitionEnabledByConfigOnly(MetadataPartitionType partitionType, boolean isTablePartitioned) {
     HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
 
     // Simulate the configuration enabling given partition type, but the meta client not having it available (yet to initialize the partition)
+    Mockito.when(tableConfig.isTablePartitioned()).thenReturn(isTablePartitioned);
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(partitionType)).thenReturn(false);
     Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
@@ -65,24 +81,27 @@ public class TestMetadataPartitionType {
     switch (partitionType) {
       case EXPRESSION_INDEX:
         metadataConfigBuilder.enable(true).withExpressionIndexEnabled(true);
-        expectedEnabledPartitions = 4;
+        expectedEnabledPartitions = 3;
         break;
       case SECONDARY_INDEX:
-        metadataConfigBuilder.enable(true).withEnableRecordIndex(true).withSecondaryIndexEnabled(true);
-        expectedEnabledPartitions = 5;
+        metadataConfigBuilder.enable(true).withEnableRecordIndex(true).withSecondaryIndexEnabled(true).withSecondaryIndexForColumn("col1");
+        expectedEnabledPartitions = 4;
         break;
       case BLOOM_FILTERS:
         metadataConfigBuilder.enable(true).withMetadataIndexBloomFilter(true);
-        expectedEnabledPartitions = 4;
+        expectedEnabledPartitions = 3;
         break;
       case RECORD_INDEX:
         metadataConfigBuilder.enable(true).withEnableRecordIndex(true);
-        expectedEnabledPartitions = 5;
+        expectedEnabledPartitions = 3;
         break;
       default:
         metadataConfigBuilder.enable(true);
-        expectedEnabledPartitions = 3; // by default, FILES, COLUMN_STATS, PARTITION_STATS are enabled
+        expectedEnabledPartitions = 2; // by default, FILES, COLUMN_STATS are enabled
         break;
+    }
+    if (isTablePartitioned) {
+      expectedEnabledPartitions++; // PARTITION_STATS is enabled by default if table is partitioned
     }
 
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfigBuilder.build(), metaClient);
@@ -99,6 +118,7 @@ public class TestMetadataPartitionType {
 
     // Simulate the meta client having RECORD_INDEX available but config not enabling it
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
     Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
@@ -138,6 +158,7 @@ public class TestMetadataPartitionType {
 
     // Simulate the meta client having EXPRESSION_INDEX available
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
     HoodieIndexDefinition expressionIndexDefinition = createIndexDefinition(MetadataPartitionType.EXPRESSION_INDEX, "dummy", "column_stats", "lower", Collections.singletonList("name"), null);
     HoodieIndexMetadata expressionIndexMetadata = new HoodieIndexMetadata(Collections.singletonMap("expr_index_dummy", expressionIndexDefinition));

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -506,7 +506,8 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
           .mode(SaveMode.Append)
           .save(basePath))(
           "Can not perform operation " + WriteOperationType.fromValue(operationType) + " on secondary index")
-        // disable secondary index and retry
+        // drop secondary index and retry
+        spark.sql(s"drop index idx_rider on $tableName")
         df.write.format("hudi")
           .options(hudiOpts)
           .option(HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key, "false")


### PR DESCRIPTION
### Change Logs

There are two cases that currently re-trigger the `initializeFromFilesystem` on each write:
1. Partition stats are always missing on tables that are not partitioned
2. Secondary index is missing on tables with Record Level Index

Fix:
- Return that secondary index is only enabled if a column is specified for the index
- Remove partition stats index from the list of enabled partitions if the table is not partitioned

### Impact

Reduces writer overhead

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
