### PR TITLE
[HUDI-9775] Support for show_metadata_table_history with appropriate matching data table info

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -100,6 +100,7 @@ object HoodieProcedures {
       ,(ShowCleansProcedure.NAME, ShowCleansProcedure.builder)
       ,(ShowCleansPartitionMetadataProcedure.NAME, ShowCleansPartitionMetadataProcedure.builder)
       ,(ShowCleansPlanProcedure.NAME, ShowCleansPlanProcedure.builder)
+      ,(ShowMetadataTableHistoryProcedure.NAME, ShowMetadataTableHistoryProcedure.builder)
     )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableHistoryProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableHistoryProcedure.scala
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.metadata.HoodieTableMetadata
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util.function.Supplier
+
+import scala.collection.JavaConverters._
+
+class ShowMetadataTableHistoryProcedure extends BaseProcedure with ProcedureBuilder {
+
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType, ""),
+    ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 20),
+    ProcedureParameter.optional(3, "showArchived", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(4, "filter", DataTypes.StringType, ""),
+    ProcedureParameter.optional(5, "startTime", DataTypes.StringType, ""),
+    ProcedureParameter.optional(6, "endTime", DataTypes.StringType, "")
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("instant_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("metadata_table_action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("metadata_table_state", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("metadata_table_requested_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("metadata_table_inflight_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("metadata_table_completed_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("data_table_action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("data_table_state", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("data_table_requested_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("data_table_inflight_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("data_table_completed_time", DataTypes.StringType, nullable = true, Metadata.empty)
+  ))
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val path = getArgValueOrDefault(args, PARAMETERS(1))
+    val limit = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[Int]
+    val showArchived = getArgValueOrDefault(args, PARAMETERS(3)).get.asInstanceOf[Boolean]
+    val filter = getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String]
+    val startTime = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[String]
+    val endTime = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[String]
+
+    validateFilter(filter, outputType)
+
+    val dataTableBasePath = getBasePath(tableName, path)
+    val metaClient = createMetaClient(jsc, dataTableBasePath)
+
+    val metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(dataTableBasePath)
+    val metadataMetaClient = try {
+      HoodieTableMetaClient.builder()
+        .setConf(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()))
+        .setBasePath(metadataTableBasePath)
+        .setLoadActiveTimelineOnLoad(false)
+        .build()
+    } catch {
+      case _: Exception =>
+        return Seq.empty[Row]
+    }
+    getTimelineEntries(metaClient, metadataMetaClient, limit, showArchived, filter, startTime, endTime)
+  }
+
+  override def build: Procedure = new ShowMetadataTableHistoryProcedure()
+
+  private def getTimelineEntries(
+                                  dataMetaClient: HoodieTableMetaClient,
+                                  metadataMetaClient: HoodieTableMetaClient,
+                                  limit: Int,
+                                  showArchived: Boolean,
+                                  filter: String,
+                                  startTime: String,
+                                  endTime: String): Seq[Row] = {
+
+    val dataInstantInfoMap = buildInstantInfoFromTimeline(dataMetaClient)
+    val metadataInstantInfoMap = buildInstantInfoFromTimeline(metadataMetaClient)
+
+    val allInstantTimes = collection.mutable.Set[String]()
+
+    val dataActiveTimeline = dataMetaClient.getActiveTimeline
+    val dataArchivedTimeline = if (showArchived) Some(dataMetaClient.getArchivedTimeline) else None
+
+    val metadataActiveTimeline = metadataMetaClient.getActiveTimeline
+    val metadataArchivedTimeline = if (showArchived) Some(metadataMetaClient.getArchivedTimeline) else None
+
+    allInstantTimes ++= dataActiveTimeline.getInstants.iterator().asScala.map(_.requestedTime())
+    if (dataArchivedTimeline.isDefined) {
+      allInstantTimes ++= dataArchivedTimeline.get.getInstants.iterator().asScala.map(_.requestedTime())
+    }
+
+    allInstantTimes ++= metadataActiveTimeline.getInstants.iterator().asScala.map(_.requestedTime())
+    if (metadataArchivedTimeline.isDefined) {
+      allInstantTimes ++= metadataArchivedTimeline.get.getInstants.iterator().asScala.map(_.requestedTime())
+    }
+
+    val filteredInstantTimes = if (startTime.nonEmpty && endTime.nonEmpty) {
+      allInstantTimes.filter { instantTime =>
+        val timeMatches = (instantTime >= startTime && instantTime <= endTime)
+        timeMatches
+      }
+    } else {
+      allInstantTimes
+    }
+
+    val sortedInstantTimes = filteredInstantTimes.toSeq.sorted(Ordering[String].reverse)
+
+    val entries = sortedInstantTimes.map { instantTime =>
+      createTimelineEntry(
+        instantTime,
+        dataActiveTimeline,
+        dataArchivedTimeline,
+        metadataActiveTimeline,
+        metadataArchivedTimeline,
+        dataInstantInfoMap,
+        metadataInstantInfoMap
+      )
+    }
+
+    val filteredEntries = applyFilter(entries, filter, outputType)
+
+    val finalEntries = if (startTime.nonEmpty && endTime.nonEmpty) {
+      filteredEntries
+    } else {
+      filteredEntries.take(limit)
+    }
+
+    finalEntries
+  }
+
+  private def createTimelineEntry(
+                                   instantTime: String,
+                                   dataActiveTimeline: HoodieTimeline,
+                                   dataArchivedTimeline: Option[HoodieTimeline],
+                                   metadataActiveTimeline: HoodieTimeline,
+                                   metadataArchivedTimeline: Option[HoodieTimeline],
+                                   dataInstantInfoMap: Map[String, Map[HoodieInstant.State, HoodieInstantWithModTime]],
+                                   metadataInstantInfoMap: Map[String, Map[HoodieInstant.State, HoodieInstantWithModTime]]): Row = {
+
+    val dataInstant = findInstant(dataActiveTimeline, dataArchivedTimeline, instantTime)
+    val metadataInstant = findInstant(metadataActiveTimeline, metadataArchivedTimeline, instantTime)
+
+    val action = dataInstant.map(_.getAction).orNull
+    val state = dataInstant.map(_.getState.toString).orNull
+    val requestedTime = getFormattedDateForState(instantTime, HoodieInstant.State.REQUESTED, dataInstantInfoMap)
+    val inflightTime = getFormattedDateForState(instantTime, HoodieInstant.State.INFLIGHT, dataInstantInfoMap)
+    val completedTime = getFormattedDateForState(instantTime, HoodieInstant.State.COMPLETED, dataInstantInfoMap)
+
+    val mtAction = metadataInstant.map(_.getAction).orNull
+    val mtState = metadataInstant.map(_.getState.toString).orNull
+    val mtRequestedTime = getFormattedDateForState(instantTime, HoodieInstant.State.REQUESTED, metadataInstantInfoMap)
+    val mtInflightTime = getFormattedDateForState(instantTime, HoodieInstant.State.INFLIGHT, metadataInstantInfoMap)
+    val mtCompletedTime = getFormattedDateForState(instantTime, HoodieInstant.State.COMPLETED, metadataInstantInfoMap)
+
+    Row(
+      instantTime,
+      mtAction,
+      mtState,
+      mtRequestedTime,
+      mtInflightTime,
+      mtCompletedTime,
+      action,
+      state,
+      requestedTime,
+      inflightTime,
+      completedTime
+    )
+  }
+
+  private def findInstant(
+                           activeTimeline: HoodieTimeline,
+                           archivedTimeline: Option[HoodieTimeline],
+                           instantTime: String): Option[HoodieInstant] = {
+
+    val activeInstant = activeTimeline.getInstants.iterator().asScala
+      .find(_.requestedTime() == instantTime)
+
+    if (activeInstant.isDefined) {
+      return activeInstant
+    }
+
+    archivedTimeline.flatMap { archived =>
+      archived.getInstants.iterator().asScala
+        .find(_.requestedTime() == instantTime)
+    }
+  }
+
+  private case class HoodieInstantWithModTime(state: HoodieInstant.State,
+                                              action: String,
+                                              requestedTime: String,
+                                              completionTime: String,
+                                              modificationTimeMs: Long
+                                             ) {
+    def getModificationTime: Long = modificationTimeMs
+  }
+
+  private def buildInstantInfoFromTimeline(metaClient: HoodieTableMetaClient): Map[String, Map[HoodieInstant.State, HoodieInstantWithModTime]] = {
+    try {
+      val storage = metaClient.getStorage
+      val timelinePath = metaClient.getTimelinePath
+      val instantFileNameParser = metaClient.getInstantFileNameParser
+      val instantGenerator = metaClient.getInstantGenerator
+
+      val instantMap = scala.collection.mutable.Map[String, scala.collection.mutable.Map[HoodieInstant.State, HoodieInstantWithModTime]]()
+
+      val fileStream = HoodieTableMetaClient.scanFiles(storage, timelinePath, path => {
+        val extension = instantFileNameParser.getTimelineFileExtension(path.getName)
+        metaClient.getActiveTimeline.getValidExtensionsInActiveTimeline.contains(extension)
+      })
+
+      fileStream.forEach { storagePathInfo =>
+        try {
+          val instant = instantGenerator.createNewInstant(storagePathInfo)
+          val instantWithModTime = HoodieInstantWithModTime(
+            instant.getState,
+            instant.getAction,
+            instant.requestedTime(),
+            instant.getCompletionTime,
+            storagePathInfo.getModificationTime
+          )
+
+          instantMap.getOrElseUpdate(instant.requestedTime(), scala.collection.mutable.Map[HoodieInstant.State, HoodieInstantWithModTime]())
+            .put(instant.getState, instantWithModTime)
+        } catch {
+          case _: Exception => // Skip invalid files
+        }
+      }
+      instantMap.map { case (timestamp, stateMap) =>
+        timestamp -> stateMap.toMap
+      }.toMap
+    } catch {
+      case _: Exception => Map.empty[String, Map[HoodieInstant.State, HoodieInstantWithModTime]]
+    }
+  }
+
+  private def getFormattedDateForState(instantTimestamp: String, state: HoodieInstant.State,
+                                       instantInfoMap: Map[String, Map[HoodieInstant.State, HoodieInstantWithModTime]]): String = {
+    val stateMap = instantInfoMap.get(instantTimestamp)
+    if (stateMap.isDefined) {
+      val stateInfo = stateMap.get.get(state)
+      if (stateInfo.isDefined) {
+        val modificationTime = stateInfo.get.getModificationTime
+        if (modificationTime > 0) {
+          val date = new java.util.Date(modificationTime)
+          val formatter = new java.text.SimpleDateFormat("MM-dd HH:mm:ss")
+          formatter.format(date)
+        } else {
+          instantTimestamp
+        }
+      } else {
+        null
+      }
+    } else {
+      null
+    }
+  }
+}
+
+object ShowMetadataTableHistoryProcedure {
+  val NAME = "show_metadata_table_history"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get(): ProcedureBuilder = new ShowMetadataTableHistoryProcedure()
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowMetadataTableHistoryProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestShowMetadataTableHistoryProcedure.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+import org.apache.hudi.HoodieSparkUtils
+
+class TestShowMetadataTableHistoryProcedure extends HoodieSparkProcedureTestBase {
+
+  test("Test show_metadata_table_history procedure") {
+    withSQLConf("hoodie.metadata.enable" -> "true") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        if (HoodieSparkUtils.isSpark3_4) {
+          spark.sql("set spark.sql.defaultColumn.enabled = false")
+        }
+        spark.sql(
+          s"""
+             |create table $tableName (
+             | id int,
+             | name string,
+             | price double,
+             | ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             | primaryKey = 'id',
+             | orderingFields = 'ts',
+             | 'hoodie.metadata.enable' = 'true'
+             | )
+             |""".stripMargin)
+
+        spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
+        spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
+        spark.sql(s"update $tableName set price = 15 where id = 1")
+
+        val historyDf = spark.sql(s"""call show_metadata_table_history(table => '$tableName', limit => 10)""")
+        historyDf.show(false)
+        val history = historyDf.collect()
+
+        assert(history.length >= 3, s"Expected at least 3 history entry, got ${history.length}")
+
+        val dataTableEntries = history.filter(row => row.getString(6) != null && row.getString(6).nonEmpty)
+        val metadataTableEntries = history.filter(row => row.getString(1) != null && row.getString(1).nonEmpty)
+
+        assert(dataTableEntries.length > 0, "Should have data table entries")
+        assert(metadataTableEntries.length > 0, "Should have metadata table entries")
+      }
+    }
+  }
+
+  test("Test show_metadata_table_history procedure - without metadata table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      if (HoodieSparkUtils.isSpark3_4) {
+        spark.sql("set spark.sql.defaultColumn.enabled = false")
+      }
+      spark.sql(
+        s"""
+           |create table $tableName (
+           | id int,
+           | name string,
+           | price double,
+           | ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           | primaryKey = 'id',
+           | orderingFields = 'ts',
+           | 'hoodie.metadata.enable' = 'false'
+           | )
+           |""".stripMargin)
+
+      spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
+      spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
+
+      val history = spark.sql(s"""call show_metadata_table_history(table => '$tableName', limit => 10)""").collect()
+
+      assertResult(0)(history.length)
+    }
+  }
+
+  test("Test show_metadata_table_history procedure - with filters and showArchived") {
+    withSQLConf("hoodie.metadata.enable" -> "true") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        if (HoodieSparkUtils.isSpark3_4) {
+          spark.sql("set spark.sql.defaultColumn.enabled = false")
+        }
+        spark.sql(
+          s"""
+             |create table $tableName (
+             | id int,
+             | name string,
+             | price double,
+             | ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             | primaryKey = 'id',
+             | orderingFields = 'ts',
+             | 'hoodie.metadata.enable' = 'true'
+             | )
+             |""".stripMargin)
+
+        spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
+        spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
+        spark.sql(s"insert into $tableName select 3, 'a3', 30, 2000")
+        spark.sql(s"insert into $tableName select 4, 'a4', 20, 1500")
+        spark.sql(s"insert into $tableName select 5, 'a5', 10, 1000")
+        spark.sql(s"update $tableName set price = 15 where id = 1")
+        spark.sql(s"update $tableName set price = 20 where id = 2")
+
+        val allHistoryDf = spark.sql(s"""call show_metadata_table_history(table => '$tableName', limit => 20)""")
+        allHistoryDf.show(false)
+        val allHistory = allHistoryDf.collect()
+        assert(allHistory.length > 0, "Should have history entries")
+
+        val archivedHistoryDf = spark.sql(
+          s"""call show_metadata_table_history(
+             | table => '$tableName',
+             | limit => 20,
+             | showArchived => true
+             |)""".stripMargin)
+        archivedHistoryDf.show(false)
+        val archivedHistory = archivedHistoryDf.collect()
+
+        assert(archivedHistory.length >= allHistory.length, "Archived timeline should include at least active entries")
+
+        val commitHistory = spark.sql(
+          s"""call show_metadata_table_history(
+             | table => '$tableName',
+             | limit => 10,
+             | filter => "metadata_table_action = 'commit'"
+             |)""".stripMargin).collect()
+
+        assertResult(0)(commitHistory.length)
+
+        val completedMetadataHistory = spark.sql(
+          s"""call show_metadata_table_history(
+             | table => '$tableName',
+             | limit => 10,
+             | filter => "metadata_table_state = 'COMPLETED'"
+             |)""".stripMargin).collect()
+
+        assertResult(completedMetadataHistory.length)(allHistory.length)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Change Logs

This PR introduces the `ShowMetadataTableHistoryProcedure`, a new Spark SQL procedure that displays timeline information for both data table and metadata table side-by-side, enabling analysis of metadata table synchronization and evolution.

### Key Features:
- **Unified Timeline View**: Shows data table and metadata table timelines in a single result
- **Side-by-Side Format**: Metadata table columns first, then data table columns
- **Time Formatting**: Proper MM-dd HH:mm:ss formatting for requested/inflight/completed times
- **Archive Support**: Includes archived timeline via `showArchived` parameter
- **Filtering**: SQL-based filtering and time range support (`startTime`/`endTime`)
- **Error Handling**: Graceful handling when metadata table doesn't exist

## Impact

**New Public API**: 
- `show_metadata_table_history` procedure with parameters: `table`, `path`, `limit`, `showArchived`, `filter`, `startTime`, `endTime`
- 11-column output schema showing metadata table and data table timeline information

**User Benefits**:
- Analyze metadata table synchronization with data operations
- Debug metadata table issues and performance bottlenecks
- Monitor metadata table bootstrap and maintenance operations

**Performance Impact**: Minimal - read-only procedure with efficient timeline scanning.

## Risk level (write none, low medium or high below)
**Low** - New read-only procedure that doesn't modify data or table state.

## Documentation Update
Update Hudi Spark SQL procedures documentation to include `show_metadata_table_history` usage examples and parameter descriptions.

## Contributor's checklist
- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed

### Usage Example:
```sql
-- Basic usage
CALL show_metadata_table_history(table => 'my_table');

-- With archives and filtering
CALL show_metadata_table_history(
  table => 'my_table', 
  showArchived => true,
  filter => "metadata_table_action = 'commit'"
);
```