### PR TITLE
[HUDI-9640] Replace merge_properties with a list properties with a given prefix

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -120,6 +120,11 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final String HOODIE_TABLE_NAME_KEY = "hoodie.table.name";
   public static final String PARTIAL_UPDATE_CUSTOM_MARKER = "hoodie.write.partial.update.custom.marker";
   public static final String DEBEZIUM_UNAVAILABLE_VALUE = "__debezium_unavailable_value";
+  // This prefix is used to set merging related properties.
+  // A reader might need to read some writer properties to function as expected,
+  // and Hudi stores properties with this prefix so the reader parses these properties,
+  // and produces a map of key value pairs (Key1->Value1, Key2->Value2, ...) to use.
+  public static final String MERGE_CUSTOM_PROPERTY_PREFIX = "hoodie.merge.custom.property.prefix.";
 
   public static final ConfigProperty<String> DATABASE_NAME = ConfigProperty
       .key("hoodie.database.name")
@@ -322,14 +327,6 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("1.1.0")
       .withDocumentation("This property when set, will define how two versions of the record will be "
           + "merged together where the later contains only partial set of values and not entire record.");
-
-  public static final ConfigProperty<String> MERGE_CUSTOM_PROPERTY_PREFIX = ConfigProperty
-      .key("hoodie.merge.custom.property.prefix")
-      .noDefaultValue()
-      .sinceVersion("1.1.0")
-      .withDocumentation("Some merge mode might need writer properties that are required for readers "
-          + "to function as expected, e.g., Ki=Vi. Hudi stores those properties with this prefix so readers "
-          + "can set them while reading, e.g., hoodie.merge.custom.prefix.Ki=Vi.");
 
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = KeyGeneratorOptions.URL_ENCODE_PARTITIONING;
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -121,10 +121,10 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final String PARTIAL_UPDATE_CUSTOM_MARKER = "hoodie.write.partial.update.custom.marker";
   public static final String DEBEZIUM_UNAVAILABLE_VALUE = "__debezium_unavailable_value";
   // This prefix is used to set merging related properties.
-  // A reader might need to read some writer properties to function as expected,
+  // A reader might need to read some merger properties to function as expected,
   // and Hudi stores properties with this prefix so the reader parses these properties,
   // and produces a map of key value pairs (Key1->Value1, Key2->Value2, ...) to use.
-  public static final String MERGE_CUSTOM_PROPERTY_PREFIX = "hoodie.merge.custom.property.prefix.";
+  public static final String MERGE_PROPERTIES_PREFIX = "hoodie.table.merge.properties.";
 
   public static final ConfigProperty<String> DATABASE_NAME = ConfigProperty
       .key("hoodie.database.name")
@@ -1201,6 +1201,10 @@ public class HoodieTableConfig extends HoodieConfig {
       return Option.of(getBaseFileFormat());
     }
     return Option.empty();
