### PR TITLE
[HUDI-9656] Index prefix lookup path refactor

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -402,9 +402,8 @@ public class SparkMetadataWriterUtils {
         // Fetch EI column stat records for above files
         List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata =
             tableMetadata.getRecordsByKeyPrefixes(
-                    HoodieListData.lazy(HoodieTableMetadataUtil.generateRawKeyPrefixes(validColumnsToIndex, partitionName)),
-                    indexPartition, false,
-                    HoodieTableMetadataUtil.getColumnStatsKeyEncoder())
+                    HoodieListData.lazy(HoodieTableMetadataUtil.generateColumnStatsKeys(validColumnsToIndex, partitionName)),
+                    indexPartition, false)
                 // schema and properties are ignored in getInsertValue, so simply pass as null
                 .map(record -> record.getData().getInsertValue(null, null))
                 .filter(Option::isPresent)

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -108,7 +108,6 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.COLUMN_STATS_FIELD_
 import static org.apache.hudi.metadata.HoodieMetadataPayload.COLUMN_STATS_FIELD_VALUE_COUNT;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.createBloomFilterMetadataRecord;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.createColumnStatsRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.IDENTITY_ENCODING;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getFileSystemViewForMetadataTable;
@@ -403,7 +402,9 @@ public class SparkMetadataWriterUtils {
         // Fetch EI column stat records for above files
         List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata =
             tableMetadata.getRecordsByKeyPrefixes(
-                    HoodieListData.lazy(HoodieTableMetadataUtil.generateKeyPrefixes(validColumnsToIndex, partitionName)), indexPartition, false, IDENTITY_ENCODING)
+                    HoodieListData.lazy(HoodieTableMetadataUtil.generateRawKeyPrefixes(validColumnsToIndex, partitionName)),
+                    indexPartition, false,
+                    HoodieTableMetadataUtil.getColumnStatsKeyEncoder())
                 // schema and properties are ignored in getInsertValue, so simply pass as null
                 .map(record -> record.getData().getInsertValue(null, null))
                 .filter(Option::isPresent)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/NoOpTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/NoOpTableMetadata.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodieListPairData;
 import org.apache.hudi.common.data.HoodiePairData;
-import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.util.Option;
@@ -34,6 +33,7 @@ import org.apache.hudi.internal.schema.Types;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.RawKey;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
@@ -115,10 +115,10 @@ class NoOpTableMetadata implements HoodieTableMetadata {
   }
 
   @Override
