### PR TITLE
[HUDI-9158] Add lock provider constructor which supports 0.14.x LP constructor format

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction.lock;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.client.transaction.lock.models.HeartbeatManager;
 import org.apache.hudi.client.transaction.lock.models.LockGetResult;
 import org.apache.hudi.client.transaction.lock.models.LockProviderHeartbeatManager;
@@ -118,6 +119,23 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
    * @param conf              Storage config, ignored.
    */
   public StorageBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
+    this(
+            UUID.randomUUID().toString(),
+            lockConfiguration.getConfig(),
+            LockProviderHeartbeatManager::new,
+            getStorageLockClientClassName(),
+            LOGGER);
+  }
+
+  /**
+   * Default constructor for StorageBasedLockProvider, required by LockManager
+   * to instantiate it using reflection, supports 0.14.1 LP format.
+   * 
+   * @param lockConfiguration The lock configuration, should be transformable into
+   *                          StorageBasedLockConfig
+   * @param conf              Storage config, ignored.
+   */
+  public StorageBasedLockProvider(final LockConfiguration lockConfiguration, final Configuration conf) {
     this(
             UUID.randomUUID().toString(),
             lockConfiguration.getConfig(),

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction.lock;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.client.transaction.lock.models.LockUpsertResult;
 import org.apache.hudi.client.transaction.lock.models.StorageLockData;
 import org.apache.hudi.client.transaction.lock.models.StorageLockFile;
@@ -111,6 +112,21 @@ class TestStorageBasedLockProvider {
 
     HoodieLockException ex = assertThrows(HoodieLockException.class,
         () -> new StorageBasedLockProvider(lockConf, storageConf));
+    assertTrue(ex.getMessage().contains("Failed to load and initialize StorageLock"));
+  }
+
+  @Test
+  void testHadoopConstructorWithLockConfigurationAndConfiguration() {
+    TypedProperties props = new TypedProperties();
+    props.put(BASE_PATH.key(), "file:///tmp/lake/db/tbl-default");
+    props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "20");
+    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "2");
+
+    LockConfiguration lockConf = new LockConfiguration(props);
+
+    // Test that constructor throws expected exception when trying to load non-existent storage lock client
+    HoodieLockException ex = assertThrows(HoodieLockException.class,
+        () -> new StorageBasedLockProvider(lockConf, new Configuration()));
     assertTrue(ex.getMessage().contains("Failed to load and initialize StorageLock"));
   }
 


### PR DESCRIPTION
### Change Logs

The LP constructor format changed in 0.15, so need to support both formats in 0.x branch

### Impact

Allows for 0.14 support

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
