### PR TITLE
[MINOR] Rename to clarify global index checking for partial update

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommand.scala
@@ -42,7 +42,7 @@ class TestMergeIntoHoodieTableCommand extends AnyFlatSpec with Matchers {
         HoodieIndexConfig.INDEX_TYPE.key -> indexType.name,
         config.key -> "true"
       )
-      MergeIntoHoodieTableCommand.useGlobalIndex(parameters) should be(true)
+      MergeIntoHoodieTableCommand.useGlobalIndexAndUpdatePartitionPath(parameters) should be(true)
     }
   }
 
@@ -58,13 +58,20 @@ class TestMergeIntoHoodieTableCommand extends AnyFlatSpec with Matchers {
         HoodieIndexConfig.INDEX_TYPE.key -> indexType.name,
         config.key -> "false"
       )
-      MergeIntoHoodieTableCommand.useGlobalIndex(parameters) should be(false)
+      MergeIntoHoodieTableCommand.useGlobalIndexAndUpdatePartitionPath(parameters) should be(false)
     }
+  }
+
+  it should "return false for record index without setting update partition path (default false)" in {
+    val parameters = Map(
+      HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.RECORD_INDEX.name
+    )
+    MergeIntoHoodieTableCommand.useGlobalIndexAndUpdatePartitionPath(parameters) should be(false)
   }
 
   it should "return false when index type is absent" in {
     val parameters = Map.empty[String, String]
-    MergeIntoHoodieTableCommand.useGlobalIndex(parameters) should be(false)
+    MergeIntoHoodieTableCommand.useGlobalIndexAndUpdatePartitionPath(parameters) should be(false)
   }
 
   it should "return false when index type is not global" in {
@@ -76,7 +83,7 @@ class TestMergeIntoHoodieTableCommand extends AnyFlatSpec with Matchers {
       HoodieIndex.IndexType.FLINK_STATE.name)
     nonGlobalIndices.foreach { indexType =>
       val parameters = Map(HoodieIndexConfig.INDEX_TYPE.key -> indexType)
-      MergeIntoHoodieTableCommand.useGlobalIndex(parameters) should be(false)
+      MergeIntoHoodieTableCommand.useGlobalIndexAndUpdatePartitionPath(parameters) should be(false)
     }
   }
 


### PR DESCRIPTION
### Change Logs

Rename method to clarity the partial update limitation regarding global index, which also depends on update partition path enabled or not.

### Impact

Internal method rename.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

The docs note about this should be updated:
https://hudi.apache.org/docs/sql_dml#merge-into-partial-update

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
