### PR TITLE
[Website][Minor] - Blog links redirect should open new tab

### DIFF
--- a/website/src/theme/BlogPostItem/BlogPostBox.js
+++ b/website/src/theme/BlogPostItem/BlogPostBox.js
@@ -87,7 +87,10 @@ export default function BlogPostBox({metadata = {}, assets, frontMatter}) {
                     )}
                     <TitleHeading className={styles.blogPostTitle} itemProp="headline">
                         {location.pathname.startsWith('/blog') ?
-                                <Link itemProp="url" to={permalink}>
+                                <Link itemProp="url" to={permalink} onClick={(e) => {
+                                        e.preventDefault();
+                                        window.open(permalink, '_blank', 'noopener,noreferrer');
+                                    }}>
                                     <TitleHeading className={styles.blogPostTitle} itemProp="headline">
                                         {title}
                                     </TitleHeading>
@@ -99,6 +102,7 @@ export default function BlogPostBox({metadata = {}, assets, frontMatter}) {
                                 </TitleHeading>
                         }
                     </TitleHeading>
+
                     <div className={clsx(styles.blogInfo, "margin-top--sm margin-bottom--sm")}>
                         {AuthorsList()}
                     </div>


### PR DESCRIPTION
### Change Logs

When a blog link redirects to an external page, it opens in the same tab. As a result, the browser's back button doesn't return users to the blog list—it jumps back to the redirect page and then immediately back to the external blog, which creates a frustrating loop. Users are forced to manually open a new tab and navigate back to the blog list from the Hudi homepage.

To improve the experience, external blog links should open in a new tab—just like the video guide links do.

### Impact

Minor

### Risk level (write none, low medium or high below)

None

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
