### PR TITLE
[HUDI-9784] Adding mysql binlog validation for debezium

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/MysqlDebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/MysqlDebeziumSource.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utilities.sources.debezium;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.exception.HoodieReadFromSourceException;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 
@@ -97,6 +98,12 @@ public class MysqlDebeziumSource extends DebeziumSource {
   }
 
   private static String generateUniqueSequence(String fileId, Long pos) {
+    // Minimal validations to ensure fileId and pos are valid.
+    if (fileId == null || fileId.trim().isEmpty() || pos == null || pos < 0) {
+      throw new HoodieReadFromSourceException(
+          String.format("Invalid binlog file information from Debezium: fileId=%s, pos=%s", fileId, pos));
+    }
+
     return fileId.substring(fileId.lastIndexOf('.') + 1).concat("." + pos);
   }
 }


### PR DESCRIPTION
### Change Logs

If somehow debezium pushes an invalid MySQL event without binlog or position we block the event rather than generating an invalid event_seq

### Impact

Adds validation for `MySqlDebeziumSource`

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
