### PR TITLE
[HUDI-9691] Migrate MysqlDebeziumPayload to merge mode

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.StringUtils;
 
 import java.io.File;
 import java.io.FileReader;
@@ -94,7 +95,9 @@ public class HoodiePayloadConfig extends HoodieConfig {
     }
 
     public Builder withPayloadOrderingFields(String payloadOrderingFields) {
-      payloadConfig.setValue(ORDERING_FIELDS, String.valueOf(payloadOrderingFields));
+      if (StringUtils.nonEmpty(payloadOrderingFields)) {
+        payloadConfig.setValue(ORDERING_FIELDS, payloadOrderingFields);
+      }
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -46,6 +46,8 @@ import java.util.Set;
 
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
+import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_FILE_COL_NAME;
+import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_POS_COL_NAME;
 import static org.apache.hudi.common.model.HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID;
 import static org.apache.hudi.common.model.HoodieRecordMerger.CUSTOM_MERGE_STRATEGY_UUID;
 import static org.apache.hudi.common.model.HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID;
@@ -191,6 +193,8 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
       tablePropsToAdd.put(
           ConfigProperty.key(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE).noDefaultValue(), // // to be fixed once we land PR #13721.
           DEBEZIUM_UNAVAILABLE_VALUE);
+    } else if (payloadClass.equals(MySqlDebeziumAvroPayload.class.getName())) {
+      tablePropsToAdd.put(HoodieTableConfig.PRECOMBINE_FIELDS, FLATTENED_FILE_COL_NAME + "," + FLATTENED_POS_COL_NAME);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
@@ -25,12 +25,12 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableConfig;
-import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
@@ -44,8 +44,8 @@ import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
 import static org.apache.hudi.common.model.HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID;
 import static org.apache.hudi.common.table.HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME;
-import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_MODE;
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.PAYLOAD_CLASS_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX;
@@ -65,7 +65,7 @@ import static org.apache.hudi.table.upgrade.UpgradeDowngradeUtils.PAYLOAD_CLASSE
  *     set hoodie.record.merge.mode=CUSTOM
  *     set hoodie.record.merge.strategy.id accordingly
  *   remove any properties with prefix hoodie.record.merge.property.
- *   Fix precombine field value for MySqlDebeziumAvroPayload.
+ *   fix precombine field value for MySqlDebeziumAvroPayload.
  */
 public class NineToEightDowngradeHandler implements DowngradeHandler {
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
@@ -25,6 +25,8 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -63,6 +65,7 @@ import static org.apache.hudi.table.upgrade.UpgradeDowngradeUtils.PAYLOAD_CLASSE
  *     set hoodie.record.merge.mode=CUSTOM
  *     set hoodie.record.merge.strategy.id accordingly
  *   remove any properties with prefix hoodie.record.merge.property.
+ *   Fix precombine field value for MySqlDebeziumAvroPayload.
  */
 public class NineToEightDowngradeHandler implements DowngradeHandler {
   @Override
@@ -99,7 +102,6 @@ public class NineToEightDowngradeHandler implements DowngradeHandler {
         propertiesToAdd.put(RECORD_MERGE_STRATEGY_ID, PAYLOAD_BASED_MERGE_STRATEGY_UUID);
         propertiesToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.CUSTOM.name());
       }
-      // don't we need to fix merge strategy Id for OverwriteWithLatestAvroPayload and DefaultHoodieRecordPayload ?
       if (legacyPayloadClass.equals(AWSDmsAvroPayload.class.getName())) {
         propertiesToRemove.add(
             ConfigProperty.key(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY).noDefaultValue());
@@ -109,6 +111,9 @@ public class NineToEightDowngradeHandler implements DowngradeHandler {
       if (legacyPayloadClass.equals(PostgresDebeziumAvroPayload.class.getName())) {
         propertiesToRemove.add(
             ConfigProperty.key(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE).noDefaultValue());
+      }
+      if (legacyPayloadClass.equals(MySqlDebeziumAvroPayload.class.getName())) {
+        propertiesToAdd.put(HoodieTableConfig.PRECOMBINE_FIELDS, DebeziumConstants.ADDED_SEQ_COL_NAME);
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestEightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestEightToNineUpgradeHandler.java
@@ -67,6 +67,8 @@ import static org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING
 import static org.apache.hudi.common.config.RecordMergeMode.EVENT_TIME_ORDERING;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
+import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_FILE_COL_NAME;
+import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_POS_COL_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.DEBEZIUM_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_MODE;
@@ -196,6 +198,13 @@ class TestEightToNineUpgradeHandler {
             COMMIT_TIME_ORDERING.name(),
             PartialUpdateMode.IGNORE_DEFAULTS.name(),
             "OverwriteNonDefaultsWithLatestAvroPayload"
+        ),
+        Arguments.of(
+            MySqlDebeziumAvroPayload.class.getName(),
+            "",
+            EVENT_TIME_ORDERING.name(),
+            null,
+            "MySqlDebeziumAvroPayload"
         )
     );
   }
@@ -284,6 +293,10 @@ class TestEightToNineUpgradeHandler {
     assertEquals(
         payloadClass,
         propertiesToAdd.get(LEGACY_PAYLOAD_CLASS_NAME));
+    if (payloadClass.equals(MySqlDebeziumAvroPayload.class.getName())) {
+      assertTrue(propertiesToAdd.containsKey(HoodieTableConfig.PRECOMBINE_FIELDS));
+      assertEquals(propertiesToAdd.get(HoodieTableConfig.PRECOMBINE_FIELDS).toString(), FLATTENED_FILE_COL_NAME + "," + FLATTENED_POS_COL_NAME);
+    }
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestNineToEightDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestNineToEightDowngradeHandler.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -137,7 +138,7 @@ class TestNineToEightDowngradeHandler {
             MySqlDebeziumAvroPayload.class.getName(),
             2,
             LEGACY_PAYLOAD_CLASS_NAME.key() + "," + PARTIAL_UPDATE_MODE.key(),
-            3,
+            4,
             true,
             true,
             "MySqlDebeziumAvroPayload"
@@ -185,7 +186,7 @@ class TestNineToEightDowngradeHandler {
     );
   }
 
-  @ParameterizedTest(name = "testDowngradeFor{5}")
+  @ParameterizedTest(name = "testDowngradeFor{6}")
   @MethodSource("payloadClassTestCases")
   void testDowngradeForPayloadClass(String payloadClassName, int expectedPropertiesToRemoveSize, String expectedPropsToRemove,
                                     int expectedPropertiesToAddSize, boolean hasRecordMergeMode,
@@ -222,6 +223,10 @@ class TestNineToEightDowngradeHandler {
       if (hasRecordMergeStrategyId) {
         assertEquals(PAYLOAD_BASED_MERGE_STRATEGY_UUID,
             propertiesToChange.propertiesToUpdate().get(RECORD_MERGE_STRATEGY_ID));
+      }
+      if (payloadClassName.equals(MySqlDebeziumAvroPayload.class.getName())) {
+        assertTrue(propertiesToChange.propertiesToUpdate().containsKey(HoodieTableConfig.PRECOMBINE_FIELDS));
+        assertEquals(propertiesToChange.propertiesToUpdate().get(HoodieTableConfig.PRECOMBINE_FIELDS).toString(), DebeziumConstants.ADDED_SEQ_COL_NAME);
       }
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.data.HoodieData
 import org.apache.hudi.common.engine.TaskContextSupplier
 import org.apache.hudi.common.model.HoodieRecord
-import org.apache.hudi.common.util.{OrderingValues, ReflectionUtils}
+import org.apache.hudi.common.util.{ConfigUtils, OrderingValues, ReflectionUtils}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.data.HoodieJavaRDD
 import org.apache.hudi.exception.HoodieException
@@ -121,7 +121,7 @@ object HoodieDatasetBulkInsertHelper
       }
 
       val dedupedRdd = if (config.shouldCombineBeforeInsert) {
-        dedupeRows(prependedRdd, updatedSchema, config.getPreCombineFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
+        dedupeRows(prependedRdd, updatedSchema, ConfigUtils.getOrderingFields(config.getProps).toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
       } else {
         prependedRdd
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -90,7 +90,7 @@ public class ConfigUtils {
     } else if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
       orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
     }
-    return orderField == null ? null : orderField.split(",");
+    return StringUtils.isNullOrEmpty(orderField) ? new String[0] : orderField.split(",");
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -90,7 +90,7 @@ public class ConfigUtils {
     } else if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
       orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
     }
-    return StringUtils.isNullOrEmpty(orderField) ? new String[0] : orderField.split(",");
+    return StringUtils.isNullOrEmpty(orderField) ? null : orderField.split(",");
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -1031,9 +1031,6 @@ object DataSourceOptionsHelper {
     if (!params.contains(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key()) && tableConfig.getKeyGeneratorClassName != null) {
       missingWriteConfigs ++= Map(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key() -> tableConfig.getKeyGeneratorClassName)
     }
-    if (!params.contains(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key()) && tableConfig.getPreCombineFieldsStr.isPresent) {
-      missingWriteConfigs ++= Map(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key -> tableConfig.getPreCombineFieldsStr.orElse(null))
-    }
     if (!params.contains(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key()) && tableConfig.getPayloadClass != null) {
       missingWriteConfigs ++= Map(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> tableConfig.getPayloadClass)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
@@ -143,7 +143,7 @@ object HoodieCreateRecordUtils {
               avroRecWithoutMeta
             }
 
-            val hoodieRecord = if (shouldCombine && !precombineFields.isEmpty) {
+            val hoodieRecord = if (shouldCombine && precombineFields != null && precombineFields.nonEmpty) {
               val orderingVal = OrderingValues.create(
                 precombineFields,
                 JFunction.toJavaFunction[String, Comparable[_]](

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.avro.{AvroSchemaCache, HoodieAvroUtils}
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model._
-import org.apache.hudi.common.util.{OrderingValues, StringUtils}
+import org.apache.hudi.common.util.{ConfigUtils, OrderingValues, StringUtils}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.keygen.{BaseKeyGenerator, KeyGenUtils, SparkKeyGeneratorInterface}
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
@@ -125,7 +125,7 @@ object HoodieCreateRecordUtils {
           val consistentLogicalTimestampEnabled = parameters.getOrElse(
             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()).toBoolean
-          val precombineFields = config.getPreCombineFields()
+          val precombineFields = ConfigUtils.getOrderingFields(config.getProps)
 
           // handle dropping partition columns
           it.map { avroRec =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -30,9 +30,8 @@ import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataU
 
 import org.apache.spark.sql._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.scalatest.Assertions.assertResult
 
-import scala.collection.{mutable, JavaConverters, Seq}
+import scala.collection.{mutable, JavaConverters}
 import scala.collection.JavaConverters._
 import scala.util.Using
 
@@ -161,9 +160,5 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
     assertEquals(0, nonMatchingRecords.count())
     assertEquals(readDf.count(), prevDf.count())
     readDf.unpersist()
-  }
-
-  protected def checkAnswer(sql: String)(expects: collection.immutable.Seq[Any]*): Unit = {
-    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -30,8 +30,9 @@ import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataU
 
 import org.apache.spark.sql._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.scalatest.Assertions.assertResult
 
-import scala.collection.{mutable, JavaConverters}
+import scala.collection.{mutable, JavaConverters, Seq}
 import scala.collection.JavaConverters._
 import scala.util.Using
 
@@ -160,5 +161,9 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
     assertEquals(0, nonMatchingRecords.count())
     assertEquals(readDf.count(), prevDf.count())
     readDf.unpersist()
+  }
+
+  protected def checkAnswer(sql: String)(expects: collection.immutable.Seq[Any]*): Unit = {
+    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEightToNineUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEightToNineUpgrade.scala
@@ -19,23 +19,28 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.DataSourceWriteOptions.{INSERT_OVERWRITE_OPERATION_OPT_VAL, PARTITIONPATH_FIELD, PAYLOAD_CLASS_NAME, RECORD_MERGE_IMPL_CLASSES, TABLE_TYPE, UPSERT_OPERATION_OPT_VAL}
-import org.apache.hudi.common.config.{HoodieStorageConfig, RecordMergeMode}
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.DataSourceWriteOptions.{INSERT_OVERWRITE_OPERATION_OPT_VAL, OPERATION, PARTITIONPATH_FIELD, PAYLOAD_CLASS_NAME, RECORD_MERGE_IMPL_CLASSES, RECORDKEY_FIELD, TABLE_TYPE}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, RecordMergeMode}
 import org.apache.hudi.common.model.{AWSDmsAvroPayload, EventTimeAvroPayload, HoodieRecordMerger, HoodieTableType, OverwriteNonDefaultsWithLatestAvroPayload, PartialUpdateAvroPayload}
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload.{DELETE_KEY, DELETE_MARKER}
-import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload
+import org.apache.hudi.common.model.debezium.{DebeziumConstants, MySqlDebeziumAvroPayload, PostgresDebeziumAvroPayload}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, PartialUpdateMode}
 import org.apache.hudi.common.table.HoodieTableConfig.{DEBEZIUM_UNAVAILABLE_VALUE, PARTIAL_UPDATE_UNAVAILABLE_VALUE, RECORD_MERGE_PROPERTY_PREFIX}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
-import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
+import scala.collection.immutable.Seq
+
 class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
+
   @ParameterizedTest
   @MethodSource(Array("payloadConfigs"))
   def testUpgradeDowngradeBetweenEightAndNine(tableType: HoodieTableType,
@@ -44,7 +49,7 @@ class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
     val mergerClasses = "org.apache.hudi.DefaultSparkRecordMerger," +
       "org.apache.hudi.OverwriteWithLatestSparkRecordMerger," +
       "org.apache.hudi.common.model.HoodieAvroRecordMerger"
-    var hudiOpts= commonOpts ++ Map(
+    var hudiOpts = commonOpts ++ Map(
       TABLE_TYPE.key -> tableType.name(),
       PARTITIONPATH_FIELD.key -> partitionFields,
       PAYLOAD_CLASS_NAME.key -> payloadClass,
@@ -107,6 +112,92 @@ class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
     checkResultForVersion8(payloadClass)
   }
 
+  @Test
+  def testUpgradeDowngradeMySqlDebeziumPayload(): Unit = {
+    val payloadClass = classOf[MySqlDebeziumAvroPayload].getName
+    var opts: Map[String, String] = Map(
+      HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClass,
+      HoodieMetadataConfig.ENABLE.key() -> "false"
+    )
+    val columns = Seq("ts", "key", "rider", "driver", DebeziumConstants.FLATTENED_FILE_COL_NAME, DebeziumConstants.FLATTENED_POS_COL_NAME,
+      DebeziumConstants.ADDED_SEQ_COL_NAME)
+
+    // 1. Add an insert.
+    val data = Seq(
+      (10, "1", "rider-A", "driver-A", 1, 1, "1.1"),
+      (10, "2", "rider-B", "driver-B", 2, 5, "2.5"),
+      (10, "3", "rider-C", "driver-C", 3, 10, "3.10"),
+      (10, "4", "rider-D", "driver-D", 4, 8, "4.8"),
+      (10, "5", "rider-E", "driver-E", 5, 4, "5.4"))
+    val inserts = spark.createDataFrame(data).toDF(columns: _*)
+    inserts.write.format("hudi").
+      option(RECORDKEY_FIELD.key(), "key").
+      option(TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name()).
+      option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), DebeziumConstants.ADDED_SEQ_COL_NAME).
+      option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
+      option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
+      options(opts).
+      mode(SaveMode.Overwrite).
+      save(basePath)
+    checkResultForVersion8(payloadClass)
+
+    // 2. Add an update and upgrade the table to v9
+    // first two records with larger ordering values based on debezium payload
+    // last two records with smaller ordering values based on debezium payload, below updates should be rejected
+    var updateData = Seq(
+      (9, "1", "rider-X", "driver-X", 1, 2, "1.2"),
+      (9, "2", "rider-Y", "driver-Y", 3, 2, "3.2"),
+      (9, "3", "rider-C", "driver-C", 2, 10, "2.10"),
+      (9, "4", "rider-D", "driver-D", 4, 7, "4.7")
+    )
+    var update = spark.createDataFrame(updateData).toDF(columns: _*)
+    update.write.format("hudi").
+      option(OPERATION.key(), "upsert").
+      option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      mode(SaveMode.Append).
+      save(basePath)
+    checkResultForVersion9("", payloadClass)
+
+    // Downgrade to table version 8 explicitly.
+    // Note that downgrade is NOT automatic.
+    // It has to be triggered explicitly.
+    opts = opts ++ Map(HoodieWriteConfig.WRITE_TABLE_VERSION.key -> "8")
+    new UpgradeDowngrade(metaClient, getWriteConfig(opts), context, SparkUpgradeDowngradeHelper.getInstance)
+      .run(HoodieTableVersion.EIGHT, null)
+
+    // 3. Add an update after downgrade and validate the data
+    // first two records with larger ordering values based on debezium payload
+    // last two records with smaller ordering values based on debezium payload, below updates should be rejected
+    updateData = Seq(
+      (8, "1", "rider-X", "driver-X", 1, 3, "1.3"),
+      (8, "2", "rider-Y", "driver-Y", 4, 2, "4.2"),
+      (8, "3", "rider-C", "driver-C", 2, 10, "2.10"),
+      (8, "4", "rider-D", "driver-D", 4, 7, "4.7")
+    )
+    update = spark.createDataFrame(updateData).toDF(columns: _*)
+    update.write.format("hudi").
+      option(OPERATION.key(), "upsert").
+      option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
+      mode(SaveMode.Append).
+      save(basePath)
+    checkResultForVersion8(payloadClass)
+
+    tableName = "testUpgradeDowngradeMySqlDebeziumPayload"
+    spark.sql(s"create table testUpgradeDowngradeMySqlDebeziumPayload using hudi location '$basePath'")
+    checkAnswer(s"select ts, key, rider, driver, ${DebeziumConstants.FLATTENED_FILE_COL_NAME}, ${DebeziumConstants.FLATTENED_POS_COL_NAME},"
+      + s" ${DebeziumConstants.ADDED_SEQ_COL_NAME} from default.$tableName")(
+      Seq(8, "1", "rider-X", "driver-X", 1, 3, "1.3"),
+      Seq(8, "2", "rider-Y", "driver-Y", 4, 2, "4.2"),
+      Seq(10, "3", "rider-C", "driver-C", 3, 10, "3.10"),
+      Seq(10, "4", "rider-D", "driver-D", 4, 8, "4.8"),
+      Seq(10, "5", "rider-E", "driver-E", 5, 4, "5.4")
+    )
+
+    spark.sql(s"drop table default.$tableName")
+  }
+
   def checkResultForVersion8(payloadClass: String): Unit = {
     metaClient = HoodieTableMetaClient.reload(metaClient)
     assertEquals(HoodieTableVersion.EIGHT, metaClient.getTableConfig.getTableVersion)
@@ -119,6 +210,10 @@ class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
     } else {
       // The merge mode should be CUSTOM.
       assertEquals(HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+    }
+    if (payloadClass.equals(classOf[MySqlDebeziumAvroPayload].getName)) {
+      assertFalse(metaClient.getTableConfig.getPreCombineFieldsStr.isEmpty)
+      assertEquals(DebeziumConstants.ADDED_SEQ_COL_NAME, metaClient.getTableConfig.getPreCombineFieldsStr.get())
     }
   }
 
@@ -160,6 +255,14 @@ class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
       assertEquals(AWSDmsAvroPayload.OP_FIELD, deleteField)
       val deleteMarker = metaClient.getTableConfig.getString(s"${RECORD_MERGE_PROPERTY_PREFIX}${DELETE_MARKER}")
       assertEquals(AWSDmsAvroPayload.DELETE_OPERATION_VALUE, deleteMarker)
+    } else if (payloadClass.equals(classOf[MySqlDebeziumAvroPayload].getName)) {
+      assertEquals(
+        HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
+        metaClient.getTableConfig.getRecordMergeStrategyId)
+      assertEquals(RecordMergeMode.EVENT_TIME_ORDERING, metaClient.getTableConfig.getRecordMergeMode)
+      assertTrue(metaClient.getTableConfig.getPartialUpdateMode.isEmpty)
+      assertEquals(DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME,
+        metaClient.getTableConfig.getPreCombineFieldsStr.get())
     } else {
       assertTrue(metaClient.getTableConfig.getPartialUpdateMode.isEmpty)
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEightToNineUpgrade.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEightToNineUpgrade.scala
@@ -32,12 +32,11 @@ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkAnswer
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
-
-import scala.collection.immutable.Seq
 
 class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
 
@@ -186,7 +185,7 @@ class TestEightToNineUpgrade extends RecordLevelIndexTestBase {
 
     tableName = "testUpgradeDowngradeMySqlDebeziumPayload"
     spark.sql(s"create table testUpgradeDowngradeMySqlDebeziumPayload using hudi location '$basePath'")
-    checkAnswer(s"select ts, key, rider, driver, ${DebeziumConstants.FLATTENED_FILE_COL_NAME}, ${DebeziumConstants.FLATTENED_POS_COL_NAME},"
+    checkAnswer(spark, s"select ts, key, rider, driver, ${DebeziumConstants.FLATTENED_FILE_COL_NAME}, ${DebeziumConstants.FLATTENED_POS_COL_NAME},"
       + s" ${DebeziumConstants.ADDED_SEQ_COL_NAME} from default.$tableName")(
       Seq(8, "1", "rider-X", "driver-X", 1, 3, "1.3"),
       Seq(8, "2", "rider-Y", "driver-Y", 4, 2, "4.2"),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -223,8 +223,6 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
   }
 }
 
-// TODO: Add COPY_ON_WRITE table type tests when write path is updated accordingly.
-// TODO: Add Test for MySqlDebeziumAvroPayload.
 object TestPayloadDeprecationFlow {
   def providePayloadClassTestCases(): java.util.List[Arguments] = {
     java.util.Arrays.asList(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -133,7 +133,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
-    HoodieSparkSqlTestBase.checkAnswer(spark, sql)(expects)
+    HoodieSparkSqlTestBase.checkAnswer(spark, sql)(expects: _*)
   }
 
   protected def checkAnswer(array: Array[Row])(expects: Seq[Any]*): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -35,7 +35,6 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex
 import org.apache.hudi.storage.{HoodieStorage, StoragePath}
 import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSparkConfForTest}
-import org.apache.hudi.testutils.HoodieSparkClientTestHarness
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
@@ -48,6 +47,7 @@ import org.joda.time.DateTimeZone
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
+import org.scalatest.Assertions.assertResult
 import org.slf4j.LoggerFactory
 
 import java.io.File
@@ -133,7 +133,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
-    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
+    HoodieSparkSqlTestBase.checkAnswer(spark, sql)(expects)
   }
 
   protected def checkAnswer(array: Array[Row])(expects: Seq[Any]*): Unit = {
@@ -433,6 +433,10 @@ object HoodieSparkSqlTestBase {
                            filePath: StoragePath): Unit = {
     storage.deleteFile(filePath)
     storage.createNewFile(filePath)
+  }
+
+  def checkAnswer(spark: SparkSession, sql: String)(expects: Seq[Any]*): Unit = {
+    assertResult(expects.map(row => Row(row: _*)).toArray.sortBy(_.toString()))(spark.sql(sql).collect().sortBy(_.toString()))
   }
 
   def validateDeleteLogBlockPrecombineNullOrZero(basePath: String): Unit = {


### PR DESCRIPTION
### Change Logs

Migrating MySqlDebeziumPayload to merge mode. 

Pending work:
Adding tests to TestPayloadDeprecationFlow for MySqlDebeziumPayload

### Impact

MySqlDebeziumPayload in V9 will be using merge modes w/ multiple ordering fields.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
