### PR TITLE
[HUDI-9641] Improve Serialization Performance of HoodieAvroIndexedRecord

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.OrderingValues;
 
 import org.apache.avro.Schema;
@@ -45,7 +46,7 @@ import static org.apache.spark.sql.HoodieInternalRowUtils.getCachedSchema;
 public abstract class BaseSparkInternalRecordContext extends RecordContext<InternalRow> {
 
   public BaseSparkInternalRecordContext(HoodieTableConfig tableConfig) {
-    super(tableConfig);
+    super(tableConfig, new DefaultJavaTypeConverter());
   }
 
   public static Object getFieldValueFromInternalRow(InternalRow row, Schema recordSchema, String fieldName) {

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
@@ -46,6 +46,11 @@ import java.util.Properties;
  * Record context for reading and transforming avro indexed records.
  */
 public class AvroRecordContext extends RecordContext<IndexedRecord> {
+  private static final AvroRecordContext FIELD_ACCESSOR_INSTANCE = new AvroRecordContext();
+
+  public static AvroRecordContext getFieldAccessorInstance() {
+    return FIELD_ACCESSOR_INSTANCE;
+  }
 
   private final String payloadClass;
   // This boolean indicates whether the caller requires payloads in the HoodieRecord conversion.

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
@@ -59,6 +59,13 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
     this.requiresPayloadRecords = requiresPayloadRecords;
   }
 
+  public AvroRecordContext() {
+    super();
+    this.payloadClass = null;
+    this.requiresPayloadRecords = false;
+    this.typeConverter = new AvroJavaTypeConverter();
+  }
+
   public static Object getFieldValueFromIndexedRecord(
       IndexedRecord record,
       String fieldName) {

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
@@ -53,17 +53,15 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
   private final boolean requiresPayloadRecords;
 
   public AvroRecordContext(HoodieTableConfig tableConfig, String payloadClass, boolean requiresPayloadRecords) {
-    super(tableConfig);
+    super(tableConfig, new AvroJavaTypeConverter());
     this.payloadClass = payloadClass;
-    this.typeConverter = new AvroJavaTypeConverter();
     this.requiresPayloadRecords = requiresPayloadRecords;
   }
 
   public AvroRecordContext() {
-    super();
+    super(new AvroJavaTypeConverter());
     this.payloadClass = null;
     this.requiresPayloadRecords = false;
-    this.typeConverter = new AvroJavaTypeConverter();
   }
 
   public static Object getFieldValueFromIndexedRecord(

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -632,7 +632,7 @@ public class HoodieAvroUtils {
   public static GenericRecord rewriteRecord(GenericRecord oldRecord, Schema newSchema) {
     boolean isSpecificRecord = oldRecord instanceof SpecificRecordBase;
     Object newRecord = rewriteRecordWithNewSchemaInternal(oldRecord, oldRecord.getSchema(), newSchema, Collections.emptyMap(), new LinkedList<>(), isSpecificRecord);
-    return (GenericData.Record) newRecord;
+    return (GenericRecord) newRecord;
   }
 
   /**
@@ -1022,12 +1022,12 @@ public class HoodieAvroUtils {
    */
   public static GenericRecord rewriteRecordWithNewSchema(IndexedRecord oldRecord, Schema newSchema, Map<String, String> renameCols) {
     Object newRecord = rewriteRecordWithNewSchema(oldRecord, oldRecord.getSchema(), newSchema, renameCols, new LinkedList<>(), false);
-    return (GenericData.Record) newRecord;
+    return (GenericRecord) newRecord;
   }
 
   public static GenericRecord rewriteRecordWithNewSchema(IndexedRecord oldRecord, Schema newSchema, Map<String, String> renameCols, boolean validate) {
     Object newRecord = rewriteRecordWithNewSchema(oldRecord, oldRecord.getSchema(), newSchema, renameCols, new LinkedList<>(), validate);
-    return (GenericData.Record) newRecord;
+    return (GenericRecord) newRecord;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -238,7 +238,7 @@ public abstract class RecordContext<T> implements Serializable {
    * Check if the value of column "_hoodie_is_deleted" is true.
    */
   private boolean isBuiltInDeleteRecord(T record, DeleteContext deleteContext) {
-    if (!deleteContext.getCustomDeleteMarkerKeyValue().isPresent()) {
+    if (!deleteContext.hasBuiltInDeleteField()) {
       return false;
     }
     Object columnValue = getValue(record, deleteContext.getReaderSchema(), HOODIE_IS_DELETED_FIELD);

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -70,6 +70,15 @@ public abstract class RecordContext<T> implements Serializable {
         .orElseThrow(() -> new IllegalArgumentException("No record keys specified and meta fields are not populated")));
   }
 
+  /**
+   * Constructs an instance of {@link RecordContext} that provides field accessor methods but cannot compute the record key for records.
+   */
+  protected RecordContext() {
+    this.recordKeyExtractor = (record, schema) -> {
+      throw new UnsupportedOperationException("Record key extractor is not initialized");
+    };
+  }
+
   public void setPartitionPath(String partitionPath) {
     this.partitionPath = partitionPath;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.DeleteContext;
-import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.JavaTypeConverter;
 import org.apache.hudi.common.util.LocalAvroSchemaCache;
 import org.apache.hudi.common.util.OrderingValues;
@@ -61,11 +60,11 @@ public abstract class RecordContext<T> implements Serializable {
   // for encoding and decoding schemas to the spillable map
   private final LocalAvroSchemaCache localAvroSchemaCache = LocalAvroSchemaCache.getInstance();
 
-  protected JavaTypeConverter typeConverter;
+  protected final JavaTypeConverter typeConverter;
   protected String partitionPath;
 
-  protected RecordContext(HoodieTableConfig tableConfig) {
-    this.typeConverter = new DefaultJavaTypeConverter();
+  protected RecordContext(HoodieTableConfig tableConfig, JavaTypeConverter typeConverter) {
+    this.typeConverter = typeConverter;
     this.recordKeyExtractor = tableConfig.populateMetaFields() ? metadataKeyExtractor() : virtualKeyExtractor(tableConfig.getRecordKeyFields()
         .orElseThrow(() -> new IllegalArgumentException("No record keys specified and meta fields are not populated")));
   }
@@ -73,10 +72,11 @@ public abstract class RecordContext<T> implements Serializable {
   /**
    * Constructs an instance of {@link RecordContext} that provides field accessor methods but cannot compute the record key for records.
    */
-  protected RecordContext() {
+  protected RecordContext(JavaTypeConverter typeConverter) {
     this.recordKeyExtractor = (record, schema) -> {
       throw new UnsupportedOperationException("Record key extractor is not initialized");
     };
+    this.typeConverter = typeConverter;
   }
 
   public void setPartitionPath(String partitionPath) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -274,7 +274,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   }
 
   private void setSchema(Schema recordSchema) {
-    optimizedRecord.setSchema(recordSchema);
+    optimizedRecord.decodeRecord(recordSchema);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -258,9 +258,6 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public Comparable<?> doGetOrderingValue(Schema recordSchema, Properties props, String[] orderingFields) {
-    if (orderingValue != null) {
-      return orderingValue;
-    }
     if (orderingFields == null || orderingFields.length == 0) {
       return OrderingValues.getDefault();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -334,4 +334,9 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
       }
     }
   }
+
+  @Override
+  public IndexedRecord getData() {
+    return optimizedRecord.getRecord();
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -198,7 +198,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   protected boolean checkIsDelete(Schema recordSchema, Properties props) {
-    if (data == SerializableIndexedRecord.SENTINEL) {
+    if (getData().equals(SENTINEL)) {
       return false; // Sentinel record is not a delete
     }
     setSchema(recordSchema);
@@ -208,7 +208,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public boolean shouldIgnore(Schema recordSchema, Properties props) throws IOException {
-    return data == SerializableIndexedRecord.SENTINEL;
+    return getData().equals(SENTINEL);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -50,7 +50,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELD
 public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   private static final long serialVersionUID = 1L;
   private static final AvroRecordContext AVRO_RECORD_CONTEXT = new AvroRecordContext();
-  private HoodieIndexedRecord optimizedRecord;
+  private SerializableIndexedRecord optimizedRecord;
 
   public HoodieAvroIndexedRecord(IndexedRecord data) {
     this(null, data, null, null, null);
@@ -84,8 +84,8 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, HoodieOperation operation, HoodieRecordLocation currentLocation, HoodieRecordLocation newLocation) {
-    super(key, new HoodieIndexedRecord(data), operation, currentLocation, newLocation);
-    this.optimizedRecord = (HoodieIndexedRecord) this.data;
+    super(key, new SerializableIndexedRecord(data), operation, currentLocation, newLocation);
+    this.optimizedRecord = (SerializableIndexedRecord) this.data;
   }
 
   public HoodieAvroIndexedRecord(IndexedRecord data, HoodieRecordLocation currentLocation) {
@@ -97,17 +97,17 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
       IndexedRecord data,
       HoodieOperation operation,
       Option<Map<String, String>> metaData) {
-    super(key, new HoodieIndexedRecord(data), operation, metaData);
-    this.optimizedRecord = (HoodieIndexedRecord) this.data;
+    super(key, new SerializableIndexedRecord(data), operation, metaData);
+    this.optimizedRecord = (SerializableIndexedRecord) this.data;
   }
 
   HoodieAvroIndexedRecord(HoodieRecord<IndexedRecord> record) {
     super(record);
-    this.optimizedRecord = (HoodieIndexedRecord) this.data;
+    this.optimizedRecord = (SerializableIndexedRecord) this.data;
   }
 
   public HoodieAvroIndexedRecord() {
-    this.optimizedRecord = (HoodieIndexedRecord) this.data;
+    this.optimizedRecord = (SerializableIndexedRecord) this.data;
   }
 
   @Override
@@ -117,12 +117,12 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public HoodieRecord<IndexedRecord> newInstance(HoodieKey key, HoodieOperation op) {
-    return new HoodieAvroIndexedRecord(key, new HoodieIndexedRecord(data), op, metaData);
+    return new HoodieAvroIndexedRecord(key, new SerializableIndexedRecord(data), op, metaData);
   }
 
   @Override
   public HoodieRecord<IndexedRecord> newInstance(HoodieKey key) {
-    return new HoodieAvroIndexedRecord(key, new HoodieIndexedRecord(data), operation, metaData);
+    return new HoodieAvroIndexedRecord(key, new SerializableIndexedRecord(data), operation, metaData);
   }
 
   @Override
@@ -296,7 +296,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   @Override
   protected final void writeRecordPayload(IndexedRecord payload, Kryo kryo, Output output) {
     // NOTE: We're leveraging Spark's default [[GenericAvroSerializer]] to serialize Avro
-    Serializer<HoodieIndexedRecord> avroSerializer = kryo.getSerializer(HoodieIndexedRecord.class);
+    Serializer<SerializableIndexedRecord> avroSerializer = kryo.getSerializer(SerializableIndexedRecord.class);
 
     kryo.writeObjectOrNull(output, payload, avroSerializer);
   }
@@ -308,7 +308,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   @SuppressWarnings("unchecked")
   @Override
   protected final IndexedRecord readRecordPayload(Kryo kryo, Input input) {
-    HoodieIndexedRecord data = kryo.readObjectOrNull(input, HoodieIndexedRecord.class);
+    SerializableIndexedRecord data = kryo.readObjectOrNull(input, SerializableIndexedRecord.class);
     this.optimizedRecord = data;
     return data;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieIndexedRecord.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.exception.HoodieIOException;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.io.IOException;
+
+/**
+ * Wrapper class for {@link IndexedRecord} that will serialize the record as bytes without the schema for efficient shuffling performance in Spark.
+ * After deserialization, the schema can be set using {@link #setSchema(Schema)} and that will also trigger deserialization of the record.
+ * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
+ */
+class HoodieIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
+  private IndexedRecord record;
+  private byte[] recordBytes;
+
+  HoodieIndexedRecord(IndexedRecord record) {
+    this.record = record;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    record.put(i, v);
+  }
+
+  @Override
+  public Object get(int i) {
+    return record.get(i);
+  }
+
+  @Override
+  public Schema getSchema() {
+    return record.getSchema();
+  }
+
+  private byte[] getRecordBytes() {
+    if (recordBytes == null) {
+      recordBytes = HoodieAvroUtils.avroToBytes(record);
+    }
+    return recordBytes;
+  }
+
+  void setSchema(Schema schema) {
+    if (record == null) {
+      try {
+        record = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
+      } catch (IOException e) {
+        throw new HoodieIOException("Failed to parse record into provided schema", e);
+      }
+    }
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output) {
+    byte[] bytes = getRecordBytes();
+    output.writeInt(bytes.length, true);
+    output.writeBytes(bytes);
+  }
+
+  @Override
+  public void read(Kryo kryo, Input input) {
+    int length = input.readInt(true);
+    this.recordBytes = input.readBytes(length);
+  }
+
+  @Override
+  public void put(String key, Object v) {
+    Schema.Field field = record.getSchema().getField(key);
+    record.put(field.pos(), v);
+  }
+
+  @Override
+  public Object get(String key) {
+    Schema.Field field = record.getSchema().getField(key);
+    return record.get(field.pos());
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -407,6 +407,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     writeRecordPayload(data, kryo, output);
     kryo.writeObjectOrNull(output, ignoreIndexUpdate, Boolean.class);
     kryo.writeObjectOrNull(output, isDelete, Boolean.class);
+    kryo.writeClassAndObject(output, orderingValue);
   }
 
   /**
@@ -424,6 +425,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.data = readRecordPayload(kryo, input);
     this.ignoreIndexUpdate = kryo.readObjectOrNull(input, Boolean.class);
     this.isDelete = kryo.readObjectOrNull(input, Boolean.class);
+    this.orderingValue = (Comparable<?>) kryo.readClassAndObject(input);
 
     // NOTE: We're always seal object after deserialization
     this.sealed = true;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -28,12 +28,10 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -41,26 +39,16 @@ import java.util.Objects;
  * After deserialization, the schema can be set using {@link #decodeRecord(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
-class SerializableIndexedRecord extends GenericData.Record implements IndexedRecord, GenericRecord, KryoSerializable {
-  static final SerializableIndexedRecord SENTINEL = new Sentinel();
+class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
   private IndexedRecord record;
   private byte[] recordBytes;
 
   static SerializableIndexedRecord createInstance(IndexedRecord record) {
-    if (record == null) {
-      return null;
-    }
-    return record == HoodieRecord.SENTINEL ? SENTINEL : new SerializableIndexedRecord(record);
+    return record == null ? null : new SerializableIndexedRecord(record);
   }
 
   private SerializableIndexedRecord(IndexedRecord record) {
-    super(record.getSchema());
     this.record = record;
-  }
-
-  private SerializableIndexedRecord(Schema schema) {
-    super(schema);
-    this.recordBytes = new byte[0];
   }
 
   @Override
@@ -152,22 +140,5 @@ class SerializableIndexedRecord extends GenericData.Record implements IndexedRec
   @Override
   public String toString() {
     return record == null ? "SERIALIZED: " + new String(recordBytes) : record.toString();
-  }
-
-  private static class Sentinel extends SerializableIndexedRecord {
-
-    private Sentinel() {
-      super(Schema.createRecord("sentinel", null, "org.apache.hudi", false, Collections.emptyList()));
-    }
-
-    @Override
-    public String toString() {
-      return "SENTINEL";
-    }
-
-    @Override
-    IndexedRecord getRecord() {
-      return HoodieRecord.SENTINEL;
-    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * After deserialization, the schema can be set using {@link #decodeRecord(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
-class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
+class SerializableIndexedRecord implements GenericRecord, KryoSerializable {
   private IndexedRecord record;
   private byte[] recordBytes;
 
@@ -129,6 +129,7 @@ class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSer
   }
 
   IndexedRecord getRecord() {
+    ValidationUtils.checkArgument(record != null, "Record must be deserialized before accessing");
     return record;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -28,6 +28,7 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
@@ -39,11 +40,12 @@ import java.util.Objects;
  * After deserialization, the schema can be set using {@link #setSchema(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
-class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
+class SerializableIndexedRecord extends GenericData.Record implements IndexedRecord, GenericRecord, KryoSerializable {
   private IndexedRecord record;
   private byte[] recordBytes;
 
   SerializableIndexedRecord(IndexedRecord record) {
+    super(record.getSchema());
     this.record = record;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -78,6 +78,7 @@ public class SerializableIndexedRecord implements GenericRecord, KryoSerializabl
     if (record == null) {
       try {
         record = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
+        recordBytes = null;
       } catch (IOException e) {
         throw new HoodieIOException("Failed to parse record into provided schema", e);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -42,12 +42,14 @@ import java.util.Objects;
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
 class SerializableIndexedRecord extends GenericData.Record implements IndexedRecord, GenericRecord, KryoSerializable {
-  static final SerializableIndexedRecord SENTINEL = new SerializableIndexedRecord(
-      Schema.createRecord("sentinel", null, "org.apache.hudi", false, Collections.emptyList()));
+  static final SerializableIndexedRecord SENTINEL = new Sentinel();
   private IndexedRecord record;
   private byte[] recordBytes;
 
   static SerializableIndexedRecord createInstance(IndexedRecord record) {
+    if (record == null) {
+      return null;
+    }
     return record == HoodieRecord.SENTINEL ? SENTINEL : new SerializableIndexedRecord(record);
   }
 
@@ -138,6 +140,10 @@ class SerializableIndexedRecord extends GenericData.Record implements IndexedRec
     return false;
   }
 
+  IndexedRecord getRecord() {
+    return record;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(record);
@@ -146,5 +152,22 @@ class SerializableIndexedRecord extends GenericData.Record implements IndexedRec
   @Override
   public String toString() {
     return record == null ? "SERIALIZED: " + new String(recordBytes) : record.toString();
+  }
+
+  private static class Sentinel extends SerializableIndexedRecord {
+
+    private Sentinel() {
+      super(Schema.createRecord("sentinel", null, "org.apache.hudi", false, Collections.emptyList()));
+    }
+
+    @Override
+    public String toString() {
+      return "SENTINEL";
+    }
+
+    @Override
+    IndexedRecord getRecord() {
+      return HoodieRecord.SENTINEL;
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -109,16 +109,28 @@ class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSer
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (o == null) {
       return false;
     }
-    SerializableIndexedRecord that = (SerializableIndexedRecord) o;
-    ValidationUtils.checkArgument(record != null && that.record != null, "Records must be deserialized before equality check");
-    return record.equals(that.record);
+    if (o instanceof SerializableIndexedRecord) {
+      SerializableIndexedRecord that = (SerializableIndexedRecord) o;
+      ValidationUtils.checkArgument(record != null && that.record != null, "Records must be deserialized before equality check");
+      return record.equals(that.record);
+    } else if (o instanceof IndexedRecord) {
+      // If the other object is an IndexedRecord, we can compare it directly
+      IndexedRecord that = (IndexedRecord) o;
+      return record.equals(that);
+    }
+    return false;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(record);
+  }
+
+  @Override
+  public String toString() {
+    return record == null ? "SERIALIZED: " + new String(recordBytes) : record.toString();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -37,11 +37,11 @@ import java.io.IOException;
  * After deserialization, the schema can be set using {@link #setSchema(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
-class HoodieIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
+class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSerializable {
   private IndexedRecord record;
   private byte[] recordBytes;
 
-  HoodieIndexedRecord(IndexedRecord record) {
+  SerializableIndexedRecord(IndexedRecord record) {
     this.record = record;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 
 /**
  * Wrapper class for {@link IndexedRecord} that will serialize the record as bytes without the schema for efficient shuffling performance in Spark.
- * After deserialization, the schema can be set using {@link #setSchema(Schema)} and that will also trigger deserialization of the record.
+ * After deserialization, the schema can be set using {@link #decodeRecord(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
 class SerializableIndexedRecord extends GenericData.Record implements IndexedRecord, GenericRecord, KryoSerializable {
@@ -78,14 +78,14 @@ class SerializableIndexedRecord extends GenericData.Record implements IndexedRec
     return record.getSchema();
   }
 
-  private byte[] getRecordBytes() {
+  private byte[] encodeRecord() {
     if (recordBytes == null) {
       recordBytes = HoodieAvroUtils.avroToBytes(record);
     }
     return recordBytes;
   }
 
-  void setSchema(Schema schema) {
+  void decodeRecord(Schema schema) {
     if (record == null) {
       try {
         record = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
@@ -97,7 +97,7 @@ class SerializableIndexedRecord extends GenericData.Record implements IndexedRec
 
   @Override
   public void write(Kryo kryo, Output output) {
-    byte[] bytes = getRecordBytes();
+    byte[] bytes = encodeRecord();
     output.writeInt(bytes.length, true);
     output.writeBytes(bytes);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieIOException;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -31,6 +32,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Wrapper class for {@link IndexedRecord} that will serialize the record as bytes without the schema for efficient shuffling performance in Spark.
@@ -100,5 +102,23 @@ class SerializableIndexedRecord implements IndexedRecord, GenericRecord, KryoSer
   public Object get(String key) {
     Schema.Field field = record.getSchema().getField(key);
     return record.get(field.pos());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SerializableIndexedRecord that = (SerializableIndexedRecord) o;
+    ValidationUtils.checkArgument(record != null && that.record != null, "Records must be deserialized before equality check");
+    return record.equals(that.record);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(record);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * After deserialization, the schema can be set using {@link #decodeRecord(Schema)} and that will also trigger deserialization of the record.
  * This allows the record to stay in the serialized form until the data needs to be accessed, which allows deserialization to be avoided if data is not read.
  */
-class SerializableIndexedRecord implements GenericRecord, KryoSerializable {
+public class SerializableIndexedRecord implements GenericRecord, KryoSerializable {
   private IndexedRecord record;
   private byte[] recordBytes;
 
@@ -49,6 +49,7 @@ class SerializableIndexedRecord implements GenericRecord, KryoSerializable {
 
   private SerializableIndexedRecord(IndexedRecord record) {
     this.record = record;
+    this.recordBytes = null; // Initialize recordBytes to null, will be set when encodeRecord is called
   }
 
   @Override
@@ -66,7 +67,7 @@ class SerializableIndexedRecord implements GenericRecord, KryoSerializable {
     return record.getSchema();
   }
 
-  private byte[] encodeRecord() {
+  byte[] encodeRecord() {
     if (recordBytes == null) {
       recordBytes = HoodieAvroUtils.avroToBytes(record);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/DeleteContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/DeleteContext.java
@@ -47,7 +47,6 @@ public class DeleteContext implements Serializable {
   public DeleteContext(Properties props, Schema tableSchema) {
     this.customDeleteMarkerKeyValue = getCustomDeleteMarkerKevValue(props);
     this.hasBuiltInDeleteField = hasBuiltInDeleteField(tableSchema);
-    this.hoodieOperationPos = getHoodieOperationPos(tableSchema);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/DeleteContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/DeleteContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.hudi.common.table.read;
 
-import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -28,6 +27,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.avro.Schema;
 
 import java.io.Serializable;
+import java.util.Properties;
 
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
@@ -44,9 +44,10 @@ public class DeleteContext implements Serializable {
   private int hoodieOperationPos;
   private Schema readerSchema;
 
-  public DeleteContext(TypedProperties props, Schema tableSchema) {
+  public DeleteContext(Properties props, Schema tableSchema) {
     this.customDeleteMarkerKeyValue = getCustomDeleteMarkerKevValue(props);
     this.hasBuiltInDeleteField = hasBuiltInDeleteField(tableSchema);
+    this.hoodieOperationPos = getHoodieOperationPos(tableSchema);
   }
 
   /**
@@ -54,7 +55,7 @@ public class DeleteContext implements Serializable {
    * the field which contains the corresponding delete-marker if a record is deleted. If no delete key and marker
    * are configured, the function returns an empty option.
    */
-  private static Option<Pair<String, String>> getCustomDeleteMarkerKevValue(TypedProperties props) {
+  private static Option<Pair<String, String>> getCustomDeleteMarkerKevValue(Properties props) {
     String deleteKey = props.getProperty(DELETE_KEY);
     String deleteMarker = props.getProperty(DELETE_MARKER);
     boolean deleteKeyExists = !StringUtils.isNullOrEmpty(deleteKey);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.RewriteAvroPayload;
+import org.apache.hudi.common.model.SerializableIndexedRecord;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -112,7 +113,8 @@ public class HoodieCommonKryoRegistrar {
         StoragePath.class,
         HoodieTableMetaClient.class,
         HoodieFileGroupId.class,
-        ArrayList.class
+        ArrayList.class,
+        SerializableIndexedRecord.class
     })
         .forEachOrdered(kryo::register);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
@@ -44,7 +44,7 @@ class TestSerializableIndexRecord {
         .set("field_2", 42)
         .build();
 
-    SerializableIndexedRecord serializableIndexedRecord = new SerializableIndexedRecord(record1);
+    SerializableIndexedRecord serializableIndexedRecord = SerializableIndexedRecord.createInstance(record1);
 
     assertEquals(record1, serializableIndexedRecord);
     assertEquals(serializableIndexedRecord, record1);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
@@ -46,10 +46,10 @@ class TestSerializableIndexRecord {
 
     SerializableIndexedRecord serializableIndexedRecord = SerializableIndexedRecord.createInstance(record1);
 
-    assertEquals(record1, serializableIndexedRecord);
+    assertEquals(record1, serializableIndexedRecord.getRecord());
     assertEquals(serializableIndexedRecord, record1);
 
-    assertNotEquals(record2, serializableIndexedRecord);
+    assertNotEquals(record2, serializableIndexedRecord.getRecord());
     assertNotEquals(serializableIndexedRecord, record2);
 
     assertNotEquals(serializableIndexedRecord, null);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestSerializableIndexRecord.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class TestSerializableIndexRecord {
+  private final Schema schema = SchemaBuilder.record("test")
+      .fields().optionalString("field_1").requiredInt("field_2").endRecord();
+
+  @Test
+  void testEqualsWithGenericRecord() {
+    GenericRecord record1 = new GenericRecordBuilder(schema)
+        .set("field_1", "value1")
+        .set("field_2", 42)
+        .build();
+
+    GenericRecord record2 = new GenericRecordBuilder(schema)
+        .set("field_1", "value2")
+        .set("field_2", 42)
+        .build();
+
+    SerializableIndexedRecord serializableIndexedRecord = new SerializableIndexedRecord(record1);
+
+    assertEquals(record1, serializableIndexedRecord);
+    assertEquals(serializableIndexedRecord, record1);
+
+    assertNotEquals(record2, serializableIndexedRecord);
+    assertNotEquals(serializableIndexedRecord, record2);
+
+    assertNotEquals(serializableIndexedRecord, null);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -305,7 +306,7 @@ public abstract class SchemaHandlerTestBase {
   static class StubbedReaderContext extends HoodieReaderContext<String> {
 
     protected StubbedReaderContext(HoodieTableConfig hoodieTableConfig, boolean supportsParquetRowIndex) {
-      super(null, hoodieTableConfig, Option.empty(), Option.empty(), new RecordContext<String>(hoodieTableConfig) {
+      super(null, hoodieTableConfig, Option.empty(), Option.empty(), new RecordContext<String>(hoodieTableConfig, new DefaultJavaTypeConverter()) {
         @Override
         public boolean supportsParquetRowIndex() {
           return supportsParquetRowIndex;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -55,7 +56,7 @@ public class FlinkRecordContext extends RecordContext<RowData> {
   private RecordKeyToRowDataConverter recordKeyRowConverter;
 
   public FlinkRecordContext(HoodieTableConfig tableConfig, StorageConfiguration<?> storageConf) {
-    super(tableConfig);
+    super(tableConfig, new DefaultJavaTypeConverter());
     this.utcTimezone = storageConf.getBoolean(FlinkOptions.READ_UTC_TIMEZONE.key(),
         FlinkOptions.READ_UTC_TIMEZONE.defaultValue());
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
@@ -27,6 +27,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.StringType;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -318,7 +319,7 @@ public class AvroOrcUtils {
       case STRUCT:
         StructColumnVector structColVec = (StructColumnVector) colVector;
 
-        GenericData.Record record = (GenericData.Record) value;
+        GenericRecord record = (GenericRecord) value;
 
         for (int i = 0; i < type.getFieldNames().size(); i++) {
           String fieldName = type.getFieldNames().get(i);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroIndexedRecord.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroIndexedRecord.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestHoodieAvroIndexedRecord {
+
+  @Test
+  void testIsBuiltInDelete() {
+    Schema schema = SchemaBuilder.record("TestRecord")
+        .fields()
+        .optionalBoolean("_hoodie_is_deleted")
+        .requiredString("field2")
+        .endRecord();
+    GenericRecord record1 = new GenericRecordBuilder(schema)
+        .set("_hoodie_is_deleted", true)
+        .set("field2", "value2")
+        .build();
+    HoodieAvroIndexedRecord indexedRecord1 = new HoodieAvroIndexedRecord(record1);
+    assertTrue(indexedRecord1.isDelete(schema, new TypedProperties()));
+
+    GenericRecord record2 = new GenericRecordBuilder(schema)
+        .set("_hoodie_is_deleted", false)
+        .set("field2", "value2")
+        .build();
+    HoodieAvroIndexedRecord indexedRecord2 = new HoodieAvroIndexedRecord(record2);
+    assertFalse(indexedRecord2.isDelete(schema, new TypedProperties()));
+  }
+
+  @Test
+  void testIsDeleteWithCustomField() {
+    Schema schema = SchemaBuilder.record("TestRecord")
+        .fields()
+        .optionalString("custom_is_deleted")
+        .requiredString("field2")
+        .endRecord();
+    GenericRecord record1 = new GenericRecordBuilder(schema)
+        .set("custom_is_deleted", "d")
+        .set("field2", "value2")
+        .build();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DELETE_KEY, "custom_is_deleted");
+    props.setProperty(DELETE_MARKER, "d");
+
+    HoodieAvroIndexedRecord indexedRecord1 = new HoodieAvroIndexedRecord(record1);
+    assertTrue(indexedRecord1.isDelete(schema, props));
+
+    GenericRecord record2 = new GenericRecordBuilder(schema)
+        .set("custom_is_deleted", "a")
+        .set("field2", "value2")
+        .build();
+    HoodieAvroIndexedRecord indexedRecord2 = new HoodieAvroIndexedRecord(record2);
+    assertFalse(indexedRecord2.isDelete(schema, props));
+  }
+
+  @Test
+  void testIsDeleteWithOperationField() {
+    Schema schema = SchemaBuilder.record("TestRecord")
+        .fields()
+        .optionalString("_hoodie_operation")
+        .requiredString("field2")
+        .endRecord();
+    GenericRecord record1 = new GenericRecordBuilder(schema)
+        .set("_hoodie_operation", HoodieOperation.DELETE.getName())
+        .set("field2", "value2")
+        .build();
+    HoodieAvroIndexedRecord indexedRecord1 = new HoodieAvroIndexedRecord(record1);
+    assertTrue(indexedRecord1.isDelete(schema, new TypedProperties()));
+
+    GenericRecord record2 = new GenericRecordBuilder(schema)
+        .set("_hoodie_operation", HoodieOperation.INSERT.getName())
+        .set("field2", "value2")
+        .build();
+    HoodieAvroIndexedRecord indexedRecord2 = new HoodieAvroIndexedRecord(record2);
+    assertFalse(indexedRecord2.isDelete(schema, new TypedProperties()));
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveRecordContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveRecordContext.java
@@ -52,8 +52,7 @@ public class HiveRecordContext extends RecordContext<ArrayWritable> {
   private final ObjectInspectorCache objectInspectorCache;
 
   public HiveRecordContext(HoodieTableConfig tableConfig, StorageConfiguration<?> storageConf, ObjectInspectorCache objectInspectorCache) {
-    super(tableConfig);
-    this.typeConverter = new HiveJavaTypeConverter();
+    super(tableConfig, new HiveJavaTypeConverter());
     this.objectInspectorCache = objectInspectorCache;
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.BufferedRecordMerger;
 import org.apache.hudi.common.table.read.BufferedRecordMergerFactory;
+import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -785,7 +786,7 @@ class TestBufferedRecordMerger extends SparkClientFunctionalTestHarness {
   static class DummyRecordContext extends RecordContext<InternalRow> {
 
     public DummyRecordContext(HoodieTableConfig tableConfig) {
-      super(tableConfig);
+      super(tableConfig, new DefaultJavaTypeConverter());
     }
 
     @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
@@ -81,8 +81,8 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     val hoodieInternalRow = new HoodieInternalRow(new Array[UTF8String](5), unsafeRow, false)
 
     Seq(
-      (unsafeRow, rowSchema, 90),
-      (hoodieInternalRow, addMetaFields(rowSchema), 130)
+      (unsafeRow, rowSchema, 91),
+      (hoodieInternalRow, addMetaFields(rowSchema), 131)
     ) foreach { case (row, schema, expectedSize) => routine(row, schema, expectedSize) }
   }
 
@@ -114,8 +114,8 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     val avroIndexedRecord = new HoodieAvroIndexedRecord(key, avroRecord)
     avroIndexedRecord.setIgnoreIndexUpdate(true)
 
-    val expectedLegacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 537 else 531
-    val expectedAvroIndexedRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 55 else 52
+    val expectedLegacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 538 else 532
+    val expectedAvroIndexedRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 56 else 53
 
     Seq(
       (legacyRecord, null, expectedLegacyRecordSize),
@@ -138,7 +138,7 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     }
 
     val key = new HoodieKey("rec-key", "part-path")
-    val expectedEmptyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 33 else 30
+    val expectedEmptyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 34 else 31
     Seq(
       (new HoodieEmptyRecord[GenericRecord](key, HoodieOperation.INSERT, 1, HoodieRecordType.AVRO),
         expectedEmptyRecordSize),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
@@ -115,10 +115,11 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     avroIndexedRecord.setIgnoreIndexUpdate(true)
 
     val expectedLegacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 537 else 531
+    val expectedAvroIndexedRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 55 else 52
 
     Seq(
       (legacyRecord, null, expectedLegacyRecordSize),
-      (avroIndexedRecord, avroRecord.getSchema, 56)
+      (avroIndexedRecord, avroRecord.getSchema, expectedAvroIndexedRecordSize)
     ) foreach { case (record, schema, expectedSize) => routine(record, schema, expectedSize) }
   }
 


### PR DESCRIPTION
### Change Logs

Currently, our payload based paths use `HoodieAvroRecord` to transport data between Spark Executors. As we move away from the Payloads though, we can start relying on the other record objects directly. The `HoodieAvroIndexedRecord` can fit our needs for transporting the Avro data but needs some changes to match the existing performance.

This change introduces a new class `SerializableIndexedRecord` which is used to manage the serialization of the data in the `HoodieAvroIndexedRecord`. Unlike payloads, the data is only written out to a byte array when it is required. This allows us to keep performance on par with the existing performance when working with data that only resides within a single machine.

For existing workflows that use `HoodieAvroIndexedRecord` like compaction, we expect to see the same performance. This is validate with a JMH Microbenchmark where I validate that the call the `setSchema` does not cause throughput changes when working with the object.

The serialized size of the object when using Kryo is also about 2/3 the size of the existing record with a fairly basic object with 15 fields with mainly numeric or small strings as values. The throughput of the serialization is over 90% faster.

### Impact

Allows us to move away from Payloads without performance degradation on serialization

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
