### PR TITLE
[MINOR] Add additional upgrade tests for TestMORDataSource

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2791,7 +2791,8 @@ public class HoodieTableMetadataUtil {
     if (!indexDefs.containsKey(metadataPartitionPath)) {
       return Option.empty();
     }
-    return Option.of(indexDefs.get(metadataPartitionPath).getVersion());
+    HoodieIndexVersion version = indexDefs.get(metadataPartitionPath).getVersion();
+    return version != null ? Option.of(version) : Option.empty();
   }
 
   public static HoodieIndexVersion existingIndexVersionOrDefault(String metadataPartitionPath, HoodieTableMetaClient dataMetaClient) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -1788,7 +1788,9 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     "6,6,false,NO_UPGRADE", // Auto-upgrade disabled: table=6, write=6, autoUpgrade=false → no upgrade
     "6,8,false,NO_UPGRADE", // Auto-upgrade disabled: table=6, write=8, autoUpgrade=false → no upgrade
     "4,8,true,EXCEPTION", // Auto-upgrade enabled: Should throw exception since table version is less than 6
-    "4,8,false,EXCEPTION" // Auto-upgrade disabled: Should throw exception since table version is less than 6
+    "4,8,false,EXCEPTION", // Auto-upgrade disabled: Should throw exception since table version is less than 6
+    "8,8,false,NO_UPGRADE", // Auto-upgrade disabled: Should not upgrade as auto-upgrade is disabled and same versions
+    "8,8,true,NO_UPGRADE" // Auto-upgrade enabled: Should not upgrade as auto-upgrade is enabled and same versions
   ))
   def testBaseHoodieWriteClientUpgradeDecisionLogic(
     tableVersionStr: String,


### PR DESCRIPTION
### Change Logs

@linliu-code pointed out to me that the following additional tests cases in 

```
    "8,8,false,NO_UPGRADE", // Auto-upgrade disabled
    "8,8,true,NO_UPGRADE" // Auto-upgrade enabled
```


`TestMORDataSource.testBaseHoodieWriteClientUpgradeDecisionLogic` were failing due to this




```
Caused by: java.lang.NullPointerException: Expected a non-null value. Got null
	at org.apache.hudi.common.util.Option.<init>(Option.java:65)
	at org.apache.hudi.common.util.Option.of(Option.java:76)
	at org.apache.hudi.metadata.HoodieTableMetadataUtil.getIndexVersionOption(HoodieTableMetadataUtil.java:2794)
	at org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault(HoodieTableMetadataUtil.java:2798)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.getRecordTagger(HoodieBackedTableMetadataWriter.java:1837)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.tagRecordsWithLocation(HoodieBackedTableMetadataWriter.java:1829)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.prepareAndWriteToNonStreamingPartitions(HoodieBackedTableMetadataWriter.java:1308)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.completeStreamingCommit(HoodieBackedTableMetadataWriter.java:1297)
	at org.apache.hudi.client.StreamingMetadataWriteHandler.commitToMetadataTable(StreamingMetadataWriteHandler.java:79)
	... 68 more

```

### Impact

No impact, since minor change to just add a NPE check.

### Risk level (write none, low medium or high below)

none

### Documentation Update

No doc update required 


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
