### PR TITLE
[HUDI-9794] Convert the avro into file bytes in LegacyArchivedMetaEntryReader to keep forward compatibility

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -71,6 +71,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -442,9 +443,14 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
       Map<HeaderMetadataType, String> header = new HashMap<>();
       header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, wrapperSchema.toString());
       final String keyField = table.getMetaClient().getTableConfig().getRecordKeyFieldProp();
-      List<HoodieRecord> indexRecords = records.stream().map(HoodieAvroIndexedRecord::new).collect(Collectors.toList());
-      HoodieAvroDataBlock block = new HoodieAvroDataBlock(indexRecords, header, keyField);
-      writer.appendBlock(block);
+      List<HoodieRecord> indexRecords = records.stream()
+          .filter(Objects::nonNull)
+          .map(HoodieAvroIndexedRecord::new)
+          .collect(Collectors.toList());
+      if (!indexRecords.isEmpty()) {
+        HoodieAvroDataBlock block = new HoodieAvroDataBlock(indexRecords, header, keyField);
+        writer.appendBlock(block);
+      }
       records.clear();
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -100,7 +100,7 @@ public class LegacyArchivedMetaEntryReader {
       Object actionData = record.get(key);
       if (actionData != null) {
         if (actionData instanceof IndexedRecord) {
-          return HoodieAvroUtils.avroToBytes((IndexedRecord) actionData);
+          return HoodieAvroUtils.convertIndexedRecordToAvroFileFormat((IndexedRecord) actionData);
         } else {
           // should be json bytes.
           try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -100,7 +100,7 @@ public class LegacyArchivedMetaEntryReader {
       Object actionData = record.get(key);
       if (actionData != null) {
         if (actionData instanceof IndexedRecord) {
-          return HoodieAvroUtils.convertIndexedRecordToAvroFileFormat((IndexedRecord) actionData);
+          return HoodieAvroUtils.avroToFileBytes((IndexedRecord) actionData);
         } else {
           // should be json bytes.
           try {

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -162,7 +162,7 @@ public class HoodieAvroUtils {
     }
   }
 
-  public static byte[] convertIndexedRecordToAvroFileFormat(IndexedRecord record) {
+  public static byte[] avroToFileBytes(IndexedRecord record) {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       try (DataFileWriter<IndexedRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(record.getSchema()))) {
         writer.create(record.getSchema(), baos);

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -163,18 +163,12 @@ public class HoodieAvroUtils {
   }
 
   public static byte[] convertIndexedRecordToAvroFileFormat(IndexedRecord record) {
-    try {
-      byte[] bytes = HoodieAvroUtils.avroToBytes(record);
-      if (bytes.length >= 4 && bytes[0] == 0x4F && bytes[1] == 0x62 && bytes[2] == 0x6A && bytes[3] == 0x01) { // "Obj" magic bytes to check if its already in avro file format
-        return bytes;
-      }
-      try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-        try (DataFileWriter<IndexedRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(record.getSchema()))) {
-          writer.create(record.getSchema(), baos);
-          writer.append(record);
-          writer.flush();
-          return baos.toByteArray();
-        }
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      try (DataFileWriter<IndexedRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(record.getSchema()))) {
+        writer.create(record.getSchema(), baos);
+        writer.append(record);
+        writer.flush();
+        return baos.toByteArray();
       }
     } catch (IOException e) {
       throw new HoodieIOException("Failed to convert IndexedRecord to Avro file format", e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/MetadataConversionUtils.java
@@ -183,7 +183,9 @@ public class MetadataConversionUtils {
     switch (actionType) {
       case HoodieTimeline.CLEAN_ACTION: {
         archivedMetaWrapper.setHoodieCleanMetadata(CleanerUtils.getCleanerMetadata(metaClient, new ByteArrayInputStream(instantDetails.get())));
-        archivedMetaWrapper.setHoodieCleanerPlan(CleanerUtils.getCleanerPlan(metaClient, new ByteArrayInputStream(planBytes.get())));
+        if (planBytes.isPresent()) {
+          archivedMetaWrapper.setHoodieCleanerPlan(CleanerUtils.getCleanerPlan(metaClient, new ByteArrayInputStream(planBytes.get())));
+        }
         archivedMetaWrapper.setActionType(ActionType.clean.name());
         break;
       }


### PR DESCRIPTION
### Change Logs

Fixed upgrade and downgrade back for lower version tables (like V6→V9→V6) upgrade/downgrade failures caused by Avro format inconsistency between timeline archiver versions. The issue occurred because `TimelineArchiverV1` produces raw binary-encoded Avro records (without magic bytes) while `TimelineArchiverV2` produces Avro file format (with `Obj\x01` magic bytes). During upgrade/downgrade operations, this format mismatch caused `InvalidAvroMagicException` and `NoSuchElementException`.

**Key Changes:**
- Enhanced `LegacyArchivedMetaEntryReader.readInstant()` with magic bytes detection to ensure consistent Avro file format output
- Added specific archival configurations to `testV6TableUpgradeToV9ToV6` for controlled test environment

### Impact

**User-Facing Changes:**
- Fixes table upgrade/downgrade functionality for users migrating between Hudi versions, for example V6↔V9 transitions
- Eliminates `InvalidAvroMagicException` and `NoSuchElementException` errors during upgrade/downgrade operations

**API Changes:**
- No public API changes
- Internal metadata conversion logic enhanced for better format handling

### Risk level:

low

### Documentation Update

None required.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly  
- [x] Adequate tests were added if applicable
- [ ] CI passed