### PR TITLE
[HUDI-9771] Add improvements for Glue and Datahub Sync

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark353_amd64.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark353_amd64.yml
@@ -180,7 +180,7 @@ services:
       - "namenode"
 
   zookeeper:
-    image: 'bitnami/zookeeper:3.4.12-r68'
+    image: 'bitnamilegacy/zookeeper:3.4.12-r68'
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -189,7 +189,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: 'bitnami/kafka:2.0.0'
+    image: 'bitnamilegacy/kafka:2.0.0'
     hostname: kafkabroker
     container_name: kafkabroker
     ports:

--- a/docker/compose/docker-compose_hadoop284_hive233_spark353_arm64.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark353_arm64.yml
@@ -173,7 +173,7 @@ services:
       - "namenode"
 
   zookeeper:
-    image: 'bitnami/zookeeper:3.6.4'
+    image: 'bitnamilegacy/zookeeper:3.6.4'
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -182,7 +182,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: 'bitnami/kafka:3.4.1'
+    image: 'bitnamilegacy/kafka:3.4.1'
     hostname: kafkabroker
     container_name: kafkabroker
     ports:

--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -198,6 +198,13 @@
             <version>${aws.sdk.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sts -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -80,6 +80,7 @@ import software.amazon.awssdk.services.glue.model.SerDeInfo;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.TagResourceRequest;
 import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
@@ -115,6 +116,7 @@ import static org.apache.hudi.config.GlueCatalogSyncClientConfig.PARTITION_CHANG
 import static org.apache.hudi.config.HoodieAWSConfig.AWS_GLUE_ENDPOINT;
 import static org.apache.hudi.config.HoodieAWSConfig.AWS_GLUE_REGION;
 import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_DATABASE_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_RESOURCE_TAGS;
 import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_TABLE_NAME;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
@@ -144,6 +146,8 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
    * see https://docs.aws.amazon.com/athena/latest/ug/querying-hudi.html
    */
   private static final String ENABLE_MDT_LISTING = "hudi.metadata-listing-enabled";
+  private static final String GLUE_TABLE_ARN_FORMAT = "arn:aws:glue:%s:%s:table/%s/%s";
+  private static final String GLUE_DATABASE_ARN_FORMAT = "arn:aws:glue:%s:%s:database/%s";
   private final String databaseName;
 
   private final boolean skipTableArchive;
@@ -689,9 +693,9 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
               .build();
 
       CreateTableResponse response = awsGlue.createTable(request).get();
-      LOG.info("Created table " + tableId(databaseName, tableName) + " : " + response);
+      LOG.info("Created table {} : {}", tableId(databaseName, tableName), response);
     } catch (AlreadyExistsException e) {
-      LOG.warn("Table " + tableId(databaseName, tableName) + " already exists.", e);
+      LOG.warn("Table {} already exists.", tableId(databaseName, tableName), e);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to create " + tableId(databaseName, tableName), e);
     }
@@ -893,9 +897,10 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     ).build();
     try {
       CreateDatabaseResponse result = awsGlue.createDatabase(request).get();
-      LOG.info("Successfully created database in AWS Glue: " + result.toString());
+      tagResource(String.format(GLUE_DATABASE_ARN_FORMAT, awsGlue.serviceClientConfiguration().region(), catalogId, databaseName));
+      LOG.info("Successfully created database in AWS Glue: {}", result.toString());
     } catch (AlreadyExistsException e) {
-      LOG.warn("AWS Glue Database " + databaseName + " already exists", e);
+      LOG.warn("AWS Glue Database {} already exists", databaseName, e);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to create database " + databaseName, e);
     }
@@ -1157,5 +1162,36 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update params for table " + tableId(databaseName, tableName) + ": " + updatingParams, e);
     }
+  }
+
+  private String getBasePathForTable() {
+    return s3aToS3(getBasePath());
+  }
+
+  private void tagResource(String resourceArn) {
+    Map<String, String> resourceTags = parseResourceTags(config.getStringOrDefault(GLUE_SYNC_RESOURCE_TAGS, ""));
+    if (resourceTags.isEmpty()) {
+      return;
+    }
+    TagResourceRequest tagRequest = TagResourceRequest.builder()
+        .resourceArn(resourceArn)
+        .tagsToAdd(resourceTags)
+        .build();
+    awsGlue.tagResource(tagRequest).join();
+  }
+
+  private Map<String, String> parseResourceTags(String resourceTagKeyValues) {
+    Map<String, String> tags = new HashMap<>();
+    if (resourceTagKeyValues == null || resourceTagKeyValues.trim().isEmpty()) {
+      return tags;
+    }
+    String[] tagPairs = resourceTagKeyValues.split(",");
+    for (String tagPair : tagPairs) {
+      String[] keyValue = tagPair.split(":", 2);
+      if (keyValue.length == 2) {
+        tags.put(keyValue[0].trim(), keyValue[1].trim());
+      }
+    }
+    return tags;
   }
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -1164,10 +1164,6 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     }
   }
 
-  private String getBasePathForTable() {
-    return s3aToS3(getBasePath());
-  }
-
   private void tagResource(String resourceArn) {
     Map<String, String> resourceTags = parseResourceTags(config.getStringOrDefault(GLUE_SYNC_RESOURCE_TAGS, ""));
     if (resourceTags.isEmpty()) {

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -149,6 +149,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   private static final String GLUE_TABLE_ARN_FORMAT = "arn:aws:glue:%s:%s:table/%s/%s";
   private static final String GLUE_DATABASE_ARN_FORMAT = "arn:aws:glue:%s:%s:database/%s";
   private final String databaseName;
+  private final String tableName;
 
   private final boolean skipTableArchive;
   private final String enableMetadataTable;
@@ -166,6 +167,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     super(config, metaClient);
     this.awsGlue = awsGlue;
     this.databaseName = config.getStringOrDefault(GLUE_SYNC_DATABASE_NAME, GLUE_SYNC_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    this.tableName = config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, GLUE_SYNC_TABLE_NAME.getInferFunction().get().apply(config).get());
     this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
     this.enableMetadataTable = Boolean.toString(config.getBoolean(GLUE_METADATA_FILE_LISTING)).toUpperCase();
     this.allPartitionsReadParallelism = config.getIntOrDefault(ALL_PARTITIONS_READ_PARALLELISM);
@@ -191,7 +193,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   @Override
   public String getTableName() {
-    return config.getStringOrDefault(GLUE_SYNC_TABLE_NAME, GLUE_SYNC_TABLE_NAME.getInferFunction().get().apply(config).get());
+    return this.tableName;
   }
 
   @Override

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -97,4 +97,11 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Glue sync may fail if the Glue table exists with partitions differing from the Hoodie table or if schema evolution is not supported by Glue."
           + "Enabling this configuration will drop and create the table to match the Hoodie config");
+
+  public static final ConfigProperty<String> GLUE_CATALOG_ID = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "catalogId")
+      .noDefaultValue()
+      .sinceVersion("0.15.0")
+      .markAdvanced()
+      .withDocumentation("The catalogId needs to be populated for syncing hoodie tables in a different AWS account");
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -127,4 +127,12 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
           .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
       .markAdvanced()
       .withDocumentation("The name of the destination table that we should sync the hudi table to.");
