### PR TITLE
[HUDI-9697] Fix small LP shutdown hook race condition

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -217,7 +217,8 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
       if (!isClosed && actuallyHoldsLock()) {
         tryExpireCurrentLock(true);
       }
-      // Do not execute any further actions
+      // Do not execute any further actions, mark closed
+      this.isClosed = true;
       return;
     } else {
       try {


### PR DESCRIPTION
### Change Logs

There is a small gap where the lock provider might be trying to acquire a lock but the shutdown hook is called. After we shutdown the LP we should mark it as closed so that it does not acquire the lock accidentally and lead to a dangling lock.

### Impact

Reduces the likelihood of dangling lock

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