+  }
+
+  public Map<String, String> getTableMergeProperties() {
+    return ConfigUtils.extractWithPrefix(this.props, MERGE_PROPERTIES_PREFIX);
   }
 
   public Map<String, String> propsMap() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -323,14 +323,13 @@ public class HoodieTableConfig extends HoodieConfig {
       .withDocumentation("This property when set, will define how two versions of the record will be "
           + "merged together where the later contains only partial set of values and not entire record.");
 
-  public static final ConfigProperty<String> MERGE_PROPERTIES = ConfigProperty
-      .key("hoodie.table.merge.properties")
+  public static final ConfigProperty<String> MERGE_CUSTOM_PROPERTY_PREFIX = ConfigProperty
+      .key("hoodie.merge.custom.property.prefix")
       .noDefaultValue()
       .sinceVersion("1.1.0")
-      .withDocumentation("The value of this property is in the format of 'K1=V1,K2=V2,...,Ki=Vi,...'. "
-          + "Each (Ki, Vi) pair represents a property used during merge scenarios. "
-          + "Some merge mode might need some writer properties that are required for readers to function as expected. "
-          + "Hudi stores those properties here so readers can set them while reading.");
+      .withDocumentation("Some merge mode might need writer properties that are required for readers "
+          + "to function as expected, e.g., Ki=Vi. Hudi stores those properties with this prefix so readers "
+          + "can set them while reading, e.g., hoodie.merge.custom.prefix.Ki=Vi.");
 
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = KeyGeneratorOptions.URL_ENCODE_PARTITIONING;
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -105,6 +105,7 @@ public final class HoodieFileGroupReader<T> implements Closeable {
     }
     this.props = props;
     HoodieTableConfig tableConfig = hoodieTableMetaClient.getTableConfig();
+    this.props.putAll(tableConfig.getTableMergeProperties());
     this.partitionPathFields = tableConfig.getPartitionFields();
     readerContext.initRecordMerger(props);
     readerContext.setTablePath(tablePath);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
@@ -174,6 +174,6 @@ public class PartialUpdateStrategy<T> {
   }
 
   static Map<String, String> parseMergeProperties(TypedProperties props) {
-    return extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    return extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
@@ -21,9 +21,7 @@ package org.apache.hudi.common.table.read;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.PartialUpdateMode;
-import org.apache.hudi.common.util.StringUtils;
 
 import org.apache.avro.Schema;
 
@@ -32,14 +30,15 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS_NAME_TO_POS;
+import static org.apache.hudi.common.table.HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_CUSTOM_MARKER;
-import static org.apache.hudi.common.util.ConfigUtils.toMap;
+import static org.apache.hudi.common.util.ConfigUtils.extractWithPrefix;
 
 /**
  * This class implements the detailed partial update logic for different partial update modes,
  * which is wrapped into partial update mergers
- * {@link BufferedRecordMergerFactory.CommitTimeBufferedRecordPartialUpdateMerger} and
- * {@link BufferedRecordMergerFactory.EventTimeBufferedRecordPartialUpdateMerger}.
+ * {@link BufferedRecordMergerFactory.CommitTimePartialRecordMerger} and
+ * {@link BufferedRecordMergerFactory.EventTimePartialRecordMerger}.
  */
 public class PartialUpdateStrategy<T> {
   private final HoodieReaderContext<T> readerContext;
@@ -175,11 +174,6 @@ public class PartialUpdateStrategy<T> {
   }
 
   static Map<String, String> parseMergeProperties(TypedProperties props) {
-    Map<String, String> properties = new HashMap<>();
-    String raw = props.getProperty(HoodieTableConfig.MERGE_PROPERTIES.key());
-    if (StringUtils.isNullOrEmpty(raw)) {
-      return properties;
-    }
-    return toMap(raw, ",");
+    return extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateStrategy.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS_NAME_TO_POS;
-import static org.apache.hudi.common.table.HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX;
+import static org.apache.hudi.common.table.HoodieTableConfig.MERGE_PROPERTIES_PREFIX;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_CUSTOM_MARKER;
 import static org.apache.hudi.common.util.ConfigUtils.extractWithPrefix;
 
@@ -174,6 +174,6 @@ public class PartialUpdateStrategy<T> {
   }
 
   static Map<String, String> parseMergeProperties(TypedProperties props) {
-    return extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    return extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -42,6 +42,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -661,18 +662,17 @@ public class ConfigUtils {
 
   /**
    * Extract all properties whose keys start with a given prefix.
-   * E.g., if the prefix is "a.b.c", and the props contain:
+   * E.g., if the prefix is "a.b.c.", and the props contain:
    * "a.b.c.K1=V1", "a.b.c.K2=V2", "a.b.c.K3=V3".
    * Then the output is:
    * Map(K1->V1, K2->V2, K3->V3).
    */
   public static Map<String, String> extractWithPrefix(TypedProperties props, String prefix) {
     if (props == null || props.isEmpty()) {
-      return new HashMap<>();
+      return Collections.emptyMap();
     }
-    int prefixLength = prefix.length();
-    int dotOffset = prefixLength + 1; // +1 for the dot after prefix
 
+    int prefixLength = prefix.length();
     Map<String, String> mergeProperties = new HashMap<>();
     for (Map.Entry<Object, Object> entry : props.entrySet()) {
       String key = entry.getKey().toString();
@@ -680,12 +680,8 @@ public class ConfigUtils {
       if (key.length() <= prefixLength || !key.startsWith(prefix)) {
         continue;
       }
-      // Check if the character after prefix is a dot
-      if (key.charAt(prefixLength) != '.') {
-        continue;
-      }
       // Extract and validate the property key
-      String propKey = key.substring(dotOffset).trim();
+      String propKey = key.substring(prefixLength).trim();
       if (propKey.isEmpty()) {
         continue;
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateStrategy.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateStrategy.java
@@ -20,65 +20,19 @@
 package org.apache.hudi.common.table.read;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.table.HoodieTableConfig;
 
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestPartialUpdateStrategy {
   @Test
-  void testParseValidProperties() {
+  void testEmptyProperties() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES.key(), "a=1,b=2,c=3");
-    Map<String, String> result = PartialUpdateStrategy.parseMergeProperties(props);
-
-    assertEquals(3, result.size());
-    assertEquals("1", result.get("a"));
-    assertEquals("2", result.get("b"));
-    assertEquals("3", result.get("c"));
-  }
-
-  @Test
-  void testHandlesWhitespace() {
-    TypedProperties props = new TypedProperties();
-    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES.key(), " a = 1 , b=  2 ,c=3 ");
-    Map<String, String> result = PartialUpdateStrategy.parseMergeProperties(props);
-
-    assertEquals(3, result.size());
-    assertEquals("1", result.get("a"));
-    assertEquals("2", result.get("b"));
-    assertEquals("3", result.get("c"));
-  }
-
-  @Test
-  void testIgnoresEmptyEntriesAndMissingEquals() {
-    TypedProperties props = new TypedProperties();
-    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES.key(), ",a=1,,b,c=3");
-    Map<String, String> result = PartialUpdateStrategy.parseMergeProperties(props);
-
-    assertEquals(3, result.size());
-    assertEquals("1", result.get("a"));
-    assertEquals("3", result.get("c"));
-    assertEquals("", result.get("b"));
-  }
-
-  @Test
-  void testEmptyInputReturnsEmptyMap() {
-    TypedProperties props = new TypedProperties();
-    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES.key(), "");
-    Map<String, String> result = PartialUpdateStrategy.parseMergeProperties(props);
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testMissingKeyReturnsEmptyMap() {
-    TypedProperties props = new TypedProperties(); // no property set
     Map<String, String> result = PartialUpdateStrategy.parseMergeProperties(props);
     assertTrue(result.isEmpty());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX;
+import static org.apache.hudi.common.table.HoodieTableConfig.MERGE_PROPERTIES_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -128,8 +128,8 @@ public class TestConfigUtils {
   @Test
   void testParseValidProperties() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "Ki", "Vi");
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "Ki", "Vi");
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(1, result.size());
     assertEquals("Vi", result.get("Ki"));
   }
@@ -137,18 +137,18 @@ public class TestConfigUtils {
   @Test
   void testMissingKeyReturnsEmptyMap() {
     TypedProperties props = new TypedProperties(); // no property set
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertTrue(result.isEmpty());
   }
 
   @Test
   void testMultipleValidProperties() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key1", "value1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key2", "value2");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key3", "value3");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key1", "value1");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key2", "value2");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key3", "value3");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(3, result.size());
     assertEquals("value1", result.get("key1"));
     assertEquals("value2", result.get("key2"));
@@ -158,11 +158,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithDifferentPrefixes() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "mergeKey", "mergeValue");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "mergeKey", "mergeValue");
     props.setProperty("other.prefix.key", "otherValue");
     props.setProperty("hoodie.merge.custom.property.prefix", "directPrefixValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(1, result.size());
     assertEquals("mergeValue", result.get("mergeKey"));
   }
@@ -170,9 +170,9 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithEmptyValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "emptyKey", "");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "emptyKey", "");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(1, result.size());
     assertEquals("", result.get("emptyKey"));
   }
@@ -180,11 +180,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithSpecialCharacters() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key.with.dots", "value.with.dots");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key_with_underscores", "value_with_underscores");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key-with-dashes", "value-with-dashes");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key.with.dots", "value.with.dots");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key_with_underscores", "value_with_underscores");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key-with-dashes", "value-with-dashes");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(3, result.size());
     assertEquals("value.with.dots", result.get("key.with.dots"));
     assertEquals("value_with_underscores", result.get("key_with_underscores"));