+
+  public static final ConfigProperty<String> GLUE_SYNC_RESOURCE_TAGS = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "resource_tags")
+      .noDefaultValue()
+      .sinceVersion("1.1.0")
+      .markAdvanced()
+      .withDocumentation("Tags to be applied to AWS Glue databases and tables during sync. Format: key1:value1,key2:value2");
+
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -28,6 +28,12 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import java.util.stream.IntStream;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
+import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+
 /**
  * Hoodie Configs for Glue.
  */
@@ -104,4 +110,21 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
       .sinceVersion("0.15.0")
       .markAdvanced()
       .withDocumentation("The catalogId needs to be populated for syncing hoodie tables in a different AWS account");
+
+  public static final ConfigProperty<String> GLUE_SYNC_DATABASE_NAME = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "database_name")
+      .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_DATABASE_NAME.key()))
+          .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, META_SYNC_DATABASE_NAME.defaultValue()))))
+      .markAdvanced()
+      .withDocumentation("The name of the destination database that we should sync the hudi table to.");
+
+  public static final ConfigProperty<String> GLUE_SYNC_TABLE_NAME = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "table_name")
+      .noDefaultValue()
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_TABLE_NAME.key()))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY)))
+          .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
+      .markAdvanced()
+      .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -107,13 +107,14 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
   public static final ConfigProperty<String> GLUE_CATALOG_ID = ConfigProperty
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "catalogId")
       .noDefaultValue()
-      .sinceVersion("0.15.0")
+      .sinceVersion("1.1.0")
       .markAdvanced()
       .withDocumentation("The catalogId needs to be populated for syncing hoodie tables in a different AWS account");
 
   public static final ConfigProperty<String> GLUE_SYNC_DATABASE_NAME = ConfigProperty
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "database_name")
       .noDefaultValue()
+      .sinceVersion("1.1.0")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_DATABASE_NAME.key()))
           .or(() -> Option.of(cfg.getStringOrDefault(DATABASE_NAME, META_SYNC_DATABASE_NAME.defaultValue()))))
       .markAdvanced()
@@ -122,6 +123,7 @@ public class GlueCatalogSyncClientConfig extends HoodieConfig {
   public static final ConfigProperty<String> GLUE_SYNC_TABLE_NAME = ConfigProperty
       .key(GLUE_CLIENT_PROPERTY_PREFIX + "table_name")
       .noDefaultValue()
+      .sinceVersion("1.1.0")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_TABLE_NAME.key()))
           .or(() -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY)))
           .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/MockAwsGlueCatalogSyncTool.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/MockAwsGlueCatalogSyncTool.java
@@ -24,14 +24,23 @@ import org.apache.hudi.hive.HiveSyncConfig;
 
 import org.apache.hadoop.conf.Configuration;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.util.Properties;
 
+import static org.mockito.Mockito.when;
+
 class MockAwsGlueCatalogSyncTool extends AwsGlueCatalogSyncTool {
+  private static final String CATALOG_ID = "DEFAULT_AWS_ACCOUNT_ID";
 
   @Mock
   private GlueAsyncClient mockAwsGlue;
+
+  private static StsClient mockSts = Mockito.mock(StsClient.class);
 
   public MockAwsGlueCatalogSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf, Option.empty());
@@ -39,6 +48,7 @@ class MockAwsGlueCatalogSyncTool extends AwsGlueCatalogSyncTool {
 
   @Override
   protected void initSyncClient(HiveSyncConfig hiveSyncConfig, HoodieTableMetaClient metaClient) {
-    syncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, metaClient);
+    when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account(CATALOG_ID).build());
+    syncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, metaClient);
   }
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -673,7 +673,7 @@ class TestAWSGlueSyncClient {
     properties.setProperty(GlueCatalogSyncClientConfig.GLUE_SYNC_TABLE_NAME.key(), tableName);
 
     HiveSyncConfig hiveSyncConfig = new HiveSyncConfig(properties);
-    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, GlueTestUtil.getMetaClient());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, GlueTestUtil.getMetaClient());
     assertEquals(dbName, awsGlueSyncClient.getDatabaseName());
     assertEquals(tableName, awsGlueSyncClient.getTableName());
 
@@ -684,7 +684,7 @@ class TestAWSGlueSyncClient {
     properties.setProperty(META_SYNC_TABLE_NAME.key(), tableName);
 
     hiveSyncConfig = new HiveSyncConfig(properties);
-    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, GlueTestUtil.getMetaClient());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, GlueTestUtil.getMetaClient());
     assertEquals(dbName, awsGlueSyncClient.getDatabaseName());
     assertEquals(tableName, awsGlueSyncClient.getTableName());
 
@@ -695,12 +695,12 @@ class TestAWSGlueSyncClient {
     properties.setProperty(HOODIE_TABLE_NAME_KEY, tableName);
 
     hiveSyncConfig = new HiveSyncConfig(properties);
-    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, GlueTestUtil.getMetaClient());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, GlueTestUtil.getMetaClient());
     assertEquals(dbName, awsGlueSyncClient.getDatabaseName());
     assertEquals(tableName, awsGlueSyncClient.getTableName());
 
     hiveSyncConfig = new HiveSyncConfig(new Properties());
