### PR TITLE
[HUDI-9749] Pass correct base path key to metrics of sync tool

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -38,6 +38,8 @@ import static org.apache.hudi.common.util.ConfigUtils.enumNames;
     description = "The following set of configurations are common across Hudi.")
 public class HoodieCommonConfig extends HoodieConfig {
 
+  public static final String META_SYNC_BASE_PATH_KEY = "hoodie.datasource.meta.sync.base.path";
+
   public static final ConfigProperty<String> BASE_PATH = ConfigProperty
       .key("hoodie.base.path")
       .noDefaultValue()

--- a/hudi-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -41,6 +41,8 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
+
 /**
  * Fetch the configurations used by the Metrics system.
  */
@@ -52,7 +54,6 @@ import java.util.stream.Collectors;
 public class HoodieMetricsConfig extends HoodieConfig {
 
   public static final String METRIC_PREFIX = "hoodie.metrics";
-  public static final String META_SYNC_BASE_PATH_KEY = "hoodie.datasource.meta.sync.base.path";
 
   public static final ConfigProperty<Boolean> TURN_METRICS_ON = ConfigProperty
       .key(METRIC_PREFIX + ".on")

--- a/hudi-common/src/test/java/org/apache/hudi/config/metrics/TestHoodieMetricsConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/config/metrics/TestHoodieMetricsConfig.java
@@ -20,7 +20,7 @@ package org.apache.hudi.config.metrics;
 
 import org.junit.jupiter.api.Test;
 
-import static org.apache.hudi.config.metrics.HoodieMetricsConfig.META_SYNC_BASE_PATH_KEY;
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySyncTool.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -188,7 +189,7 @@ public class TestBigQuerySyncTool extends HoodieCommonTestHarness {
     TypedProperties typedProperties = new TypedProperties();
     String location = "us-central1";
     typedProperties.setProperty("hoodie.gcp.bigquery.sync.dataset_location", location);
-    typedProperties.setProperty("hoodie.datasource.meta.sync.base.path", metaClient.getBasePath().toString());
+    typedProperties.setProperty(META_SYNC_BASE_PATH_KEY, metaClient.getBasePath().toString());
     try (MockedStatic<BigQueryOptions> mockedStatic = mockStatic(BigQueryOptions.class)) {
       BigQueryOptions.Builder builder = mock(BigQueryOptions.Builder.class);
       BigQueryOptions.Builder builderWithLocation = mock(BigQueryOptions.Builder.class);

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -57,7 +58,7 @@ class TestDataHubSyncTool extends HoodieCommonTestHarness {
   void validatePropsConstructor() throws Exception {
     initMetaClient();
     TypedProperties typedProperties = new TypedProperties();
-    typedProperties.setProperty("hoodie.datasource.meta.sync.base.path", metaClient.getBasePath().toString());
+    typedProperties.setProperty(META_SYNC_BASE_PATH_KEY, metaClient.getBasePath().toString());
     assertDoesNotThrow(() -> {
       HoodieSyncTool syncTool = new DataHubSyncTool(typedProperties);
       syncTool.close();

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -46,6 +46,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS;
 import static org.apache.hudi.common.table.HoodieTableConfig.BASE_FILE_FORMAT;
 import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
@@ -53,7 +54,6 @@ import static org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIO
 import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
 import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
 import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING;
-import static org.apache.hudi.config.metrics.HoodieMetricsConfig.META_SYNC_BASE_PATH_KEY;
 
 /**
  * Configs needed to sync data into external meta stores, catalogs, etc.

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncTool.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncTool.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestHoodieSyncTool extends HoodieCommonTestHarness {
@@ -32,7 +33,7 @@ class TestHoodieSyncTool extends HoodieCommonTestHarness {
   void testBuildMetaClient() throws Exception {
     initMetaClient();
     TypedProperties properties = new TypedProperties();
-    properties.put("hoodie.datasource.meta.sync.base.path", metaClient.getBasePath().toString());
+    properties.put(META_SYNC_BASE_PATH_KEY, metaClient.getBasePath().toString());
     HoodieSyncConfig syncConfig = new HoodieSyncConfig(properties, new Configuration());
     HoodieTableMetaClient actual = HoodieSyncTool.buildMetaClient(syncConfig);
     assertEquals(actual.getBasePath(), metaClient.getBasePath());


### PR DESCRIPTION
### Change Logs

Metrics of Sync tool tended to use `hoodie.table.path` during initialization; however, this may not be available for table created by SQL, since the base path might be passed in using `hoodie.datasource.meta.sync.base.path` config instead.
Therefore, metrics of meta sync tool gets the table path from the parameter named: `hoodie.datasource.meta.sync.base.path` during initialization if exists.

### Impact

Fix a bug from metrics initialization.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
