### PR TITLE
[HUDI-9725] Disable partial merging when partial update mode is set for MIT

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.HoodieSparkSqlWriter.CANONICALIZE_SCHEMA
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.common.config.RecordMergeMode
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecordMerger}
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableVersion}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableVersion, PartialUpdateMode}
 import org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig}
@@ -60,6 +60,7 @@ import org.apache.spark.sql.types.{BooleanType, StructField, StructType}
 import java.util.Base64
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /**
  * Exception thrown when field resolution fails during MERGE INTO validation
@@ -209,7 +210,6 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
     }).filter(_.nonEmpty).map(_.get)
     resolvedCols
   }
-
 
   private def doCasting(conditions: Seq[Expression], pkTable: Boolean): Seq[(Attribute, Expression)] = {
     val targetAttrs = mergeInto.targetTable.outputSet
@@ -519,7 +519,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
       // After HUDI-9257 is done, we can remove this limitation.
       && !useGlobalIndex(parameters)
       // Partial update is disabled when custom merge mode is set.
-      && !useCustomMergeMode(parameters))
+      && !useCustomMergeMode(parameters)
+      // Partial update is disabled when partialUpdateMode is set.
+      && getPartialUpdateMode(parameters).isEmpty)
   }
 
   private def getOperationType(parameters: Map[String, String]) = {
@@ -1118,6 +1120,12 @@ object MergeIntoHoodieTableCommand {
       throw new HoodieException("Merge mode cannot be null here")
     }
     mergeModeOpt.get.equals(RecordMergeMode.CUSTOM.name)
+  }
+
+  def getPartialUpdateMode(parameters: Map[String, String]): Option[PartialUpdateMode] = {
+    parameters.get(HoodieTableConfig.PARTIAL_UPDATE_MODE.key).flatMap { value =>
+      Try(PartialUpdateMode.valueOf(value)).toOption
+    }
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommand.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.hudi.analysis
 
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.table.{HoodieTableConfig, PartialUpdateMode}
 import org.apache.hudi.config.HoodieIndexConfig
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.index.HoodieIndex
@@ -102,5 +103,22 @@ class TestMergeIntoHoodieTableCommand extends AnyFlatSpec with Matchers {
   it should "throw HoodieException when merge mode is missing" in {
     val params = Map.empty[String, String]
     an[HoodieException] should be thrownBy MergeIntoHoodieTableCommand.useCustomMergeMode(params)
+  }
+
+  it should "return empty when no partial update mode parameter is provided" in {
+    val params: Map[String, String] = Map()
+    MergeIntoHoodieTableCommand.getPartialUpdateMode(params).isDefined should be(false)
+  }
+
+  it should "return non-empty when partial update mode parameter is provided" in {
+    var params: Map[String, String] = Map(
+      HoodieTableConfig.PARTIAL_UPDATE_MODE.key -> PartialUpdateMode.IGNORE_DEFAULTS.name
+    )
+    MergeIntoHoodieTableCommand.getPartialUpdateMode(params).isDefined should be (true)
+
+    params = Map(
+      HoodieTableConfig.PARTIAL_UPDATE_MODE.key -> PartialUpdateMode.FILL_UNAVAILABLE.name
+    )
+    MergeIntoHoodieTableCommand.getPartialUpdateMode(params).isDefined should be(true)
   }
 }


### PR DESCRIPTION
### Change Logs

Add an additional check for partial merging for MIT

### Impact

Avoid data curruption for this corner case.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