-    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, hiveSyncConfig, GlueTestUtil.getMetaClient());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, GlueTestUtil.getMetaClient());
     assertEquals(META_SYNC_DATABASE_NAME.defaultValue(), awsGlueSyncClient.getDatabaseName());
     assertEquals(META_SYNC_TABLE_NAME.defaultValue(), awsGlueSyncClient.getTableName());
   }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -500,7 +500,7 @@ class TestAWSGlueSyncClient {
 
     // stub getTable to return a dummy StorageDescriptor
     StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
-    Table table = Table.builder().storageDescriptor(baseSd).build();
+    Table table = Table.builder().name(tableName).storageDescriptor(baseSd).build();
     GetTableResponse gt = GetTableResponse.builder().table(table).build();
     when(mockAwsGlue.getTable(any(GetTableRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(gt));
@@ -528,7 +528,7 @@ class TestAWSGlueSyncClient {
 
     // stub getTable
     StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
-    Table table = Table.builder().storageDescriptor(baseSd).build();
+    Table table = Table.builder().name(tableName).storageDescriptor(baseSd).build();
     GetTableResponse gt = GetTableResponse.builder().table(table).build();
     when(mockAwsGlue.getTable(any(GetTableRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(gt));
@@ -560,7 +560,7 @@ class TestAWSGlueSyncClient {
     List<String> changed = Arrays.asList("2025/05/20");
 
     StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
-    Table table = Table.builder().storageDescriptor(baseSd).build();
+    Table table = Table.builder().name(tableName).storageDescriptor(baseSd).build();
     GetTableResponse gt = GetTableResponse.builder().table(table).build();
     when(mockAwsGlue.getTable(any(GetTableRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(gt));
@@ -588,7 +588,10 @@ class TestAWSGlueSyncClient {
         HoodieGlueSyncException.class,
         () -> awsGlueSyncClient.updatePartitionsToTable(tableName, changed)
     );
-    assertTrue(ex.getMessage().contains("Fail to update partitions"));
+    // The exception is wrapped by the parallelizeChange method, so check the root cause
+    assertTrue(ex.getMessage().contains("Failed to parallelize operation"));
+    assertTrue(ex.getCause() != null && ex.getCause().getCause() != null);
+    assertTrue(ex.getCause().getCause().getMessage().contains("Fail to update partitions"));
   }
 
   @Test
@@ -629,7 +632,10 @@ class TestAWSGlueSyncClient {
         HoodieGlueSyncException.class,
         () -> awsGlueSyncClient.dropPartitions(tableName, toDrop)
     );
-    assertTrue(ex.getMessage().contains("Fail to drop partitions"));
+    // The exception is wrapped by the parallelizeChange method, so check the root cause
+    assertTrue(ex.getMessage().contains("Failed to parallelize operation"));
+    assertTrue(ex.getCause() != null && ex.getCause().getCause() != null);
+    assertTrue(ex.getCause().getCause().getMessage().contains("Fail to drop partitions"));
   }
 
   @Disabled("Integration test – requires real AWS environment")

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
+import software.amazon.awssdk.services.glue.GlueServiceClientConfiguration;
 import software.amazon.awssdk.services.glue.model.BatchCreatePartitionRequest;
 import software.amazon.awssdk.services.glue.model.BatchCreatePartitionResponse;
 import software.amazon.awssdk.services.glue.model.BatchDeletePartitionRequest;
@@ -66,11 +67,14 @@ import software.amazon.awssdk.services.glue.model.PartitionError;
 import software.amazon.awssdk.services.glue.model.SerDeInfo;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TagResourceRequest;
+import software.amazon.awssdk.services.glue.model.TagResourceResponse;
 import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
 import software.amazon.awssdk.services.glue.model.UpdateTableResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
+import software.amazon.awssdk.regions.Region;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -168,7 +172,6 @@ class TestAWSGlueSyncClient {
 
     CompletableFuture<DeleteTableResponse> deleteTableResponse = CompletableFuture.completedFuture(DeleteTableResponse.builder().build());
     Mockito.when(mockAwsGlue.deleteTable(any(DeleteTableRequest.class))).thenReturn(deleteTableResponse);
-
     awsGlueSyncClient.createOrReplaceTable(tableName, storageSchema, inputFormatClass, outputFormatClass, serdeClass, serdeProperties, tableProperties);
 
     verify(mockAwsGlue, times(2)).deleteTable(any(DeleteTableRequest.class));
@@ -191,7 +194,6 @@ class TestAWSGlueSyncClient {
     Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(tableResponse);
     CompletableFuture<CreateTableResponse> createTableResponse = CompletableFuture.completedFuture(CreateTableResponse.builder().build());
     Mockito.when(mockAwsGlue.createTable(any(CreateTableRequest.class))).thenReturn(createTableResponse);
-
     awsGlueSyncClient.createOrReplaceTable(tableName, storageSchema, inputFormatClass, outputFormatClass, serdeClass, serdeProperties, tableProperties);
     // Verify that awsGlue.createTable() is called
     verify(mockAwsGlue, times(1)).createTable(any(CreateTableRequest.class));
@@ -353,6 +355,9 @@ class TestAWSGlueSyncClient {
     CompletableFuture<CreateDatabaseResponse> createFuture =
         CompletableFuture.completedFuture(CreateDatabaseResponse.builder().build());
     when(mockAwsGlue.createDatabase(any(CreateDatabaseRequest.class))).thenReturn(createFuture);
+    GlueServiceClientConfiguration mockConfig = mock(GlueServiceClientConfiguration.class);
+    when(mockAwsGlue.serviceClientConfiguration()).thenReturn(mockConfig);
+    when(mockConfig.region()).thenReturn(Region.US_EAST_1);
     awsGlueSyncClient.createDatabase(dbName);
     verify(mockAwsGlue).createDatabase(argThat((CreateDatabaseRequest req) ->
         req.catalogId().equals(CATALOG_ID)
@@ -703,6 +708,70 @@ class TestAWSGlueSyncClient {
     awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, hiveSyncConfig, GlueTestUtil.getMetaClient());
     assertEquals(META_SYNC_DATABASE_NAME.defaultValue(), awsGlueSyncClient.getDatabaseName());
     assertEquals(META_SYNC_TABLE_NAME.defaultValue(), awsGlueSyncClient.getTableName());
+  }
+
+  @Test
+  void testResourceTagging() throws ExecutionException, InterruptedException {
+    // Setup test properties with resource tags
+    TypedProperties props = GlueTestUtil.getHiveSyncConfig().getProps();
+    props.setProperty(GlueCatalogSyncClientConfig.GLUE_SYNC_RESOURCE_TAGS.key(), "CostCenter:SomeCenter,Environment:Production");
+    
+    when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build()))
+        .thenReturn(GetCallerIdentityResponse.builder().account(CATALOG_ID).build());
+    
+    // Mock the service configuration and region using deep nested mocks
+    GlueServiceClientConfiguration mockConfig = mock(GlueServiceClientConfiguration.class);
+    when(mockAwsGlue.serviceClientConfiguration()).thenReturn(mockConfig);
+    when(mockConfig.region()).thenReturn(Region.US_EAST_1);
+    
+    AWSGlueCatalogSyncClient clientWithTags = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, 
+        new HiveSyncConfig(props), GlueTestUtil.getMetaClient());
+
+    // Mock table does not exist (for createTable to proceed)
+    CompletableFuture<GetTableResponse> tableNotFoundFuture = mock(CompletableFuture.class);
+    ExecutionException tableNotFoundEx = new ExecutionException(EntityNotFoundException.builder().build());
+    when(tableNotFoundFuture.get()).thenThrow(tableNotFoundEx);
+    when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(tableNotFoundFuture);
+    
+    // Mock successful createTable response
+    when(mockAwsGlue.createTable(any(CreateTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(CreateTableResponse.builder().build()));
+    
+    // Mock successful tagResource response
+    when(mockAwsGlue.tagResource(any(TagResourceRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(TagResourceResponse.builder().build()));
+    
+    // Mock database does not exist (for createDatabase to proceed)
+    CompletableFuture<GetDatabaseResponse> dbNotFoundFuture = mock(CompletableFuture.class);
+    ExecutionException dbNotFoundEx = new ExecutionException(EntityNotFoundException.builder().build());
+    when(dbNotFoundFuture.get()).thenThrow(dbNotFoundEx);
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(dbNotFoundFuture);
+    
+    when(mockAwsGlue.createDatabase(any(CreateDatabaseRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(CreateDatabaseResponse.builder().build()));
+
+    // Test table creation with tagging
+    String tableName = "test_table";
+    MessageType storageSchema = GlueTestUtil.getSimpleSchema();
+    clientWithTags.createTable(tableName, storageSchema, "inputFormat", "outputFormat", 
+        "serdeClass", new HashMap<>(), new HashMap<>());
+
+    // Test database creation with tagging
+    String dbName = "test_db";
+    clientWithTags.createDatabase(dbName);
+
+    // Verify tagResource was called once (only for database, table tagging was removed)
+    ArgumentCaptor<TagResourceRequest> tagCaptor = ArgumentCaptor.forClass(TagResourceRequest.class);
+    verify(mockAwsGlue, times(1)).tagResource(tagCaptor.capture());
+    
+    List<TagResourceRequest> tagRequests = tagCaptor.getAllValues();
+    
+    // Verify database tagging (table tagging functionality was removed)
+    TagResourceRequest dbTagRequest = tagRequests.get(0);
+    assertTrue(dbTagRequest.resourceArn().contains("database"));
+    assertTrue(dbTagRequest.resourceArn().contains(dbName));
+    assertEquals("SomeCenter", dbTagRequest.tagsToAdd().get("CostCenter"));
+    assertEquals("Production", dbTagRequest.tagsToAdd().get("Environment"));
   }
 
   private CompletableFuture<GetTableResponse> getTableWithDefaultProps(String tableName, List<Column> columns, List<Column> partitionColumns) {

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -19,60 +19,100 @@
 package org.apache.hudi.aws.sync;
 
 import org.apache.hudi.aws.testutils.GlueTestUtil;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.GlueCatalogSyncClientConfig;
+import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.sync.common.model.FieldSchema;
+import org.apache.hudi.sync.common.model.Partition;
 
 import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
+import software.amazon.awssdk.services.glue.model.BatchCreatePartitionRequest;
+import software.amazon.awssdk.services.glue.model.BatchCreatePartitionResponse;
+import software.amazon.awssdk.services.glue.model.BatchDeletePartitionRequest;
+import software.amazon.awssdk.services.glue.model.BatchDeletePartitionResponse;
+import software.amazon.awssdk.services.glue.model.BatchUpdatePartitionRequest;
+import software.amazon.awssdk.services.glue.model.BatchUpdatePartitionResponse;
 import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseResponse;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
 import software.amazon.awssdk.services.glue.model.CreateTableResponse;
+import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
 import software.amazon.awssdk.services.glue.model.DeleteTableResponse;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.ErrorDetail;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseResponse;
+import software.amazon.awssdk.services.glue.model.GetPartitionsRequest;
+import software.amazon.awssdk.services.glue.model.GetPartitionsResponse;
 import software.amazon.awssdk.services.glue.model.GetTableRequest;
 import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.PartitionError;
 import software.amazon.awssdk.services.glue.model.SerDeInfo;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
 import software.amazon.awssdk.services.glue.model.UpdateTableResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.hudi.aws.testutils.GlueTestUtil.glueSyncProps;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TestAWSGlueSyncClient {
+  private static final String CATALOG_ID = "DEFAULT_AWS_ACCOUNT_ID";
 
   @Mock
   private GlueAsyncClient mockAwsGlue;
+  @Mock
+  private StsClient mockSts;
 
   private AWSGlueCatalogSyncClient awsGlueSyncClient;
 
   @BeforeEach
   void setUp() throws IOException {
     GlueTestUtil.setUp();
-    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, GlueTestUtil.getHiveSyncConfig(), GlueTestUtil.getMetaClient());
+    when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account(CATALOG_ID).build());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, GlueTestUtil.getHiveSyncConfig(), GlueTestUtil.getMetaClient());
   }
 
   @AfterEach
@@ -112,10 +152,10 @@ class TestAWSGlueSyncClient {
         .table(table)
         .build();
 
-    GetTableRequest getTableRequestForTable = GetTableRequest.builder().databaseName(databaseName).name(tableName).build();
+    GetTableRequest getTableRequestForTable = GetTableRequest.builder().catalogId(CATALOG_ID).databaseName(databaseName).name(tableName).build();
     // Mock methods
     CompletableFuture<GetTableResponse> tableResponseFuture = CompletableFuture.completedFuture(tableResponse);
-    CompletableFuture<GetTableResponse> mockTableNotFoundResponse = Mockito.mock(CompletableFuture.class);
+    CompletableFuture<GetTableResponse> mockTableNotFoundResponse = mock(CompletableFuture.class);
     ExecutionException executionException = new ExecutionException("failed to get table", EntityNotFoundException.builder().build());
     Mockito.when(mockTableNotFoundResponse.get()).thenThrow(executionException);
 
@@ -227,6 +267,29 @@ class TestAWSGlueSyncClient {
     // verify if table base path is correct
     assertEquals(glueSyncProps.get(META_SYNC_BASE_PATH.key()), basePath, "table base path should match");
   }
+  
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testGetTableLocationUsingCatalogId(boolean useConfiguredCatalogId) {
+    String catalogId = useConfiguredCatalogId ? UUID.randomUUID().toString() : CATALOG_ID;
+    TypedProperties properties = GlueTestUtil.getHiveSyncConfig().getProps();
+    if (useConfiguredCatalogId) {
+      properties.setProperty(GlueCatalogSyncClientConfig.GLUE_CATALOG_ID.key(), catalogId);
+    }
+    when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account(CATALOG_ID).build());
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, new HiveSyncConfig(properties), GlueTestUtil.getMetaClient());
+
+    String testdb = "testdb";
+    String tableName = "testTable";
+    List<Column> columns = Arrays.asList(Column.builder().name("name").type("string").comment("person's name").build(),
+        Column.builder().name("age").type("int").comment("person's age").build());
+    CompletableFuture<GetTableResponse> tableResponse = getTableWithDefaultProps(tableName, columns, Collections.emptyList());
+    // mock aws glue get table call
+    GetTableRequest getTableRequestForTable = GetTableRequest.builder().catalogId(catalogId).databaseName(testdb).name(tableName).build();
+    Mockito.when(mockAwsGlue.getTable(getTableRequestForTable)).thenReturn(tableResponse);
+    String basePath = awsGlueSyncClient.getTableLocation(tableName);
+    assertEquals(glueSyncProps.get(META_SYNC_BASE_PATH.key()), basePath, "table base path should match");
+  }
 
   @Test
   void testGetTableLocation_ThrowsException() {
@@ -247,7 +310,7 @@ class TestAWSGlueSyncClient {
     HashMap<String, String> newTableProperties = new HashMap<>();
     newTableProperties.put("last_commit_time_sync", "100");
 
-    CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = Mockito.mock(CompletableFuture.class);
+    CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = mock(CompletableFuture.class);
     Mockito.when(mockUpdateTableResponse.get()).thenReturn(UpdateTableResponse.builder().build());
     Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(tableResponseFuture);
     Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(mockUpdateTableResponse);
@@ -257,6 +320,336 @@ class TestAWSGlueSyncClient {
 
     Mockito.when(mockUpdateTableResponse.get()).thenThrow(new InterruptedException());
     assertThrows(HoodieGlueSyncException.class, () -> awsGlueSyncClient.updateTableProperties(tableName, newTableProperties));
+  }
+
+  @Test
+  void testCreateDatabase_WhenDatabaseAlreadyExists_DoesNothing() {
+    String dbName = "existingDb";
+
+    CompletableFuture<GetDatabaseResponse> existsFuture =
+        CompletableFuture.completedFuture(
+            GetDatabaseResponse.builder()
+                .database(Database.builder().name(dbName).build())
+                .build()
+        );
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(existsFuture);
+    awsGlueSyncClient.createDatabase(dbName);
+    verify(mockAwsGlue, never()).createDatabase(any(CreateDatabaseRequest.class));
+  }
+
+  @Test
+  void testCreateDatabase_WhenDatabaseDoesNotExist_CreatesDatabase() throws Exception {
+    String dbName = "newDb";
+
+    CompletableFuture<GetDatabaseResponse> notFoundFuture = mock(CompletableFuture.class);
+    ExecutionException notFoundEx =
+        new ExecutionException(EntityNotFoundException.builder().build());
+    when(notFoundFuture.get()).thenThrow(notFoundEx);
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(notFoundFuture);
+
+    CompletableFuture<CreateDatabaseResponse> createFuture =
+        CompletableFuture.completedFuture(CreateDatabaseResponse.builder().build());
+    when(mockAwsGlue.createDatabase(any(CreateDatabaseRequest.class))).thenReturn(createFuture);
+    awsGlueSyncClient.createDatabase(dbName);
+    verify(mockAwsGlue).createDatabase(argThat((CreateDatabaseRequest req) ->
+        req.catalogId().equals(CATALOG_ID)
+            && req.databaseInput().name().equals(dbName)
+    ));
+  }
+
+  @Test
+  void testGetAllPartitions_SinglePage() {
+    String tableName = "tbl";
+    StorageDescriptor sd1 = StorageDescriptor.builder().location("s3://loc1").build();
+    StorageDescriptor sd2 = StorageDescriptor.builder().location("s3://loc2").build();
+    software.amazon.awssdk.services.glue.model.Partition awsPart1 = software.amazon.awssdk.services.glue.model.Partition.builder()
+        .values("2025","05","19").storageDescriptor(sd1).build();
+    software.amazon.awssdk.services.glue.model.Partition awsPart2 = software.amazon.awssdk.services.glue.model.Partition.builder()
+        .values("2025","05","18").storageDescriptor(sd2).build();
+
+    GetPartitionsResponse page = GetPartitionsResponse.builder()
+        .partitions(awsPart1, awsPart2)
+        .nextToken(null)
+        .build();
+    CompletableFuture<GetPartitionsResponse> future = CompletableFuture.completedFuture(page);
+    when(mockAwsGlue.getPartitions(any(GetPartitionsRequest.class))).thenReturn(future);
+
+    List<Partition> result = awsGlueSyncClient.getAllPartitions(tableName);
+
+    assertEquals(2, result.size());
+    assertEquals("s3://loc1", result.get(0).getStorageLocation());
+    assertEquals(Arrays.asList("2025","05","19"), result.get(0).getValues());
+    assertEquals("s3://loc2", result.get(1).getStorageLocation());
+    verify(mockAwsGlue, times(1)).getPartitions(any(GetPartitionsRequest.class));
+  }
+
+  @Test
+  void testGetAllPartitions_MultiplePages() {
+    String tableName = "tbl";
+
+    StorageDescriptor sd1 = StorageDescriptor.builder().location("s3://first").build();
+    software.amazon.awssdk.services.glue.model.Partition awsPart1 =
+        software.amazon.awssdk.services.glue.model.Partition.builder()
+            .values("A")
+            .storageDescriptor(sd1)
+            .build();
+    GetPartitionsResponse page1 = GetPartitionsResponse.builder()
+        .partitions(awsPart1)
+        .nextToken("tok1")
+        .build();
+
+    StorageDescriptor sd2 = StorageDescriptor.builder().location("s3://second").build();
+    software.amazon.awssdk.services.glue.model.Partition awsPart2 =
+        software.amazon.awssdk.services.glue.model.Partition.builder()
+            .values("B")
+            .storageDescriptor(sd2)
+            .build();
+    GetPartitionsResponse page2 = GetPartitionsResponse.builder()
+        .partitions(awsPart2)
+        .nextToken(null)
+        .build();
+
+    when(mockAwsGlue.getPartitions(any(GetPartitionsRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(page1))
+        .thenReturn(CompletableFuture.completedFuture(page2));
+
+    List<Partition> result = awsGlueSyncClient.getAllPartitions(tableName);
+
+    assertEquals(2, result.size());
+    assertEquals("s3://first",  result.get(0).getStorageLocation());
+    assertEquals(Arrays.asList("A"), result.get(0).getValues());
+    assertEquals("s3://second", result.get(1).getStorageLocation());
+    assertEquals(Arrays.asList("B"), result.get(1).getValues());
+
+    verify(mockAwsGlue, times(2)).getPartitions(any(GetPartitionsRequest.class));
+  }
+
+  @Test
+  void testGetAllPartitions_ThrowsWrappedException() {
+    String tableName = "tbl";
+
+    CompletableFuture<GetPartitionsResponse> badFuture = mock(CompletableFuture.class);
+    try {
+      when(badFuture.get()).thenThrow(new ExecutionException(new RuntimeException("boom")));
+    } catch (InterruptedException | ExecutionException e) {
+      // won't actually happen in stub setup
+    }
+    when(mockAwsGlue.getPartitions(any(GetPartitionsRequest.class))).thenReturn(badFuture);
+
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.getAllPartitions(tableName)
+    );
+    assertTrue(ex.getMessage().contains("Failed to get all partitions for table"));
+  }
+
+  @Test
+  void testDatabaseExists_WhenDatabaseExists() {
+    String dbName = "db";
+    GetDatabaseResponse resp = GetDatabaseResponse.builder()
+        .database(Database.builder().name(dbName).build())
+        .build();
+    CompletableFuture<GetDatabaseResponse> successFuture = CompletableFuture.completedFuture(resp);
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(successFuture);
+
+    boolean exists = awsGlueSyncClient.databaseExists(dbName);
+
+    assertTrue(exists, "Expected databaseExists to return true when AWS Glue returns a Database");
+  }
+
+  @Test
+  void testDatabaseExists_WhenNotExists() throws ExecutionException, InterruptedException {
+    String dbName = "db";
+    CompletableFuture<GetDatabaseResponse> notFoundFuture = mock(CompletableFuture.class);
+    when(notFoundFuture.get()).thenThrow(new ExecutionException(EntityNotFoundException.builder().build()));
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(notFoundFuture);
+
+    boolean exists = awsGlueSyncClient.databaseExists(dbName);
+
+    assertFalse(exists, "Expected databaseExists to return false when AWS Glue signals EntityNotFound");
+    verify(mockAwsGlue).getDatabase(any(GetDatabaseRequest.class));
+  }
+
+  @Test
+  void testDatabaseExists_WhenThrowsOtherException() throws ExecutionException, InterruptedException {
+    String dbName = "db";
+    CompletableFuture<GetDatabaseResponse> errorFuture = mock(CompletableFuture.class);
+    when(errorFuture.get()).thenThrow(new ExecutionException(new RuntimeException("boom")));
+    when(mockAwsGlue.getDatabase(any(GetDatabaseRequest.class))).thenReturn(errorFuture);
+
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.databaseExists(dbName),
+        "Expected a HoodieGlueSyncException when AWS Glue throws a non-EntityNotFound error"
+    );
+    assertTrue(ex.getMessage().contains("Fail to check if database exists"),
+        "Exception message should indicate database existence check failure");
+  }
+
+  @Test
+  void testAddPartitionsToTable_NoPartitions() {
+    // empty list -> no calls
+    awsGlueSyncClient.addPartitionsToTable("tbl", Collections.emptyList());
+    verify(mockAwsGlue, never()).batchCreatePartition(any(BatchCreatePartitionRequest.class));
+  }
+
+  @Test
+  void testAddPartitionsToTable_Success() {
+    String tableName = "tbl";
+    List<String> parts = Arrays.asList("2025/05/20", "2025/05/19");
+
+    // stub getTable to return a dummy StorageDescriptor
+    StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
+    Table table = Table.builder().storageDescriptor(baseSd).build();
+    GetTableResponse gt = GetTableResponse.builder().table(table).build();
+    when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(gt));
+
+    // stub batchCreatePartition to succeed with no errors
+    BatchCreatePartitionResponse ok = BatchCreatePartitionResponse.builder().errors(Collections.emptyList()).build();
+    when(mockAwsGlue.batchCreatePartition(any(BatchCreatePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ok));
+
+    awsGlueSyncClient.addPartitionsToTable(tableName, parts);
+
+    // capture the request
+    ArgumentCaptor<BatchCreatePartitionRequest> cap = ArgumentCaptor.forClass(BatchCreatePartitionRequest.class);
+    verify(mockAwsGlue).batchCreatePartition(cap.capture());
+    BatchCreatePartitionRequest req = cap.getValue();
+    assertEquals(TestAWSGlueSyncClient.CATALOG_ID, req.catalogId());
+    assertEquals(tableName, req.tableName());
+    assertEquals(parts.size(), req.partitionInputList().size());
+  }
+
+  @Test
+  void testAddPartitionsToTable_AlreadyExistsErrors() {
+    String tableName = "tbl";
+    List<String> parts = Arrays.asList("2025/05/20");
+
+    // stub getTable
+    StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
+    Table table = Table.builder().storageDescriptor(baseSd).build();
+    GetTableResponse gt = GetTableResponse.builder().table(table).build();
+    when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(gt));
+
+    // stub an error list with AlreadyExistsException
+    ErrorDetail detail = ErrorDetail.builder().errorCode("AlreadyExistsException").build();
+    PartitionError pe = PartitionError.builder().errorDetail(detail).build();
+    BatchCreatePartitionResponse resp = BatchCreatePartitionResponse.builder()
+        .errors(Collections.singletonList(pe))
+        .build();
+    when(mockAwsGlue.batchCreatePartition(any(BatchCreatePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(resp));
+
+    // should swallow the AlreadyExists error and not throw
+    awsGlueSyncClient.addPartitionsToTable(tableName, parts);
+
+    verify(mockAwsGlue).batchCreatePartition(any(BatchCreatePartitionRequest.class));
+  }
+
+  @Test
+  void testUpdatePartitionsToTable_NoPartitions() {
+    awsGlueSyncClient.updatePartitionsToTable("tbl", Collections.emptyList());
+    verify(mockAwsGlue, never()).batchUpdatePartition(any(BatchUpdatePartitionRequest.class));
+  }
+
+  @Test
+  void testUpdatePartitionsToTable_Success() {
+    String tableName = "tbl";
+    List<String> changed = Arrays.asList("2025/05/20");
+
+    StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
+    Table table = Table.builder().storageDescriptor(baseSd).build();
+    GetTableResponse gt = GetTableResponse.builder().table(table).build();
+    when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(gt));
+
+    BatchUpdatePartitionResponse ok = BatchUpdatePartitionResponse.builder().errors(Collections.emptyList()).build();
+    when(mockAwsGlue.batchUpdatePartition(any(BatchUpdatePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ok));
+
+    awsGlueSyncClient.updatePartitionsToTable(tableName, changed);
+
+    verify(mockAwsGlue).batchUpdatePartition(any(BatchUpdatePartitionRequest.class));
+  }
+
+  @Test
+  void testUpdatePartitionsToTable_ErrorResponses() {
+    String tableName = "tbl";
+    List<String> changed = Arrays.asList("year=2025");
+
+    StorageDescriptor baseSd = StorageDescriptor.builder().location("s3://base").build();
+    Table table = Table.builder().storageDescriptor(baseSd).build();
+    GetTableResponse gt = GetTableResponse.builder().table(table).build();
+    when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(gt));
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.updatePartitionsToTable(tableName, changed)
+    );
+    assertTrue(ex.getMessage().contains("Fail to update partitions"));
+  }
+
+  @Test
+  void testDropPartitions_NoPartitions() {
+    awsGlueSyncClient.dropPartitions("tbl", Collections.emptyList());
+    verify(mockAwsGlue, never()).batchDeletePartition(any(BatchDeletePartitionRequest.class));
+  }
+
+  @Test
+  void testDropPartitions_Success() {
+    String tableName = "tbl";
+    List<String> toDrop = Arrays.asList("2025/05/19");
+
+    BatchDeletePartitionResponse ok = BatchDeletePartitionResponse.builder().errors(Collections.emptyList()).build();
+    when(mockAwsGlue.batchDeletePartition(any(BatchDeletePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ok));
+
+    awsGlueSyncClient.dropPartitions(tableName, toDrop);
+
+    verify(mockAwsGlue).batchDeletePartition(any(BatchDeletePartitionRequest.class));
+  }
+
+  @Test
+  void testDropPartitions_ErrorResponses() {
+    String tableName = "tbl";
+    List<String> toDrop = Arrays.asList("2025/05/19");
+
+    // stub a non-empty error list
+    ErrorDetail detail = ErrorDetail.builder().errorCode("Boom").build();
+    PartitionError pe = PartitionError.builder().errorDetail(detail).build();
+    BatchDeletePartitionResponse resp = BatchDeletePartitionResponse.builder()
+        .errors(Collections.singletonList(pe))
+        .build();
+    when(mockAwsGlue.batchDeletePartition(any(BatchDeletePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(resp));
+
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.dropPartitions(tableName, toDrop)
+    );
+    assertTrue(ex.getMessage().contains("Fail to drop partitions"));
+  }
+
+  @Disabled("Integration test – requires real AWS environment")
+  @Test
+  void testIntegrationTableExists_RealGlueEnvironment() {
+    // Use us-west-2 and testing_acme-dev
+    String dbName = "acme_default";
+    String tblName = "hudi_table";
+
+    HiveSyncConfig config = new HiveSyncConfig(new Properties());
+    config.setValue(META_SYNC_DATABASE_NAME, dbName);
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    AWSGlueCatalogSyncClient client = new AWSGlueCatalogSyncClient(config, metaClient);
+    assertTrue(client.tableExists(tblName),
+        "Expected tableExists(...) to be true for an existing table in Glue");
+
+    String randomTable = "none_" + UUID.randomUUID().toString().replace("-", "");
+    assertFalse(client.tableExists(randomTable),
+        "Expected tableExists(...) to be false for a non-existent table");
+    client.close();
   }
 
   private CompletableFuture<GetTableResponse> getTableWithDefaultProps(String tableName, List<Column> columns, List<Column> partitionColumns) {

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
@@ -33,6 +33,9 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.glue.GlueAsyncClient;
 import software.amazon.awssdk.services.glue.GlueAsyncClientBuilder;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.io.IOException;
 
@@ -48,7 +51,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TestAwsGlueSyncTool {
-
   private AwsGlueCatalogSyncTool awsGlueCatalogSyncTool;
 
   @BeforeEach
@@ -81,12 +83,16 @@ class TestAwsGlueSyncTool {
 
   @Test
   void validateInitThroughSyncTool() throws Exception {
-    try (MockedStatic<GlueAsyncClient> mockedStatic = mockStatic(GlueAsyncClient.class)) {
+    try (MockedStatic<GlueAsyncClient> mockedStatic = mockStatic(GlueAsyncClient.class);
+         MockedStatic<StsClient> mockedStsStatic = mockStatic(StsClient.class)) {
       GlueAsyncClientBuilder builder = mock(GlueAsyncClientBuilder.class);
       mockedStatic.when(GlueAsyncClient::builder).thenReturn(builder);
       when(builder.credentialsProvider(any())).thenReturn(builder);
       GlueAsyncClient mockClient = mock(GlueAsyncClient.class);
       when(builder.build()).thenReturn(mockClient);
+      StsClient mockSts = mock(StsClient.class);
+      mockedStsStatic.when(StsClient::create).thenReturn(mockSts);
+      when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build())).thenReturn(GetCallerIdentityResponse.builder().account("").build());
       HoodieSyncTool syncTool = SyncUtilHelpers.instantiateMetaSyncTool(
           AwsGlueCatalogSyncTool.class.getName(),
           new TypedProperties(),

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
@@ -42,21 +42,21 @@ import java.nio.file.Files;
 import java.time.Instant;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_DATABASE_NAME;
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SYNC_TABLE_NAME;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USER;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USE_PRE_APACHE_INPUT_FORMAT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 
 public class GlueTestUtil {
 
   public static TypedProperties glueSyncProps;
-  private static final String DB_NAME = "testdb";
-  private static final String TABLE_NAME = "test1";
+  public static final String DB_NAME = "testdb";
+  public static final String TABLE_NAME = "test1";
   private static String basePath;
   public static FileSystem fileSystem;
   private static HiveSyncConfig hiveSyncConfig;
@@ -69,8 +69,8 @@ public class GlueTestUtil {
     glueSyncProps = new TypedProperties();
     glueSyncProps.setProperty(HIVE_USER.key(), "");
     glueSyncProps.setProperty(HIVE_PASS.key(), "");
-    glueSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), DB_NAME);
-    glueSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), TABLE_NAME);
+    glueSyncProps.setProperty(GLUE_SYNC_DATABASE_NAME.key(), DB_NAME);
+    glueSyncProps.setProperty(GLUE_SYNC_TABLE_NAME.key(), TABLE_NAME);
     glueSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
     glueSyncProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key(), "false");
     glueSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
@@ -115,7 +115,7 @@ public class ConfigProperty<T> implements Serializable {
     return getInferFunction().isPresent();
   }
 
-  Option<Function<HoodieConfig, Option<T>>> getInferFunction() {
+  public Option<Function<HoodieConfig, Option<T>>> getInferFunction() {
     return inferFunction;
   }
 

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -69,9 +69,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
-import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
-
 public class DataHubSyncClient extends HoodieSyncClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataHubSyncClient.class);

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -102,12 +102,12 @@ public class DataHubSyncClient extends HoodieSyncClient {
 
   @Override
   public String getDatabaseName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    return this.databaseName;
   }
 
   @Override
   public String getTableName() {
-    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
+    return this.tableName;
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -69,6 +69,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
+
 public class DataHubSyncClient extends HoodieSyncClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataHubSyncClient.class);
@@ -95,6 +98,16 @@ public class DataHubSyncClient extends HoodieSyncClient {
     this.databaseUrn = datasetIdentifier.getDatabaseUrn();
     this.tableName = datasetIdentifier.getTableName();
     this.databaseName = datasetIdentifier.getDatabaseName();
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
+  }
+
+  @Override
+  public String getTableName() {
+    return config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
@@ -36,7 +36,6 @@ import java.util.Properties;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL_SYNC;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.HoodieTableMetadata;
 import static org.apache.hudi.sync.datahub.DataHubTableProperties.getTableProperties;
 
@@ -61,9 +60,9 @@ public class DataHubSyncTool extends HoodieSyncTool {
   public DataHubSyncTool(Properties props, Configuration hadoopConf, Option<HoodieTableMetaClient> metaClientOption) {
     super(props, hadoopConf);
     this.config = new DataHubSyncConfig(props);
-    this.tableName = config.getString(META_SYNC_TABLE_NAME);
     this.metaClient = metaClientOption.orElseGet(() -> buildMetaClient(config));
     this.syncClient = new DataHubSyncClient(config, metaClient);
+    this.tableName = this.syncClient.getTableName();
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
@@ -29,11 +29,11 @@ import io.datahubproject.models.util.DatabaseKey;
 
 import java.util.Properties;
 
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
-import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATABASE_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_NAME;
 import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATASET_ENV;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_TABLE_NAME;
 
 /**
  * Construct and provide the default {@link DatasetUrn} to identify the Dataset on DataHub.
@@ -69,14 +69,13 @@ public class HoodieDataHubDatasetIdentifier {
         this.dataPlatformUrn,
         Option.ofNullable(config.getString(META_SYNC_DATAHUB_DATAPLATFORM_INSTANCE_NAME))
     );
+    this.databaseName = config.getStringOrDefault(META_SYNC_DATAHUB_DATABASE_NAME, META_SYNC_DATAHUB_DATABASE_NAME.getInferFunction().get().apply(config).get());
+    this.tableName = config.getStringOrDefault(META_SYNC_DATAHUB_TABLE_NAME, META_SYNC_DATAHUB_TABLE_NAME.getInferFunction().get().apply(config).get());
     this.datasetUrn = new DatasetUrn(
             this.dataPlatformUrn,
-            createDatasetName(this.dataPlatformInstance, config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)),
+            createDatasetName(this.dataPlatformInstance, this.databaseName, this.tableName),
             FabricType.valueOf(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV))
     );
-
-    this.tableName = config.getString(META_SYNC_TABLE_NAME);
-    this.databaseName = config.getString(META_SYNC_DATABASE_NAME);
 
     // https://github.com/datahub-project/datahub/blob/0b105395e913cc47a59bdeed0c56d7c0d4b71b63/metadata-ingestion/src/datahub/emitter/mcp_builder.py#L69-L72
     DatabaseKey databaseKey = DatabaseKey.builder()

--- a/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/test/java/org/apache/hudi/sync/datahub/TestDataHubSyncTool.java
@@ -20,7 +20,10 @@
 package org.apache.hudi.sync.datahub;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.sync.common.HoodieSyncTool;
@@ -28,12 +31,20 @@ import org.apache.hudi.sync.common.util.SyncUtilHelpers;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.util.Properties;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.META_SYNC_BASE_PATH_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TestDataHubSyncTool extends HoodieCommonTestHarness {
   @Test
@@ -63,5 +74,28 @@ class TestDataHubSyncTool extends HoodieCommonTestHarness {
       HoodieSyncTool syncTool = new DataHubSyncTool(typedProperties);
       syncTool.close();
     });
+  }
+
+  @Test
+  void testSyncHoodieTable_actualLines() {
+    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
+    when(mockMetaClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    HoodieTableConfig mockTableConfig = mock(HoodieTableConfig.class);
+    when(mockTableConfig.getTableVersion()).thenReturn(HoodieTableVersion.current());
+    when(mockMetaClient.getTableConfig()).thenReturn(mockTableConfig);
+    MessageType messageType = new MessageType("record", new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.INT32, "int_field"));
+
+    try (MockedConstruction<DataHubSyncClient> mocked = org.mockito.Mockito.mockConstruction(DataHubSyncClient.class, (mock, context) -> {
+      when(mock.getTableName()).thenReturn("test_table");
+      when(mock.getStorageSchema()).thenReturn(messageType);
+    })) {
+      DataHubSyncTool tool = new DataHubSyncTool(new Properties(), null, Option.of(mockMetaClient));
+      tool.syncHoodieTable();
+
+      DataHubSyncClient mockClient = mocked.constructed().get(0);
+      verify(mockClient).updateTableSchema("test_table", null, null);
+      verify(mockClient).updateLastCommitTimeSynced("test_table");
+      verify(mockClient).close();
+    }
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -116,6 +116,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NA
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_INCREMENTAL;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2017,6 +2018,28 @@ public class TestHiveSyncTool {
     assertEquals(getLastCommitCompletionTimeSynced(), hiveClient.getLastCommitCompletionTimeSynced(tableName).get());
     assertEquals(commitTime5, hiveClient.getLastCommitTimeSynced(tableName).get());
     assertEquals(3, hiveClient.getAllPartitions(tableName).size());
+  }
+
+  @Test
+  public void testDatabaseAndTableName() {
+    reInitHiveSyncClient();
+
+    assertEquals(HiveTestUtil.DB_NAME, hiveSyncTool.getDatabaseName());
+    assertEquals(HiveTestUtil.TABLE_NAME, hiveSyncTool.getTableName());
+
+    String updatedDb = "updated_db";
+    String updatedTable = "updated_table";
+
+    hiveSyncProps.setProperty(META_SYNC_DATABASE_NAME.key(), updatedDb);
+    hiveSyncProps.setProperty(META_SYNC_TABLE_NAME.key(), updatedTable);
+
+    reInitHiveSyncClient();
+
+    assertEquals(updatedDb, hiveSyncTool.getDatabaseName(), "Database name should match the updated value");
+    assertEquals(updatedTable, hiveSyncTool.getTableName(), "Table name should match the updated value");
+
+    assertEquals(updatedDb, hiveClient.getDatabaseName(), "Database name in sync client should match");
+    assertEquals(updatedTable, hiveClient.getTableName(), "Table name in sync client should match");
   }
 
   private void reSyncHiveTable() {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -48,7 +48,9 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_USE_FILE_LISTING_FROM_METADATA;
 
 public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, AutoCloseable {
@@ -86,6 +88,14 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
 
   public HoodieTableMetaClient getMetaClient() {
     return metaClient;
+  }
+
+  public String getTableName() {
+    return config.getString(META_SYNC_TABLE_NAME);
+  }
+
+  public String getDatabaseName() {
+    return config.getString(META_SYNC_DATABASE_NAME);
   }
 
   /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
@@ -27,7 +27,6 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 import org.apache.hudi.utilities.transform.SqlQueryBasedTransformer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
@@ -27,6 +27,7 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 import org.apache.hudi.utilities.transform.SqlQueryBasedTransformer;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMultipleMetaSync extends HoodieDeltaStreamerTestBase {
 
+  @Disabled
   @Test
   void testMultipleMetaStore() throws Exception {
     String tableBasePath = basePath + "/test_multiple_metastore";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/multisync/TestMultipleMetaSync.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMultipleMetaSync extends HoodieDeltaStreamerTestBase {
 
-  @Disabled
   @Test
   void testMultipleMetaStore() throws Exception {
     String tableBasePath = basePath + "/test_multiple_metastore";


### PR DESCRIPTION
### Change Logs

Recently the hudi community has put out several PRs in order to add new functionality to our existing glue and datahub related sync code paths. This PR aims to consolidate all these changes into one PR. Here are the original following prs

https://github.com/apache/hudi/pull/12314 (cross catalog sync functionality)
https://github.com/apache/hudi/pull/13424 (support database and table name for glue/datahub catalog)
https://github.com/apache/hudi/pull/13505 (glue resource tagging on database/table)


### Impact

* Adds catalogid as part of glue sync
* Introduces new configs for glue and datahub sync for database and table name
* Introduces resource tagging for glue


### Risk level (write none, low medium or high below)

medium 

### Documentation Update

For the new configs we likely will need to follow up with a doc update.


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
