### PR TITLE
Handle autoUpgrade is disabled case in Upgrade/Downgrade command

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -48,11 +48,6 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
         HoodieTableType.MERGE_ON_READ.equals(table.getMetaClient().getTableType()),
         HoodieTableVersion.NINE);
 
-    // If auto upgrade is disabled, set writer version to 8 and return
-    if (!config.autoUpgrade()) {
-      config.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
-      return Collections.emptyMap();
-    }
     HoodieTableMetaClient metaClient = table.getMetaClient();
 
     // Populate missing index versions indexes

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -90,11 +90,6 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
     HoodieTableMetaClient metaClient = table.getMetaClient();
     HoodieTableConfig tableConfig = metaClient.getTableConfig();
-    // If auto upgrade is disabled, set writer version to 6 and return
-    if (!config.autoUpgrade()) {
-      config.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
-      return tablePropsToAdd;
-    }
 
     // If metadata is enabled for the data table, and existing metadata table is behind the data table, then delete it
     if (!table.isMetadataTable() && config.isMetadataTableEnabled() && isMetadataTableBehindDataTable(config, metaClient)) {


### PR DESCRIPTION
### Change Logs

This pr aims to address the case for certain upgrade handlers when the following config `AUTO_UPGRADE_VERSION` is disabled. Based on my understanding we can avoid running the upgrade process all together if we do this check earlier within the `run` command.

For example see code path here: https://github.com/apache/hudi/blob/master/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java#L94

As well as here: https://github.com/apache/hudi/blob/master/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java#L52



### Risk level (write none, low medium or high below)

low

### Documentation Update

No doc update needed for this change.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