@@ -194,11 +194,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithNumericValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "intKey", "123");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "doubleKey", "123.45");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "booleanKey", "true");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "intKey", "123");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "doubleKey", "123.45");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "booleanKey", "true");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(3, result.size());
     assertEquals("123", result.get("intKey"));
     assertEquals("123.45", result.get("doubleKey"));
@@ -208,9 +208,9 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithWhitespace() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  spacedKey  ", "  spacedValue  ");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "  spacedKey  ", "  spacedValue  ");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(1, result.size());
     assertEquals("spacedValue", result.get("spacedKey")); // Values should be trimmed
   }
@@ -218,10 +218,10 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithWhitespaceInKeysAndValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  keyWithSpaces  ", "  valueWithSpaces  ");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "keyWithoutSpaces", "valueWithoutSpaces");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "  keyWithSpaces  ", "  valueWithSpaces  ");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "keyWithoutSpaces", "valueWithoutSpaces");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(2, result.size());
     assertEquals("valueWithSpaces", result.get("keyWithSpaces")); // Both key and value should be trimmed
     assertEquals("valueWithoutSpaces", result.get("keyWithoutSpaces"));
@@ -230,28 +230,28 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithExactPrefixMatch() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "exactPrefixValue");
+    props.setProperty(MERGE_PROPERTIES_PREFIX, "exactPrefixValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(0, result.size()); // Exact prefix match should not be included as it has no suffix
   }
 
   @Test
   void testPropertiesWithPrefixFollowedByDot() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "valueAfterDot");
