### PR TITLE
[HUDI-9621] Fix divergence between file index and incremental file index

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
@@ -17,14 +17,12 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
+import org.apache.hudi.common.model.HoodieLogFile
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.storage.StoragePathInfo
 import org.apache.hudi.util.JFunction
 
-import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.datasources.{FileIndex, FileStatusCache, NoopCache, PartitionDirectory}
 import org.apache.spark.sql.sources.Filter
@@ -48,64 +46,13 @@ class HoodieIncrementalFileIndex(override val spark: SparkSession,
     spark.sqlContext, options, metaClient, schemaSpec, schemaSpec)
 
   override def listFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
-    hasPushedDownPartitionPredicates = true
-
-    val fileSlices = mergeOnReadIncrementalRelation.listFileSplits(partitionFilters, dataFilters)
-    if (fileSlices.isEmpty) {
-      Seq.empty
-    } else {
-      val prunedPartitionsAndFilteredFileSlices = fileSlices.map {
+    val fileSlices = mergeOnReadIncrementalRelation.listFileSplits(partitionFilters, dataFilters).toSeq.flatMap(
+      {
         case (partitionValues, fileSlices) =>
-          if (shouldEmbedFileSlices) {
-            val baseFileStatusesAndLogFileOnly: Seq[FileStatus] = fileSlices.map(slice => {
-              if (slice.getBaseFile.isPresent) {
-                slice.getBaseFile.get().getPathInfo
-              } else if (includeLogFiles && slice.getLogFiles.findAny().isPresent) {
-                slice.getLogFiles.findAny().get().getPathInfo
-              } else {
-                null
-              }
-            }).filter(slice => slice != null)
-              .map(pathInfo => new FileStatus(pathInfo.getLength, pathInfo.isDirectory, pathInfo.getBlockReplication, pathInfo.getBlockSize,
-                pathInfo.getModificationTime, new Path(pathInfo.getPath.toUri)))
-            val c = fileSlices.filter(f => (includeLogFiles && f.getLogFiles.findAny().isPresent)
-              || (f.getBaseFile.isPresent && f.getBaseFile.get().getBootstrapBaseFile.isPresent)).
-              foldLeft(Map[String, FileSlice]()) { (m, f) => m + (f.getFileId -> f) }
-            if (c.nonEmpty) {
-              sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
-                new HoodiePartitionFileSliceMapping(partitionValues, c), baseFileStatusesAndLogFileOnly)
-            } else {
-              sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
-                partitionValues, baseFileStatusesAndLogFileOnly)
-            }
-          } else {
-            val allCandidateFiles: Seq[FileStatus] = fileSlices.flatMap(fs => {
-              val baseFileStatusOpt = getBaseFileInfo(Option.apply(fs.getBaseFile.orElse(null)))
-              val logFilesStatus = if (includeLogFiles) {
-                fs.getLogFiles.map[StoragePathInfo](JFunction.toJavaFunction[HoodieLogFile, StoragePathInfo](lf => lf.getPathInfo))
-              } else {
-                java.util.stream.Stream.empty()
-              }
-              val files = logFilesStatus.collect(Collectors.toList[StoragePathInfo]).asScala
-              baseFileStatusOpt.foreach(f => files.append(f))
-              files
-            })
-              .map(fileInfo => new FileStatus(fileInfo.getLength, fileInfo.isDirectory, 0, fileInfo.getBlockSize,
-                fileInfo.getModificationTime, new Path(fileInfo.getPath.toUri)))
-            sparkAdapter.getSparkPartitionedFileUtils.newPartitionDirectory(
-              partitionValues, allCandidateFiles)
-          }
-      }.toSeq
-
-      if (shouldReadAsPartitionedTable()) {
-        prunedPartitionsAndFilteredFileSlices
-      } else if (shouldEmbedFileSlices) {
-        assert(partitionSchema.isEmpty)
-        prunedPartitionsAndFilteredFileSlices
-      } else {
-        Seq(PartitionDirectory(InternalRow.empty, prunedPartitionsAndFilteredFileSlices.flatMap(_.files)))
+          fileSlices.filter(!_.isEmpty).map(fs => ( partitionValues, fs.withLogFiles(includeLogFiles)))
       }
-    }
+    )
+    prepareFileSlices(fileSlices)
   }
 
   override def inputFiles: Array[String] = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestPartitionDirectoryConverter.scala
@@ -17,7 +17,6 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.BaseHoodieTableFileIndex.PartitionPath
 import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{FileSlice, HoodieBaseFile, HoodieFileGroupId, HoodieLogFile}
@@ -26,6 +25,7 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.getSparkConfForTest
 
 import org.apache.commons.lang.math.RandomUtils.nextInt
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.junit.jupiter.params.ParameterizedTest
@@ -79,10 +79,9 @@ class TestPartitionDirectoryConverter extends SparkAdapterSupport {
     val expectedTaskCount = 100
     val maxSplitSize = totalSize / expectedTaskCount
     val partitionValues = Seq("2025-01-01")
-    val partitionOpt = Some(new PartitionPath(partitionPath, partitionValues.toArray))
 
     val partitionedFiles = slices.flatMap(slice => {
-      val dir = PartitionDirectoryConverter.convertFileSliceToPartitionDirectory(partitionOpt, slice, options)
+      val dir = PartitionDirectoryConverter.convertFileSliceToPartitionDirectory(InternalRow.fromSeq(partitionValues), slice, options)
       dir.files.flatMap(file => {
         // getPath() is very expensive so we only want to call it once in this block:
         val filePath = file.getPath


### PR DESCRIPTION
### Change Logs

There was duplicate code and then some of it was changed in:
https://issues.apache.org/jira/browse/HUDI-9250
https://issues.apache.org/jira/browse/HUDI-9451
causing a divergence. This pr breaks out the common logic so that changes will be used by both branches now.

### Impact

benefits of  HUDI-9250 and HUDI-9451 apply to incremental queries and prevent further divergence

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
