### PR TITLE
[HUDI-9754] Initialize timeline from client and use it to create view

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -214,6 +214,7 @@ public class EmbeddedTimelineService {
         .withRemoteTimelineInitialRetryIntervalMs(clientWriteConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineInitialRetryIntervalMs())
         .withRemoteTimelineClientMaxRetryIntervalMs(clientWriteConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientMaxRetryIntervalMs())
         .withRemoteTimelineClientRetryExceptions(clientWriteConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientRetryExceptions())
+        .withRemoteInitTimeline(writeConfig.getClientSpecifiedViewStorageConfig().isRemoteInitEnabled())
         .build();
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestTransactionManager.java
@@ -53,7 +53,7 @@ public class TestTransactionManager extends HoodieCommonTestHarness {
   TransactionManager transactionManager;
 
   @BeforeEach
-  private void init(TestInfo testInfo) throws IOException {
+  public void init(TestInfo testInfo) throws IOException {
     initPath();
     initMetaClient();
     this.writeConfig = getWriteConfig(testInfo.getTags().contains("useLockProviderWithRuntimeError"));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -594,6 +594,10 @@ public class TimelineUtils {
     return factory.createNewInstant(HoodieInstant.State.INFLIGHT, instant.getAction(), instant.requestedTime());
   }
 
+  public static HoodieTimeline getVisibleTimelineForFsView(HoodieTableMetaClient metaClient) {
+    return metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+  }
+
   public enum HollowCommitHandling {
     FAIL, BLOCK, USE_TRANSITION_TIME
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/InstantDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/InstantDTO.java
@@ -36,11 +36,12 @@ public class InstantDTO {
   String timestamp;
   @JsonProperty("state")
   String state;
-  @JsonProperty("completionTime")
-  String completionTime;
 
   @JsonProperty("requestedTime")
   String requestedTime;
+
+  @JsonProperty("completionTime")
+  String completionTime;
 
   public static InstantDTO fromInstant(HoodieInstant instant) {
     if (null == instant) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/InstantDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/InstantDTO.java
@@ -36,12 +36,11 @@ public class InstantDTO {
   String timestamp;
   @JsonProperty("state")
   String state;
+  @JsonProperty("completionTime")
+  String completionTime;
 
   @JsonProperty("requestedTime")
   String requestedTime;
-
-  @JsonProperty("completionTime")
-  String completionTime;
 
   public static InstantDTO fromInstant(HoodieInstant instant) {
     if (null == instant) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -25,7 +25,8 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.Functions.Function2;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.util.Functions.Function3;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
@@ -67,14 +68,14 @@ public class FileSystemViewManager {
   // The View Storage config used to store file-system views
   private final FileSystemViewStorageConfig viewStorageConfig;
   // Factory Map to create file-system views
-  private final Function2<HoodieTableMetaClient, FileSystemViewStorageConfig, SyncableFileSystemView> viewCreator;
+  private final Function3<HoodieTableMetaClient, HoodieTimeline, FileSystemViewStorageConfig, SyncableFileSystemView> viewCreator;
   // Map from Base-Path to View
   private final ConcurrentHashMap<String, SyncableFileSystemView> globalViewMap;
 
   private FileSystemViewManager(
       HoodieEngineContext context,
       FileSystemViewStorageConfig viewStorageConfig,
-      Function2<HoodieTableMetaClient, FileSystemViewStorageConfig, SyncableFileSystemView> viewCreator) {
+      Function3<HoodieTableMetaClient, HoodieTimeline, FileSystemViewStorageConfig, SyncableFileSystemView> viewCreator) {
     this.conf = context.getStorageConf();
     this.viewStorageConfig = viewStorageConfig;
     this.viewCreator = viewCreator;
@@ -93,6 +94,10 @@ public class FileSystemViewManager {
     }
   }
 
+  public boolean doesFileSystemViewExists(String basePath) {
+    return globalViewMap.containsKey(basePath);
+  }
+
   /**
    * Main API to get the file-system view for the base-path.
    *
@@ -103,7 +108,7 @@ public class FileSystemViewManager {
     return globalViewMap.computeIfAbsent(basePath, (path) -> {
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
           .setConf(conf.newInstance()).setBasePath(path).build();
-      return viewCreator.apply(metaClient, viewStorageConfig);
+      return viewCreator.apply(metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), viewStorageConfig);
     });
   }
 
@@ -115,7 +120,11 @@ public class FileSystemViewManager {
    */
   public SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient) {
     return globalViewMap.computeIfAbsent(metaClient.getBasePath().toString(),
-        (path) -> viewCreator.apply(metaClient, viewStorageConfig));
+        (path) -> viewCreator.apply(metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), viewStorageConfig));
+  }
+
+  public SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline) {
+    return globalViewMap.computeIfAbsent(metaClient.getBasePath().toString(), (path) -> viewCreator.apply(metaClient, timeline, viewStorageConfig));
   }
 
   /**
@@ -139,11 +148,13 @@ public class FileSystemViewManager {
    * @param metadataCreator creates {@link HoodieTableMetadata}
    * @return
    */
-  private static RocksDbBasedFileSystemView createRocksDBBasedFileSystemView(HoodieEngineContext engineContext, FileSystemViewStorageConfig viewConf, HoodieTableMetaClient metaClient,
+  private static RocksDbBasedFileSystemView createRocksDBBasedFileSystemView(HoodieEngineContext engineContext,
+                                                                             FileSystemViewStorageConfig viewConf,
+                                                                             HoodieTableMetaClient metaClient,
+                                                                             HoodieTimeline timeline,
                                                                              boolean metadataTableEnabled,
                                                                              SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator) {
     LOG.info("Creating RocksDB based view for basePath {}.", metaClient.getBasePath());
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
     HoodieTableMetadata tableMetadata = getTableMetadata(engineContext, metaClient, metadataTableEnabled, metadataCreator);
     return new RocksDbBasedFileSystemView(tableMetadata, metaClient, timeline, viewConf);
   }
@@ -155,12 +166,14 @@ public class FileSystemViewManager {
    * @param metaClient HoodieTableMetaClient
    * @return {@link SpillableMapBasedFileSystemView}
    */
-  private static SpillableMapBasedFileSystemView createSpillableMapBasedFileSystemView(HoodieEngineContext engineContext, FileSystemViewStorageConfig viewConf,
-                                                                                       HoodieTableMetaClient metaClient, HoodieCommonConfig commonConfig,
+  private static SpillableMapBasedFileSystemView createSpillableMapBasedFileSystemView(HoodieEngineContext engineContext,
+                                                                                       FileSystemViewStorageConfig viewConf,
+                                                                                       HoodieTableMetaClient metaClient,
+                                                                                       HoodieTimeline timeline,
+                                                                                       HoodieCommonConfig commonConfig,
                                                                                        boolean metadataTableEnabled,
                                                                                        SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator) {
     LOG.info("Creating SpillableMap based view for basePath {}.", metaClient.getBasePath());
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
     HoodieTableMetadata tableMetadata = getTableMetadata(engineContext, metaClient, metadataTableEnabled, metadataCreator);
     return new SpillableMapBasedFileSystemView(tableMetadata, metaClient, timeline, viewConf, commonConfig);
   }
@@ -168,11 +181,13 @@ public class FileSystemViewManager {
   /**
    * Create an in-memory file System view for a table.
    */
-  private static HoodieTableFileSystemView createInMemoryFileSystemView(HoodieEngineContext engineContext, FileSystemViewStorageConfig viewConf,
-                                                                        HoodieTableMetaClient metaClient, boolean metadataTableEnabled,
+  private static HoodieTableFileSystemView createInMemoryFileSystemView(HoodieEngineContext engineContext,
+                                                                        FileSystemViewStorageConfig viewConf,
+                                                                        HoodieTableMetaClient metaClient,
+                                                                        HoodieTimeline timeline,
+                                                                        boolean metadataTableEnabled,
                                                                         SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator) {
     LOG.info("Creating InMemory based view for basePath {}.", metaClient.getBasePath());
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
     HoodieTableMetadata tableMetadata = getTableMetadata(engineContext, metaClient, metadataTableEnabled, metadataCreator);
     if (metaClient.getMetaserverConfig().isMetaserverEnabled()) {
       return (HoodieTableFileSystemView) ReflectionUtils.loadClass(HOODIE_METASERVER_FILE_SYSTEM_VIEW_CLASS,
@@ -182,7 +197,8 @@ public class FileSystemViewManager {
     return new HoodieTableFileSystemView(tableMetadata, metaClient, timeline, viewConf.isIncrementalTimelineSyncEnabled());
   }
 
-  private static HoodieTableMetadata getTableMetadata(HoodieEngineContext engineContext, HoodieTableMetaClient metaClient,
+  private static HoodieTableMetadata getTableMetadata(HoodieEngineContext engineContext,
+                                                      HoodieTableMetaClient metaClient,
                                                       boolean metadataTableEnabled,
                                                       SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator) {
     if (metadataTableEnabled && metaClient.getTableConfig().isMetadataTableAvailable()) {
@@ -224,10 +240,11 @@ public class FileSystemViewManager {
    * @return {@link RemoteHoodieTableFileSystemView}
    */
   private static RemoteHoodieTableFileSystemView createRemoteFileSystemView(FileSystemViewStorageConfig viewConf,
-                                                                            HoodieTableMetaClient metaClient) {
+                                                                            HoodieTableMetaClient metaClient,
+                                                                            HoodieTimeline timeline) {
     LOG.info("Creating remote view for basePath {}. Server={}:{}, Timeout={}", metaClient.getBasePath(),
         viewConf.getRemoteViewServerHost(), viewConf.getRemoteViewServerPort(), viewConf.getRemoteTimelineClientTimeoutSecs());
-    return new RemoteHoodieTableFileSystemView(metaClient, viewConf);
+    return new RemoteHoodieTableFileSystemView(metaClient, timeline, viewConf);
   }
 
   public static FileSystemViewManager createViewManagerWithTableMetadata(
@@ -260,25 +277,25 @@ public class FileSystemViewManager {
       case EMBEDDED_KV_STORE:
         LOG.debug("Creating embedded rocks-db based Table View");
         return new FileSystemViewManager(context, config,
-            (metaClient, viewConf) -> createRocksDBBasedFileSystemView(context, viewConf, metaClient, metadataTableEnabled, metadataCreator));
+            (metaClient, timeline, viewConf) -> createRocksDBBasedFileSystemView(context, viewConf, metaClient, timeline, metadataTableEnabled, metadataCreator));
       case SPILLABLE_DISK:
         LOG.debug("Creating Spillable Disk based Table View");
         return new FileSystemViewManager(context, config,
-            (metaClient, viewConf) -> createSpillableMapBasedFileSystemView(context, viewConf, metaClient, commonConfig, metadataTableEnabled, metadataCreator));
+            (metaClient, timeline, viewConf) -> createSpillableMapBasedFileSystemView(context, viewConf, metaClient, timeline, commonConfig, metadataTableEnabled, metadataCreator));
       case MEMORY:
         LOG.debug("Creating in-memory based Table View");
         return new FileSystemViewManager(context, config,
-            (metaClient, viewConfig) -> createInMemoryFileSystemView(context, viewConfig, metaClient, metadataTableEnabled, metadataCreator));
+            (metaClient, timeline, viewConfig) -> createInMemoryFileSystemView(context, viewConfig, metaClient, timeline, metadataTableEnabled, metadataCreator));
       case REMOTE_ONLY:
         LOG.debug("Creating remote only table view");
-        return new FileSystemViewManager(context, config, (metaClient, viewConfig) -> createRemoteFileSystemView(viewConfig,
-            metaClient));
+        return new FileSystemViewManager(context, config, (metaClient, timeline, viewConfig) -> createRemoteFileSystemView(viewConfig,
+            metaClient, timeline));
       case REMOTE_FIRST:
         LOG.debug("Creating remote first table view");
-        return new FileSystemViewManager(context, config, (metaClient, viewConfig) -> {
+        return new FileSystemViewManager(context, config, (metaClient, timeline, viewConfig) -> {
           RemoteHoodieTableFileSystemView remoteFileSystemView =
-              createRemoteFileSystemView(viewConfig, metaClient);
-          SecondaryViewCreator secondaryViewSupplier = new SecondaryViewCreator(viewConfig, metaClient, commonConfig, metadataTableEnabled, metadataCreator);
+              createRemoteFileSystemView(viewConfig, metaClient, timeline);
+          SecondaryViewCreator secondaryViewSupplier = new SecondaryViewCreator(viewConfig, metaClient, timeline, commonConfig, metadataTableEnabled, metadataCreator);
           return new PriorityBasedFileSystemView(remoteFileSystemView, secondaryViewSupplier, context);
         });
       default:
@@ -286,18 +303,23 @@ public class FileSystemViewManager {
     }
   }
 
-  static class SecondaryViewCreator implements SerializableFunctionUnchecked<HoodieEngineContext, SyncableFileSystemView> {    private final FileSystemViewStorageConfig viewConfig;
+  static class SecondaryViewCreator implements SerializableFunctionUnchecked<HoodieEngineContext, SyncableFileSystemView> {
+    private final FileSystemViewStorageConfig viewConfig;
     private final HoodieTableMetaClient metaClient;
+    private final HoodieTimeline timeline;
     private final HoodieCommonConfig commonConfig;
     private final boolean metadataTableEnabled;
     private final SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator;
 
     SecondaryViewCreator(FileSystemViewStorageConfig viewConfig,
-                         HoodieTableMetaClient metaClient, HoodieCommonConfig commonConfig,
+                         HoodieTableMetaClient metaClient,
+                         HoodieTimeline timeline,
+                         HoodieCommonConfig commonConfig,
                          boolean metadataTableEnabled,
                          SerializableFunctionUnchecked<HoodieTableMetaClient, HoodieTableMetadata> metadataCreator) {
       this.viewConfig = viewConfig;
       this.metaClient = metaClient;
+      this.timeline = timeline;
       this.commonConfig = commonConfig;
       this.metadataTableEnabled = metadataTableEnabled;
       this.metadataCreator = metadataCreator;
@@ -307,11 +329,11 @@ public class FileSystemViewManager {
     public SyncableFileSystemView apply(HoodieEngineContext engineContext) {
       switch (viewConfig.getSecondaryStorageType()) {
         case MEMORY:
-          return createInMemoryFileSystemView(engineContext, viewConfig, metaClient, metadataTableEnabled, metadataCreator);
+          return createInMemoryFileSystemView(engineContext, viewConfig, metaClient, timeline, metadataTableEnabled, metadataCreator);
         case EMBEDDED_KV_STORE:
-          return createRocksDBBasedFileSystemView(engineContext, viewConfig, metaClient, metadataTableEnabled, metadataCreator);
+          return createRocksDBBasedFileSystemView(engineContext, viewConfig, metaClient, timeline, metadataTableEnabled, metadataCreator);
         case SPILLABLE_DISK:
-          return createSpillableMapBasedFileSystemView(engineContext, viewConfig, metaClient, commonConfig, metadataTableEnabled, metadataCreator);
+          return createSpillableMapBasedFileSystemView(engineContext, viewConfig, metaClient, timeline, commonConfig, metadataTableEnabled, metadataCreator);
         default:
           throw new IllegalArgumentException("Secondary Storage type can only be in-memory or spillable. Was :"
               + viewConfig.getSecondaryStorageType());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -173,6 +173,12 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
       .withDocumentation("Config to control whether backup needs to be configured if clients were not able to reach"
           + " timeline service.");
 
+  public static final ConfigProperty<Boolean> REMOTE_INIT_TIMELINE_ENABLE = ConfigProperty
+      .key("hoodie.filesystem.remote.init.timeline.enable")
+      .defaultValue(false) // Need to be disabled only for tests.
+      .markAdvanced()
+      .withDocumentation("Config to control whether timeline from client needs to be initialized on the server through a remote call");
+
   public static FileSystemViewStorageConfig.Builder newBuilder() {
     return new Builder();
   }
@@ -273,6 +279,10 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public String getRocksdbBasePath() {
     return getString(ROCKSDB_BASE_PATH);
+  }
+
+  public boolean isRemoteInitEnabled() {
+    return getBoolean(REMOTE_INIT_TIMELINE_ENABLE);
   }
 
   /**
@@ -376,6 +386,11 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
     public Builder withEnableBackupForRemoteFileSystemView(boolean enable) {
       fileSystemViewStorageConfig.setValue(REMOTE_BACKUP_VIEW_ENABLE, Boolean.toString(enable));
+      return this;
+    }
+
+    public Builder withRemoteInitTimeline(boolean enableRemoteInit) {
+      fileSystemViewStorageConfig.setValue(REMOTE_INIT_TIMELINE_ENABLE, Boolean.toString(enableRemoteInit));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -165,7 +165,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
   public RemoteHoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline, TimelineServiceClient timelineServiceClient, FileSystemViewStorageConfig viewConf) {
     this.basePath = metaClient.getBasePath().toString();
     this.metaClient = metaClient;
-    this.timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+    this.timeline = timeline;
     this.timelineServiceClient = timelineServiceClient;
     if (viewConf.isRemoteInitEnabled()) {
       initialiseTimelineInRemoteView(timeline);

--- a/hudi-common/src/main/java/org/apache/hudi/timeline/TimelineServiceClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/timeline/TimelineServiceClient.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 
 import org.apache.http.client.utils.URIBuilder;
 
+import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,17 +61,19 @@ public class TimelineServiceClient extends TimelineServiceClientBase {
 
     String url = builder.toString();
     LOG.debug("Sending request : ({})", url);
-    org.apache.http.client.fluent.Response response = get(request.getMethod(), url, timeoutMs);
+    org.apache.http.client.fluent.Response response = get(request.getMethod(), url, timeoutMs, request.getBody());
     return new Response(response.returnContent().asStream());
   }
 
-  private org.apache.http.client.fluent.Response get(RequestMethod method, String url, int timeoutMs) throws IOException {
+  private org.apache.http.client.fluent.Response get(RequestMethod method, String url, int timeoutMs, String body) throws IOException {
     switch (method) {
       case GET:
         return org.apache.http.client.fluent.Request.Get(url).connectTimeout(timeoutMs).socketTimeout(timeoutMs).execute();
       case POST:
       default:
-        return org.apache.http.client.fluent.Request.Post(url).connectTimeout(timeoutMs).socketTimeout(timeoutMs).execute();
+        return org.apache.http.client.fluent.Request.Post(url).connectTimeout(timeoutMs).socketTimeout(timeoutMs)
+            .bodyString(body, ContentType.APPLICATION_JSON)
+            .execute();
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/timeline/TimelineServiceClientBase.java
+++ b/hudi-common/src/main/java/org/apache/hudi/timeline/TimelineServiceClientBase.java
@@ -21,6 +21,7 @@ package org.apache.hudi.timeline;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.RetryHelper;
+import org.apache.hudi.common.util.StringUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,12 +61,14 @@ public abstract class TimelineServiceClientBase implements Serializable {
   public static class Request {
     private final TimelineServiceClient.RequestMethod method;
     private final String path;
+    private final String body;
     private final Option<Map<String, String>> queryParameters;
 
-    private Request(TimelineServiceClient.RequestMethod method, String path, Option<Map<String, String>> queryParameters) {
+    private Request(TimelineServiceClient.RequestMethod method, String path, Option<Map<String, String>> queryParameters, String body) {
       this.method = method;
       this.path = path;
       this.queryParameters = queryParameters;
+      this.body = body;
     }
 
     public RequestMethod getMethod() {
@@ -80,6 +83,10 @@ public abstract class TimelineServiceClientBase implements Serializable {
       return queryParameters;
     }
 
+    public String getBody() {
+      return body == null ? StringUtils.EMPTY_STRING : body;
+    }
+
     public static TimelineServiceClient.Request.Builder newBuilder(TimelineServiceClient.RequestMethod method, String path) {
       return new TimelineServiceClient.Request.Builder(method, path);
     }
@@ -88,6 +95,7 @@ public abstract class TimelineServiceClientBase implements Serializable {
       private final TimelineServiceClient.RequestMethod method;
       private final String path;
       private Option<Map<String, String>> queryParameters;
+      private String body;
 
       public Builder(TimelineServiceClient.RequestMethod method, String path) {
         this.method = method;
@@ -107,8 +115,13 @@ public abstract class TimelineServiceClientBase implements Serializable {
         return this;
       }
 
+      public Request.Builder setBody(String jsonString) {
+        this.body = jsonString;
+        return this;
+      }
+
       public TimelineServiceClient.Request build() {
-        return new TimelineServiceClient.Request(method, path, queryParameters);
+        return new TimelineServiceClient.Request(method, path, queryParameters, body);
       }
     }
   }

--- a/hudi-hadoop-common/pom.xml
+++ b/hudi-hadoop-common/pom.xml
@@ -123,6 +123,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-io</artifactId>
       <classifier>tests</classifier>

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineServiceClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineServiceClient.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.timeline.TimelineServiceClient;
+import org.apache.hudi.timeline.TimelineServiceClientBase;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.ParseException;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests {@link public class TestTimelineServiceClient}.
+ */
+public class TestTimelineServiceClient {
+
+  private static final String TEST_ENDPOINT = "/test-endpoint";
+  private static final int DEFAULT_READ_TIMEOUT_SECS = 5;
+  private static final boolean DEFAULT_HTTP_RESPONSE = true;
+
+  private Server server;
+  private int serverPort;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    // Create a Jetty server
+    server = new Server(0);
+    ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+    context.setContextPath("/");
+    server.setHandler(context);
+    context.addServlet(new ServletHolder(new TestServlet()), TEST_ENDPOINT);
+
+    // Start the server
+    server.start();
+    serverPort = server.getURI().getPort();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    // Stop the server after each test
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testSuccessfulGetRequest() throws IOException {
+    FileSystemViewStorageConfig.Builder builder = FileSystemViewStorageConfig.newBuilder().withRemoteServerHost("localhost")
+        .withRemoteServerPort(serverPort)
+        .withRemoteTimelineClientTimeoutSecs(DEFAULT_READ_TIMEOUT_SECS);
+    MockTimelineServiceNetworkClient client = new MockTimelineServiceNetworkClient(builder.build());
+    TimelineServiceClientBase.Request request =
+        TimelineServiceClientBase.Request.newBuilder(TimelineServiceClientBase.RequestMethod.GET, TEST_ENDPOINT).build();
+    TimelineServiceClientBase.Response response = client.makeRequest(request);
+    assertEquals(DEFAULT_HTTP_RESPONSE, response.getDecodedContent(new TypeReference<Boolean>() {}));
+  }
+
+  @Test
+  public void testSuccessfulPostRequest() throws IOException {
+    FileSystemViewStorageConfig.Builder builder = FileSystemViewStorageConfig.newBuilder().withRemoteServerHost("localhost")
+        .withRemoteServerPort(serverPort)
+        .withRemoteTimelineClientTimeoutSecs(DEFAULT_READ_TIMEOUT_SECS);
+    MockTimelineServiceNetworkClient client = new MockTimelineServiceNetworkClient(builder.build());
+    TimelineServiceClientBase.Request request = TimelineServiceClientBase.Request.newBuilder(TimelineServiceClientBase.RequestMethod.POST, TEST_ENDPOINT)
+        .addQueryParam("key1", "val1")
+        .addQueryParams(Collections.singletonMap("key2", "val2"))
+        .setBody(StringUtils.EMPTY_STRING)
+        .build();
+    TimelineServiceClientBase.Response response = client.makeRequest(request);
+    assertEquals(DEFAULT_HTTP_RESPONSE, response.getDecodedContent(new TypeReference<Boolean>() {}));
+  }
+
+  private static List<Arguments> testScenariosForFailures() {
+    return asList(
+        // Ensure that the retries can handle both IOExceptions and RuntimeExceptions.
+        Arguments.of(5, 2, InducedFailuresInfo.ExceptionType.NO_HTTP_RESPONSE_EXCEPTION, true),
+        Arguments.of(5, 2, InducedFailuresInfo.ExceptionType.PARSE_EXCEPTION, true),
+        Arguments.of(2, 5, InducedFailuresInfo.ExceptionType.NO_HTTP_RESPONSE_EXCEPTION, false),
+        Arguments.of(2, 5, InducedFailuresInfo.ExceptionType.PARSE_EXCEPTION, false)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testScenariosForFailures")
+  public void testRetriesForExceptions(int numberOfRetries,
+                                       int numberOfInducedFailures,
+                                       InducedFailuresInfo.ExceptionType exceptionType,
+                                       boolean shouldSucceed) throws IOException {
+    FileSystemViewStorageConfig.Builder builder = FileSystemViewStorageConfig.newBuilder().withRemoteServerHost("localhost")
+        .withRemoteServerPort(serverPort)
+        .withRemoteTimelineClientTimeoutSecs(DEFAULT_READ_TIMEOUT_SECS)
+        .withRemoteTimelineClientRetry(true)
+        .withRemoteTimelineClientMaxRetryIntervalMs(2000L)
+        .withRemoteTimelineClientMaxRetryNumbers(numberOfRetries);
+
+    InducedFailuresInfo inducedFailuresInfo = new InducedFailuresInfo(exceptionType, numberOfInducedFailures);
+    MockTimelineServiceNetworkClient client = new MockTimelineServiceNetworkClient(builder.build(), Option.of(inducedFailuresInfo));
+
+    TimelineServiceClientBase.Request request = TimelineServiceClientBase.Request.newBuilder(TimelineServiceClientBase.RequestMethod.GET, TEST_ENDPOINT).build();
+    if (shouldSucceed) {
+      TimelineServiceClientBase.Response response = client.makeRequest(request);
+      assertEquals(DEFAULT_HTTP_RESPONSE, response.getDecodedContent(new TypeReference<Boolean>() {}));
+    } else {
+      Class<? extends Exception> expectedException = exceptionType.getExceptionType();
+      assertThrows(expectedException, () -> client.makeRequest(request), "Should throw an Exception.'");
+    }
+  }
+
+  private static class MockTimelineServiceNetworkClient extends TimelineServiceClient {
+
+    private final Option<InducedFailuresInfo> inducedFailuresInfo;
+    private int currentInducedFailures;
+
+    public MockTimelineServiceNetworkClient(FileSystemViewStorageConfig config) {
+      this(config, Option.empty());
+    }
+
+    public MockTimelineServiceNetworkClient(FileSystemViewStorageConfig config, Option<InducedFailuresInfo> inducedFailuresInfo) {
+      super(config);
+      this.inducedFailuresInfo = inducedFailuresInfo;
+      currentInducedFailures = 0;
+    }
+
+    @Override
+    protected Response executeRequest(Request request) throws IOException {
+      if (inducedFailuresInfo.isPresent() && ++currentInducedFailures <= inducedFailuresInfo.get().maxInducedFailures) {
+        switch (inducedFailuresInfo.get().exceptionType) {
+          case PARSE_EXCEPTION:
+            throw new ParseException("Parse Exception");
+          case NO_HTTP_RESPONSE_EXCEPTION:
+          default:
+            throw new NoHttpResponseException("No HTTP Response Exception");
+        }
+      }
+      return super.executeRequest(request);
+    }
+  }
+
+  private static class InducedFailuresInfo {
+    private final ExceptionType exceptionType;
+    private final int maxInducedFailures;
+
+    public InducedFailuresInfo(ExceptionType exceptionType, int maxInducedFailures) {
+      this.exceptionType = exceptionType;
+      this.maxInducedFailures = maxInducedFailures;
+    }
+
+    public enum ExceptionType {
+      NO_HTTP_RESPONSE_EXCEPTION(NoHttpResponseException.class),
+      PARSE_EXCEPTION(ParseException.class);
+
+      private final Class<? extends Exception> exceptionType;
+
+      // Constructor to set the float value for each enum constant
+      ExceptionType(Class<? extends Exception> exceptionType) {
+        this.exceptionType = exceptionType;
+      }
+
+      // Method to get the float value for an enum constant
+      public Class<? extends Exception> getExceptionType() {
+        return this.exceptionType;
+      }
+    }
+  }
+
+  // A simple servlet to handle HTTP requests for test purposes.
+  private static class TestServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      sendResponse(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      sendResponse(req, resp);
+    }
+
+    private void sendResponse(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      // Set the content type
+      resp.setContentType("text/plain");
+      resp.setStatus(HttpServletResponse.SC_OK);
+      ObjectMapper objectMapper = new ObjectMapper();
+      resp.getWriter().println(objectMapper.writeValueAsString(DEFAULT_HTTP_RESPONSE));
+    }
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestFileSystemViewManager.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestFileSystemViewManager.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.view;
+
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.exception.HoodieRemoteException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+
+import static org.apache.hudi.common.table.view.FileSystemViewStorageType.REMOTE_FIRST;
+import static org.apache.hudi.common.table.view.FileSystemViewStorageType.REMOTE_ONLY;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestFileSystemViewManager extends HoodieCommonTestHarness {
+
+  @BeforeEach
+  public void setup() throws IOException {
+    metaClient = HoodieTestUtils.init(tempDir.toAbsolutePath().toString());
+    basePath = metaClient.getBasePath().toString();
+    refreshFsView();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    cleanMetaClient();
+  }
+
+  @Test
+  void testSecondaryViewSupplier() throws Exception {
+    HoodieCommonConfig config = HoodieCommonConfig.newBuilder().build();
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getStorageConf());
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+    try (HoodieTableMetadata metadata = new HoodieBackedTableMetadata(engineContext, metaClient.getStorage(), metadataConfig, basePath, true)) {
+      FileSystemViewManager.SecondaryViewCreator secondaryViewCreator = new FileSystemViewManager.SecondaryViewCreator(getViewConfig(FileSystemViewStorageType.MEMORY),
+          metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), config, true, unused -> metadata);
+      Assertions.assertTrue(secondaryViewCreator.apply(engineContext) instanceof HoodieTableFileSystemView);
+      FileSystemViewManager.SecondaryViewCreator spillableSupplier = new FileSystemViewManager.SecondaryViewCreator(getViewConfig(FileSystemViewStorageType.SPILLABLE_DISK),
+          metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), config, true, unused -> metadata);
+      Assertions.assertTrue(spillableSupplier.apply(engineContext) instanceof SpillableMapBasedFileSystemView);
+      FileSystemViewManager.SecondaryViewCreator embeddedSupplier = new FileSystemViewManager.SecondaryViewCreator(getViewConfig(FileSystemViewStorageType.EMBEDDED_KV_STORE),
+          metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), config, true, unused -> metadata);
+      Assertions.assertTrue(embeddedSupplier.apply(engineContext) instanceof RocksDbBasedFileSystemView);
+      assertThrows(IllegalArgumentException.class, () -> new FileSystemViewManager.SecondaryViewCreator(getViewConfig(REMOTE_FIRST),
+          metaClient, TimelineUtils.getVisibleTimelineForFsView(metaClient), config, true, unused -> metadata).apply(engineContext));
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(FileSystemViewStorageType.class)
+  void testCreateViewManager(FileSystemViewStorageType storageType) throws Exception {
+    HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().build();
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getStorageConf());
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+    FileSystemViewStorageConfig fileSystemViewStorageConfig = FileSystemViewStorageConfig.newBuilder()
+        .withStorageType(storageType)
+        .withRemoteInitTimeline(true)
+        .build();
+    FileSystemViewManager viewManager = FileSystemViewManager.createViewManager(engineContext, metadataConfig, fileSystemViewStorageConfig, commonConfig);
+    FileSystemViewManager viewManagerWithMetadata = FileSystemViewManager.createViewManagerWithTableMetadata(engineContext, metadataConfig, fileSystemViewStorageConfig, commonConfig);
+    if (storageType == REMOTE_ONLY || storageType == REMOTE_FIRST) {
+      assertThrows(HoodieRemoteException.class, () -> viewManager.getFileSystemView(metaClient));
+      assertThrows(HoodieRemoteException.class, () -> viewManagerWithMetadata.getFileSystemView(metaClient));
+      assertThrows(HoodieRemoteException.class, () -> viewManager.getFileSystemView(metaClient, metaClient.getActiveTimeline()));
+      assertThrows(HoodieRemoteException.class, () -> viewManagerWithMetadata.getFileSystemView(metaClient, metaClient.getActiveTimeline()));
+    } else {
+      viewManager.getFileSystemView(metaClient);
+      viewManagerWithMetadata.getFileSystemView(metaClient);
+      viewManager.getFileSystemView(metaClient, metaClient.getActiveTimeline());
+      viewManagerWithMetadata.getFileSystemView(metaClient, metaClient.getActiveTimeline());
+    }
+    viewManager.close();
+    viewManagerWithMetadata.close();
+  }
+
+  private FileSystemViewStorageConfig getViewConfig(FileSystemViewStorageType type) {
+    return FileSystemViewStorageConfig.newBuilder()
+        .withSecondaryStorageType(type)
+        .build();
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -1907,7 +1907,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     assertTrue(fileIdsInCompaction.contains(fileId));
   }
 
-  private void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
+  protected void saveAsComplete(HoodieActiveTimeline timeline, HoodieInstant inflight, HoodieCommitMetadata metadata) {
     if (inflight.getAction().equals(HoodieTimeline.COMPACTION_ACTION)) {
       timeline.transitionCompactionInflightToComplete(true, inflight, metadata);
     } else {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestRemoteHoodieTableFileSystemView.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.view;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.exception.HoodieRemoteException;
+import org.apache.hudi.timeline.TimelineServiceClient;
+import org.apache.hudi.timeline.TimelineServiceClientBase;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView.GET_TIMELINE_HASH_URL;
+import static org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView.INIT_TIMELINE_URL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSystemView {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
+
+  @Mock
+  TimelineServiceClient timelineServiceClient;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void initialiseTimelineInRemoteView(boolean enableRemoteInitTimeline) throws IOException {
+    // Write data to a single partition.
+    String partitionPath = "partition1";
+    Paths.get(basePath, partitionPath).toFile().mkdirs();
+    String fileId = UUID.randomUUID().toString();
+    String instantTime1 = "1";
+    String fileName1 = FSUtils.makeBaseFileName(instantTime1,"1-0-1", fileId, HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().getFileExtension());
+    Paths.get(basePath, partitionPath, fileName1).toFile().createNewFile();
+    HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
+    HoodieInstant instant1 = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, instantTime1, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    saveAsComplete(commitTimeline, instant1, new HoodieCommitMetadata());
+    metaClient.reloadActiveTimeline();
+
+    FileSystemViewStorageConfig config = FileSystemViewStorageConfig.newBuilder()
+        .withRemoteInitTimeline(enableRemoteInitTimeline)
+        .build();
+    when(timelineServiceClient.makeRequest(any())).thenReturn(new TimelineServiceClientBase.Response(
+        new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsString("timeline-hash").getBytes(StandardCharsets.UTF_8))));
+    when(timelineServiceClient.makeRequest(any())).thenReturn(new TimelineServiceClientBase.Response(
+        new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsString("true").getBytes(StandardCharsets.UTF_8))));
+    RemoteHoodieTableFileSystemView view = new RemoteHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), timelineServiceClient, config);
+    String expectedBody = OBJECT_MAPPER.writeValueAsString(TimelineDTO.fromTimeline(metaClient.getActiveTimeline()));
+    if (enableRemoteInitTimeline) {
+      verify(timelineServiceClient, times(1)).makeRequest(argThat(
+          request -> request.getMethod().equals(TimelineServiceClientBase.RequestMethod.GET) && request.getPath().equals(GET_TIMELINE_HASH_URL)));
+      verify(timelineServiceClient, times(1)).makeRequest(argThat(request -> request.getMethod().equals(TimelineServiceClientBase.RequestMethod.POST)
+          && request.getPath().equals(INIT_TIMELINE_URL)
+          && request.getBody().equals(expectedBody))
+      );
+    }
+
+    when(timelineServiceClient.makeRequest(any())).thenThrow(new IOException("Failed to connect to server"));
+    assertThrows(HoodieRemoteException.class, () -> view.initialiseTimelineInRemoteView(metaClient.getActiveTimeline()));
+  }
+
+  @Test
+  void remoteLoadPartitions() throws Exception {
+    FileSystemViewStorageConfig config = FileSystemViewStorageConfig.newBuilder().build();
+    RemoteHoodieTableFileSystemView view = new RemoteHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), timelineServiceClient, config);
+
+    when(timelineServiceClient.makeRequest(any())).thenReturn(new TimelineServiceClientBase.Response(
+        new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsString("true").getBytes(StandardCharsets.UTF_8))));
+    List<String> partitionPath = Collections.singletonList("partition-path");
+    view.loadPartitions(partitionPath);
+
+    ArgumentCaptor<TimelineServiceClientBase.Request> argCaptor = ArgumentCaptor.forClass(TimelineServiceClientBase.Request.class);
+    verify(timelineServiceClient, times(1)).makeRequest(argCaptor.capture());
+    TimelineServiceClientBase.Request request = argCaptor.getValue();
+    assertFalse(request.getBody().isEmpty());
+    assertEquals(OBJECT_MAPPER.writeValueAsString(partitionPath), request.getBody());
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestRemoteHoodieTableFileSystemView.java
@@ -85,11 +85,17 @@ class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSystemView 
     FileSystemViewStorageConfig config = FileSystemViewStorageConfig.newBuilder()
         .withRemoteInitTimeline(enableRemoteInitTimeline)
         .build();
-    when(timelineServiceClient.makeRequest(any())).thenReturn(new TimelineServiceClientBase.Response(
-        new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsString("timeline-hash").getBytes(StandardCharsets.UTF_8))));
-    when(timelineServiceClient.makeRequest(any())).thenReturn(new TimelineServiceClientBase.Response(
-        new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsString("true").getBytes(StandardCharsets.UTF_8))));
-    RemoteHoodieTableFileSystemView view = new RemoteHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), timelineServiceClient, config);
+    when(timelineServiceClient.makeRequest(any()))
+        .thenReturn(new TimelineServiceClientBase.Response(
+            new ByteArrayInputStream(
+                OBJECT_MAPPER.writeValueAsString("timeline-hash")
+                    .getBytes(StandardCharsets.UTF_8))))
+        .thenReturn(new TimelineServiceClientBase.Response(
+            new ByteArrayInputStream(
+                OBJECT_MAPPER.writeValueAsString("true")
+                    .getBytes(StandardCharsets.UTF_8))));
+    RemoteHoodieTableFileSystemView view = new RemoteHoodieTableFileSystemView(
+        metaClient, metaClient.getActiveTimeline(), timelineServiceClient, config);
     String expectedBody = OBJECT_MAPPER.writeValueAsString(TimelineDTO.fromTimeline(metaClient.getActiveTimeline()));
     if (enableRemoteInitTimeline) {
       verify(timelineServiceClient, times(1)).makeRequest(argThat(

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/TimelineHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/TimelineHandler.java
@@ -18,11 +18,17 @@
 
 package org.apache.hudi.timeline.service.handlers;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.dto.InstantDTO;
 import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.timeline.service.TimelineService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +38,7 @@ import java.util.List;
  * REST Handler servicing timeline requests.
  */
 public class TimelineHandler extends Handler {
+  private static final Logger LOG = LoggerFactory.getLogger(TimelineHandler.class);
 
   public TimelineHandler(StorageConfiguration<?> conf, TimelineService.Config timelineServiceConfig,
                          FileSystemViewManager viewManager) {
@@ -45,5 +52,34 @@ public class TimelineHandler extends Handler {
 
   public TimelineDTO getTimeline(String basePath) {
     return TimelineDTO.fromTimeline(viewManager.getFileSystemView(basePath).getTimeline());
+  }
+
+  public String getTimelineHash(String basePath) {
+    return viewManager.getFileSystemView(basePath).getTimeline().getTimelineHash();
+  }
+
+  public boolean initializeTimeline(String basePath, TimelineDTO timelineDTO) {
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setConf(conf)
+        .setBasePath(basePath)
+        .build();
+    HoodieTimeline hoodieTimeline = TimelineDTO.toTimeline(timelineDTO, metaClient);
+    // Check if we already have the right view.
+    if (viewManager.doesFileSystemViewExists(basePath)
+        && hoodieTimeline.getTimelineHash().equals(
+        viewManager.getFileSystemView(basePath).getTimeline().getTimelineHash())) {
+      LOG.debug("Timeline hashes match returning view for basePath {}", basePath);
+      return true;
+    }
+    // Lock on the viewManager.
+    synchronized (viewManager) {
+      SyncableFileSystemView viewInServer = viewManager.getFileSystemView(metaClient, hoodieTimeline);
+      if (!hoodieTimeline.getTimelineHash().equals(viewInServer.getTimeline().getTimelineHash())) {
+        LOG.info("Clearing and Re-creating view as timeline hashes don't match for basePath {}", basePath);
+        viewManager.clearFileSystemView(basePath);
+        viewManager.getFileSystemView(metaClient, hoodieTimeline);
+      }
+      return true;
+    }
   }
 }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/handlers/TestTimelineHandler.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/handlers/TestTimelineHandler.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.timeline.service.handlers;
+
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
+import org.apache.hudi.common.table.view.SyncableFileSystemView;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.timeline.service.TimelineService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestTimelineHandler extends HoodieCommonTestHarness {
+
+  private TimelineHandler timelineHandler;
+
+  private FileSystemViewManager fileSystemViewManager;
+
+  private final FileSystemViewManager mockFileSystemViewManager = Mockito.mock(FileSystemViewManager.class);
+
+  @BeforeEach
+  void setUp() throws IOException {
+    metaClient = HoodieTestUtils.init(tempDir.toAbsolutePath().toString());
+    basePath = metaClient.getBasePath().toString();
+    HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().build();
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+    FileSystemViewStorageConfig fileSystemViewStorageConfig = FileSystemViewStorageConfig.newBuilder()
+        .withStorageType(FileSystemViewStorageType.MEMORY)
+        .build();
+    fileSystemViewManager = FileSystemViewManager.createViewManager(new HoodieLocalEngineContext(metaClient.getStorageConf()), metadataConfig, fileSystemViewStorageConfig, commonConfig);
+    timelineHandler = new TimelineHandler(metaClient.getStorageConf(), new TimelineService.Config(), fileSystemViewManager);
+  }
+
+  @AfterEach
+  void teardown() {
+    fileSystemViewManager.close();
+  }
+
+  @Test
+  void getTimelineHash() {
+    assertEquals(metaClient.getActiveTimeline().getTimelineHash(), timelineHandler.getTimelineHash(basePath));
+  }
+
+  @Test
+  void initializeTimeline() throws IOException {
+    TimelineHandler timelineHandler = new TimelineHandler(metaClient.getStorageConf(), new TimelineService.Config(), mockFileSystemViewManager);
+    // Init without any view.
+    SyncableFileSystemView firstView = fileSystemViewManager.getFileSystemView(basePath);
+    when(mockFileSystemViewManager.doesFileSystemViewExists(basePath)).thenReturn(false);
+    when(mockFileSystemViewManager.getFileSystemView(basePath)).thenReturn(firstView);
+    when(mockFileSystemViewManager.getFileSystemView(eq(metaClient), argThat(timeline -> timeline.getInstants().isEmpty()))).thenReturn(firstView);
+    timelineHandler.initializeTimeline(basePath, TimelineDTO.fromTimeline(metaClient.getActiveTimeline()));
+    verify(mockFileSystemViewManager, times(0)).clearFileSystemView(basePath);
+    // Init with one instant in client.
+    writeInstantToTimeline(basePath);
+    when(mockFileSystemViewManager.doesFileSystemViewExists(basePath)).thenReturn(true);
+    when(mockFileSystemViewManager.getFileSystemView(eq(metaClient), argThat(timeline -> timeline.getInstants().size() == 1))).thenReturn(firstView);
+    timelineHandler.initializeTimeline(basePath, TimelineDTO.fromTimeline(metaClient.reloadActiveTimeline()));
+    verify(mockFileSystemViewManager, times(1)).clearFileSystemView(basePath);
+    verify(mockFileSystemViewManager, times(1)).getFileSystemView(basePath);
+    verify(mockFileSystemViewManager, times(2)).getFileSystemView(any(), argThat(timeline -> timeline.getInstants().size() == 1));
+    // Init again for no=op.
+    SyncableFileSystemView secondView = fileSystemViewManager.getFileSystemView(basePath);
+    Mockito.clearInvocations(mockFileSystemViewManager);
+    when(mockFileSystemViewManager.getFileSystemView(basePath)).thenReturn(secondView);
+    timelineHandler.initializeTimeline(basePath, TimelineDTO.fromTimeline(metaClient.reloadActiveTimeline()));
+    verify(mockFileSystemViewManager, times(1)).clearFileSystemView(basePath);
+  }
+
+  @Disabled
+  void initializeTimelineConcurrency() throws IOException {
+    int concurrentRequests = 64;
+    ExecutorService executorService = Executors.newFixedThreadPool(4);
+    List<CompletableFuture<Boolean>> futureList = new ArrayList<>();
+    for (int i = 0; i < concurrentRequests; i++) {
+      futureList.add(CompletableFuture.supplyAsync(() -> timelineHandler.initializeTimeline(basePath, TimelineDTO.fromTimeline(metaClient.getActiveTimeline())), executorService));
+    }
+    CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0])).join();
+    // Init with one instant in client.
+    writeInstantToTimeline(basePath);
+    futureList.clear();
+    for (int i = 0; i < concurrentRequests; i++) {
+      futureList.add(CompletableFuture.supplyAsync(() -> timelineHandler.initializeTimeline(basePath, TimelineDTO.fromTimeline(metaClient.reloadActiveTimeline())), executorService));
+    }
+    CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0])).join();
+  }
+
+  @Test
+  void testTimelineSerDe() throws IOException {
+    writeInstantToTimeline(basePath);
+    TimelineDTO dto = TimelineDTO.fromTimeline(metaClient.reloadActiveTimeline());
+    // The instants from metaClient and timelineDTO should be same.
+    List<HoodieInstant> instantsFromMetaClient = metaClient.getActiveTimeline().getInstants();
+    List<HoodieInstant> instantsFromDTO = TimelineDTO.toTimeline(dto, metaClient).getInstants();
+    assertEquals(instantsFromMetaClient, instantsFromDTO);
+    assertEquals(instantsFromMetaClient.get(0).getCompletionTime(), instantsFromDTO.get(0).getCompletionTime());
+  }
+
+  private void writeInstantToTimeline(String basePath) throws IOException {
+    // Write data to a single partition.
+    String partitionPath = "partition1";
+    Paths.get(basePath, partitionPath).toFile().mkdirs();
+    String fileId = UUID.randomUUID().toString();
+    String newInstantTime = metaClient.createNewInstantTime(true);
+    String fileName1 = FSUtils.makeBaseFileName(newInstantTime,"1-0-1", fileId, HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().getFileExtension());
+    Paths.get(basePath, partitionPath, fileName1).toFile().createNewFile();
+    HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
+    HoodieInstant inflight = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, newInstantTime, InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    HoodieInstant requested = new HoodieInstant(HoodieInstant.State.REQUESTED, inflight.getAction(), inflight.requestedTime(), InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    commitTimeline.createNewInstant(requested);
+    commitTimeline.transitionRequestedToInflight(requested, Option.empty());
+    commitTimeline.saveAsComplete(inflight, Option.empty());
+  }
+}


### PR DESCRIPTION
### Change Logs
https://github.com/apache/hudi/pull/13766

Each spark executor holds onto it's RemoteHoodieTableFileSystemView object but the view loaded at the client side can mismatch between the client side and one which has been loaded on the server side. Adding a new method in RemoteHoodieTableFileSystemView known as initialiseTimelineInRemoteView which calls TimelineService to re-init the timeline on the server side and re-creates the view.

### Impact

Fixes race condition and unblocks ability to run multiple timeline servers.

### Risk level (write none, low medium or high below)

Medium, can be rolled back easily using a feature flag.

### Documentation Update

The function call initialiseTimelineInRemoteView will be behind a feature flag.
hoodie.filesystem.remote.init.timeline.enable

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
