### PR TITLE
[MINOR] Enable test for PartialUpdateAvroPayload

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -411,6 +411,15 @@ object TestPayloadDeprecationFlow {
       ),
       Arguments.of(
         "COPY_ON_WRITE",
+        classOf[PartialUpdateAvroPayload].getName,
+        Map(
+          HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[PartialUpdateAvroPayload].getName,
+          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
+          HoodieTableConfig.PARTIAL_UPDATE_MODE.key() -> "IGNORE_DEFAULTS")
+      ),
+      Arguments.of(
+        "COPY_ON_WRITE",
         classOf[PostgresDebeziumAvroPayload].getName,
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",


### PR DESCRIPTION
### Change Logs

Previously the functional tests in `TestPayloadDeprecationFlow` fail for `PartialUpdateAvroPayload` due to a bug for partial update handler; therefore, we decided to disable the test for `PartialUpdateAvroPayload` and fix in a separate PR.

However, later we found that the bug was just fixed in https://github.com/apache/hudi/pull/13734 in latest master. Therefore, we re-enable the tests for `PartialUpdateAvroPayload` in this PR.

### Impact

Better coverage.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
