### PR TITLE
[minor][docs][HUDI-9761] Updating Spark quick-start doc for spark.kryo.registrator

### DIFF
--- a/website/versioned_docs/version-1.0.2/quick-start-guide.md
+++ b/website/versioned_docs/version-1.0.2/quick-start-guide.md
@@ -99,7 +99,7 @@ spark-sql --packages org.apache.hudi:hudi-spark$SPARK_VERSION-bundle_2.12:1.0.2 
 Users are recommended to set this config to reduce Kryo serialization overhead
 
 ```
---conf 'spark.kryo.registrator=org.apache.spark.HoodieKryoRegistrar'
+--conf 'spark.kryo.registrator=org.apache.spark.HoodieSparkKryoRegistrar'
 ```
 :::
 


### PR DESCRIPTION
### Change Logs

Updating Spark Quick Start doc (version 1.0.2) for spark.kryo.registrator

Before:
```sh
--conf 'spark.kryo.registrator=org.apache.spark.HoodieKryoRegistrar'
```

After:
```sh
--conf 'spark.kryo.registrator=org.apache.spark.HoodieSparkKryoRegistrar'
```

### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

Updating Spark quick start doc (version 1.0.2) for spark.kryo.registrator

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