-  public HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(HoodieData<String> keyPrefixes,
-                                                                                 String partitionName,
-                                                                                 boolean shouldLoadInMemory,
-                                                                                 SerializableFunctionUnchecked<String, String> keyEncoder) {
+  public HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(
+      HoodieData<? extends RawKey> rawKeys,
+      String partitionName,
+      boolean shouldLoadInMemory) {
     throw new HoodieMetadataException("Unsupported operation: getRecordsByKeyPrefixes!");
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/ColumnStatsIndexKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/ColumnStatsIndexKey.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+
+import java.util.Objects;
+
+/**
+ * Represents a raw key for column stats index consisting of column name and optional partition name.
+ */
+public class ColumnStatsIndexKey implements RawKey {
+  private static final long serialVersionUID = 1L;
+  
+  private final String columnName;
+  private final Option<String> partitionName;
+  
+  public ColumnStatsIndexKey(String columnName) {
+    this(columnName, Option.empty());
+  }
+  
+  public ColumnStatsIndexKey(String columnName, String partitionName) {
+    this(columnName, Option.of(partitionName));
+  }
+  
+  public ColumnStatsIndexKey(String columnName, Option<String> partitionName) {
+    this.columnName = Objects.requireNonNull(columnName, "Column name cannot be null");
+    this.partitionName = Objects.requireNonNull(partitionName, "Partition name option cannot be null");
+  }
+  
+  public String getColumnName() {
+    return columnName;
+  }
+  
+  public Option<String> getPartitionName() {
+    return partitionName;
+  }
+  
+  @Override
+  public String encode() {
+    ColumnIndexID columnIndexID = new ColumnIndexID(columnName);
+    String encodedValue;
+    
+    if (partitionName.isPresent()) {
+      PartitionIndexID partitionIndexId = new PartitionIndexID(
+          HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionName.get()));
+      encodedValue = columnIndexID.asBase64EncodedString()
+          .concat(partitionIndexId.asBase64EncodedString());
+    } else {
+      encodedValue = columnIndexID.asBase64EncodedString();
+    }
+    
+    return encodedValue;
+  }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnStatsIndexKey that = (ColumnStatsIndexKey) o;
+    return Objects.equals(columnName, that.columnName) && Objects.equals(partitionName, that.partitionName);
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hash(columnName, partitionName);
+  }
+  
+  @Override
+  public String toString() {
+    return "ColumnStatsIndexKey{columnName='" + columnName + "', partitionName=" + partitionName + "}";
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
@@ -311,10 +310,10 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
   }
 
   @Override
-  public HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(HoodieData<String> keyPrefixes,
-                                                                                 String partitionName,
-                                                                                 boolean shouldLoadInMemory,
-                                                                                 SerializableFunctionUnchecked<String, String> keyEncoder) {
+  public HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(
+      HoodieData<? extends RawKey> rawKeys,
+      String partitionName,
+      boolean shouldLoadInMemory) {
     throw new HoodieMetadataException("Unsupported operation: getRecordsByKeyPrefixes!");
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -22,7 +22,6 @@ import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
-import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -255,17 +254,18 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
   }
 
   /**
-   * Fetch records by key prefixes. Key prefix passed is expected to match the same prefix as stored in Metadata table partitions. For eg, in case of col stats partition,
-   * actual keys in metadata partition is encoded values of column name, partition name and file name. So, key prefixes passed to this method is expected to be encoded already.
+   * Fetch records by key prefixes. The raw keys are encoded using their encode() method to generate
+   * the actual key prefixes used for lookup in the metadata table partitions.
    *
-   * @param keyPrefixes   list of key prefixes for which interested records are looked up for.
-   * @param partitionName partition name in metadata table where the records are looked up for.
-   * @return {@link HoodieData} of {@link HoodieRecord}s with records matching the passed in key prefixes.
+   * @param rawKeys           list of raw key objects to be encoded into key prefixes
+   * @param partitionName     partition name in metadata table where the records are looked up for
+   * @param shouldLoadInMemory whether to load records in memory
+   * @return {@link HoodieData} of {@link HoodieRecord}s with records matching the encoded key prefixes
    */
-  HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(HoodieData<String> keyPrefixes,
-                                                                          String partitionName,
-                                                                          boolean shouldLoadInMemory,
-                                                                          SerializableFunctionUnchecked<String, String> keyEncoder);
+  HoodieData<HoodieRecord<HoodieMetadataPayload>> getRecordsByKeyPrefixes(
+      HoodieData<? extends RawKey> rawKeys,
+      String partitionName,
+      boolean shouldLoadInMemory);
 
   /**
    * Get the instant time to which the metadata is synced w.r.t data timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/RawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/RawKey.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import java.io.Serializable;
+
+/**
+ * Interface for raw keys that can be encoded for storage in the metadata table.
+ */
+public interface RawKey extends Serializable {
+  
+  /**
+   * Encode this raw key into a string for storage.
+   * @return The encoded string key
+   */
+  String encode();
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRawKey.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import java.util.Objects;
+
+/**
+ * Represents a secondary index key, whose raw content is the column value of the data table.
+ */
+public class SecondaryIndexRawKey implements RawKey {
+  private final String secondaryKey;
+
+  public SecondaryIndexRawKey(String secondaryKey) {
+    this.secondaryKey = Objects.requireNonNull(secondaryKey);
+  }
+
+  @Override
+  public String encode() {
+    return SecondaryIndexKeyUtils.escapeSpecialChars(secondaryKey);
+  }
+
+  public String getSecondaryKey() {
+    return secondaryKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SecondaryIndexRawKey that = (SecondaryIndexRawKey) o;
+    return Objects.equals(secondaryKey, that.secondaryKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(secondaryKey);
+  }
+
+  @Override
+  public String toString() {
+    return "SecondaryIndexKey{" + "secondaryKey='" + secondaryKey + '\'' + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRawKey.java
@@ -28,7 +28,7 @@ public class SecondaryIndexRawKey implements RawKey {
   private final String secondaryKey;
 
   public SecondaryIndexRawKey(String secondaryKey) {
-    this.secondaryKey = Objects.requireNonNull(secondaryKey);
+    this.secondaryKey = secondaryKey;
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ExpressionIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ExpressionIndexSupport.scala
@@ -35,7 +35,7 @@ import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.hash.{ColumnIndexID, PartitionIndexID}
 import org.apache.hudi.data.HoodieJavaRDD
 import org.apache.hudi.index.expression.HoodieExpressionIndex
-import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil, MetadataPartitionType}
+import org.apache.hudi.metadata.{ColumnStatsIndexKey, HoodieMetadataPayload, HoodieTableMetadataUtil, MetadataPartitionType}
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionStatsIndexKey
 import org.apache.hudi.util.JFunction
 
@@ -345,19 +345,18 @@ class ExpressionIndexSupport(spark: SparkSession,
     checkState(targetColumns.nonEmpty)
 
     // Create raw key prefixes based on column names and optional partition names
-    val rawKeyPrefixes = if (prunedPartitions.isDefined) {
+    val rawKeys = if (prunedPartitions.isDefined) {
       val partitionsList = prunedPartitions.get.toList
       targetColumns.flatMap(colName =>
-        partitionsList.map(partitionPath => HoodieTableMetadataUtil.generateRawKeyPrefixes(List(colName).asJava, partitionPath).get(0))
+        partitionsList.map(partitionPath => new ColumnStatsIndexKey(colName, partitionPath))
       )
     } else {
-      targetColumns
+      targetColumns.map(colName => new ColumnStatsIndexKey(colName))
     }
 
     val metadataRecords: HoodieData[HoodieRecord[HoodieMetadataPayload]] =
       metadataTable.getRecordsByKeyPrefixes(
-        HoodieListData.eager(rawKeyPrefixes.asJava), HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, shouldReadInMemory,
-        HoodieTableMetadataUtil.getColumnStatsKeyEncoder())
+        HoodieListData.eager(rawKeys.asJava), HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, shouldReadInMemory)
 
     val columnStatsRecords: HoodieData[HoodieMetadataColumnStats] =
       //TODO: [HUDI-8303] Explicit conversion might not be required for Scala 2.12+
@@ -501,9 +500,11 @@ class ExpressionIndexSupport(spark: SparkSession,
 
   private def loadExpressionIndexPartitionStatRecords(indexDefinition: HoodieIndexDefinition, shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
     // We are omitting the partition name and only using the column name and expression index partition stat prefix to fetch the records
-    val recordKeyPrefix = getPartitionStatsIndexKey(HoodieExpressionIndex.HOODIE_EXPRESSION_INDEX_PARTITION_STAT_PREFIX, indexDefinition.getSourceFields.get(0))
+    // Create a ColumnStatsIndexKey with the column and partition prefix
+    val rawKey = new ColumnStatsIndexKey(indexDefinition.getSourceFields.get(0),
+      toJavaOption(Option(HoodieExpressionIndex.HOODIE_EXPRESSION_INDEX_PARTITION_STAT_PREFIX)))
     val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = loadExpressionIndexForColumnsInternal(
-      indexDefinition.getIndexName, shouldReadInMemory, Seq(recordKeyPrefix))
+      indexDefinition.getIndexName, shouldReadInMemory, Seq(rawKey))
     //TODO: [HUDI-8303] Explicit conversion might not be required for Scala 2.12+
     colStatsRecords
   }
@@ -544,25 +545,24 @@ class ExpressionIndexSupport(spark: SparkSession,
     //    - Extracting [[HoodieMetadataColumnStats]] records
     //    - Filtering out nulls
     checkState(targetColumns.nonEmpty)
-    
+
     // Create raw key prefixes based on column names and optional partition names
-    val rawKeyPrefixes = if (prunedPartitions.nonEmpty) {
+    val rawKeys = if (prunedPartitions.nonEmpty) {
       val partitionsList = prunedPartitions.toList
       targetColumns.flatMap(colName =>
-        partitionsList.map(partitionPath => HoodieTableMetadataUtil.generateRawKeyPrefixes(List(colName).asJava, partitionPath).get(0))
+        partitionsList.map(partitionPath => new ColumnStatsIndexKey(colName, partitionPath))
       )
     } else {
-      targetColumns
+      targetColumns.map(colName => new ColumnStatsIndexKey(colName))
     }
-    
-    loadExpressionIndexForColumnsInternal(indexPartition, shouldReadInMemory, rawKeyPrefixes)
+
+    loadExpressionIndexForColumnsInternal(indexPartition, shouldReadInMemory, rawKeys)
   }
 
-  private def loadExpressionIndexForColumnsInternal(indexPartition: String, shouldReadInMemory: Boolean, keyPrefixes: Iterable[String]) = {
+  private def loadExpressionIndexForColumnsInternal(indexPartition: String, shouldReadInMemory: Boolean, keyPrefixes: Iterable[ColumnStatsIndexKey]) = {
     val metadataRecords: HoodieData[HoodieRecord[HoodieMetadataPayload]] =
       metadataTable.getRecordsByKeyPrefixes(
-        HoodieListData.eager(keyPrefixes.toSeq.asJava), indexPartition, shouldReadInMemory,
-        HoodieTableMetadataUtil.getColumnStatsKeyEncoder())
+        HoodieListData.eager(keyPrefixes.toSeq.asJava), indexPartition, shouldReadInMemory)
     val columnStatsRecords: HoodieData[HoodieMetadataColumnStats] =
       //TODO: [HUDI-8303] Explicit conversion might not be required for Scala 2.12+
       metadataRecords.map(JFunction.toJavaSerializableFunction(record => {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -89,8 +89,6 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.collection.Triple;
-import org.apache.hudi.common.util.hash.ColumnIndexID;
-import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieClusteringConfig;
@@ -104,9 +102,11 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
+import org.apache.hudi.metadata.ColumnStatsIndexKey;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieBackedTableMetadataWriter;
 import org.apache.hudi.metadata.HoodieMetadataMetrics;
+import org.apache.hudi.metadata.RawKey;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
@@ -194,7 +194,6 @@ import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT_NUM_D
 import static org.apache.hudi.io.storage.HoodieSparkIOFactory.getHoodieSparkIOFactory;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
 import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBasePath;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.IDENTITY_ENCODING;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataTable;
 import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
@@ -2012,19 +2011,20 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       HoodieTableMetadata tableMetadata = metadata(client, storage);
       // prefix search for column (_hoodie_record_key)
-      ColumnIndexID columnIndexID = new ColumnIndexID(HoodieRecord.RECORD_KEY_METADATA_FIELD);
+      ColumnStatsIndexKey columnKey = new ColumnStatsIndexKey(HoodieRecord.RECORD_KEY_METADATA_FIELD);
       List<HoodieRecord<HoodieMetadataPayload>> result = tableMetadata.getRecordsByKeyPrefixes(
-          HoodieListData.lazy(Collections.singletonList(columnIndexID.asBase64EncodedString())),
-          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true, IDENTITY_ENCODING).collectAsList();
+          HoodieListData.lazy(Collections.singletonList(columnKey)),
+          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true).collectAsList();
 
       // there are 3 partitions in total and 2 commits. total entries should be 6.
       assertEquals(result.size(), 6);
 
       // prefix search for col(_hoodie_record_key) and first partition. only 2 files should be matched
-      PartitionIndexID partitionIndexID = new PartitionIndexID(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
+      ColumnStatsIndexKey columnWithPartitionKey = new ColumnStatsIndexKey(HoodieRecord.RECORD_KEY_METADATA_FIELD, 
+          HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
       result = tableMetadata.getRecordsByKeyPrefixes(
-          HoodieListData.lazy(Collections.singletonList(columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString()))),
-          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true, IDENTITY_ENCODING).collectAsList();
+          HoodieListData.lazy(Collections.singletonList(columnWithPartitionKey)),
+          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true).collectAsList();
       // 1 partition and 2 commits. total entries should be 2.
       assertEquals(result.size(), 2);
       result.forEach(entry -> {
@@ -2040,10 +2040,11 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       });
 
       // prefix search for column {commit time} and first partition
-      columnIndexID = new ColumnIndexID(HoodieRecord.COMMIT_TIME_METADATA_FIELD);
+      ColumnStatsIndexKey commitTimeKey = new ColumnStatsIndexKey(HoodieRecord.COMMIT_TIME_METADATA_FIELD,
+          HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
       result = tableMetadata.getRecordsByKeyPrefixes(
-          HoodieListData.lazy(Collections.singletonList(columnIndexID.asBase64EncodedString().concat(partitionIndexID.asBase64EncodedString()))),
-          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true, IDENTITY_ENCODING).collectAsList();
+          HoodieListData.lazy(Collections.singletonList(commitTimeKey)),
+          MetadataPartitionType.COLUMN_STATS.getPartitionPath(), true).collectAsList();
 
       // 1 partition and 2 commits. total entries should be 2.
       assertEquals(result.size(), 2);
@@ -3030,9 +3031,16 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // assert entry is not present for deleted partition in metadata table
       HoodieTableMetadata tableMetadata = metadata(client, storage);
+      // Create a simple RawKey implementation for the partition path
+      RawKey partitionKey = new RawKey() {
+        @Override
+        public String encode() {
+          return HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+        }
+      };
       assertTrue(tableMetadata.getRecordsByKeyPrefixes(
-          HoodieListData.lazy(Collections.singletonList(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH)),
-          FILES.getPartitionPath(), false, IDENTITY_ENCODING).isEmpty());
+          HoodieListData.lazy(Collections.singletonList(partitionKey)),
+          FILES.getPartitionPath(), false).isEmpty());
       assertTrue(tableMetadata.getAllPartitionPaths().contains(HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH));
       assertFalse(tableMetadata.getAllPartitionPaths().contains(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH));
       // above upsert would have triggered clean

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -792,7 +792,8 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
   private def testSecondaryIndexWithNullableColumns(tableType: String): Unit = {
     withSparkSqlSessionConfig(
       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> "9",
-      "hoodie.embed.timeline.server" -> "false") {
+      "hoodie.embed.timeline.server" -> "false",
+      "hoodie.parquet.small.file.limit" -> "0") {
       withTempDir { tmp =>
         val tableName = generateTableName + s"_nullable_${tableType}"
         val basePath = s"${tmp.getCanonicalPath}/$tableName"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
@@ -64,7 +64,7 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
        |) using hudi
        | options (
        |  primaryKey ='id',
-       |  type = 'cow',
+       |  type = 'mor',
        |  preCombineField = 'ts',
        |  hoodie.metadata.enable = 'true',
        |  hoodie.metadata.record.index.enable = 'true',
@@ -123,6 +123,7 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
     // Create shared temporary directory
     tmpDir = Utils.createTempDir()
 
+    spark.sql("set hoodie.parquet.small.file.limit=0")
     // Setup shared test data
     setupSharedTestData()
   }
@@ -170,6 +171,9 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
     spark.sql(s"insert into $tableName" + " values('$a', 'sec$key', 40, 1001)")
     spark.sql(s"insert into $tableName" + " values('a$a', '$sec$', 50, 1002)")
     spark.sql(s"insert into $tableName" + " values('$$', '$$', 60, 1003)")
+    // generate some deleted records
+    spark.sql(s"insert into $tableName" + " values('$$3', '$$', 60, 1003)")
+    spark.sql(s"delete from $tableName" + " where id = '$$3'")
 
     val props = Map(
       "hoodie.insert.shuffle.parallelism" -> "4",


### PR DESCRIPTION
# please start review from commit "eliminate identity encoding in prefix lookup"
### Change Logs

Revise the prefix lookup path with a better abstraction. Now all key encode logic is hidden behind the RawKey interface. RawKey stands for the raw value that constitutes a index key for lookup. It has an encode method which construct the encoded version of the key.

### Impact

Much cleaner interface.

### Risk level (write none, low medium or high below)

pure refactor, no functional changes.
no risk

### Documentation Update
none
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
