### PR TITLE
[HUDI-9675] Add safety check to Savepoint when earliest commit retained is not set in cleaner output

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -161,12 +161,12 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
         throw new HoodieSavepointException("Failed to savepoint " + instantTime, e);
       }
     }).orElseGet(() ->
-      // If there is no earliest commit to retain, but there are clean instants on the timeline, we must assume KEEP_LATEST_FILE_VERSIONS policy is used.
-      // In that case, the last commit before the clean instant is the last commit guaranteed to be retained.
+      // If there is no earliest commit to retain in the clean commit's metadata, but there are clean instants on the timeline,
+      // we assume the last commit before the clean instant is the last commit guaranteed to be retained.
       table.getActiveTimeline().getWriteTimeline().filterCompletedInstants()
           .filter(instant -> compareTimestamps(instant.requestedTime(), LESSER_THAN_OR_EQUALS, cleanInstant.get().requestedTime()))
           .lastInstant()
           .map(HoodieInstant::requestedTime)
-          .orElseThrow(() -> new HoodieSavepointException("No commits found before clean instant " + cleanInstant.get())));
+          .orElse(cleanInstant.get().requestedTime()));
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
@@ -46,6 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
+import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 
 public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K, O, HoodieSavepointMetadata> {
@@ -74,26 +76,11 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
 
     try {
       // Check the last commit that was not cleaned and check if savepoint time is > that commit
-      Option<HoodieInstant> cleanInstant = table.getCleanTimeline().lastInstant();
-      String lastCommitRetained = cleanInstant.map(instant -> {
-        try {
-          if (instant.isCompleted()) {
-            return table.getActiveTimeline().readCleanMetadata(instant)
-                .getEarliestCommitToRetain();
-          } else {
-            // clean is pending or inflight
-            return table.getActiveTimeline().readCleanerPlan(
-                    instantGenerator.createNewInstant(REQUESTED, instant.getAction(), instant.requestedTime()))
-                .getEarliestInstantToRetain().getTimestamp();
-          }
-        } catch (IOException e) {
-          throw new HoodieSavepointException("Failed to savepoint " + instantTime, e);
-        }
-      }).orElseGet(() -> table.getCompletedCommitsTimeline().firstInstant().get().requestedTime());
+      String lastCommitRetained = getLastCommitRetained();
 
       // Cannot allow savepoint time on a commit that could have been cleaned
       ValidationUtils.checkArgument(compareTimestamps(instantTime, GREATER_THAN_OR_EQUALS, lastCommitRetained),
-          "Could not savepoint commit " + instantTime + " as this is beyond the lookup window " + lastCommitRetained);
+          () -> "Could not savepoint commit " + instantTime + " as this is beyond the lookup window " + lastCommitRetained);
 
       context.setJobStatus(this.getClass().getSimpleName(), "Collecting latest files for savepoint " + instantTime + " " + table.getConfig().getTableName());
       TableFileSystemView.SliceView view = table.getSliceView();
@@ -125,7 +112,7 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
         List<String> partitions = FSUtils.getAllPartitionPaths(context, table.getMetaClient(), config.getMetadataConfig());
         latestFilesMap = context.mapToPair(partitions, partitionPath -> {
           // Scan all partitions files with this commit time
-          LOG.info("Collecting latest files in partition path " + partitionPath);
+          LOG.info("Collecting latest files in partition path {}", partitionPath);
           List<String> latestFiles = new ArrayList<>();
           view.getLatestFileSlicesBeforeOrOn(partitionPath, instantTime, true).forEach(fileSlice -> {
             if (fileSlice.getBaseFile().isPresent()) {
@@ -145,10 +132,41 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
           .saveAsComplete(
               true, instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.SAVEPOINT_ACTION, instantTime), Option.of(metadata),
               savepointCompletedInstant -> table.getMetaClient().getTableFormat().savepoint(savepointCompletedInstant, table.getContext(), table.getMetaClient(), table.getViewManager()));
-      LOG.info("Savepoint " + instantTime + " created");
+      LOG.info("Savepoint {} created", instantTime);
       return metadata;
     } catch (HoodieIOException e) {
       throw new HoodieSavepointException("Failed to savepoint " + instantTime, e);
     }
+  }
+
+  @VisibleForTesting
+  String getLastCommitRetained() {
+    Option<HoodieInstant> cleanInstant = table.getCleanTimeline().lastInstant();
+    // if there are no clean instants, we can use the first completed commit
+    if (cleanInstant.isEmpty()) {
+      return table.getCompletedCommitsTimeline().firstInstant().get().requestedTime();
+    }
+    return cleanInstant.map(instant -> {
+      try {
+        if (instant.isCompleted()) {
+          return table.getActiveTimeline().readCleanMetadata(instant)
+              .getEarliestCommitToRetain();
+        } else {
+          // clean is pending or inflight
+          return table.getActiveTimeline().readCleanerPlan(
+                  instantGenerator.createNewInstant(REQUESTED, instant.getAction(), instant.requestedTime()))
+              .getEarliestInstantToRetain().getTimestamp();
+        }
+      } catch (IOException e) {
+        throw new HoodieSavepointException("Failed to savepoint " + instantTime, e);
+      }
+    }).orElseGet(() ->
+      // If there is no earliest commit to retain, but there are clean instants on the timeline, we must assume KEEP_LATEST_FILE_VERSIONS policy is used.
+      // In that case, the last commit before the clean instant is the last commit guaranteed to be retained.
+      table.getActiveTimeline().getWriteTimeline().filterCompletedInstants()
+          .filter(instant -> compareTimestamps(instant.requestedTime(), LESSER_THAN_OR_EQUALS, cleanInstant.get().requestedTime()))
+          .lastInstant()
+          .map(HoodieInstant::requestedTime)
+          .orElseThrow(() -> new HoodieSavepointException("No commits found before clean instant " + cleanInstant.get())));
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/savepoint/TestSavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/savepoint/TestSavepointActionExecutor.java
@@ -74,7 +74,6 @@ class TestSavepointActionExecutor {
     assertEquals(expectedInstant, executor.getLastCommitRetained());
   }
 
-
   @Test
   void testLastCommitRetained_requestedClean() throws IOException {
     String expectedInstant = "20240101101012345";
@@ -91,7 +90,8 @@ class TestSavepointActionExecutor {
     when(mockTable.getCleanTimeline().lastInstant()).thenReturn(Option.of(cleanInstant));
 
     HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan();
-    HoodieActionInstant lastInstantToRetain = HoodieActionInstant.newBuilder().setAction(HoodieTimeline.COMMIT_ACTION).setState(HoodieInstant.State.COMPLETED.name()).setTimestamp(expectedInstant).build();
+    HoodieActionInstant lastInstantToRetain = HoodieActionInstant.newBuilder().setAction(HoodieTimeline.COMMIT_ACTION)
+        .setState(HoodieInstant.State.COMPLETED.name()).setTimestamp(expectedInstant).build();
     cleanerPlan.setEarliestInstantToRetain(lastInstantToRetain);
     when(mockTable.getActiveTimeline().readCleanerPlan(cleanInstant)).thenReturn(cleanerPlan);
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/savepoint/TestSavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/savepoint/TestSavepointActionExecutor.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.savepoint;
+
+import org.apache.hudi.avro.model.HoodieActionInstant;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantGenerator;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+import org.apache.hudi.table.HoodieTable;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestSavepointActionExecutor {
+  private final HoodieTable mockTable = mock(HoodieTable.class, RETURNS_DEEP_STUBS);
+  private final HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(new HadoopStorageConfiguration(false));
+  private final String instantTime = "20240121101012345";
+
+  @Test
+  void testLastCommitRetained_noCleanCommits() {
+    String expectedInstant = "20240101101012345";
+    when(mockTable.getCompletedCommitsTimeline().firstInstant()).thenReturn(Option.of(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, expectedInstant,
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    when(mockTable.getCleanTimeline().lastInstant()).thenReturn(Option.empty());
+
+    SavepointActionExecutor executor = new SavepointActionExecutor(engineContext, null, mockTable, instantTime, "user", "comment");
+    assertEquals(expectedInstant, executor.getLastCommitRetained());
+  }
+
+  @Test
+  void testLastCommitRetained_completedClean() throws IOException {
+    String expectedInstant = "20240101101012345";
+    HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "20240111101012345",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    when(mockTable.getCompletedCommitsTimeline().firstInstant()).thenReturn(Option.of(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, expectedInstant,
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    when(mockTable.getCleanTimeline().lastInstant()).thenReturn(Option.of(cleanInstant));
+
+    HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata();
+    cleanMetadata.setEarliestCommitToRetain(expectedInstant);
+    when(mockTable.getActiveTimeline().readCleanMetadata(cleanInstant)).thenReturn(cleanMetadata);
+
+    SavepointActionExecutor executor = new SavepointActionExecutor(engineContext, null, mockTable, instantTime, "user", "comment");
+    assertEquals(expectedInstant, executor.getLastCommitRetained());
+  }
+
+
+  @Test
+  void testLastCommitRetained_requestedClean() throws IOException {
+    String expectedInstant = "20240101101012345";
+    String cleanRequested = "20240111101012345";
+    HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, cleanRequested,
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    InstantGenerator instantGenerator = mock(InstantGenerator.class);
+    when(mockTable.getInstantGenerator()).thenReturn(instantGenerator);
+    when(instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, cleanRequested))
+        .thenReturn(cleanInstant);
+
+    when(mockTable.getCompletedCommitsTimeline().firstInstant()).thenReturn(Option.of(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, expectedInstant,
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    when(mockTable.getCleanTimeline().lastInstant()).thenReturn(Option.of(cleanInstant));
+
+    HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan();
+    HoodieActionInstant lastInstantToRetain = HoodieActionInstant.newBuilder().setAction(HoodieTimeline.COMMIT_ACTION).setState(HoodieInstant.State.COMPLETED.name()).setTimestamp(expectedInstant).build();
+    cleanerPlan.setEarliestInstantToRetain(lastInstantToRetain);
+    when(mockTable.getActiveTimeline().readCleanerPlan(cleanInstant)).thenReturn(cleanerPlan);
+
+    SavepointActionExecutor executor = new SavepointActionExecutor(engineContext, null, mockTable, instantTime, "user", "comment");
+    assertEquals(expectedInstant, executor.getLastCommitRetained());
+  }
+
+  @Test
+  void testLastCommitRetained_completedCleanWithoutEarliestInstantRetained() throws IOException {
+    String expectedInstant = "20240110101012345";
+    HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "20240111101012345",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    when(mockTable.getCompletedCommitsTimeline().firstInstant()).thenReturn(Option.of(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, expectedInstant,
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    when(mockTable.getCleanTimeline().lastInstant()).thenReturn(Option.of(cleanInstant));
+
+    HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata();
+    when(mockTable.getActiveTimeline().readCleanMetadata(cleanInstant)).thenReturn(cleanMetadata);
+
+    MockHoodieTimeline mockTimeline = new MockHoodieTimeline(Stream.of("20240108101012345", "20240109101012345", expectedInstant), Stream.empty());
+    when(mockTable.getActiveTimeline().getWriteTimeline().filterCompletedInstants()).thenReturn(mockTimeline);
+
+    SavepointActionExecutor executor = new SavepointActionExecutor(engineContext, null, mockTable, instantTime, "user", "comment");
+    assertEquals(expectedInstant, executor.getLastCommitRetained());
+  }
+}


### PR DESCRIPTION
### Change Logs

In the case of cleaner policy `KEEP_LATEST_FILE_VERSIONS`, the `earliestCommitToRetain` is never set in the cleaner plan or clean metadata. The savepoint operation currently relies on this field to determine whether the instant is valid for a savepoint. If that value is not set, the code will assume all instants are valid which is not accurate.

To handle the case where the `KEEP_LATEST_FILE_VERSIONS` policy is used, we instead ensure that the instant provided to the savepoint is no older than the last commit before the last clean operation. Since the clean metadata does not include the number of file versions it kept, this is the only commit that we can guarantee is fully intact with this cleaner policy.

### Impact

Adds more safety when creating savepoints

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
