### PR TITLE
[MINOR] fix flaky test

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListDataPairData.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListDataPairData.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -153,7 +154,7 @@ public class TestHoodieListDataPairData {
 
   @Test
   void testReduceByKeyWithCloseableInput() {
-    List<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ArrayList<>();
+    ConcurrentLinkedQueue<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ConcurrentLinkedQueue<>();
     HoodiePairData<Integer, Integer> data = HoodieListData.lazy(Arrays.asList(1, 1, 1))
         .flatMapToPair(key -> {
           CloseValidationIterator<Pair<Integer, Integer>> iter = new CloseValidationIterator<>(Collections.singletonList(Pair.of(key, 1)).iterator());
@@ -167,7 +168,7 @@ public class TestHoodieListDataPairData {
 
   @Test
   void testLeftOuterJoinWithCloseableInput() {
-    List<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ArrayList<>();
+    ConcurrentLinkedQueue<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ConcurrentLinkedQueue<>();
     HoodiePairData<Integer, Integer> dataToJoin = HoodieListData.lazy(Arrays.asList(1, 2, 3))
         .flatMapToPair(key -> {
           CloseValidationIterator<Pair<Integer, Integer>> iter = new CloseValidationIterator<>(Collections.singletonList(Pair.of(key, 1)).iterator());
@@ -182,7 +183,7 @@ public class TestHoodieListDataPairData {
 
   @Test
   void testJoinWithCloseableInput() {
-    List<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ArrayList<>();
+    ConcurrentLinkedQueue<CloseValidationIterator<Pair<Integer, Integer>>> createdIterators = new ConcurrentLinkedQueue<>();
     HoodiePairData<Integer, Integer> dataToJoin = HoodieListData.lazy(Arrays.asList(1, 2, 3))
         .flatMapToPair(key -> {
           CloseValidationIterator<Pair<Integer, Integer>> iter = new CloseValidationIterator<>(Collections.singletonList(Pair.of(key, 1)).iterator());


### PR DESCRIPTION
### Change Logs

the test is flaky because it use a non thread safe ArrayList and use it in the lambda function of HoodieListData.map, which underlying implementation is parallelStream based, exposing the list to a multi-threading context.

You might have already noticed that anything captured in lambda functions has to be "effective final", which serves the purpose of safely publish the variable across all threads that consume the lambda function. Yet if we want to write to the list and later read its content back after the operation, we need a thread safe variable. Otherwise, we only protect the safety of the reference to the list variable, but not the reference to the elements that the list holds, this is a classic escape pattern.

Hit such issues in [Azure CI](https://dev.azure.com/apachehudi/hudi-oss-ci/_build/results?buildId=7147&view=logs&j=0035eb77-b078-5c5d-f860-43f6048d5884&t=301fcb38-c144-521f-2fe9-3883dedf585c)

```
[ERROR] Tests run: 26, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.045 s <<< FAILURE! - in org.apache.hudi.common.data.TestHoodieListDataPairData
[ERROR] testReduceByKeyWithCloseableInput  Time elapsed: 0.012 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.hudi.common.data.TestHoodieListDataPairData.lambda$testReduceByKeyWithCloseableInput$0(TestHoodieListDataPairData.java:168)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at org.apache.hudi.common.data.TestHoodieListDataPairData.testReduceByKeyWithCloseableInput(TestHoodieListDataPairData.java:168)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
```

Fixed by use a thread safe concurrent linked list instead.
### Impact

stablize the CI
### Risk level (write none, low medium or high below)

none
### Documentation Update
none
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
