### PR TITLE
[MINOR][DOCS] Updating 1.x release to call out ComplexKeyGenerator regression

### DIFF
--- a/website/releases/release-0.14.1.md
+++ b/website/releases/release-0.14.1.md
@@ -36,7 +36,7 @@ We discovered a regression in Hudi 0.14.1 release related to Complex Key gen whe
 It can silently ingest duplicates if table is upgraded from previous versions.
 
 :::tip
-Avoid upgrading any existing table to 0.14.1 if you are using ComplexKeyGenerator with single field as record key and multiple partition fields
+Avoid upgrading any existing table to 0.14.1 if you are using ComplexKeyGenerator with single field as record key and multiple partition fields.
 :::
 
 ## Raw Release Notes

--- a/website/releases/release-0.14.1.md
+++ b/website/releases/release-0.14.1.md
@@ -36,7 +36,7 @@ We discovered a regression in Hudi 0.14.1 release related to Complex Key gen whe
 It can silently ingest duplicates if table is upgraded from previous versions.
 
 :::tip
-Avoid upgrading any existing table to 0.14.1 if you are using ComplexKeyGenerator and number of fields in record key is 1.
+Avoid upgrading any existing table to 0.14.1 if you are using ComplexKeyGenerator with single field as record key and multiple partition fields
 :::
 
 ## Raw Release Notes

--- a/website/releases/release-0.15.0.md
+++ b/website/releases/release-0.15.0.md
@@ -323,7 +323,7 @@ single field. This issue was also present in version 0.14.1. When upgrading a ta
 it may silently ingest duplicate records.
 
 :::tip
-Avoid upgrading any existing table to 0.14.1 and 0.15.0 from any prior version if you are using ComplexKeyGenerator with single field as record key and multiple partition fields
+Avoid upgrading any existing table to 0.14.1 and 0.15.0 from any prior version if you are using ComplexKeyGenerator with single field as record key and multiple partition fields.
 :::
 
 ## Raw Release Notes

--- a/website/releases/release-0.15.0.md
+++ b/website/releases/release-0.15.0.md
@@ -323,8 +323,7 @@ single field. This issue was also present in version 0.14.1. When upgrading a ta
 it may silently ingest duplicate records.
 
 :::tip
-Avoid upgrading any existing table to 0.14.1 and 0.15.0 from any prior version if you are using ComplexKeyGenerator and 
-number of fields in record key is 1.
+Avoid upgrading any existing table to 0.14.1 and 0.15.0 from any prior version if you are using ComplexKeyGenerator with single field as record key and multiple partition fields
 :::
 
 ## Raw Release Notes

--- a/website/releases/release-1.0.0.md
+++ b/website/releases/release-1.0.0.md
@@ -174,7 +174,7 @@ experience the new features and enhancements.
 ## Known Regressions
 - We discovered a regression in Hudi 1.0.0 release for backwards compatible writer for MOR table.
 It can silently deletes committed data after upgrade when new data is ingested to the table.
-- We also have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating. if you have single field as a part of complex key generator.
+- We also have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as record key and multiple fields as partition fields.
 
 :::tip
 Avoid upgrading any existing table to 1.0.0 if any of the above scenario matches your workload. Incase of backwards compatible writer for MOR table, you are good to upgrade to 1.0.2 release. 

--- a/website/releases/release-1.0.0.md
+++ b/website/releases/release-1.0.0.md
@@ -172,9 +172,11 @@ The 1.0.0 GA release is the culmination of extensive development, testing, and f
 experience the new features and enhancements.
 
 ## Known Regressions
-We discovered a regression in Hudi 1.0.0 release for backwards compatible writer for MOR table.
+- We discovered a regression in Hudi 1.0.0 release for backwards compatible writer for MOR table.
 It can silently deletes committed data after upgrade when new data is ingested to the table.
+- If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
 
 :::tip
-Avoid upgrading any existing table to 1.0.0 if you are using MOR table in 0.x. But you are good to upgrade to 1.0.1.
+Avoid upgrading any existing table to 1.0.0 if any of the above scenario matches your workload. Incase of backwards compatible writer for MOR table, you are good to upgrade to 1.0.2 release. 
 :::
+

--- a/website/releases/release-1.0.0.md
+++ b/website/releases/release-1.0.0.md
@@ -174,7 +174,7 @@ experience the new features and enhancements.
 ## Known Regressions
 - We discovered a regression in Hudi 1.0.0 release for backwards compatible writer for MOR table.
 It can silently deletes committed data after upgrade when new data is ingested to the table.
