### PR TITLE
[HUDI-9653] [WIP] Add Spark Procedures for showing requested , completed cleans

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -48,6 +48,8 @@ object HoodieProcedures {
       ,(ShowCommitFilesProcedure.NAME, ShowCommitFilesProcedure.builder)
       ,(ShowCommitPartitionsProcedure.NAME, ShowCommitPartitionsProcedure.builder)
       ,(ShowCommitWriteStatsProcedure.NAME, ShowCommitWriteStatsProcedure.builder)
+      ,(ShowCleansProcedure.NAME, ShowCleansProcedure.builder)
+      ,(ShowCleanPlansProcedure.NAME, ShowCleanPlansProcedure.builder)
       ,(CommitsCompareProcedure.NAME, CommitsCompareProcedure.builder)
       ,(ShowSavepointsProcedure.NAME, ShowSavepointsProcedure.builder)
       ,(DeleteMarkerProcedure.NAME, DeleteMarkerProcedure.builder)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCleanPlansProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCleanPlansProcedure.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.{HoodieCLIUtils, SparkAdapterSupport}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.{HoodieInstant, TimelineLayout}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util
+import java.util.Collections
+import java.util.function.Supplier
+
+import scala.collection.JavaConverters._
+
+class ShowCleanPlansProcedure extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport with Logging {
+
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10)
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("plan_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("earliest_instant_to_retain", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("last_completed_commit_timestamp", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("policy", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("version", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("total_partitions_to_clean", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("total_partitions_to_delete", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("extra_metadata", DataTypes.StringType, nullable = true, Metadata.empty)
+  ))
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val table = getArgValueOrDefault(args, PARAMETERS(0)).get.asInstanceOf[String]
+    val limit = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[Int]
+
+    val hoodieCatalogTable = HoodieCLIUtils.getHoodieCatalogTable(sparkSession, table)
+    val basePath = hoodieCatalogTable.tableLocation
+    val metaClient = createMetaClient(jsc, basePath)
+
+    getCleanerPlans(metaClient, limit)
+  }
+
+  override def build: Procedure = new ShowCleanPlansProcedure()
+
+  private def getCleanerPlans(metaClient: HoodieTableMetaClient, limit: Int): Seq[Row] = {
+    val activeTimeline = metaClient.getActiveTimeline
+    val rows = new util.ArrayList[Row]
+    val cleanerInstants: util.List[HoodieInstant] = activeTimeline.getCleanerTimeline.getInstants
+    val sortedCleanInstants = new util.ArrayList[HoodieInstant](cleanerInstants)
+    val layout = TimelineLayout.fromVersion(activeTimeline.getTimelineLayoutVersion)
+    Collections.sort(sortedCleanInstants, layout.getInstantComparator.requestedTimeOrderedComparator.reversed)
+
+    for (i <- 0 until sortedCleanInstants.size) {
+      val cleanInstant = sortedCleanInstants.get(i)
+
+      try {
+        val requestedCleanInstant = metaClient.createNewInstant(HoodieInstant.State.REQUESTED,
+          cleanInstant.getAction, cleanInstant.requestedTime())
+        val cleanerPlan = activeTimeline.readCleanerPlan(requestedCleanInstant)
+
+        val earliestInstantToRetain = if (cleanerPlan.getEarliestInstantToRetain != null) {
+          cleanerPlan.getEarliestInstantToRetain.getTimestamp
+        } else null
+
+        val totalPartitionsToClean = if (cleanerPlan.getFilePathsToBeDeletedPerPartition != null) {
+          cleanerPlan.getFilePathsToBeDeletedPerPartition.size()
+        } else 0
+
+        val totalPartitionsToDelete = if (cleanerPlan.getPartitionsToBeDeleted != null) {
+          cleanerPlan.getPartitionsToBeDeleted.size()
+        } else 0
+
+        val extraMetadataStr = if (cleanerPlan.getExtraMetadata != null) {
+          cleanerPlan.getExtraMetadata.asScala.map { case (k, v) => s"$k=$v" }.mkString(", ")
+        } else null
+
+        rows.add(Row(
+          cleanInstant.requestedTime,
+          cleanInstant.getAction,
+          earliestInstantToRetain,
+          cleanerPlan.getLastCompletedCommitTimestamp,
+          cleanerPlan.getPolicy,
+          cleanerPlan.getVersion,
+          totalPartitionsToClean,
+          totalPartitionsToDelete,
+          extraMetadataStr
+        ))
+      } catch {
+        case e: Exception =>
+          logWarning(s"Failed to read cleaner plan for instant ${cleanInstant.requestedTime}", e)
+      }
+    }
+
+    rows.stream().limit(limit).toArray().map(r => r.asInstanceOf[Row]).toList
+  }
+}
+
+object ShowCleanPlansProcedure {
+  val NAME = "show_clean_plans"
+
+  def builder: Supplier[ProcedureBuilder] = () => new ShowCleanPlansProcedure()
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCleansProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCleansProcedure.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.{HoodieCLIUtils, SparkAdapterSupport}
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline, TimelineLayout}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util
+import java.util.Collections
+import java.util.function.Supplier
+
+import scala.collection.JavaConverters._
+
+class ShowCleansProcedure(includePartitionMetadata: Boolean) extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport with Logging {
+
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10)
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("clean_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("state_transition_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("start_clean_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("time_taken_in_millis", DataTypes.LongType, nullable = true, Metadata.empty),
+    StructField("total_files_deleted", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("earliest_commit_to_retain", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("last_completed_commit_timestamp", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("version", DataTypes.IntegerType, nullable = true, Metadata.empty)
+  ))
+
+  private val PARTITION_METADATA_OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("clean_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("state_transition_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("start_clean_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("partition_path", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("policy", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("delete_path_patterns", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("success_delete_files", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("failed_delete_files", DataTypes.IntegerType, nullable = true, Metadata.empty),
+    StructField("is_partition_deleted", DataTypes.BooleanType, nullable = true, Metadata.empty),
+    StructField("time_taken_in_millis", DataTypes.LongType, nullable = true, Metadata.empty),
+    StructField("total_files_deleted", DataTypes.IntegerType, nullable = true, Metadata.empty)
+  ))
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = if (includePartitionMetadata) PARTITION_METADATA_OUTPUT_TYPE else OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val table = getArgValueOrDefault(args, PARAMETERS(0)).get.asInstanceOf[String]
+    val limit = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[Int]
+
+    val hoodieCatalogTable = HoodieCLIUtils.getHoodieCatalogTable(sparkSession, table)
+    val basePath = hoodieCatalogTable.tableLocation
+    val metaClient = createMetaClient(jsc, basePath)
+
+    val activeTimeline = metaClient.getActiveTimeline
+    if (includePartitionMetadata) {
+      getCleansWithPartitionMetadata(activeTimeline, limit)
+    } else {
+      getCleans(activeTimeline, limit)
+    }
+  }
+
+  override def build: Procedure = new ShowCleansProcedure(includePartitionMetadata)
+
+  private def getCleansWithPartitionMetadata(timeline: HoodieTimeline,
+                                             limit: Int): Seq[Row] = {
+    import scala.collection.JavaConverters._
+
+    val (rows: util.ArrayList[Row], cleanInstants: util.ArrayList[HoodieInstant]) = getSortedCleans(timeline)
+
+    for (i <- 0 until cleanInstants.size) {
+      val cleanInstant = cleanInstants.get(i)
+      val cleanMetadata = timeline.readCleanMetadata(cleanInstant)
+
+      for (partitionMetadataEntry <- cleanMetadata.getPartitionMetadata.entrySet.asScala) {
+        val partitionPath = partitionMetadataEntry.getKey
+        val partitionMetadata = partitionMetadataEntry.getValue
+
+        rows.add(Row(
+          cleanInstant.requestedTime,
+          cleanInstant.getCompletionTime,
+          cleanInstant.getAction,
+          cleanMetadata.getStartCleanTime,
+          partitionPath,
+          partitionMetadata.getPolicy,
+          partitionMetadata.getDeletePathPatterns.size(),
+          partitionMetadata.getSuccessDeleteFiles.size(),
+          partitionMetadata.getFailedDeleteFiles.size(),
+          partitionMetadata.getIsPartitionDeleted,
+          cleanMetadata.getTimeTakenInMillis,
+          cleanMetadata.getTotalFilesDeleted
+        ))
+      }
+    }
+
+    rows.stream().limit(limit).toArray().map(r => r.asInstanceOf[Row]).toList
+  }
+
+  private def getSortedCleans(timeline: HoodieTimeline): (util.ArrayList[Row], util.ArrayList[HoodieInstant]) = {
+    val rows = new util.ArrayList[Row]
+    val cleanInstants: util.List[HoodieInstant] = timeline.getCleanerTimeline.filterCompletedInstants
+      .getInstants.toArray().map(instant => instant.asInstanceOf[HoodieInstant]).toList.asJava
+    val sortedCleanInstants = new util.ArrayList[HoodieInstant](cleanInstants)
+    val layout = TimelineLayout.fromVersion(timeline.getTimelineLayoutVersion)
+    Collections.sort(sortedCleanInstants, layout.getInstantComparator.requestedTimeOrderedComparator.reversed)
+    (rows, sortedCleanInstants)
+  }
+
+  def getCleans(timeline: HoodieTimeline,
+                limit: Int): Seq[Row] = {
+    val (rows: util.ArrayList[Row], cleanInstants: util.ArrayList[HoodieInstant]) = getSortedCleans(timeline)
+
+    for (i <- 0 until cleanInstants.size) {
+      val cleanInstant = cleanInstants.get(i)
+      val cleanMetadata = timeline.readCleanMetadata(cleanInstant)
+
+      rows.add(Row(
+        cleanInstant.requestedTime,
+        cleanInstant.getCompletionTime,
+        cleanInstant.getAction,
+        cleanMetadata.getStartCleanTime,
+        cleanMetadata.getTimeTakenInMillis,
+        cleanMetadata.getTotalFilesDeleted,
+        cleanMetadata.getEarliestCommitToRetain,
+        cleanMetadata.getLastCompletedCommitTimestamp,
+        cleanMetadata.getVersion
+      ))
+    }
+
+    rows.stream().limit(limit).toArray().map(r => r.asInstanceOf[Row]).toList
+  }
+}
+
+object ShowCleansProcedure {
+  val NAME = "show_cleans"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get() = new ShowCleansProcedure(false)
+  }
+}
+
+object ShowCleansPartitionMetadataProcedure {
+  val NAME = "show_cleans_metadata"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get() = new ShowCleansProcedure(true)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowCleanPlansProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowCleanPlansProcedure.scala
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+class TestShowCleanPlansProcedure extends HoodieSparkProcedureTestBase {
+
+  test("Test Call show_clean_plans Procedure") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning configuration
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Insert initial data
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)").show
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000)").show
+
+      // Update data to trigger cleaning
+      spark.sql(s"update $tableName set price = 15 where id = 1").show
+      spark.sql(s"update $tableName set price = 25 where id = 2").show
+
+      // Another update to ensure cleaning happens
+      spark.sql(s"update $tableName set name = 'updated1' where id = 1").show
+
+      // Test basic show_clean_plans procedure
+      spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 10)""").show
+
+      val cleanerPlanDF = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 10)""")
+      cleanerPlanDF.select("plan_time", "action", "policy", "version", "extra_metadata").show
+
+      val basicResult = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 10)""").collect()
+
+      // Should have at least one cleaner plan
+      assertResult(true)(basicResult.length > 0)
+
+      // Verify the schema of basic result
+      val basicColumns = basicResult.head.schema.fieldNames
+      assertResult(true)(basicColumns.contains("plan_time"))
+      assertResult(true)(basicColumns.contains("action"))
+      assertResult(true)(basicColumns.contains("earliest_instant_to_retain"))
+      assertResult(true)(basicColumns.contains("last_completed_commit_timestamp"))
+      assertResult(true)(basicColumns.contains("policy"))
+      assertResult(true)(basicColumns.contains("version"))
+      assertResult(true)(basicColumns.contains("total_partitions_to_clean"))
+      assertResult(true)(basicColumns.contains("total_partitions_to_delete"))
+      assertResult(true)(basicColumns.contains("extra_metadata"))
+
+      // Verify that action is CLEAN
+      basicResult.foreach { row =>
+        assertResult("clean")(row.getAs[String]("action"))
+        assertResult(true)(row.getAs[Int]("total_partitions_to_clean") >= 0)
+        assertResult(true)(row.getAs[Int]("total_partitions_to_delete") >= 0)
+        val version = row.getAs[Int]("version")
+        assertResult(true)(version == null || version >= 1)
+        val policy = row.getAs[String]("policy")
+        assertResult(true)(policy != null && policy.nonEmpty)
+      }
+    }
+  }
+
+  test("Test Call show_clean_plans with Partitioned Table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create partitioned table with cleaning configuration
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  partition_key string
+           |) using hudi
+           | location '$tablePath'
+           | partitioned by (partition_key)
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Insert initial data with different partitions
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, 'part1')")
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000, 'part2')")
+      spark.sql(s"insert into $tableName values(3, 'a3', 30, 3000, 'part1')")
+
+      // Update data to create more file versions
+      spark.sql(s"update $tableName set price = 15 where id = 1")
+      spark.sql(s"update $tableName set price = 25 where id = 2")
+
+      // More updates to ensure cleaning
+      spark.sql(s"update $tableName set name = 'updated1' where id = 1")
+      spark.sql(s"update $tableName set name = 'updated2' where id = 2")
+
+      // Test show_clean_plans procedure
+      val cleanerPlanResult = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 20)""").collect()
+
+      // Should have at least one cleaner plan with partition details
+      assertResult(true)(cleanerPlanResult.length > 0)
+
+      // Verify the schema and data
+      cleanerPlanResult.foreach { row =>
+        assertResult("clean")(row.getAs[String]("action"))
+        val totalPartitionsToClean = row.getAs[Int]("total_partitions_to_clean")
+        assertResult(true)(totalPartitionsToClean >= 0)
+        val extraMetadata = row.getAs[String]("extra_metadata")
+        // Extra metadata should be displayed as a string or null
+        assertResult(true)(extraMetadata == null || extraMetadata.isInstanceOf[String])
+      }
+    }
+  }
+
+  test("Test Call show_clean_plans with No Clean Operations") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning disabled
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'false'
+           | )
+       """.stripMargin)
+
+      // Insert some data
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000)")
+
+      // Test show_clean_plans procedure - should return empty result
+      val result = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 10)""").collect()
+
+      // Should have no cleaner plan operations
+      assertResult(0)(result.length)
+    }
+  }
+
+  test("Test Call show_clean_plans with Limit Parameter") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with aggressive cleaning to generate multiple clean operations
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Generate multiple operations to create multiple clean plans
+      for (i <- 1 to 10) {
+        spark.sql(s"insert into $tableName values($i, 'name$i', ${i * 10}, ${i * 1000})")
+        if (i > 1) {
+          spark.sql(s"update $tableName set price = ${i * 15} where id = $i")
+        }
+      }
+
+      // Test with limit parameter
+      val limitedResult = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 3)""").collect()
+      val unlimitedResult = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 100)""").collect()
+
+      // Limited result should have at most 3 entries
+      assertResult(true)(limitedResult.length <= 3)
+
+      // If we have cleaner plans, unlimited should have same or more entries
+      if (unlimitedResult.length > 0) {
+        assertResult(true)(unlimitedResult.length >= limitedResult.length)
+      }
+    }
+  }
+
+  test("Test Call show_clean_plans ExtraMetadata Display") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning configuration
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Insert and update data to trigger cleaning
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+      spark.sql(s"update $tableName set price = 15 where id = 1")
+      spark.sql(s"update $tableName set name = 'updated1' where id = 1")
+
+      // Test show_clean_plans procedure and verify extra_metadata column
+      val result = spark.sql(s"""call show_clean_plans(table => '$tableName', limit => 10)""").collect()
+
+      if (result.length > 0) {
+        // Verify that extra_metadata column exists and is properly formatted
+        val extraMetadataColumn = result.head.schema.fieldNames.contains("extra_metadata")
+        assertResult(true)(extraMetadataColumn)
+
+        result.foreach { row =>
+          val extraMetadata = row.getAs[String]("extra_metadata")
+          // Extra metadata should be either null or a properly formatted string
+          if (extraMetadata != null) {
+            // Should be in key=value format separated by commas
+            assertResult(true)(extraMetadata.isInstanceOf[String])
+          }
+        }
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowCleansProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowCleansProcedure.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+import org.apache.spark.sql.Row
+
+class TestShowCleansProcedure extends HoodieSparkProcedureTestBase {
+
+  test("Test Call show_cleans Procedure") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning configuration
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Insert initial data
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)").show
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000)").show
+
+      // Update data to trigger cleaning
+      spark.sql(s"update $tableName set price = 15 where id = 1").show
+      spark.sql(s"update $tableName set price = 25 where id = 2").show
+
+      // Another update to ensure cleaning happens
+      spark.sql(s"update $tableName set name = 'updated1' where id = 1").show
+
+      // Test basic show_cleans procedure
+      spark.sql(s"""call show_cleans(table => '$tableName', limit => 10)""").show
+
+      val cleanDF = spark.sql(s"""call show_cleans(table => '$tableName', limit => 10)""")
+      cleanDF.select("clean_time", "action", "total_files_deleted", "time_taken_in_millis").show
+
+      val basicResult = spark.sql(s"""call show_cleans(table => '$tableName', limit => 10)""").collect()
+
+      // Should have at least one clean operation
+      assertResult(true)(basicResult.length > 0)
+
+      // Verify the schema of basic result
+      val basicColumns = basicResult.head.schema.fieldNames
+      assertResult(true)(basicColumns.contains("clean_time"))
+      assertResult(true)(basicColumns.contains("action"))
+      assertResult(true)(basicColumns.contains("total_files_deleted"))
+      assertResult(true)(basicColumns.contains("start_clean_time"))
+      assertResult(true)(basicColumns.contains("time_taken_in_millis"))
+
+      // Verify that action is CLEAN
+      basicResult.foreach { row =>
+        assertResult("clean")(row.getAs[String]("action"))
+        assertResult(true)(row.getAs[Int]("total_files_deleted") >= 0)
+        assertResult(true)(row.getAs[Long]("time_taken_in_millis") >= 0)
+      }
+    }
+  }
+
+  test("Test Call show_cleans_metadata Procedure") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning configuration
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  partition_key string
+           |) using hudi
+           | location '$tablePath'
+           | partitioned by (partition_key)
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Insert initial data with different partitions
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, 'part1')")
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000, 'part2')")
+      spark.sql(s"insert into $tableName values(3, 'a3', 30, 3000, 'part1')")
+
+      // Update data to create more file versions
+      spark.sql(s"update $tableName set price = 15 where id = 1")
+      spark.sql(s"update $tableName set price = 25 where id = 2")
+
+      // More updates to ensure cleaning
+      spark.sql(s"update $tableName set name = 'updated1' where id = 1")
+      spark.sql(s"update $tableName set name = 'updated2' where id = 2")
+
+      // Test detailed show_cleans_metadata procedure
+      val detailedResult = spark.sql(s"""call show_cleans_metadata(table => '$tableName', limit => 20)""").collect()
+
+      // Should have at least one clean operation with partition details
+      assertResult(true)(detailedResult.length > 0)
+
+      // Verify the schema of detailed result
+      val detailedColumns = detailedResult.head.schema.fieldNames
+      assertResult(true)(detailedColumns.contains("clean_time"))
+      assertResult(true)(detailedColumns.contains("action"))
+      assertResult(true)(detailedColumns.contains("partition_path"))
+      assertResult(true)(detailedColumns.contains("policy"))
+      assertResult(true)(detailedColumns.contains("success_delete_files"))
+      assertResult(true)(detailedColumns.contains("failed_delete_files"))
+      assertResult(true)(detailedColumns.contains("delete_path_patterns"))
+
+      // Verify that action is CLEAN and we have partition-level details
+      detailedResult.foreach { row =>
+        assertResult("clean")(row.getAs[String]("action"))
+        // Partition path should be present
+        val partitionPath = row.getAs[String]("partition_path")
+        assertResult(true)(partitionPath != null)
+        // Should have some metrics
+        assertResult(true)(row.getAs[Int]("success_delete_files") >= 0)
+        assertResult(true)(row.getAs[Int]("failed_delete_files") >= 0)
+      }
+    }
+  }
+
+  test("Test Call show_cleans with No Clean Operations") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with cleaning disabled
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'false'
+           | )
+       """.stripMargin)
+
+      // Insert some data
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+      spark.sql(s"insert into $tableName values(2, 'a2', 20, 2000)")
+
+      // Test show_cleans procedure - should return empty result
+      val result = spark.sql(s"""call show_cleans(table => '$tableName', limit => 10)""").collect()
+
+      // Should have no clean operations
+      assertResult(0)(result.length)
+    }
+  }
+
+  test("Test Call show_cleans with Limit Parameter") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+
+      // Create table with aggressive cleaning to generate multiple clean operations
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  'hoodie.clean.automatic' = 'true',
+           |  'hoodie.clean.trigger.max.commits' = '1',
+           |  'hoodie.clean.commits.retained' = '1'
+           | )
+       """.stripMargin)
+
+      // Generate multiple operations to create multiple clean operations
+      for (i <- 1 to 10) {
+        spark.sql(s"insert into $tableName values($i, 'name$i', ${i * 10}, ${i * 1000})")
+        if (i > 1) {
+          spark.sql(s"update $tableName set price = ${i * 15} where id = $i")
+        }
+      }
+
+      // Test with limit parameter
+      val limitedResult = spark.sql(s"""call show_cleans(table => '$tableName', limit => 3)""").collect()
+      val unlimitedResult = spark.sql(s"""call show_cleans(table => '$tableName', limit => 100)""").collect()
+
+      // Limited result should have at most 3 entries
+      assertResult(true)(limitedResult.length <= 3)
+
+      // If we have clean operations, unlimited should have same or more entries
+      if (unlimitedResult.length > 0) {
+        assertResult(true)(unlimitedResult.length >= limitedResult.length)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

 - show_cleans(...) for completed clean operations
 - show_clean_plans(...) for plans for completed and requested clean operations
 - SQL tests for both
 
### Impact

New Spark procedures

### Risk level (write none, low medium or high below)

Low

### Documentation Update

SQL procedure docs to be potentially updated.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
