### PR TITLE
[HUDI-9739] Create meta client in Spark driver for FGReader based format to avoid performance degradation

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -34,6 +34,7 @@ import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.hudi.io.IOUtils
 import org.apache.hudi.storage.StorageConfiguration
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.Job
@@ -54,6 +55,7 @@ import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnarBatchUtils}
 import org.apache.spark.util.SerializableConfiguration
 
 import java.io.Closeable
+
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 trait HoodieFormatTrait {


### PR DESCRIPTION
…degradation

### Change Logs

FGReader should take necessary information from the constructor/builder without having to do additional FS calls and scanning on the executor (e.g., loading table config, scanning timeline, reading schema, etc.) before reading the records.
 
Constructing meta client incurs loading table config, scanning timeline, reading schema, etc., which are very expensive operations, which must not happen per file group.


### Impact

Aim of PR is ensure that metaclient is not being created in each metaclient.

### Risk level (write none, low medium or high below)
low

### Documentation Update

No doc update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