+    props.setProperty(MERGE_PROPERTIES_PREFIX, "valueAfterDot");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(0, result.size()); // Empty key after trimming should be filtered out
   }
 
   @Test
   void testPropertiesWithWhitespaceOnlyKeys() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "   ", "valueForWhitespaceKey");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  \t  \n  ", "valueForTabNewlineKey");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "   ", "valueForWhitespaceKey");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "  \t  \n  ", "valueForTabNewlineKey");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(0, result.size());
   }
 
@@ -259,21 +259,21 @@ public class TestConfigUtils {
   void testPropertiesWithNullKeys() {
     TypedProperties props = new TypedProperties();
     // Note: TypedProperties doesn't allow null keys, but we test the edge case
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "valueForNullKey");
+    props.setProperty(MERGE_PROPERTIES_PREFIX, "valueForNullKey");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(0, result.size()); // Empty key should be filtered out
   }
 
   @Test
   void testPropertiesWithMixedValidAndInvalidKeys() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "validKey", "validValue");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "   ", "invalidValue1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "invalidValue2");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "anotherValidKey", "anotherValidValue");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "validKey", "validValue");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "   ", "invalidValue1");
+    props.setProperty(MERGE_PROPERTIES_PREFIX, "invalidValue2");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "anotherValidKey", "anotherValidValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(2, result.size()); // Only valid keys should be included
     assertEquals("validValue", result.get("validKey"));
     assertEquals("anotherValidValue", result.get("anotherValidKey"));
@@ -282,10 +282,10 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithCaseSensitivity() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "Key1", "Value1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key1", "value1");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "Key1", "Value1");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "key1", "value1");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(2, result.size());
     assertEquals("Value1", result.get("Key1"));
     assertEquals("value1", result.get("key1"));
