### PR TITLE
[HUDI-9736] Fix lock provider for gcs when bucket has underscores

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
@@ -91,7 +91,7 @@ public class GCSStorageLockClient implements StorageLockClient {
       // This logic can likely be extended to other lock client implementations.
       // Consider creating base class with utilities, incl error handling.
       URI uri = new URI(lockFileUri);
-      this.bucketName = uri.getHost();
+      this.bucketName = uri.getAuthority();
       this.lockFilePath = uri.getPath().replaceFirst("/", "");
       this.gcsClient = gcsClientSupplier.apply(properties);
 

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/transaction/lock/TestGCSStorageLockClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/transaction/lock/TestGCSStorageLockClient.java
@@ -37,6 +37,8 @@ import com.google.cloud.storage.StorageException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
@@ -67,6 +69,7 @@ public class TestGCSStorageLockClient {
 
   private static final String OWNER_ID = "ownerId";
   private static final String LOCK_FILE_URI = "gs://bucket/lockFilePath";
+  private static final String LOCK_FILE_URI_WITH_UNDERSCORES = "gs://bucket_with_underscores/lockFilePath";
   private static final String LOCK_FILE_PATH = "lockFilePath";
   private static final String BUCKET_NAME = "bucket";
 
@@ -107,12 +110,17 @@ public class TestGCSStorageLockClient {
 
   @BeforeEach
   void setUp() {
-    lockService = new GCSStorageLockClient(OWNER_ID, LOCK_FILE_URI, new Properties(), (a) -> mockStorage, mockLogger);
+    setUp(LOCK_FILE_URI);
   }
 
-  @Test
-  void testTryCreateOrUpdateLockFile_noPreviousLock_success() {
-    StorageLockData lockData = new StorageLockData(false, 123L, "test-owner");
+  private void setUp(String lockFileUri) {
+    lockService = new GCSStorageLockClient(OWNER_ID, lockFileUri, new Properties(), (a) -> mockStorage, mockLogger);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {LOCK_FILE_URI, LOCK_FILE_URI_WITH_UNDERSCORES})
+  void testTryCreateOrUpdateLockFile_noPreviousLock_success(String lockFileUri) {
+    setUp(lockFileUri);    StorageLockData lockData = new StorageLockData(false, 123L, "test-owner");
 
     when(mockStorage.create(
         any(BlobInfo.class),

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/transaction/lock/TestGCSStorageLockClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/transaction/lock/TestGCSStorageLockClient.java
@@ -120,7 +120,8 @@ public class TestGCSStorageLockClient {
   @ParameterizedTest
   @ValueSource(strings = {LOCK_FILE_URI, LOCK_FILE_URI_WITH_UNDERSCORES})
   void testTryCreateOrUpdateLockFile_noPreviousLock_success(String lockFileUri) {
-    setUp(lockFileUri);    StorageLockData lockData = new StorageLockData(false, 123L, "test-owner");
+    setUp(lockFileUri);
+    StorageLockData lockData = new StorageLockData(false, 123L, "test-owner");
 
     when(mockStorage.create(
         any(BlobInfo.class),


### PR DESCRIPTION
### Change Logs
GCS buckets could have underscores in their name, and getHost does NOT like it since it does not conform with the standard DNS naming. This PR fixes it by using getAuthority instead. S3 does not allow underscores so we can keep that as getHost().

### Impact
None to core path or any APIs.

### Risk level (write none, low medium or high below)
Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
