### PR TITLE
[HUDI-9793] Implement multi-table support for PrometheusReporter with reference counting

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/prometheus/TestPrometheusReporter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/prometheus/TestPrometheusReporter.java
@@ -21,23 +21,42 @@ package org.apache.hudi.metrics.prometheus;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
+import org.apache.hudi.config.metrics.HoodieMetricsPrometheusConfig;
 import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.metrics.MetricsReporterType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TestPrometheusReporter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestPrometheusReporter.class);
 
   @Mock
   HoodieWriteConfig writeConfig;
@@ -45,11 +64,35 @@ public class TestPrometheusReporter {
   HoodieMetricsConfig metricsConfig;
   HoodieMetrics hoodieMetrics;
   Metrics metrics;
+  
+  private static final int TEST_PORT = 19090;
+  private static final int TEST_PORT_2 = 19091;
+  private List<PrometheusReporter> reportersToCleanup;
+
+  @BeforeEach
+  void setUp() {
+    reportersToCleanup = new ArrayList<>();
+  }
 
   @AfterEach
   void shutdownMetrics() {
     if (metrics != null) {
       metrics.shutdown();
+    }
+    
+    for (PrometheusReporter reporter : reportersToCleanup) {
+      try {
+        reporter.stop();
+      } catch (Exception e) {
+        LOG.debug("Exception during test cleanup: {}", e.getMessage());
+      }
+    }
+    reportersToCleanup.clear();
+    
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -65,5 +108,195 @@ public class TestPrometheusReporter {
       hoodieMetrics = new HoodieMetrics(writeConfig, HoodieTestUtils.getDefaultStorage());
       metrics = hoodieMetrics.getMetrics();
     });
+  }
+
+  @Test
+  public void testMultiTableReferenceCountingBasic() {
+    MetricRegistry registry1 = new MetricRegistry();
+    MetricRegistry registry2 = new MetricRegistry();
+    
+    HoodieMetricsConfig config1 = createMockConfig(TEST_PORT);
+    HoodieMetricsConfig config2 = createMockConfig(TEST_PORT);
+    
+    assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+    
+    PrometheusReporter reporter1 = new PrometheusReporter(config1, registry1);
+    reportersToCleanup.add(reporter1);
+    
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    PrometheusReporter reporter2 = new PrometheusReporter(config2, registry2);
+    reportersToCleanup.add(reporter2);
+    
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(2, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(2, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reporter1.stop();
+    
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reporter2.stop();
+    
+    assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reportersToCleanup.clear();
+  }
+
+  @Test
+  public void testMultiplePortsIndependent() {
+    MetricRegistry registry1 = new MetricRegistry();
+    MetricRegistry registry2 = new MetricRegistry();
+    
+    HoodieMetricsConfig config1 = createMockConfig(TEST_PORT);
+    HoodieMetricsConfig config2 = createMockConfig(TEST_PORT_2);
+    
+    PrometheusReporter reporter1 = new PrometheusReporter(config1, registry1);
+    PrometheusReporter reporter2 = new PrometheusReporter(config2, registry2);
+    reportersToCleanup.add(reporter1);
+    reportersToCleanup.add(reporter2);
+    
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT_2));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT_2));
+    
+    reporter1.stop();
+    
+    assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT_2));
+    assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT_2));
+    
+    reporter2.stop();
+    reportersToCleanup.clear();
+  }
+
+  @Test
+  public void testConcurrentReporterCreation() throws Exception {
+    final int numThreads = 10;
+    final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final CountDownLatch completeLatch = new CountDownLatch(numThreads);
+    final List<PrometheusReporter> reporters = new ArrayList<>();
+    
+    try {
+      List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < numThreads; i++) {
+        futures.add(executor.submit(() -> {
+          try {
+            startLatch.await();
+            MetricRegistry registry = new MetricRegistry();
+            HoodieMetricsConfig config = createMockConfig(TEST_PORT);
+            PrometheusReporter reporter = new PrometheusReporter(config, registry);
+            synchronized (reporters) {
+              reporters.add(reporter);
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debug("Thread interrupted during concurrent test setup");
+          } catch (Exception e) {
+            LOG.debug("Expected exception during concurrent PrometheusReporter test: {}", e.getMessage());
+          } finally {
+            completeLatch.countDown();
+          }
+        }));
+      }
+      
+      startLatch.countDown();
+      
+      assertTrue(completeLatch.await(10, TimeUnit.SECONDS));
+      
+      for (Future<?> future : futures) {
+        assertDoesNotThrow(() -> future.get());
+      }
+      
+      assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+      assertEquals(numThreads, PrometheusReporter.getReferenceCount(TEST_PORT));
+      assertEquals(numThreads, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+      
+      synchronized (reporters) {
+        for (PrometheusReporter reporter : reporters) {
+          reporter.stop();
+        }
+        reportersToCleanup.addAll(reporters);
+      }
+      
+      assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+      assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+      
+    } finally {
+      executor.shutdown();
+      reportersToCleanup.clear();
+    }
+  }
+
+  @Test
+  public void testReporterLifecycle() {
+    MetricRegistry registry = new MetricRegistry();
+    HoodieMetricsConfig config = createMockConfig(TEST_PORT);
+    
+    PrometheusReporter reporter = new PrometheusReporter(config, registry);
+    reportersToCleanup.add(reporter);
+    
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(1, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reporter.stop();
+    
+    assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reportersToCleanup.clear();
+  }
+
+  @Test
+  public void testPartialFailureScenario() {
+    MetricRegistry registry1 = new MetricRegistry();
+    MetricRegistry registry2 = new MetricRegistry();
+    MetricRegistry registry3 = new MetricRegistry();
+    
+    HoodieMetricsConfig config = createMockConfig(TEST_PORT);
+    
+    PrometheusReporter reporter1 = new PrometheusReporter(config, registry1);
+    PrometheusReporter reporter2 = new PrometheusReporter(config, registry2);
+    PrometheusReporter reporter3 = new PrometheusReporter(config, registry3);
+    reportersToCleanup.add(reporter1);
+    reportersToCleanup.add(reporter2);
+    reportersToCleanup.add(reporter3);
+    
+    assertEquals(3, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    
+    reporter2.stop();
+    
+    assertEquals(2, PrometheusReporter.getReferenceCount(TEST_PORT));
+    assertTrue(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(2, PrometheusReporter.getActiveExportsCount(TEST_PORT));
+    
+    reporter1.stop();
+    reporter3.stop();
+    
+    assertFalse(PrometheusReporter.isServerRunning(TEST_PORT));
+    assertEquals(0, PrometheusReporter.getReferenceCount(TEST_PORT));
+    
+    reportersToCleanup.clear();
+  }
+
+  private HoodieMetricsConfig createMockConfig(int port) {
+    Properties props = new Properties();
+    props.setProperty(HoodieMetricsPrometheusConfig.PROMETHEUS_PORT_NUM.key(), String.valueOf(port));
+    return HoodieMetricsConfig.newBuilder()
+        .fromProperties(props)
+        .build();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/prometheus/PrometheusReporter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/prometheus/PrometheusReporter.java
@@ -38,6 +38,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 /**
@@ -50,10 +53,15 @@ public class PrometheusReporter extends MetricsReporter {
   private static final Logger LOG = LoggerFactory.getLogger(PrometheusReporter.class);
   private static final Map<Integer, CollectorRegistry> PORT_TO_COLLECTOR_REGISTRY = new HashMap<>();
   private static final Map<Integer, HTTPServer> PORT_TO_SERVER = new HashMap<>();
+  
+  private static final Map<Integer, AtomicInteger> PORT_TO_REFERENCE_COUNT = new HashMap<>();
+  private static final Map<Integer, Set<DropwizardExports>> PORT_TO_EXPORTS = new HashMap<>();
 
   private final DropwizardExports metricExports;
   private final CollectorRegistry collectorRegistry;
   private final int serverPort;
+  private volatile boolean stopped = false;
+  private volatile boolean unregistered = false;
 
   public PrometheusReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
     this.serverPort = metricsConfig.getPrometheusPort();
@@ -71,22 +79,38 @@ public class PrometheusReporter extends MetricsReporter {
     }
     metricExports = new DropwizardExports(registry, new LabeledSampleBuilder(labelNames, labelValues));
     this.collectorRegistry = PORT_TO_COLLECTOR_REGISTRY.get(serverPort);
-    metricExports.register(collectorRegistry);
+    
+    synchronized (PrometheusReporter.class) {
+      metricExports.register(collectorRegistry);
+      PORT_TO_EXPORTS.computeIfAbsent(serverPort, k -> ConcurrentHashMap.newKeySet()).add(metricExports);
+      PORT_TO_REFERENCE_COUNT.computeIfAbsent(serverPort, k -> new AtomicInteger(0)).incrementAndGet();
+      
+      LOG.debug("Registered PrometheusReporter for port {}, reference count: {}", 
+               serverPort, PORT_TO_REFERENCE_COUNT.get(serverPort).get());
+    }
   }
 
-  private static synchronized void startHttpServer(int serverPort) {
-    if (!PORT_TO_COLLECTOR_REGISTRY.containsKey(serverPort)) {
-      PORT_TO_COLLECTOR_REGISTRY.put(serverPort, new CollectorRegistry());
-    }
-    if (!PORT_TO_SERVER.containsKey(serverPort)) {
-      try {
-        HTTPServer server = new HTTPServer(new InetSocketAddress(serverPort), PORT_TO_COLLECTOR_REGISTRY.get(serverPort), true);
-        PORT_TO_SERVER.put(serverPort, server);
-        Runtime.getRuntime().addShutdownHook(new Thread(server::stop));
-      } catch (Exception e) {
-        String msg = "Could not start PrometheusReporter HTTP server on port " + serverPort;
-        LOG.error(msg, e);
-        throw new HoodieException(msg, e);
+  private static void startHttpServer(int serverPort) {
+    synchronized (PrometheusReporter.class) {
+      if (!PORT_TO_COLLECTOR_REGISTRY.containsKey(serverPort)) {
+        PORT_TO_COLLECTOR_REGISTRY.put(serverPort, new CollectorRegistry());
+      }
+      if (!PORT_TO_SERVER.containsKey(serverPort)) {
+        try {
+          HTTPServer server = new HTTPServer(new InetSocketAddress(serverPort), PORT_TO_COLLECTOR_REGISTRY.get(serverPort), true);
+          PORT_TO_SERVER.put(serverPort, server);
+          Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+              server.close();
+            } catch (Exception e) {
+              LOG.debug("Error closing Prometheus HTTP server during shutdown: {}", e.getMessage());
+            }
+          }));
+        } catch (Exception e) {
+          String msg = "Could not start PrometheusReporter HTTP server on port " + serverPort;
+          LOG.error(msg, e);
+          throw new HoodieException(msg, e);
+        }
       }
     }
   }
@@ -101,12 +125,118 @@ public class PrometheusReporter extends MetricsReporter {
 
   @Override
   public void stop() {
-    collectorRegistry.unregister(metricExports);
+    try {
+      synchronized (PrometheusReporter.class) {
+        if (isAlreadyStopped()) {
+          return;
+        }
+        
+        markAsStopped();
+        unregisterMetricExports();
+        removeFromExportsTracking();
+        
+        int newReferenceCount = decrementReferenceCount();
+        if (newReferenceCount <= 0) {
+          cleanupServerResources();
+        } else {
+          logServerKeptAlive(newReferenceCount);
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error in PrometheusReporter.stop() for port {}", serverPort, e);
+    }
+  }
+
+  private boolean isAlreadyStopped() {
+    if (stopped) {
+      LOG.debug("PrometheusReporter.stop() called for port {} but already stopped", serverPort);
+      return true;
+    }
+    return false;
+  }
+
+  private void markAsStopped() {
+    stopped = true;
+    LOG.debug("PrometheusReporter.stop() called for port {}", serverPort);
+  }
+
+  private void unregisterMetricExports() {
+    if (!unregistered) {
+      try {
+        collectorRegistry.unregister(metricExports);
+        unregistered = true;
+      } catch (Exception e) {
+        LOG.debug("Error unregistering metric exports for port {}: {}", serverPort, e.getMessage());
+      }
+    }
+  }
+
+  private void removeFromExportsTracking() {
+    Set<DropwizardExports> exports = PORT_TO_EXPORTS.get(serverPort);
+    if (exports != null) {
+      exports.remove(metricExports);
+    }
+  }
+
+  private int decrementReferenceCount() {
+    AtomicInteger refCount = PORT_TO_REFERENCE_COUNT.get(serverPort);
+    if (refCount != null) {
+      int newCount = refCount.decrementAndGet();
+      LOG.debug("Unregistered PrometheusReporter for port {}, reference count: {}", 
+               serverPort, newCount);
+      return newCount;
+    } else {
+      LOG.warn("No reference count found for port {} during stop()", serverPort);
+      return 0;
+    }
+  }
+
+  private void cleanupServerResources() {
+    LOG.info("No more references to Prometheus server on port {}, stopping server", serverPort);
+    closeHttpServer();
+    removeAllPortResources();
+  }
+
+  private void closeHttpServer() {
     HTTPServer httpServer = PORT_TO_SERVER.remove(serverPort);
     if (httpServer != null) {
-      httpServer.stop();
+      try {
+        httpServer.close();
+      } catch (Exception e) {
+        LOG.debug("Error closing Prometheus HTTP server on port {}: {}", serverPort, e.getMessage());
+      }
     }
+  }
+
+  private void removeAllPortResources() {
     PORT_TO_COLLECTOR_REGISTRY.remove(serverPort);
+    PORT_TO_REFERENCE_COUNT.remove(serverPort);
+    PORT_TO_EXPORTS.remove(serverPort);
+  }
+
+  private void logServerKeptAlive(int referenceCount) {
+    LOG.debug("Prometheus server on port {} still has {} references, keeping server alive", 
+             serverPort, referenceCount);
+  }
+
+  public static boolean isServerRunning(int port) {
+    synchronized (PrometheusReporter.class) {
+      return PORT_TO_SERVER.containsKey(port);
+    }
+  }
+
+  public static int getReferenceCount(int port) {
+    synchronized (PrometheusReporter.class) {
+      AtomicInteger refCount = PORT_TO_REFERENCE_COUNT.get(port);
+      return refCount != null ? refCount.get() : 0;
+    }
+  }
+
+  public static int getActiveExportsCount(int port) {
+    synchronized (PrometheusReporter.class) {
+      Set<DropwizardExports> exports = PORT_TO_EXPORTS.get(port);
+      return exports != null ? exports.size() : 0;
+    }
   }
 
   private static class LabeledSampleBuilder implements SampleBuilder {


### PR DESCRIPTION
### Change Logs

- Implemented multi-table support for `PrometheusReporter` to resolve the issue where stopping metrics for one table would break metrics collection for other tables sharing the same Prometheus server port. Added reference counting mechanism to track multiple tables using the same server and only stop the HTTP server when all tables have finished reporting. 
- got `deprecationwarnings` and fixed them by replacing `server.stop()` with `server.close()` 
- refactored the big stop() method into focused private methods for better maintainability.


### Impact

No breaking changes. It now supports to run multiple Hudi tables with Prometheus metrics on the same port without one table's shutdown breaking metrics for other active tables.

### Risk level (write none, low medium or high below)

LOW. 

### Documentation Update

NONE

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