@@ -294,10 +294,10 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithLeadingAndTrailingWhitespace() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  leadingSpaceKey", "trailingSpaceValue  ");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "trailingSpaceKey  ", "  leadingSpaceValue");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "  leadingSpaceKey", "trailingSpaceValue  ");
+    props.setProperty(MERGE_PROPERTIES_PREFIX + "trailingSpaceKey  ", "  leadingSpaceValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_PROPERTIES_PREFIX);
     assertEquals(2, result.size());
     assertEquals("trailingSpaceValue", result.get("leadingSpaceKey")); // Trimmed
     assertEquals("leadingSpaceValue", result.get("trailingSpaceKey")); // Trimmed
@@ -305,7 +305,7 @@ public class TestConfigUtils {
 
   @Test
   void testNullProperties() {
-    Map<String, String> result = ConfigUtils.extractWithPrefix(null, MERGE_CUSTOM_PROPERTY_PREFIX);
+    Map<String, String> result = ConfigUtils.extractWithPrefix(null, MERGE_PROPERTIES_PREFIX);
     assertTrue(result.isEmpty());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
@@ -128,8 +128,8 @@ public class TestConfigUtils {
   @Test
   void testParseValidProperties() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".Ki", "Vi");
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "Ki", "Vi");
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(1, result.size());
     assertEquals("Vi", result.get("Ki"));
   }
@@ -137,18 +137,18 @@ public class TestConfigUtils {
   @Test
   void testMissingKeyReturnsEmptyMap() {
     TypedProperties props = new TypedProperties(); // no property set
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertTrue(result.isEmpty());
   }
 
   @Test
   void testMultipleValidProperties() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key1", "value1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key2", "value2");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key3", "value3");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key1", "value1");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key2", "value2");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key3", "value3");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(3, result.size());
     assertEquals("value1", result.get("key1"));
     assertEquals("value2", result.get("key2"));
@@ -158,11 +158,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithDifferentPrefixes() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".mergeKey", "mergeValue");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "mergeKey", "mergeValue");
     props.setProperty("other.prefix.key", "otherValue");
     props.setProperty("hoodie.merge.custom.property.prefix", "directPrefixValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(1, result.size());
     assertEquals("mergeValue", result.get("mergeKey"));
   }
@@ -170,9 +170,9 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithEmptyValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".emptyKey", "");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "emptyKey", "");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(1, result.size());
     assertEquals("", result.get("emptyKey"));
   }
@@ -180,11 +180,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithSpecialCharacters() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key.with.dots", "value.with.dots");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key_with_underscores", "value_with_underscores");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key-with-dashes", "value-with-dashes");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key.with.dots", "value.with.dots");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key_with_underscores", "value_with_underscores");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key-with-dashes", "value-with-dashes");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(3, result.size());
     assertEquals("value.with.dots", result.get("key.with.dots"));
     assertEquals("value_with_underscores", result.get("key_with_underscores"));
@@ -194,11 +194,11 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithNumericValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".intKey", "123");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".doubleKey", "123.45");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".booleanKey", "true");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "intKey", "123");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "doubleKey", "123.45");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "booleanKey", "true");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(3, result.size());
     assertEquals("123", result.get("intKey"));
     assertEquals("123.45", result.get("doubleKey"));
@@ -208,9 +208,9 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithWhitespace() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".  spacedKey  ", "  spacedValue  ");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  spacedKey  ", "  spacedValue  ");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(1, result.size());
     assertEquals("spacedValue", result.get("spacedKey")); // Values should be trimmed
   }
@@ -218,10 +218,10 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithWhitespaceInKeysAndValues() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".  keyWithSpaces  ", "  valueWithSpaces  ");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".keyWithoutSpaces", "valueWithoutSpaces");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  keyWithSpaces  ", "  valueWithSpaces  ");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "keyWithoutSpaces", "valueWithoutSpaces");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(2, result.size());
     assertEquals("valueWithSpaces", result.get("keyWithSpaces")); // Both key and value should be trimmed
     assertEquals("valueWithoutSpaces", result.get("keyWithoutSpaces"));