-- If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
+- We also have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating. if you have single field as a part of complex key generator.
 
 :::tip
 Avoid upgrading any existing table to 1.0.0 if any of the above scenario matches your workload. Incase of backwards compatible writer for MOR table, you are good to upgrade to 1.0.2 release. 

--- a/website/releases/release-1.0.1.md
+++ b/website/releases/release-1.0.1.md
@@ -32,11 +32,10 @@ import TabItem from '@theme/TabItem';
 * Unit, functional, integration tests and CI
 
 ## Known Regressions
-If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
+We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as a part of complex key generator.
 
 :::tip
-Avoid upgrading any existing table to 1.0.1 if you are using ComplexKeyGenerator with single record key
-configured.
+Avoid upgrading any existing table to 1.0.1 if you are using ComplexKeyGenerator with single record key configured.
 :::
 
 ## Raw Release Notes

--- a/website/releases/release-1.0.1.md
+++ b/website/releases/release-1.0.1.md
@@ -31,6 +31,14 @@ import TabItem from '@theme/TabItem';
 * Flink engine
 * Unit, functional, integration tests and CI
 
+## Known Regressions
+If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
+
+:::tip
+Avoid upgrading any existing table to 1.0.1 if you are using ComplexKeyGenerator with single record key
+configured.
+:::
+
 ## Raw Release Notes
 
 The raw release notes are available [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12322822&version=12355195)

--- a/website/releases/release-1.0.1.md
+++ b/website/releases/release-1.0.1.md
@@ -32,7 +32,7 @@ import TabItem from '@theme/TabItem';
 * Unit, functional, integration tests and CI
 
 ## Known Regressions
-We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as a part of complex key generator.
+We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as record key and multiple partition fields.
 
 :::tip
 Avoid upgrading any existing table to 1.0.1 if you are using ComplexKeyGenerator with single record key configured.

--- a/website/releases/release-1.0.2.md
+++ b/website/releases/release-1.0.2.md
@@ -34,7 +34,7 @@ The 1.0.2 release primarily focuses on bug fixes, stability enhancements, and cr
 * **Testing, CI, and Dependencies:** Fixes for flaky tests, improved code coverage, bundle validation, dependency cleanup (HBase removal), and extensive release testing.
 
 ## Known Regressions
-If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
+We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as a part of complex key generator.
 
 :::tip
 Avoid upgrading any existing table to 1.0.2 if you are using ComplexKeyGenerator with single record key configured.

--- a/website/releases/release-1.0.2.md
+++ b/website/releases/release-1.0.2.md
@@ -34,7 +34,7 @@ The 1.0.2 release primarily focuses on bug fixes, stability enhancements, and cr
 * **Testing, CI, and Dependencies:** Fixes for flaky tests, improved code coverage, bundle validation, dependency cleanup (HBase removal), and extensive release testing.
 
 ## Known Regressions
-We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as a part of complex key generator.
+We have a ComplexKeyGenerator related regression reported [here](release-0.14.1#known-regressions). Please refrain from migrating, if you have single field as record key and mutiple partition fields.
 
 :::tip
 Avoid upgrading any existing table to 1.0.2 if you are using ComplexKeyGenerator with single record key configured.

--- a/website/releases/release-1.0.2.md
+++ b/website/releases/release-1.0.2.md
@@ -33,6 +33,13 @@ The 1.0.2 release primarily focuses on bug fixes, stability enhancements, and cr
 * **Performance:** Optimizations in areas like log file writing, schema reuse, and metadata initialization.
 * **Testing, CI, and Dependencies:** Fixes for flaky tests, improved code coverage, bundle validation, dependency cleanup (HBase removal), and extensive release testing.
 
+## Known Regressions
+If you use ComplexKeyGenerator with a single field, there is a known regression with key encoding format change that could introduce duplicates. Please refrain from migrating. and raise a GH issue to work through fixes. Note, if you have multiple fields as a part of complex key generator, there there are no issues. You can safely proceed.
+
+:::tip
+Avoid upgrading any existing table to 1.0.2 if you are using ComplexKeyGenerator with single record key configured.
+:::
+
 ## Raw Release Notes
 
 The raw release notes are available [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12322822&version=12355558)


### PR DESCRIPTION
### Change Logs

Updating 1.x release docs to call out ComplexKeyGenerator regression

### Impact

Updating 1.x release docs to call out ComplexKeyGenerator regression

### Risk level (write none, low medium or high below)

This is a doc update patch. 

### Documentation Update

The change itself is a doc update. 

<img width="895" height="221" alt="image" src="https://github.com/user-attachments/assets/a105f8f8-ad03-4358-ab10-ac941df3454f" />


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
