### PR TITLE
[HUDI-9687] Set min parallelism to 10 for SparkHoodieBloomIndexHelper

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -95,8 +95,9 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
     int configuredBloomIndexParallelism = config.getBloomIndexParallelism();
 
     // NOTE: Target parallelism could be overridden by the config
+    // Otherwise, default to minimum of 10
     int targetParallelism =
-        configuredBloomIndexParallelism > 0 ? configuredBloomIndexParallelism : inputParallelism;
+        configuredBloomIndexParallelism > 0 ? configuredBloomIndexParallelism : Math.max(inputParallelism, 10);
 
     LOG.info("Input parallelism: {}, Index parallelism: {}", inputParallelism, targetParallelism);
 


### PR DESCRIPTION
### Change Logs

If the input RDD's parallelism is 1, we will use that parallelism as the target parallelism. We should set a default min of 10 to avoid scenarios where there is bottlenecking.

### Impact

Adjusts the min parallelism to 10 for SparkHoodieBloomIndexHelper.

### Risk level (write none, low medium or high below)

Low. The main config `hoodie.bloom.index.parallelism` still takes precedence.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
