### PR TITLE
[HUDI-9683] Fix field renames in HoodieInternalRowUtils.genUnsafeRowWriter

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -188,7 +188,7 @@ object HoodieInternalRowUtils {
       fieldNamesStack.push(newField.name)
 
       val (fieldWriter, prevFieldPos): (RowFieldUpdater, Int) =
-        prevStructType.getFieldIndex(lookupRenamedField(createFullName(fieldNamesStack), renamedColumnsMap)) match {
+        prevStructType.getFieldIndex(lookupRenamedField(newField.name, createFullName(fieldNamesStack), renamedColumnsMap)) match {
           case Some(prevFieldPos) =>
             val prevField = prevStructType(prevFieldPos)
             (newWriterRenaming(prevField.dataType, newField.dataType, renamedColumnsMap, fieldNamesStack), prevFieldPos)
@@ -404,9 +404,14 @@ object HoodieInternalRowUtils {
     }
   }
 
-  private def lookupRenamedField(newFieldQualifiedName: String, renamedColumnsMap: JMap[String, String]) = {
-    val prevFieldQualifiedName = renamedColumnsMap.getOrDefault(newFieldQualifiedName, newFieldQualifiedName)
-    val prevFieldQualifiedNameParts = prevFieldQualifiedName.split("\\.")
+  private def lookupRenamedField(newFieldName: String,
+                                 newFieldQualifiedName: String,
+                                 renamedColumnsMap: JMap[String, String]): String = {
+    val renamed = renamedColumnsMap.get(newFieldQualifiedName)
+    if (renamed == null) {
+      return newFieldName
+    }
+    val prevFieldQualifiedNameParts = renamed.split("\\.")
     val prevFieldName = prevFieldQualifiedNameParts(prevFieldQualifiedNameParts.length - 1)
 
     prevFieldName

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -188,25 +188,14 @@ object HoodieInternalRowUtils {
       fieldNamesStack.push(newField.name)
 
       val (fieldWriter, prevFieldPos): (RowFieldUpdater, Int) =
-        prevStructType.getFieldIndex(newField.name) match {
+        prevStructType.getFieldIndex(lookupRenamedField(createFullName(fieldNamesStack), renamedColumnsMap)) match {
           case Some(prevFieldPos) =>
             val prevField = prevStructType(prevFieldPos)
             (newWriterRenaming(prevField.dataType, newField.dataType, renamedColumnsMap, fieldNamesStack), prevFieldPos)
 
           case None =>
-            val newFieldQualifiedName = createFullName(fieldNamesStack)
-            val prevFieldName: String = lookupRenamedField(newFieldQualifiedName, renamedColumnsMap)
-
-            // Handle rename
-            prevStructType.getFieldIndex(prevFieldName) match {
-              case Some(prevFieldPos) =>
-                val prevField = prevStructType.fields(prevFieldPos)
-                (newWriterRenaming(prevField.dataType, newField.dataType, renamedColumnsMap, fieldNamesStack), prevFieldPos)
-
-              case None =>
-                val updater: RowFieldUpdater = (fieldUpdater, ordinal, _) => fieldUpdater.setNullAt(ordinal)
-                (updater, -1)
-            }
+            val updater: RowFieldUpdater = (fieldUpdater, ordinal, _) => fieldUpdater.setNullAt(ordinal)
+            (updater, -1)
         }
 
       fieldWriters += fieldWriter
@@ -416,7 +405,7 @@ object HoodieInternalRowUtils {
   }
 
   private def lookupRenamedField(newFieldQualifiedName: String, renamedColumnsMap: JMap[String, String]) = {
-    val prevFieldQualifiedName = renamedColumnsMap.getOrDefault(newFieldQualifiedName, "")
+    val prevFieldQualifiedName = renamedColumnsMap.getOrDefault(newFieldQualifiedName, newFieldQualifiedName)
     val prevFieldQualifiedNameParts = prevFieldQualifiedName.split("\\.")
     val prevFieldName = prevFieldQualifiedNameParts(prevFieldQualifiedNameParts.length - 1)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
@@ -137,7 +137,7 @@ class TestHoodieInternalRowUtils extends FunSuite with Matchers with BeforeAndAf
       StructField("age", IntegerType)
     ))
 
-    // Rename mapping: old -> new
+    // Rename mapping: new -> old
     val renameMap: java.util.Map[String, String] = new java.util.HashMap()
     renameMap.put("name", "first_name")
     renameMap.put("age", "years_old")
@@ -167,7 +167,7 @@ class TestHoodieInternalRowUtils extends FunSuite with Matchers with BeforeAndAf
       StructField("first_name", IntegerType)
     ))
 
-    // Rename mapping: old -> new
+    // Rename mapping: new -> old
     val renameMap: java.util.Map[String, String] = new java.util.HashMap()
     renameMap.put("years_old", "first_name")
     renameMap.put("first_name", "years_old")
@@ -207,7 +207,7 @@ class TestHoodieInternalRowUtils extends FunSuite with Matchers with BeforeAndAf
         )
         ))))
 
-    // Rename mapping: old -> new
+    // Rename mapping: new -> old
     val renameMap: java.util.Map[String, String] = new java.util.HashMap()
     renameMap.put("years_old", "first_name")
     renameMap.put("first_name", "years_old")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
