### PR TITLE
[HUDI-9673] Remove event_time metadata support from DefaultHoodieRecordPayload

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -199,28 +198,6 @@ public class TestDefaultHoodieRecordPayload {
     assertFalse(payload.getMetadata().isPresent());
   }
 
-  @ParameterizedTest
-  @ValueSource(longs = {1L, 1612542030000L})
-  public void testGetEventTimeInMetadata(long eventTime) throws IOException {
-    GenericRecord record1 = new GenericData.Record(schema);
-    record1.put("id", "1");
-    record1.put("partition", "partition0");
-    record1.put("ts", 0L);
-    record1.put("_hoodie_is_deleted", false);
-
-    GenericRecord record2 = new GenericData.Record(schema);
-    record2.put("id", "1");
-    record2.put("partition", "partition0");
-    record2.put("ts", eventTime);
-    record2.put("_hoodie_is_deleted", false);
-
-    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(record2, eventTime);
-    payload2.combineAndGetUpdateValue(record1, schema, props);
-    assertTrue(payload2.getMetadata().isPresent());
-    assertEquals(eventTime,
-        Long.parseLong(payload2.getMetadata().get().get(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY)));
-  }
-
   @Test
   public void testEmptyProperty() throws IOException {
     GenericRecord record1 = new GenericData.Record(schema);
@@ -239,21 +216,5 @@ public class TestDefaultHoodieRecordPayload {
     Properties properties = new Properties();
     payload.getInsertValue(schema, properties);
     payload.combineAndGetUpdateValue(record2, schema, properties);
-  }
-
-  @ParameterizedTest
-  @ValueSource(longs = {1L, 1612542030000L})
-  public void testGetEventTimeInMetadataForInserts(long eventTime) throws IOException {
-    GenericRecord record = new GenericData.Record(schema);
-
-    record.put("id", "1");
-    record.put("partition", "partition0");
-    record.put("ts", eventTime);
-    record.put("_hoodie_is_deleted", false);
-    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, eventTime);
-    payload.getInsertValue(schema, props);
-    assertTrue(payload.getMetadata().isPresent());
-    assertEquals(eventTime,
-        Long.parseLong(payload.getMetadata().get().get(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY)));
   }
 }


### PR DESCRIPTION
### Change Logs

Since `event_time` is populated in HoodieWriteHandle, there is no need to duplicate the logic in `DefaultHoodieRecordPayload`. So far, `event_time` is the only payload that supports `event_time` metadata.
Therefore, we remove the support from `DefaultHoodieRecordPayload` now.

### Impact

No duplicated support for `event_time` from `DefaultHoodieRecordPayload`.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