@@ -230,69 +230,50 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithExactPrefixMatch() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key(), "exactPrefixValue");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "exactPrefixValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(0, result.size()); // Exact prefix match should not be included as it has no suffix
   }
 
   @Test
   void testPropertiesWithPrefixFollowedByDot() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".", "valueAfterDot");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "valueAfterDot");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(0, result.size()); // Empty key after trimming should be filtered out
-  }
-
-  @Test
-  void testPropertiesWithPrefixWithoutDot() {
-    TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + "suffix", "valueWithoutDot");
-
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
-    assertEquals(0, result.size()); // Should not match as it doesn't have the expected format
-  }
-
-  @Test
-  void testPropertiesWithPrefixFollowedBySpace() {
-    TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + " key", "valueWithSpace");
-
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
-    assertEquals(0, result.size()); // Should not match as it doesn't have the expected format
   }
 
   @Test
   void testPropertiesWithWhitespaceOnlyKeys() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".   ", "valueForWhitespaceKey");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".  \t  \n  ", "valueForTabNewlineKey");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "   ", "valueForWhitespaceKey");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  \t  \n  ", "valueForTabNewlineKey");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
-    assertEquals(0, result.size()); // Keys with only whitespace should be filtered out
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    assertEquals(0, result.size());
   }
 
   @Test
   void testPropertiesWithNullKeys() {
     TypedProperties props = new TypedProperties();
     // Note: TypedProperties doesn't allow null keys, but we test the edge case
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".", "valueForNullKey");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "valueForNullKey");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(0, result.size()); // Empty key should be filtered out
   }
 
   @Test
   void testPropertiesWithMixedValidAndInvalidKeys() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".validKey", "validValue");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".   ", "invalidValue1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".", "invalidValue2");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".anotherValidKey", "anotherValidValue");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + "invalidSuffix", "invalidValue3");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "validKey", "validValue");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "   ", "invalidValue1");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX, "invalidValue2");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "anotherValidKey", "anotherValidValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(2, result.size()); // Only valid keys should be included
     assertEquals("validValue", result.get("validKey"));
     assertEquals("anotherValidValue", result.get("anotherValidKey"));
@@ -301,10 +282,10 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithCaseSensitivity() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".Key1", "Value1");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".key1", "value1");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "Key1", "Value1");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "key1", "value1");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertEquals(2, result.size());
     assertEquals("Value1", result.get("Key1"));
     assertEquals("value1", result.get("key1"));
@@ -313,17 +294,18 @@ public class TestConfigUtils {
   @Test
   void testPropertiesWithLeadingAndTrailingWhitespace() {
     TypedProperties props = new TypedProperties();
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".  leadingSpaceKey", "trailingSpaceValue  ");
-    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX.key() + "trailingSpaceKey  ", "  leadingSpaceValue");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "  leadingSpaceKey", "trailingSpaceValue  ");
+    props.setProperty(MERGE_CUSTOM_PROPERTY_PREFIX + "trailingSpaceKey  ", "  leadingSpaceValue");
 
-    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX.key());
-    assertEquals(1, result.size()); // Only the first one should match due to proper format
+    Map<String, String> result = ConfigUtils.extractWithPrefix(props, MERGE_CUSTOM_PROPERTY_PREFIX);
+    assertEquals(2, result.size());
     assertEquals("trailingSpaceValue", result.get("leadingSpaceKey")); // Trimmed
