### PR TITLE
[HUDI-9780] Concurrency Control test for Show Commit, Compaction and Clustering procedures - applies the same to all the remaining action, file group procedures using the Lock Provider

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestConcurrencyControlProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestConcurrencyControlProcedures.scala
@@ -81,7 +81,7 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
       try {
         val schedule1Task: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
+          latch.await(6, TimeUnit.SECONDS)
           Try {
             spark.sql(
               s"""CALL run_clustering(
@@ -94,7 +94,7 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
 
         val schedule2Task: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
+          latch.await(6, TimeUnit.SECONDS)
           Thread.sleep(1000)
           Try {
             spark.sql(
@@ -108,8 +108,8 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
 
         val schedule3Task: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
-          Thread.sleep(2000)
+          latch.await(6, TimeUnit.SECONDS)
+          Thread.sleep(3000)
           Try {
             spark.sql(
               s"""CALL run_clustering(
@@ -122,7 +122,7 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
 
         val showEarlyTask: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
+          latch.await(6, TimeUnit.SECONDS)
           Thread.sleep(500)
           Try {
             val early = spark.sql(s"call show_clustering(table => '$tableName')")
@@ -133,8 +133,8 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
 
         val showMiddleTask: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
-          Thread.sleep(1500)
+          latch.await(6, TimeUnit.SECONDS)
+          Thread.sleep(2500)
           Try {
             val mid = spark.sql(s"call show_clustering(table => '$tableName')")
             mid.show(false)
@@ -144,19 +144,19 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
 
         val executeTask: Future[Try[Array[Row]]] = executor.submit(() => {
           latch.countDown()
-          latch.await(3, TimeUnit.SECONDS)
-          Thread.sleep(2500)
+          latch.await(6, TimeUnit.SECONDS)
+          Thread.sleep(4000)
           Try {
             spark.sql(s"call run_clustering(table => '$tableName', op => 'execute')").collect()
           }
         })
 
-        val schedule1Result = schedule1Task.get(10, TimeUnit.SECONDS)
-        val schedule2Result = schedule2Task.get(10, TimeUnit.SECONDS)
-        val schedule3Result = schedule3Task.get(10, TimeUnit.SECONDS)
-        val showEarlyResult = showEarlyTask.get(10, TimeUnit.SECONDS)
-        val showMiddleResult = showMiddleTask.get(10, TimeUnit.SECONDS)
-        val executeResult = executeTask.get(10, TimeUnit.SECONDS)
+        val schedule1Result = schedule1Task.get(15, TimeUnit.SECONDS)
+        val schedule2Result = schedule2Task.get(15, TimeUnit.SECONDS)
+        val schedule3Result = schedule3Task.get(15, TimeUnit.SECONDS)
+        val showEarlyResult = showEarlyTask.get(15, TimeUnit.SECONDS)
+        val showMiddleResult = showMiddleTask.get(15, TimeUnit.SECONDS)
+        val executeResult = executeTask.get(15, TimeUnit.SECONDS)
 
         assert(schedule1Result.isSuccess, s"Schedule 1 failed: ${schedule1Result.failed.getOrElse("Unknown")}")
         assert(schedule2Result.isSuccess, s"Schedule 2 failed: ${schedule2Result.failed.getOrElse("Unknown")}")
@@ -169,7 +169,7 @@ class TestConcurrencyControlProcedures extends HoodieSparkProcedureTestBase {
         val earlyCount = showEarlyResult.get.length
         val middleCount = showMiddleResult.get.length
 
-        Thread.sleep(3000)
+        Thread.sleep(5000)
         val finalShowResultDf = spark.sql(s"call show_clustering(table => '$tableName')")
         finalShowResultDf.show(false)
         val finalShowResult = finalShowResultDf.collect()


### PR DESCRIPTION
### Change Logs

Added comprehensive concurrency control test cases for Hudi Spark SQL Show procedures to validate thread-safe behavior during concurrent operations:

- **TestConcurrencyControlProcedures**: New test class with three focused test cases validating show procedures during concurrent clustering, compaction, and commit operations
- **Clustering Concurrency Test**: Validates show_clustering procedure behavior during concurrent schedule/execute operations
- **Compaction Concurrency Test**: Tests show_compaction procedure reliability during concurrent schedule/execute operations
- **Commit Concurrency Test**: Verifies show_commits procedure consistency during concurrent insert operations with timeline progression validation
- **Lock Provider Integration**: Configured InProcessLockProvider with optimistic concurrency control to simulate realistic concurrent execution scenarios
- **Progressive Validation**: Implemented multi-stage validation checking early, middle, and late operation states to ensure proper timeline progression

### Impact

- **Enhanced Test Coverage**: Validates that Hudi Show procedures work correctly under concurrent access patterns, improving confidence in multi-user environments
- **Concurrency Safety Verification**: Ensures show procedures don't interfere with ongoing write operations and provide consistent results
- **Lock Provider Validation**: Tests integration between procedures and Hudi's lock provider infrastructure for proper concurrency control
- **Timeline Consistency**: Verifies that timeline operations remain consistent and progress correctly during concurrent modifications

No user-facing changes - this is purely test infrastructure enhancement.

### Risk level (write none, low medium or high below)

none

Test-only changes with no impact on production code or user functionality.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed