### PR TITLE
[HUDI-9634] Archival considers retaining the `the earliest retain instant` in the clean plan

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.client.timeline.versioning.v2;
 
+import org.apache.hudi.avro.model.HoodieActionInstant;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.client.timeline.HoodieTimelineArchiver;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -32,10 +34,12 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -254,6 +258,25 @@ public class TimelineArchiverV2<T extends HoodieAvroPayload, I, K, O> implements
       // the active timeline of metadata table to be extremely long, leading to performance issues
       // for loading the timeline.
       earliestInstantToRetainCandidates.add(qualifiedEarliestInstant);
+    }
+
+    // 6. If archival should consider `earliest retain instant` in the clean plan,
+    // we should add the earliest retain instant from the clean plan to the candidates.
+    if (config.shouldArchiveKeepCleanPlanRetainInstant()) {
+      Option<HoodieInstant> latestCleanInstantOpt = table.getActiveTimeline().getCleanerTimeline().lastInstant();
+      if (latestCleanInstantOpt.isPresent()) {
+        HoodieCleanerPlan cleanerPlan = CleanerUtils.getCleanerPlan(metaClient, latestCleanInstantOpt.get());
+        Option<String> earliestInstantTimeToRetain = Option.ofNullable(cleanerPlan.getEarliestInstantToRetain()).map(HoodieActionInstant::getTimestamp);
+        if (earliestInstantTimeToRetain.isPresent() && !StringUtils.isNullOrEmpty(earliestInstantTimeToRetain.get())) {
+          HoodieActionInstant earliestInstantToRetainForCleaning = cleanerPlan.getEarliestInstantToRetain();
+          earliestInstantToRetainCandidates.add(
+                  Option.of(new HoodieInstant(
+                      HoodieInstant.State.valueOf(earliestInstantToRetainForCleaning.getState()),
+                      earliestInstantToRetainForCleaning.getAction(),
+                      earliestInstantToRetainForCleaning.getTimestamp(),
+                      InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+        }
+      }
     }
 
     // Choose the instant in earliestInstantToRetainCandidates with the smallest

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -102,6 +102,13 @@ public class HoodieArchivalConfig extends HoodieConfig {
       .withDocumentation("If enabled, archival will proceed beyond savepoint, skipping savepoint commits."
           + " If disabled, archival will stop at the earliest savepoint commit.");
 
+  public static final ConfigProperty<Boolean> ARCHIVE_KEEP_CLEAN_PLAN_RETAIN_INSTANT = ConfigProperty
+      .key("hoodie.archive.keep.clean.plan.retain.instant")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("If enabled, archival will consider to keep `earliest retain instant` in the clean plan.");
+
   /**
    * @deprecated Use {@link #MAX_COMMITS_TO_KEEP} and its methods instead
    */
@@ -190,6 +197,11 @@ public class HoodieArchivalConfig extends HoodieConfig {
 
     public Builder withArchiveBeyondSavepoint(boolean archiveBeyondSavepoint) {
       archivalConfig.setValue(ARCHIVE_BEYOND_SAVEPOINT, String.valueOf(archiveBeyondSavepoint));
+      return this;
+    }
+
+    public Builder withArchiveKeepCleanPlanRetainInstant(boolean archiveKeepCleanPlanRetainInstant) {
+      archivalConfig.setValue(ARCHIVE_KEEP_CLEAN_PLAN_RETAIN_INSTANT, String.valueOf(archiveKeepCleanPlanRetainInstant));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1681,6 +1681,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP);
   }
 
+  public boolean shouldArchiveKeepCleanPlanRetainInstant() {
+    return getBoolean(HoodieArchivalConfig.ARCHIVE_KEEP_CLEAN_PLAN_RETAIN_INSTANT);
+  }
+
   public int getTimelineCompactionBatchSize() {
     return getInt(HoodieArchivalConfig.TIMELINE_COMPACTION_BATCH_SIZE);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -188,6 +188,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
           return getPartitionPathsForIncrementalCleaning(cleanMetadata, instantToRetain);
         }
       }
+      LOG.info("Falling back to full cleaning as no previous clean metadata found or earliest commit to retain is not valid. Last Clean: {}", lastClean);
     }
     return getPartitionPathsForFullCleaning();
   }


### PR DESCRIPTION
In most of our scenarios, we use the clean incremental scanning form to ensure the stability of clean because our table has a large number of partitions and the update frequency of the partitions is relatively low. If we do not use incremental scanning to clean, then each time we need to load the files of all partitions of the entire table.

### Change Logs

1. Archival considers retaining the `the earliest retain instant` in the clean plan


### Impact

Enhance the stability of cleaning service

### Risk level (write none, low medium or high below)

low


### Documentation Update

none


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
