### PR TITLE
[HUDI-9671] Spark reads should skip record with UPDATE_BEFORE operation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -992,6 +992,29 @@ public class TestInputFormat {
   }
 
   @Test
+  void testMergeRecordWithUpdateBefore() throws Exception {
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.CHANGELOG_ENABLED.key(), "true");
+    beforeEach(HoodieTableType.COPY_ON_WRITE, options);
+
+    // write first batch with all insert data
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+    // write second batch with UPDATE_BEFORE record, send UPDATE_BEFORE for `id1`
+    TestData.writeData(TestData.DATA_SET_UPDATE_BEFORE, conf);
+    InputFormat<RowData, ?> inputFormat = this.tableSource.getInputFormat();
+    final String baseResult = TestData.rowDataToString(readData(inputFormat));
+    String expected = "["
+        + "+I[id2, Stephen, 33, 1970-01-01T00:00:00.002, par1], "
+        + "+I[id3, Julian, 53, 1970-01-01T00:00:00.003, par2], "
+        + "+I[id4, Fabian, 31, 1970-01-01T00:00:00.004, par2], "
+        + "+I[id5, Sophia, 18, 1970-01-01T00:00:00.005, par3], "
+        + "+I[id6, Emma, 20, 1970-01-01T00:00:00.006, par3], "
+        + "+I[id7, Bob, 44, 1970-01-01T00:00:00.007, par4], "
+        + "+I[id8, Han, 56, 1970-01-01T00:00:00.008, par4]]";
+    assertThat(baseResult, is(expected));
+  }
+
+  @Test
   void testReadArchivedCommitsIncrementally() throws Exception {
     Map<String, String> options = new HashMap<>();
     options.put(FlinkOptions.QUERY_TYPE.key(), FlinkOptions.QUERY_TYPE_INCREMENTAL);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -167,6 +167,10 @@ public class TestData {
             TimestampData.fromEpochMillis(i), StringData.fromString("par1"))));
   }
 
+  public static List<RowData> DATA_SET_UPDATE_BEFORE = Arrays.asList(
+      updateBeforeRow(StringData.fromString("id1"), StringData.fromString("Danny"), 23,
+          TimestampData.fromEpochMillis(1), StringData.fromString("par1")));
+
   // data set of test_source.data
   public static List<RowData> DATA_SET_SOURCE_INSERT = Arrays.asList(
       insertRow(StringData.fromString("id1"), StringData.fromString("Danny"), 23,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
@@ -47,7 +47,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Properties;
@@ -87,8 +88,9 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
     schema = new Schema.Parser().parse(jsonSchema);
   }
 
-  @Test
-  public void test() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void test(boolean isUpdateBefore) throws Exception {
     HoodieWriteConfig config = createHoodieWriteConfig();
     metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, config.getProps());
 
@@ -98,9 +100,10 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
     List<WriteStatus> writeStatuses1 = writeData(client, insertTime1, dataset1);
     client.commit(insertTime1, jsc().parallelize(writeStatuses1));
 
+    String hoodieOperation = isUpdateBefore ? "-U" : "D";
     String[] dataset2 = new String[] {
         "I,id1,Danny,30,2,par1",
-        "D,id2,Tony,20,2,par1",
+        hoodieOperation + ",id2,Tony,20,2,par1",
         "I,id3,Julian,40,2,par1",
         "D,id4,Stephan,35,2,par1"};
     String insertTime2 = HoodieActiveTimeline.createNewInstantTime();
@@ -165,7 +168,7 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
   private List<HoodieRecord> str2HoodieRecord(String[] records) {
     return Stream.of(records).map(rawRecordStr -> {
       String[] parts = rawRecordStr.split(",");
-      boolean isDelete = parts[0].equalsIgnoreCase("D");
+      String hoodieOperationStr = parts[0];
       GenericRecord record = new GenericData.Record(schema);
       record.put("id", parts[1]);
       record.put("name", parts[2]);
@@ -176,7 +179,7 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
       return new HoodieAvroRecord<>(
           new HoodieKey((String) record.get("id"), (String) record.get("part")),
           payload,
-          isDelete ? HoodieOperation.DELETE : HoodieOperation.INSERT);
+          HoodieOperation.fromName(hoodieOperationStr));
     }).collect(Collectors.toList());
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceReadWithDeletes.java
@@ -48,7 +48,7 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
 import java.util.Properties;
@@ -89,8 +89,8 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void test(boolean isUpdateBefore) throws Exception {
+  @EnumSource(value = HoodieOperation.class, names = {"UPDATE_BEFORE", "DELETE"})
+  public void test(HoodieOperation hoodieOperation) throws Exception {
     HoodieWriteConfig config = createHoodieWriteConfig();
     metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, config.getProps());
 
@@ -100,10 +100,9 @@ public class TestDataSourceReadWithDeletes extends SparkClientFunctionalTestHarn
     List<WriteStatus> writeStatuses1 = writeData(client, insertTime1, dataset1);
     client.commit(insertTime1, jsc().parallelize(writeStatuses1));
 
-    String hoodieOperation = isUpdateBefore ? "-U" : "D";
     String[] dataset2 = new String[] {
         "I,id1,Danny,30,2,par1",
-        hoodieOperation + ",id2,Tony,20,2,par1",
+        hoodieOperation.getName() + ",id2,Tony,20,2,par1",
         "I,id3,Julian,40,2,par1",
         "D,id4,Stephan,35,2,par1"};
     String insertTime2 = HoodieActiveTimeline.createNewInstantTime();


### PR DESCRIPTION
### Change Logs

Spark reads should skip record with UPDATE_BEFORE operation

### Impact

Ensure records with UPDATE_BEFORE operation are not read by spark snapshot scan

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
