### PR TITLE
[HUDI-9698] Ensure valid upgrade/downgrade checks for table versions greater than SIX

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -111,7 +111,7 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
     }).map(Arguments::of);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @MethodSource("testArgsForUpgradeDowngradeCommand")
   public void testUpgradeDowngradeCommand(HoodieTableVersion fromVersion, HoodieTableVersion toVersion) throws Exception {

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -36,6 +36,7 @@ import org.apache.hudi.testutils.HoodieClientTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -110,6 +111,7 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
     }).map(Arguments::of);
   }
 
+  @Disabled
   @ParameterizedTest
   @MethodSource("testArgsForUpgradeDowngradeCommand")
   public void testUpgradeDowngradeCommand(HoodieTableVersion fromVersion, HoodieTableVersion toVersion) throws Exception {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1359,6 +1359,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return HoodieTableVersion.fromVersionCode(getIntOrDefault(WRITE_TABLE_VERSION));
   }
 
+  public void setWriteVersion(HoodieTableVersion version) {
+    setValue(WRITE_TABLE_VERSION, String.valueOf(version.versionCode()));
+  }
+
   public boolean autoUpgrade() {
     return getBoolean(AUTO_UPGRADE_VERSION);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -22,7 +22,6 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieIndexVersion;
@@ -40,11 +39,6 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
                                              SupportsUpgradeDowngrade upgradeDowngradeHelper) {
     final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
 
-    // If auto upgrade is disabled, set writer version to 8 and return
-    if (!config.autoUpgrade()) {
-      config.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
-      return Collections.emptyMap();
-    }
     HoodieTableMetaClient metaClient = table.getMetaClient();
 
     // Populate missing index versions indexes

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -89,11 +89,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
     HoodieTableMetaClient metaClient = table.getMetaClient();
     HoodieTableConfig tableConfig = metaClient.getTableConfig();
-    // If auto upgrade is disabled, set writer version to 6 and return
-    if (!config.autoUpgrade()) {
-      config.setValue(HoodieWriteConfig.WRITE_TABLE_VERSION, String.valueOf(HoodieTableVersion.SIX.versionCode()));
-      return tablePropsToAdd;
-    }
+
 
     // If metadata is enabled for the data table, and existing metadata table is behind the data table, then delete it
     if (!table.isMetadataTable() && config.isMetadataTableEnabled() && isMetadataTableBehindDataTable(config, metaClient)) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -103,12 +103,12 @@ public class UpgradeDowngrade {
     }
     if (!config.autoUpgrade()) {
       if (fromTableVersion.versionCode() < HoodieTableVersion.SIX.versionCode()) {
-        // throw an expcetion saying autoUpgrade is disabled, and table version is less than SIX
-        // need to upgrade to SIX and set to autoUpgrade to true
+        // throw an exception as autoUpgrade is disabled, and table version is less than SIX
+        // need to upgrade to SIX and set to autoUpgrade to true, otherwise the setting the write config value to a value lower than six will fail
         throw new HoodieUpgradeDowngradeException(
-                String.format("Please upgrade table from version %s to %s before upgrading to version %s.", fromTableVersion, HoodieTableVersion.SIX.versionCode(), toWriteVersion));
+                String.format("AUTO_UPGRADE_VERSION was disabled, Please upgrade table to version %s by setting AUTO_UPGRADE_VERSION to true.", HoodieTableVersion.SIX.versionCode()));
       }
-      // if autoUpgrade is disabled, then we must ensure the write version is set to the table version.
+      // if autoUpgrade is disabled and table version is greater than SIX, then we must ensure the write version is set to the table version.
       // and skip the upgrade
       config.setWriteVersion(fromTableVersion);
       LOG.warn("AUTO_UPGRADE_VERSION was disabled. Table version {} does not match write version {}. "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -90,13 +90,11 @@ public class UpgradeDowngrade {
 
   public static boolean needsUpgrade(HoodieTableMetaClient metaClient, HoodieWriteConfig config, HoodieTableVersion toWriteVersion) {
     HoodieTableVersion fromTableVersion = metaClient.getTableConfig().getTableVersion();
-    if (fromTableVersion.versionCode() >= toWriteVersion.versionCode()) {
-      // if the table version is greater than or equal to the write version, then this is not an upgrade
+    if (fromTableVersion.greaterThanOrEquals(toWriteVersion)) {
       LOG.warn("Table version {} is greater than or equal to write version {}. No upgrade needed", fromTableVersion, toWriteVersion);
       return false;
     }
     if (fromTableVersion.versionCode() < HoodieTableVersion.SIX.versionCode() && toWriteVersion.versionCode() >= HoodieTableVersion.EIGHT.versionCode()) {
-      // if the table's current version is less than SIX and the write version is greater than or equal to EIGHT,
       // we require the user to upgrade to SIX before upgrading to versions greater than or equal to EIGHT
       throw new HoodieUpgradeDowngradeException(
               String.format("Please upgrade table from version %s to %s before upgrading to version %s.", fromTableVersion, HoodieTableVersion.SIX.versionCode(), toWriteVersion));
@@ -106,7 +104,7 @@ public class UpgradeDowngrade {
         // throw an exception as autoUpgrade is disabled, and table version is less than SIX
         // need to upgrade to SIX and set to autoUpgrade to true, otherwise the setting the write config value to a value lower than six will fail
         throw new HoodieUpgradeDowngradeException(
-                String.format("AUTO_UPGRADE_VERSION was disabled, Please upgrade table to version %s by setting AUTO_UPGRADE_VERSION to true.", HoodieTableVersion.SIX.versionCode()));
+                String.format("hoodie.write.auto.upgrade was disabled, Please upgrade table to version %s by setting hoodie.write.auto.upgrade to true.", HoodieTableVersion.SIX.versionCode()));
       }
       // if autoUpgrade is disabled and table version is greater than SIX, then we must ensure the write version is set to the table version.
       // and skip the upgrade

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -28,8 +28,8 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
@@ -90,11 +90,11 @@ public class UpgradeDowngrade {
 
   public static boolean needsDowngrade(HoodieTableVersion fromTableVersion, HoodieTableVersion toWriteVersion) {
     if (toWriteVersion.lesserThan(HoodieTableVersion.SIX)) {
-      // for 1.1 we will do not allow downgrades to below SIX
-      // user will have to downgrade the table using a prior hudi version.
       throw new HoodieUpgradeDowngradeException(
-              String.format("1.1.0 only supports table version greater then version SIX or above."
-                      + " Please downgrade table from version %s to %s using a hudi version prior to 1.1.0", fromTableVersion, toWriteVersion));
+          String.format("Hudi 1.x release only supports table version greater than "
+                  + "version SIX or above. Please downgrade table from version %s to %s "
+                  + "using a Hudi release prior to 1.0.0",
+              HoodieTableVersion.SIX.versionCode(), toWriteVersion.versionCode()));
     }
     return toWriteVersion.lesserThan(fromTableVersion);
   }
@@ -106,14 +106,15 @@ public class UpgradeDowngrade {
       return false;
     }
     if (fromTableVersion.lesserThan(HoodieTableVersion.SIX)) {
-      // for 1.1 we require table version be SIX at the minimum before upgrading.
-      // user will have to upgrade the table to SIX by using a prior hudi version.
       throw new HoodieUpgradeDowngradeException(
-              String.format("1.1.0 only supports table version greater then version SIX or above."
-                      + " Please upgrade table from version %s to %s using a hudi version prior to 1.1.0", fromTableVersion, HoodieTableVersion.SIX));
+          String.format("Hudi 1.x release only supports table version greater than "
+                  + "version SIX or above. Please upgrade table from version %s to %s "
+                  + "using a Hudi release prior to 1.0.0",
+              fromTableVersion.versionCode(), HoodieTableVersion.SIX.versionCode()));
     }
     if (!config.autoUpgrade()) {
-      // if autoUpgrade is disabled and table version is greater than SIX, then we must ensure the write version is set to the table version.
+      // if autoUpgrade is disabled and table version is greater than or equal to SIX,
+      // then we must ensure the write version is set to the table version.
       // and skip the upgrade
       config.setWriteVersion(fromTableVersion);
       LOG.warn("hoodie.write.auto.upgrade was disabled. Table version {} does not match write version {}. "
@@ -233,7 +234,7 @@ public class UpgradeDowngrade {
       // add alternate keys.
       metaClient.getTableConfig().setValue(entry.getKey(), entry.getValue());
       entry.getKey().getAlternatives().forEach(alternateKey -> {
-        metaClient.getTableConfig().setValue((String)alternateKey, entry.getValue());
+        metaClient.getTableConfig().setValue((String) alternateKey, entry.getValue());
       });
     }
     for (ConfigProperty configProperty : tablePropsToRemove) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -239,12 +239,8 @@ public class UpgradeDowngrade {
     for (ConfigProperty configProperty : tablePropsToRemove) {
       metaClient.getTableConfig().clearValue(configProperty);
     }
-    // user could have disabled auto upgrade (probably to deploy the new binary only),
-    // in which case, we should not update the table version
-    if (config.autoUpgrade()) {
-      metaClient.getTableConfig().setTableVersion(toVersion);
-    }
 
+    metaClient.getTableConfig().setTableVersion(toVersion);
     HoodieTableConfig.update(metaClient.getStorage(),
         metaClient.getMetaPath(), metaClient.getTableConfig().getProps());
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -92,7 +92,7 @@ public class UpgradeDowngrade {
     if (toWriteVersion.lesserThan(HoodieTableVersion.SIX)) {
       throw new HoodieUpgradeDowngradeException(
           String.format("Hudi 1.x release only supports table version greater than "
-                  + "version SIX or above. Please downgrade table from version %s to %s "
+                  + "version 6 or above. Please downgrade table from version %s to %s "
                   + "using a Hudi release prior to 1.0.0",
               HoodieTableVersion.SIX.versionCode(), toWriteVersion.versionCode()));
     }
@@ -108,7 +108,7 @@ public class UpgradeDowngrade {
     if (fromTableVersion.lesserThan(HoodieTableVersion.SIX)) {
       throw new HoodieUpgradeDowngradeException(
           String.format("Hudi 1.x release only supports table version greater than "
-                  + "version SIX or above. Please upgrade table from version %s to %s "
+                  + "version 6 or above. Please upgrade table from version %s to %s "
                   + "using a Hudi release prior to 1.0.0",
               fromTableVersion.versionCode(), HoodieTableVersion.SIX.versionCode()));
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestTwoToThreeUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestTwoToThreeUpgradeHandler.java
@@ -27,6 +27,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.keygen.KeyGenerator;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -50,6 +51,7 @@ class TestTwoToThreeUpgradeHandler {
         .build();
   }
 
+  @Disabled
   @ParameterizedTest
   @ValueSource(strings = {"hoodie.table.keygenerator.class", "hoodie.datasource.write.keygenerator.class"})
   void upgradeHandlerShouldRetrieveKeyGeneratorConfig(String keyGenConfigKey) {
@@ -59,6 +61,7 @@ class TestTwoToThreeUpgradeHandler {
     assertEquals(KeyGenerator.class.getName(), kv.get(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME));
   }
 
+  @Disabled
   @ParameterizedTest
   @EnumSource(EngineType.class)
   void upgradeHandlerWhenKeyGeneratorNotSet(EngineType engineType) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestTwoToThreeUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestTwoToThreeUpgradeHandler.java
@@ -51,7 +51,7 @@ class TestTwoToThreeUpgradeHandler {
         .build();
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @ValueSource(strings = {"hoodie.table.keygenerator.class", "hoodie.datasource.write.keygenerator.class"})
   void upgradeHandlerShouldRetrieveKeyGeneratorConfig(String keyGenConfigKey) {
@@ -61,7 +61,7 @@ class TestTwoToThreeUpgradeHandler {
     assertEquals(KeyGenerator.class.getName(), kv.get(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME));
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @EnumSource(EngineType.class)
   void upgradeHandlerWhenKeyGeneratorNotSet(EngineType engineType) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
@@ -187,13 +187,13 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(HoodieTableVersion.SIX, metaClient.getTableConfig().getTableVersion());
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testLeftOverUpdatedPropFileCleanup() throws IOException {
     testUpgradeZeroToOneInternal(true, true, HoodieTableType.MERGE_ON_READ);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest(name = TEST_NAME_WITH_PARAMS)
   @MethodSource("configParams")
   public void testUpgradeZeroToOne(boolean deletePartialMarkerFiles, HoodieTableType tableType) throws IOException {
@@ -262,7 +262,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     }*/
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @EnumSource(value = HoodieTableType.class)
   public void testUpgradeOneToTwo(HoodieTableType tableType) throws IOException {
@@ -295,7 +295,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertTableProps(cfg);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @MethodSource("twoToThreeUpgradeConfigParams")
   public void testUpgradeTwoToThree(
@@ -341,7 +341,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
         HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), SimpleKeyGenerator.class.getName()));
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeDowngradeBetweenThreeAndCurrentVersion() throws IOException {
     // init config, table and client.
@@ -376,31 +376,31 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(checksum, metaClient.getTableConfig().getProps().getString(HoodieTableConfig.TABLE_CHECKSUM.key()));
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeFourtoFive() throws Exception {
     testUpgradeFourToFiveInternal(false, false, false);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartition() throws Exception {
     testUpgradeFourToFiveInternal(true, false, false);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartitionWithSkipValidation() throws Exception {
     testUpgradeFourToFiveInternal(true, true, false);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeFourtoFiveWithHiveStyleDefaultPartition() throws Exception {
     testUpgradeFourToFiveInternal(true, false, true);
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeFourtoFiveWithHiveStyleDefaultPartitionWithSkipValidation() throws Exception {
     testUpgradeFourToFiveInternal(true, true, true);
@@ -560,7 +560,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(tableConfig.getBaseFileFormat().name(), originalProps.getProperty(BASE_FILE_FORMAT.key()));
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testDowngradeSixToFiveShouldDeleteRecordIndexPartition() throws Exception {
     HoodieWriteConfig config = getConfigBuilder()
@@ -604,7 +604,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
 
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest(name = TEST_NAME_WITH_DOWNGRADE_PARAMS)
   @MethodSource("downGradeConfigParams")
   public void testDowngrade(

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
@@ -680,6 +680,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
     when(writeConfig.autoUpgrade()).thenReturn(true);
+    when(writeConfig.getWriteVersion()).thenReturn(HoodieTableVersion.EIGHT);
 
     // assert no downgrade for table version 7 from table version 8
     boolean shouldDowngrade = new UpgradeDowngrade(metaClient, writeConfig, context, null)
@@ -709,10 +710,11 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertTrue(shouldUpgrade);
 
     // assert upgrade for table version 8 from table version 6 with auto upgrade set to false
+    // should return false
     when(writeConfig.autoUpgrade()).thenReturn(false);
     shouldUpgrade = new UpgradeDowngrade(metaClient, writeConfig, context, null)
         .needsUpgrade(HoodieTableVersion.EIGHT);
-    assertTrue(shouldUpgrade);
+    assertFalse(shouldUpgrade);
   }
 
   private void assertMarkerFilesForDowngrade(HoodieTable table, HoodieInstant commitInstant, boolean assertExists) throws IOException {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeLegacy.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -186,11 +187,13 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(HoodieTableVersion.SIX, metaClient.getTableConfig().getTableVersion());
   }
 
+  @Disabled
   @Test
   public void testLeftOverUpdatedPropFileCleanup() throws IOException {
     testUpgradeZeroToOneInternal(true, true, HoodieTableType.MERGE_ON_READ);
   }
 
+  @Disabled
   @ParameterizedTest(name = TEST_NAME_WITH_PARAMS)
   @MethodSource("configParams")
   public void testUpgradeZeroToOne(boolean deletePartialMarkerFiles, HoodieTableType tableType) throws IOException {
@@ -259,6 +262,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     }*/
   }
 
+  @Disabled
   @ParameterizedTest
   @EnumSource(value = HoodieTableType.class)
   public void testUpgradeOneToTwo(HoodieTableType tableType) throws IOException {
@@ -291,6 +295,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertTableProps(cfg);
   }
 
+  @Disabled
   @ParameterizedTest
   @MethodSource("twoToThreeUpgradeConfigParams")
   public void testUpgradeTwoToThree(
@@ -336,6 +341,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
         HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), SimpleKeyGenerator.class.getName()));
   }
 
+  @Disabled
   @Test
   public void testUpgradeDowngradeBetweenThreeAndCurrentVersion() throws IOException {
     // init config, table and client.
@@ -370,26 +376,31 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(checksum, metaClient.getTableConfig().getProps().getString(HoodieTableConfig.TABLE_CHECKSUM.key()));
   }
 
+  @Disabled
   @Test
   public void testUpgradeFourtoFive() throws Exception {
     testUpgradeFourToFiveInternal(false, false, false);
   }
 
+  @Disabled
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartition() throws Exception {
     testUpgradeFourToFiveInternal(true, false, false);
   }
 
+  @Disabled
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartitionWithSkipValidation() throws Exception {
     testUpgradeFourToFiveInternal(true, true, false);
   }
 
+  @Disabled
   @Test
   public void testUpgradeFourtoFiveWithHiveStyleDefaultPartition() throws Exception {
     testUpgradeFourToFiveInternal(true, false, true);
   }
 
+  @Disabled
   @Test
   public void testUpgradeFourtoFiveWithHiveStyleDefaultPartitionWithSkipValidation() throws Exception {
     testUpgradeFourToFiveInternal(true, true, true);
@@ -549,6 +560,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
     assertEquals(tableConfig.getBaseFileFormat().name(), originalProps.getProperty(BASE_FILE_FORMAT.key()));
   }
 
+  @Disabled
   @Test
   public void testDowngradeSixToFiveShouldDeleteRecordIndexPartition() throws Exception {
     HoodieWriteConfig config = getConfigBuilder()
@@ -592,6 +604,7 @@ public class TestUpgradeDowngradeLegacy extends HoodieClientTestBase {
 
   }
 
+  @Disabled
   @ParameterizedTest(name = TEST_NAME_WITH_DOWNGRADE_PARAMS)
   @MethodSource("downGradeConfigParams")
   public void testDowngrade(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -2657,6 +2657,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
   }
 
+  @Disabled
   @Test
   public void testUpgradeDowngrade() throws IOException {
     init(HoodieTableType.COPY_ON_WRITE, false);
@@ -2729,6 +2730,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * When table needs to be upgraded and when multi writer is enabled, hudi rolls back partial commits. Upgrade itself is happening
    * within a lock and hence rollback should not lock again.
    */
+  @Disabled
   @Test
   public void testRollbackDuringUpgradeForDoubleLocking() throws IOException {
     init(HoodieTableType.COPY_ON_WRITE, false);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -101,16 +101,16 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.io.storage.HoodieIOFactory;
-import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
 import org.apache.hudi.metadata.ColumnStatsIndexPrefixRawKey;
+import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieBackedTableMetadataWriter;
 import org.apache.hudi.metadata.HoodieMetadataMetrics;
-import org.apache.hudi.metadata.RawKey;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.RawKey;
 import org.apache.hudi.metadata.SparkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.storage.HoodieStorage;
@@ -2657,7 +2657,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testUpgradeDowngrade() throws IOException {
     init(HoodieTableType.COPY_ON_WRITE, false);
@@ -2730,7 +2730,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * When table needs to be upgraded and when multi writer is enabled, hudi rolls back partial commits. Upgrade itself is happening
    * within a lock and hence rollback should not lock again.
    */
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   public void testRollbackDuringUpgradeForDoubleLocking() throws IOException {
     init(HoodieTableType.COPY_ON_WRITE, false);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -138,14 +138,9 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
     LOG.info("Testing auto-upgrade disabled for version {} (below SIX)", originalVersion);
     
     HoodieTableMetaClient originalMetaClient = loadFixtureTable(originalVersion);
-    
-    Option<HoodieTableVersion> targetVersionOpt = getNextVersion(originalVersion);
-    if (!targetVersionOpt.isPresent()) {
-      LOG.info("Skipping auto-upgrade test for version {} (no higher version available)", originalVersion);
-      return;
-    }
-    HoodieTableVersion targetVersion = targetVersionOpt.get();
-    
+
+    HoodieTableVersion targetVersion = getNextVersion(originalVersion).get();
+
     HoodieWriteConfig config = createWriteConfig(originalMetaClient, false);
     
     // For versions below SIX with autoUpgrade disabled, expect exception
@@ -155,10 +150,10 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
     );
     
     // Validate exception message
-    assertTrue(exception.getMessage().contains("Please upgrade table from version " + originalVersion), 
-               "Exception message should mention upgrading from " + originalVersion);
-    assertTrue(exception.getMessage().contains("to " + HoodieTableVersion.SIX.versionCode()), 
-               "Exception message should mention upgrading to SIX");
+    String expectedMessage = String.format("AUTO_UPGRADE_VERSION was disabled, Please upgrade table to version %s by setting AUTO_UPGRADE_VERSION to true.",
+        HoodieTableVersion.SIX.versionCode());
+    assertEquals(expectedMessage, exception.getMessage(),
+        "Exception message should match expected format");
     
     LOG.info("Auto-upgrade disabled test passed for version {} (expected exception thrown)", originalVersion);
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -299,8 +299,8 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
             () -> new UpgradeDowngrade(originalMetaClient, config, context(), SparkUpgradeDowngradeHelper.getInstance()).run(toVersion, null),
             "Expected HoodieUpgradeDowngradeException for downgrade from " + fromVersion + " to " + toVersion
     );
-    String expectedMessage = String.format("Hudi 1.x release only supports table version greater than version 6 or above. " +
-            "Please downgrade table from version 6 to %s using a Hudi release prior to 1.0.0",
+    String expectedMessage = String.format("Hudi 1.x release only supports table version greater than version 6 or above. "
+            + "Please downgrade table from version 6 to %s using a Hudi release prior to 1.0.0",
         toVersion.versionCode());
     assertEquals(expectedMessage, exception.getMessage(),
         "Exception message should match expected blocked downgrade format");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -132,6 +133,7 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
     LOG.info("Successfully completed {} test for version {} -> {}", operation, fromVersion, toVersion);
   }
 
+  @Disabled
   @ParameterizedTest
   @MethodSource("versionsBelowSix")
   public void testAutoUpgradeDisabledForVersionsBelowSix(HoodieTableVersion originalVersion) throws Exception {
@@ -202,13 +204,13 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
             Arguments.of(Option.empty(), HoodieTableVersion.current(), "Default version upgrade to current version NINE"),
 
             // Case 2: hoodie.write.table.version = 6 (same as current table version)
-            Arguments.of(Option.of(HoodieTableVersion.SIX), HoodieTableVersion.SIX, HoodieTableVersion.SIX, "No upgrade when versions match"),
+            Arguments.of(Option.of(HoodieTableVersion.SIX), HoodieTableVersion.SIX, "No upgrade when versions match"),
 
             // Case 3: hoodie.write.table.version = 8
-            Arguments.of(Option.of(HoodieTableVersion.EIGHT), HoodieTableVersion.EIGHT, HoodieTableVersion.EIGHT, "Upgrade to table version EIGHT"),
+            Arguments.of(Option.of(HoodieTableVersion.EIGHT), HoodieTableVersion.EIGHT, "Upgrade to table version EIGHT"),
 
             // Case 4: hoodie.write.table.version = 9
-            Arguments.of(Option.of(HoodieTableVersion.NINE), HoodieTableVersion.NINE, HoodieTableVersion.NINE, "Upgrade to table version NINE")
+            Arguments.of(Option.of(HoodieTableVersion.NINE), HoodieTableVersion.NINE, "Upgrade to table version NINE")
     );
   }
 
@@ -294,6 +296,7 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
     LOG.info("needsUpgrade test with auto-upgrade disabled passed successfully");
   }
 
+  @Disabled
   @ParameterizedTest
   @MethodSource("metadataTableCorruptionTestVersionPairs")
   public void testMetadataTableUpgradeDowngradeFailure(HoodieTableVersion fromVersion, HoodieTableVersion toVersion) throws Exception {
@@ -436,17 +439,13 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
 
   private static Stream<Arguments> upgradeDowngradeVersionPairs() {
     return Stream.of(
-        // Upgrade test cases
-        Arguments.of(HoodieTableVersion.FOUR, HoodieTableVersion.FIVE),   // V4 -> V5
-        Arguments.of(HoodieTableVersion.FIVE, HoodieTableVersion.SIX),    // V5 -> V6  
+        // Upgrade test cases for six and greater
         Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.EIGHT),   // V6 -> V8
         Arguments.of(HoodieTableVersion.EIGHT, HoodieTableVersion.NINE),  // V8 -> V9
         
-        // Downgrade test cases
+        // Downgrade test cases til six
         Arguments.of(HoodieTableVersion.NINE, HoodieTableVersion.EIGHT),  // V9 -> V8
-        Arguments.of(HoodieTableVersion.EIGHT, HoodieTableVersion.SIX),   // V8 -> V6
-        Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.FIVE),    // V6 -> V5
-        Arguments.of(HoodieTableVersion.FIVE, HoodieTableVersion.FOUR)    // V5 -> V4
+        Arguments.of(HoodieTableVersion.EIGHT, HoodieTableVersion.SIX)   // V8 -> V6
     );
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -405,7 +405,7 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
   /**
    * Get fixture zip file name for a given table version.
    */
-  private String getFixtureName(HoodieTableVersion version) {
+  public static String getFixtureName(HoodieTableVersion version) {
     switch (version) {
       case FOUR:
         return "hudi-v4-table.zip";

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -37,7 +37,6 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SQLContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -271,6 +270,19 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
         "Write version should be set to match table version when auto-upgrade is disabled");
   }
 
+  /**
+   * Version pairs for testing blocked downgrades to versions below SIX.
+   * These test cases should trigger exceptions in the needsDowngrade method.
+   */
+  private static Stream<Arguments> blockedDowngradeVersionPairs() {
+    return Stream.of(
+        Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.FIVE),    // V6 -> V5 (blocked)
+        Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.FOUR),    // V6 -> V4 (blocked)
+        Arguments.of(HoodieTableVersion.EIGHT, HoodieTableVersion.FIVE),  // V8 -> V5 (blocked)
+        Arguments.of(HoodieTableVersion.NINE, HoodieTableVersion.FOUR)    // V9 -> V4 (blocked)
+    );
+  }
+
   @ParameterizedTest
   @MethodSource("blockedDowngradeVersionPairs")
   public void testDowngradeToVersionsBelowSixBlocked(HoodieTableVersion fromVersion, HoodieTableVersion toVersion) throws Exception {
@@ -459,19 +471,6 @@ public class TestUpgradeDowngrade extends SparkClientFunctionalTestHarness {
 
         // Non-rollback downgrade pairs  
         Arguments.of(HoodieTableVersion.FIVE, HoodieTableVersion.FOUR)    // V5 -> V4 (works)
-    );
-  }
-
-  /**
-   * Version pairs for testing blocked downgrades to versions below SIX.
-   * These test cases should trigger exceptions in the needsDowngrade method.
-   */
-  private static Stream<Arguments> blockedDowngradeVersionPairs() {
-    return Stream.of(
-        Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.FIVE),    // V6 -> V5 (blocked)
-        Arguments.of(HoodieTableVersion.SIX, HoodieTableVersion.FOUR),    // V6 -> V4 (blocked)  
-        Arguments.of(HoodieTableVersion.EIGHT, HoodieTableVersion.FIVE),  // V8 -> V5 (blocked)
-        Arguments.of(HoodieTableVersion.NINE, HoodieTableVersion.FOUR)    // V9 -> V4 (blocked)
     );
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceReadOptions, DataSourceUtils, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieDataSourceHelpers, SparkDatasetMixin}
+import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceReadOptions, DataSourceUtils, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieDataSourceHelpers, ScalaAssertionSupport, SparkDatasetMixin}
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.client.SparkRDDWriteClient
@@ -45,7 +45,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
 
@@ -59,7 +59,7 @@ import scala.collection.JavaConverters._
 /**
  * Tests on Spark DataSource for MOR table.
  */
-class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin {
+class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin with ScalaAssertionSupport {
 
   var spark: SparkSession = null
   val commonOpts = Map(
@@ -1878,12 +1878,12 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
 
         case "EXCEPTION" =>
           // Should throw HoodieUpgradeDowngradeException
-          val exception = assertThrows(classOf[HoodieUpgradeDowngradeException], () => {
+          val exception = assertThrows(classOf[HoodieUpgradeDowngradeException]) {
             inputDF.write.format("hudi")
               .options(testWriteOpts)
               .mode(SaveMode.Append)
               .save(testBasePath)
-          }, s"Expected HoodieUpgradeDowngradeException for table=${tableVersionStr}, write=${writeVersionStr}, autoUpgrade=${autoUpgrade}")
+          }
 
           // Verify exception message contains expected content
           val expectedMessageFragment = if (tableVersion.versionCode() < HoodieTableVersion.SIX.versionCode() && writeVersion.versionCode() >= HoodieTableVersion.EIGHT.versionCode()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -1782,10 +1782,12 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
 
   @ParameterizedTest
   @CsvSource(Array(
-    "6,8,true,UPGRADE",           // Normal upgrade: table=6, write=8, autoUpgrade=true → should upgrade
-    "6,8,false,VERSION_ADJUST",   // Auto-upgrade disabled: table=6, write=8, autoUpgrade=false → adjust version
-    "4,8,true,EXCEPTION",         // Auto-upgrade enabled: Should throw exception since table version is less than 6
-    "4,8,false,EXCEPTION"         // Auto-upgrade disabled: Should throw exception since table version is less than 6
+    "6,8,true,UPGRADE", // Normal upgrade: table=6, write=8, autoUpgrade=true → should upgrade
+    "6,9,true,UPGRADE", // Normal upgrade: table=6, write=9, autoUpgrade=true → should upgrade
+    "6,6,false,NO_UPGRADE", // Auto-upgrade disabled: table=6, write=6, autoUpgrade=false → no upgrade
+    "6,8,false,NO_UPGRADE", // Auto-upgrade disabled: table=6, write=8, autoUpgrade=false → no upgrade
+    "4,8,true,EXCEPTION", // Auto-upgrade enabled: Should throw exception since table version is less than 6
+    "4,8,false,EXCEPTION" // Auto-upgrade disabled: Should throw exception since table version is less than 6
   ))
   def testBaseHoodieWriteClientUpgradeDecisionLogic(
     tableVersionStr: String,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
@@ -40,7 +40,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
 
   private var partitionPaths: java.util.List[StoragePath] = null
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testDowngradeWithMDTAndLogFiles(tableType: HoodieTableType): Unit = {
@@ -72,7 +72,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
     }
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @Test
   def testDowngradeWithoutLogFiles(): Unit = {
     val hudiOpts = commonOpts + (
@@ -92,7 +92,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
     assertEquals(HoodieTableVersion.FIVE, metaClient.getTableConfig.getTableVersion)
   }
 
-  @Disabled
+  @Disabled("HUDI-9700")
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testDowngradeWithoutMDT(tableType: HoodieTableType): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
@@ -29,8 +29,8 @@ import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 
 import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{Disabled, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -40,6 +40,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
 
   private var partitionPaths: java.util.List[StoragePath] = null
 
+  @Disabled
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testDowngradeWithMDTAndLogFiles(tableType: HoodieTableType): Unit = {
@@ -71,6 +72,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
     }
   }
 
+  @Disabled
   @Test
   def testDowngradeWithoutLogFiles(): Unit = {
     val hudiOpts = commonOpts + (
@@ -90,6 +92,7 @@ class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
     assertEquals(HoodieTableVersion.FIVE, metaClient.getTableConfig.getTableVersion)
   }
 
+  @Disabled
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testDowngradeWithoutMDT(tableType: HoodieTableType): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
 
 class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
 
-  test("Test Call downgrade_table and upgrade_table Procedure") {
+  ignore("Test Call downgrade_table and upgrade_table Procedure") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"
@@ -87,7 +87,7 @@ class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  test("Test Call upgrade_table from version three") {
+  ignore("Test Call upgrade_table from version three") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
 
 class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
 
-  ignore("Test Call downgrade_table and upgrade_table Procedure") {
+  ignore("[HUDI-9700] Test Call downgrade_table and upgrade_table Procedure") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"
@@ -87,7 +87,7 @@ class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  ignore("Test Call upgrade_table from version three") {
+  ignore("[HUDI-9700] Test Call upgrade_table from version three") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"


### PR DESCRIPTION
### Change Logs

https://issues.apache.org/jira/browse/HUDI-9698

Discussed with @nsivabalan @yihua @linliu-code, this pr aims to make a couple of changes around what is considered a valid upgrade in 1.1.x.

For 1.1 going forward users will only be to upgrade table that are six or greater, and downgrade max to the lowest table version of six. Also depending on if `AUTO_UPGRADE` flag is disabled, we will need to ensure that the `hoodie.write.table.version` is brought down to the same version as the `hoodie.table.version` and skip the upgrade process. 

This pr adds several tests to ensure coverage of these new checks, as well as disables older legacy tests for versions below six.

### Impact

The apis themselves are not changing but the behavior is which will mention in doc update section

### Risk level (write none, low medium or high below)

medium risk, we have tried to add many test coverage in `TestUpgradeDowngrade` as well as spark data source functional test to ensure that the different configuration values cover valid and invalid cases.

### Documentation Update

We will need to call out this in our docs that we are not allowing upgrades for table versions that start below six, as well as not allowing downgrading to table versions below six.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