+    assertEquals("leadingSpaceValue", result.get("trailingSpaceKey")); // Trimmed
   }
 
   @Test
   void testNullProperties() {
-    Map<String, String> result = ConfigUtils.extractWithPrefix(null, MERGE_CUSTOM_PROPERTY_PREFIX.key());
+    Map<String, String> result = ConfigUtils.extractWithPrefix(null, MERGE_CUSTOM_PROPERTY_PREFIX);
     assertTrue(result.isEmpty());
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -298,7 +298,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   @Test
   void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(41, configProperties.size());
+    assertEquals(40, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -47,7 +47,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -80,7 +82,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * Tests {@link HoodieTableConfig}.
  */
 class TestHoodieTableConfig extends HoodieCommonTestHarness {
-
   private HoodieStorage storage;
   private StoragePath metaPath;
   private StoragePath cfgPath;
@@ -93,14 +94,18 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     metaPath = new StoragePath(basePath, HoodieTableMetaClient.METAFOLDER_NAME);
     Properties props = new Properties();
     props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
-    HoodieTableConfig.create(storage, metaPath, props);
-    cfgPath = new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE);
-    backupCfgPath = new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE_BACKUP);
+    initializeNewTableConfig(props);
   }
 
   @AfterEach
   public void tearDown() throws Exception {
     storage.close();
+  }
+
+  private void initializeNewTableConfig(Properties properties) throws IOException {
+    HoodieTableConfig.create(storage, metaPath, properties);
+    cfgPath = new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE);
+    backupCfgPath = new StoragePath(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE_BACKUP);
   }
 
   @Test
@@ -298,6 +303,32 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());
     });
+  }
+
+  @Test
+  void testTableMergeProperties() throws IOException {
+    // for out of the box, there are no merge properties
+    HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
+    assertTrue(config.getTableMergeProperties().isEmpty());
+
+    // delete and re-create w/ merge properties
+    storage.deleteFile(cfgPath);
+    storage.deleteFile(backupCfgPath);
+
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+    // no merge props
+    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES_PREFIX + "key1", "value1");
+    props.setProperty(HoodieTableConfig.MERGE_PROPERTIES_PREFIX + "key2", "value2");
+    // add some random property which does not match the prefix.
+    props.setProperty("key3", "value3");
+
+    initializeNewTableConfig(props);
+    config = new HoodieTableConfig(storage, metaPath, null, null, null);
+    Map<String, String> expectedProps = new HashMap<>();
+    expectedProps.put("key1","value1");
+    expectedProps.put("key2","value2");
+    assertEquals(expectedProps, config.getTableMergeProperties());
   }
 
   private static Stream<Arguments> argumentsForInferringRecordMergeMode() {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -38,8 +38,8 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
                                payloadClazz: String): Unit = {
     val opts: Map[String, String] = Map(
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
-      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX + "hoodie.payload.delete.field" -> "Op",
-      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX + "hoodie.payload.delete.marker" -> "d")
+      HoodieTableConfig.MERGE_PROPERTIES_PREFIX + "hoodie.payload.delete.field" -> "Op",
+      HoodieTableConfig.MERGE_PROPERTIES_PREFIX + "hoodie.payload.delete.marker" -> "d")
     val columns = Seq("ts", "key", "rider", "driver", "fare", "Op")
 
     // 1. Add an insert.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -38,8 +38,8 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
                                payloadClazz: String): Unit = {
     val opts: Map[String, String] = Map(
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
-      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".hoodie.payload.delete.field" -> "Op",
-      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".hoodie.payload.delete.marker" -> "d")
+      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX + "hoodie.payload.delete.field" -> "Op",
+      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX + "hoodie.payload.delete.marker" -> "d")
     val columns = Seq("ts", "key", "rider", "driver", "fare", "Op")
 
     // 1. Add an insert.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -38,8 +38,8 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
                                payloadClazz: String): Unit = {
     val opts: Map[String, String] = Map(
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
-      HoodieTableConfig.MERGE_PROPERTIES.key() ->
-        "hoodie.payload.delete.field=xp,hoodie.payload.delete.marker=d")
+      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".hoodie.payload.delete.field" -> "Op",
+      HoodieTableConfig.MERGE_CUSTOM_PROPERTY_PREFIX.key() + ".hoodie.payload.delete.marker" -> "d")
     val columns = Seq("ts", "key", "rider", "driver", "fare", "Op")
 
     // 1. Add an insert.


### PR DESCRIPTION
### Change Logs

Replace original one property with multiple properties with the same prefix.

### Impact

More conventional.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
