### PR TITLE
[HUDI-9750] Fix empty partition handling with HoodieMetadataTableVadlidator

### DIFF
--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -49,7 +49,7 @@ public class TestStringUtils {
 
   private static final String[] STRINGS = {"This", "is", "a", "test"};
 
-  private static final String CHARACTERS_FOR_RANDOM_GEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_/";
+  private static final String CHARACTERS_FOR_RANDOM_GEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_/:";
   private static final Random RANDOM = new SecureRandom();
 
   private static String toHexString(byte[] bytes) {

--- a/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -49,7 +49,7 @@ public class TestStringUtils {
 
   private static final String[] STRINGS = {"This", "is", "a", "test"};
 
-  private static final String CHARACTERS_FOR_RANDOM_GEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_/:";
+  private static final String CHARACTERS_FOR_RANDOM_GEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_/";
   private static final Random RANDOM = new SecureRandom();
 
   private static String toHexString(byte[] bytes) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -784,8 +784,8 @@ public class HoodieMetadataTableValidator implements Serializable {
         // check for all additional partitions from FS is they are empty ones.
         List<String> emptyPartitions = additionalFromFS.stream().filter(partition -> {
           try {
-            Path partitionPath = new Path(basePath, partition);
-            return Arrays.stream(metaClient.getFs().listStatus(partitionPath))
+            StoragePath partitionPath = new StoragePath(basePath, partition);
+            return metaClient.getStorage().listFiles(partitionPath).stream()
                 .noneMatch(fileStatus -> fileStatus.isFile() && !fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX));
           } catch (IOException ex) {
             throw new HoodieIOException("Error listing partition " + partition, ex);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -780,6 +780,25 @@ public class HoodieMetadataTableValidator implements Serializable {
           misMatch.set(false);
         }
       }
+      if (!additionalFromFS.isEmpty()) {
+        // check for all additional partitions from FS is they are empty ones.
+        List<String> emptyPartitions = additionalFromFS.stream().filter(partition -> {
+          try {
+            Path partitionPath = new Path(basePath, partition);
+            return Arrays.stream(metaClient.getFs().listStatus(partitionPath))
+                .noneMatch(fileStatus -> fileStatus.isFile() && !fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX));
+          } catch (IOException ex) {
+            throw new HoodieIOException("Error listing partition " + partition, ex);
+          }
+        }).collect(Collectors.toList());
+        additionalFromFS.removeAll(emptyPartitions);
+        if (additionalFromFS.isEmpty()) {
+          LOG.warn("All out of sync partitions turned out to be empty {}", emptyPartitions);
+          misMatch.set(false);
+        } else {
+          misMatch.set(true);
+        }
+      }
       if (misMatch.get()) {
         String message = "Compare Partitions Failed! " + " Additional "
             + additionalFromFS.size() + " partitions from FS, but missing from MDT : \""

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -66,6 +66,7 @@ import org.apache.hudi.testutils.SparkRDDValidationUtils;
 
 import jodd.io.FileUtil;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -511,6 +512,50 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     assertTrue(validator.getThrowables().isEmpty());
   }
 
+  @Test
+  void testAdditionalEmptyPartitionInFileSystem() throws IOException {
+    String partition1 = "PARTITION1";
+    String partition2 = "PARTITION2";
+    // create a new partition which exists only in FS based listing. mimicing a scenario where new partition was added by a commit which failed eventually.
+    // so empty dir exists w/o any valid data. In this case, FS based listing will list this additional partiton, while MDT may not list it.
+    String partition3 = "PARTITION3";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    config.validateLatestFileSlices = true;
+    config.validateAllFileGroups = true;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    when(storage.exists(new StoragePath(basePath + "/" + partition1))).thenReturn(true);
+    when(storage.exists(new StoragePath(basePath + "/" + partition2))).thenReturn(true);
+    // mock partitions 1-3 to have at least one file
+    mockPartitionWithFiles(Arrays.asList(partition1, partition2), storage);
+    // mock that partition4 only has the partition marker file
+    StoragePathInfo storagePathInfo = mock(StoragePathInfo.class);
+    when(storagePathInfo.isFile()).thenReturn(true);
+    when(storagePathInfo.getPath()).thenReturn(new StoragePath(basePath, partition3 + "/.hoodie_partition_metadata"));
+    when(storage.listFiles(new StoragePath(basePath, partition3))).thenReturn(Collections.singletonList(storagePathInfo));
+
+    // mock list of partitions to return
+    // - FS listing to have one additonal partition which is empty.
+    List<String> mdtPartitions = Arrays.asList(partition1, partition2);
+    validator.setMetadataPartitionsToReturn(mdtPartitions);
+    List<String> fsPartitions = Arrays.asList(partition1, partition2, partition3);
+    validator.setFsPartitionsToReturn(fsPartitions);
+
+    // mock completed timeline.
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    // validate that all 3 partitions are returned
+    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, basePath, metaClient));
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testAdditionalPartitionsinMDT(boolean testFailureCase) throws IOException, InterruptedException {
@@ -546,7 +591,9 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     when(storage.exists(new StoragePath(basePath + "/" + partition2))).thenReturn(true);
     when(storage.exists(new StoragePath(basePath + "/" + partition3))).thenReturn(true);
 
-    // mock list of partitions to return from MDT to have 1 additional partition compared to FS based listing.
+    // mock list of partitions to return
+    // - MDT to have 1 additional partition compared to FS based listing.
+    // - FS listing to have one additonal partition which is empty.
     List<String> mdtPartitions = Arrays.asList(partition1, partition2, partition3);
     validator.setMetadataPartitionsToReturn(mdtPartitions);
     List<String> fsPartitions = Arrays.asList(partition1, partition2);
@@ -1487,7 +1534,8 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     for (String partition : mdtPartitions) {
       when(fs.exists(new StoragePath(basePath + "/" + partition))).thenReturn(true);
     }
-    
+    mockPartitionWithFiles(fsPartitions, fs);
+
     // Mock timeline
     HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
     HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
@@ -1497,7 +1545,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     // Setup validator with test data
     validator.setMetadataPartitionsToReturn(mdtPartitions);
     validator.setFsPartitionsToReturn(fsPartitions);
-    
+
     // Test validation with truncation
     HoodieValidationException exception = assertThrows(HoodieValidationException.class, () -> {
       validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient);
@@ -1573,5 +1621,14 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
         fsFileSlices.size())));
     assertTrue(errorMsg.contains(String.format("MDT-based listing (%d file slices)", 
         mdtFileSlices.size())));
+  }
+
+  private void mockPartitionWithFiles(List<String> partition1, HoodieStorage storage) throws IOException {
+    for (String partition : partition1) {
+      StoragePathInfo storagePathInfo = mock(StoragePathInfo.class);
+      when(storagePathInfo.getPath()).thenReturn(new StoragePath(basePath + "/" + partition + "/001.parquet"));
+      when(storagePathInfo.isFile()).thenReturn(true);
+      when(storage.listFiles(new StoragePath(basePath + "/" + partition))).thenReturn(Collections.singletonList(storagePathInfo));
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -66,7 +66,6 @@ import org.apache.hudi.testutils.SparkRDDValidationUtils;
 
 import jodd.io.FileUtil;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -553,7 +552,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
 
     // validate that all 3 partitions are returned
-    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, basePath, metaClient));
+    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

Fix empty partition handling with HoodieMetadataTableVadlidator. 
If a write failed mid-way after creating a new partition, there are chances that, FS based listing could list this partition, but MDT based listing may not. This patch accounts for this mis match with HoodieMetadataTableVadlidator. In other words, validation will not fail for this case. 

### Impact

Fix empty partition handling with HoodieMetadataTableVadlidator. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
