### PR TITLE
[HUDI-9758] Allow reflection utils to use the ThreadContextClassLoader

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
@@ -19,24 +19,64 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.common.config.DFSPropertiesConfiguration;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.conflict.detection.DirectMarkerBasedDetectionStrategy;
 import org.apache.hudi.common.conflict.detection.EarlyConflictDetectionStrategy;
 import org.apache.hudi.common.conflict.detection.TimelineServerBasedDetectionStrategy;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathFilter;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 import static org.apache.hudi.common.util.ReflectionUtils.getMethod;
 import static org.apache.hudi.common.util.ReflectionUtils.isSubClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link ReflectionUtils}
  */
 public class TestReflectionUtils {
+
+  private ClassLoader originalClassLoader;
+  private URLClassLoader customClassLoader;
+
+  @BeforeEach
+  public void setUp() {
+    originalClassLoader = Thread.currentThread().getContextClassLoader();
+    // Create a custom class loader for testing
+    customClassLoader = new URLClassLoader(new URL[0], originalClassLoader);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Thread.currentThread().setContextClassLoader(originalClassLoader);
+    if (customClassLoader != null) {
+      try {
+        customClassLoader.close();
+      } catch (Exception e) {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
   @Test
   public void testIsSubClass() {
     String subClassName1 = DirectMarkerBasedDetectionStrategy.class.getName();
@@ -56,5 +96,162 @@ public class TestReflectionUtils {
     assertFalse(getMethod(HoodieStorage.class,
         "listDirectEntries", StoragePathFilter.class).isPresent());
     assertFalse(getMethod(HoodieStorage.class, "nonExistentMethod").isPresent());
+  }
+}
+
+  @Test
+  public void testThreadContextClassLoaderWithNonSystemClass() throws NoSuchFieldException, IllegalAccessException {
+    // Use a class that exists in the current context but simulate it's not in system loader
+    String testClassName = "org.apache.hudi.test.CustomTestClass";
+
+    // Create a custom class loader that can load our test class
+    ClassLoader isolatedLoader = new ClassLoader(getClass().getClassLoader()) {
+      @Override
+      public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (name.equals(testClassName)) {
+          // Create a simple class that just extends Object
+          byte[] classBytes = createSimpleClassBytes(name);
+          return defineClass(name, classBytes, 0, classBytes.length);
+        }
+        // For all other classes, delegate to parent
+        return super.loadClass(name);
+      }
+    };
+
+    // Reset the cached value before each test part
+    Field useThreadContextField = ReflectionUtils.class.getDeclaredField("useThreadContextClassLoader");
+    useThreadContextField.setAccessible(true);
+
+    // Test with hoodie.reflection.usethreadcontext=true
+    TypedProperties propsTrue = new TypedProperties();
+    propsTrue.setProperty("hoodie.reflection.usethreadcontext", "true");
+
+    try (MockedStatic<DFSPropertiesConfiguration> mockedConfig = Mockito.mockStatic(DFSPropertiesConfiguration.class)) {
+      useThreadContextField.set(null, null);
+
+      mockedConfig.when(DFSPropertiesConfiguration::getGlobalProps).thenReturn(propsTrue);
+
+      ClassLoader originalTCCL = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(isolatedLoader);
+      clearReflectionUtilsCache();
+
+      try {
+        // This should succeed because thread context class loader is used
+        Class<?> clazz = ReflectionUtils.getClass(testClassName);
+        assertNotNull(clazz);
+        assertEquals(testClassName, clazz.getName());
+      } finally {
+        Thread.currentThread().setContextClassLoader(originalTCCL);
+      }
+    }
+
+    // Test with hoodie.reflection.usethreadcontext=false
+    TypedProperties propsFalse = new TypedProperties();
+    propsFalse.setProperty("hoodie.reflection.usethreadcontext", "false");
+
+    try (MockedStatic<DFSPropertiesConfiguration> mockedConfig = Mockito.mockStatic(DFSPropertiesConfiguration.class)) {
+      useThreadContextField.set(null, null);
+
+      mockedConfig.when(DFSPropertiesConfiguration::getGlobalProps).thenReturn(propsFalse);
+
+      clearReflectionUtilsCache();
+
+      // This should always fail regardless of configuration
+      assertThrows(HoodieException.class, () -> ReflectionUtils.getClass("org.apache.hudi.test.CustomTestClass"));
+    }
+  }
+
+  @Test
+  public void testGetClassWithSystemClassLoader() {
+    // Test loading a standard JDK class
+    Class<?> clazz = ReflectionUtils.getClass("java.lang.String");
+    assertNotNull(clazz);
+    assertEquals(String.class, clazz);
+  }
+
+  @Test
+  public void testGetClassWithInvalidClassName() {
+    assertThrows(HoodieException.class, () -> ReflectionUtils.getClass("com.nonexistent.InvalidClass"));
+  }
+
+  private byte[] createSimpleClassBytes(String className) {
+    // Convert class name to internal format (replace . with /)
+    String internalName = className.replace('.', '/');
+
+    // This is a minimal valid class file structure
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    try {
+      // Magic number
+      dos.writeInt(0xCAFEBABE);
+
+      // Version (Java 8: minor=0, major=52)
+      dos.writeShort(0); // minor version
+      dos.writeShort(52); // major version
+
+      // Constant pool count (we need at least 5 entries)
+      dos.writeShort(5);
+
+      // Constant pool:
+      // #1 = Class reference to this class
+      dos.writeByte(7); // CONSTANT_Class
+      dos.writeShort(2); // name_index pointing to #2
+
+      // #2 = UTF8 string with class name
+      dos.writeByte(1); // CONSTANT_Utf8
+      dos.writeUTF(internalName);
+
+      // #3 = Class reference to Object
+      dos.writeByte(7); // CONSTANT_Class
+      dos.writeShort(4); // name_index pointing to #4
+
+      // #4 = UTF8 string "java/lang/Object"
+      dos.writeByte(1); // CONSTANT_Utf8
+      dos.writeUTF("java/lang/Object");
+
+      // Access flags (ACC_PUBLIC | ACC_SUPER)
+      dos.writeShort(0x0021);
+
+      // This class (index to constant pool entry #1)
+      dos.writeShort(1);
+
+      // Super class (index to constant pool entry #3)
+      dos.writeShort(3);
+
+      // Interfaces count
+      dos.writeShort(0);
+
+      // Fields count
+      dos.writeShort(0);
+
+      // Methods count
+      dos.writeShort(0);
+
+      // Attributes count
+      dos.writeShort(0);
+
+      dos.flush();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate class bytes", e);
+    }
+  }
+
+  private void clearReflectionUtilsCache() {
+    try {
+      java.lang.reflect.Field cacheField = ReflectionUtils.class.getDeclaredField("CLAZZ_CACHE");
+      cacheField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      java.util.Map<String, Class<?>> cache = (java.util.Map<String, Class<?>>) cacheField.get(null);
+      cache.clear();
+    } catch (NoSuchFieldException e) {
+      // If the field doesn't exist, the implementation might have changed
+      // Log a warning or decide how to handle this
+      System.err.println("Warning: Unable to find CLAZZ_CACHE field in ReflectionUtils");
+    } catch (IllegalAccessException e) {
+      // If we can't access the field, log but don't fail the test
+      System.err.println("Warning: Unable to access CLAZZ_CACHE field in ReflectionUtils");
+    }
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.exception.HoodieException;
 
 import org.slf4j.Logger;
@@ -47,10 +48,34 @@ public class ReflectionUtils {
 
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<>();
 
+  private static final String ENABLE_THREAD_CONTEXT_REFLECTION_KEY = "hoodie.reflection.usethreadcontext";
+  // The properties must be on the classpath for this to evaluate to true.
+  // This allows us to use the thread context class loader in cases
+  // where the jars are dynamically added to the classpath.
+  private static volatile Boolean useThreadContextClassLoader = null;
+
+  /**
+   * Protected method that can be mocked in tests.
+   * This method is called to determine whether to use thread context class loader.
+   */
+  protected static boolean shouldUseThreadContextClassLoader() {
+    if (useThreadContextClassLoader == null) {
+      synchronized (ReflectionUtils.class) {
+        if (useThreadContextClassLoader == null) {
+          useThreadContextClassLoader = DFSPropertiesConfiguration.getGlobalProps()
+              .getBoolean(ENABLE_THREAD_CONTEXT_REFLECTION_KEY, false);
+        }
+      }
+    }
+    return useThreadContextClassLoader;
+  }
+
   public static Class<?> getClass(String clazzName) {
     return CLAZZ_CACHE.computeIfAbsent(clazzName, c -> {
       try {
-        return Class.forName(c);
+        return shouldUseThreadContextClassLoader()
+            ? Class.forName(clazzName, true, Thread.currentThread().getContextClassLoader())
+            : Class.forName(c);
       } catch (ClassNotFoundException e) {
         throw new HoodieException("Unable to load class", e);
       }


### PR DESCRIPTION
### Change Logs

There is a gap in the current spark driver/executor model with spark where the executor fetches jars passed in --conf spark.jars=...  but these hudi cannot load classes from these jars due to the way that the SystemClassLoader has been restricted in Java 17. This means if the user specifies custom payloads in the jar they provide to spark.jars, it must exist on the class path BEFORE the JVM starts.

More context for why the current logic is like this can be found here: https://github.com/apache/hudi/pull/3535

### Impact

Adds a config to allow for loading classes using thread context class loader instead of system class loader.

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