@@ -211,8 +211,8 @@ class TestHoodieInternalRowUtils extends FunSuite with Matchers with BeforeAndAf
     val renameMap: java.util.Map[String, String] = new java.util.HashMap()
     renameMap.put("years_old", "first_name")
     renameMap.put("first_name", "years_old")
-    renameMap.put("address.city", "address.street")
-    renameMap.put("address.street", "address.city")
+    renameMap.put("address.city", "street")
+    renameMap.put("address.street", "city")
 
     // Sample row
     val oldRowData = sparkSession.sparkContext.parallelize(Seq(Row("Alice", 30, Row("SF", "Mission st"))))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieInternalRowUtils.scala
@@ -124,6 +124,108 @@ class TestHoodieInternalRowUtils extends FunSuite with Matchers with BeforeAndAf
     assertEquals(serDe.deserializeRow(newRow2), Row("Andrew", 25, Row("Mission st", "SF")));
   }
 
+  test("Test rewrite row with renamed columns") {
+    // Original schema
+    val oldSchema = StructType(Seq(
+      StructField("first_name", StringType),
+      StructField("years_old", IntegerType)
+    ))
+
+    // Renamed schema
+    val newSchema = StructType(Seq(
+      StructField("name", StringType),
+      StructField("age", IntegerType)
+    ))
+
+    // Rename mapping: old -> new
+    val renameMap: java.util.Map[String, String] = new java.util.HashMap()
+    renameMap.put("name", "first_name")
+    renameMap.put("age", "years_old")
+
+    // Sample row
+    val oldRowData = sparkSession.sparkContext.parallelize(Seq(Row("Alice", 30)))
+    val oldRow = sparkSession.createDataFrame(oldRowData, oldSchema).queryExecution.toRdd.first()
+
+    // Generate writer with rename map
+    val rowWriter = HoodieInternalRowUtils.genUnsafeRowWriter(oldSchema, newSchema, renameMap, JCollections.emptyMap())
+    val newRow = rowWriter(oldRow)
+
+    val serDe = sparkAdapter.createSparkRowSerDe(newSchema)
+    assertEquals(Row("Alice", 30), serDe.deserializeRow(newRow))
+  }
+
+  test("Test rewrite row with columns swap") {
+    // Original schema
+    val oldSchema = StructType(Seq(
+      StructField("first_name", StringType),
+      StructField("years_old", IntegerType)
+    ))
+
+    // Renamed schema
+    val newSchema = StructType(Seq(
+      StructField("years_old", StringType),
+      StructField("first_name", IntegerType)
+    ))
+
+    // Rename mapping: old -> new
+    val renameMap: java.util.Map[String, String] = new java.util.HashMap()
+    renameMap.put("years_old", "first_name")
+    renameMap.put("first_name", "years_old")
+
+    // Sample row
+    val oldRowData = sparkSession.sparkContext.parallelize(Seq(Row("Alice", 30)))
+    val oldRow = sparkSession.createDataFrame(oldRowData, oldSchema).queryExecution.toRdd.first()
+
+    // Generate writer with rename map
+    val rowWriter = HoodieInternalRowUtils.genUnsafeRowWriter(oldSchema, newSchema, renameMap, JCollections.emptyMap())
+    val newRow = rowWriter(oldRow)
+
+    val serDe = sparkAdapter.createSparkRowSerDe(newSchema)
+    assertEquals(Row("Alice", 30), serDe.deserializeRow(newRow))
+  }
+
+  test("Test rewrite row with columns swap nested") {
+    // Original schema
+    val oldSchema = StructType(Seq(
+      StructField("first_name", StringType),
+      StructField("years_old", IntegerType),
+      StructField("address",
+        StructType(Seq(
+          StructField("city", StringType),
+          StructField("street", StringType)
+        )
+    ))))
+
+    // Renamed schema
+    val newSchema = StructType(Seq(
+      StructField("years_old", StringType),
+      StructField("first_name", IntegerType),
+      StructField("address",
+        StructType(Seq(
+          StructField("street", StringType),
+          StructField("city", StringType)
+        )
+        ))))
+
+    // Rename mapping: old -> new
+    val renameMap: java.util.Map[String, String] = new java.util.HashMap()
+    renameMap.put("years_old", "first_name")
+    renameMap.put("first_name", "years_old")
+    renameMap.put("address.city", "address.street")
+    renameMap.put("address.street", "address.city")
+
+    // Sample row
+    val oldRowData = sparkSession.sparkContext.parallelize(Seq(Row("Alice", 30, Row("SF", "Mission st"))))
+    val oldRow = sparkSession.createDataFrame(oldRowData, oldSchema).queryExecution.toRdd.first()
+
+    // Generate writer with rename map
+    val rowWriter = HoodieInternalRowUtils.genUnsafeRowWriter(oldSchema, newSchema, renameMap, JCollections.emptyMap())
+    val newRow = rowWriter(oldRow)
+
+    val serDe = sparkAdapter.createSparkRowSerDe(newSchema)
+    assertEquals(Row("Alice", 30, Row("SF", "Mission st")), serDe.deserializeRow(newRow))
+  }
+
   /**
    * test record data type changes.
    * int => long/float/double/string


### PR DESCRIPTION
### Change Logs

Rename columns are not respected if a column is renamed to the name of a column in the old schema

avro had a similar issue: https://github.com/apache/hudi/pull/13663


### Impact

Fix schema on read for spark log files

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
