### PR TITLE
[HUDI-9759] Expose methods as protected in MultipleSparkJobExecutionStrategy

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -229,9 +229,9 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
   /**
    * Submit job to execute clustering for the group using Avro/HoodieRecord representation.
    */
-  private CompletableFuture<HoodieData<WriteStatus>> runClusteringForGroupAsync(HoodieClusteringGroup clusteringGroup, Map<String, String> strategyParams,
-                                                                                boolean preserveHoodieMetadata, String instantTime,
-                                                                                ExecutorService clusteringExecutorService) {
+  protected CompletableFuture<HoodieData<WriteStatus>> runClusteringForGroupAsync(HoodieClusteringGroup clusteringGroup, Map<String, String> strategyParams,
+                                                                                  boolean preserveHoodieMetadata, String instantTime,
+                                                                                  ExecutorService clusteringExecutorService) {
     return CompletableFuture.supplyAsync(() -> {
       JavaSparkContext jsc = HoodieSparkEngineContext.getSparkContext(getEngineContext());
       HoodieData<HoodieRecord<T>> inputRecords = readRecordsForGroup(jsc, clusteringGroup, instantTime);
@@ -250,11 +250,11 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
   /**
    * Submit job to execute clustering for the group, directly using the spark native Row representation.
    */
-  private CompletableFuture<HoodieData<WriteStatus>> runClusteringForGroupAsyncAsRow(HoodieClusteringGroup clusteringGroup,
-                                                                                     Map<String, String> strategyParams,
-                                                                                     boolean shouldPreserveHoodieMetadata,
-                                                                                     String instantTime,
-                                                                                     ExecutorService clusteringExecutorService) {
+  protected CompletableFuture<HoodieData<WriteStatus>> runClusteringForGroupAsyncAsRow(HoodieClusteringGroup clusteringGroup,
+                                                                                       Map<String, String> strategyParams,
+                                                                                       boolean shouldPreserveHoodieMetadata,
+                                                                                       String instantTime,
+                                                                                       ExecutorService clusteringExecutorService) {
     return CompletableFuture.supplyAsync(() -> {
       JavaSparkContext jsc = HoodieSparkEngineContext.getSparkContext(getEngineContext());      // incase of MIT, config.getSchema may not contain the full table schema
       Schema tableSchemaWithMetaFields = null;


### PR DESCRIPTION
### Change Logs

- Make methods protected so we can plug in our strategy at a clustering group level

### Impact

- Allows more customization for clustering

### Risk level (write none, low medium or high below)

None

### Documentation Update

No doc update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
