### PR TITLE
[MINOR] Increase async index loading to 10s to reduce probability of …

### DIFF
--- a/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -671,7 +671,7 @@ public class TestHudiSmokeTest
         Session session = SessionBuilder.from(getSession())
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(true)
-                .withColumnStatsTimeout("1s")
+                .withColumnStatsTimeout("10s")
                 .withRecordLevelIndexEnabled(false)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
@@ -691,7 +691,7 @@ public class TestHudiSmokeTest
         Session session = SessionBuilder.from(getSession())
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(true)
-                .withColumnStatsTimeout("1s")
+                .withColumnStatsTimeout("10s")
                 .withRecordLevelIndexEnabled(false)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
@@ -723,7 +723,7 @@ public class TestHudiSmokeTest
         Session session = SessionBuilder.from(getSession())
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(true)
-                .withColumnStatsTimeout("5s")
+                .withColumnStatsTimeout("10s")
                 .withRecordLevelIndexEnabled(false)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
@@ -748,7 +748,7 @@ public class TestHudiSmokeTest
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(false)
                 .withRecordLevelIndexEnabled(true)
-                .withRecordIndexTimeout("1s")
+                .withRecordIndexTimeout("10s")
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
                 .build();
@@ -772,7 +772,7 @@ public class TestHudiSmokeTest
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(false)
                 .withRecordLevelIndexEnabled(true)
-                .withRecordIndexTimeout("1s")
+                .withRecordIndexTimeout("10s")
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
                 .build();
@@ -801,7 +801,7 @@ public class TestHudiSmokeTest
                 .withRecordLevelIndexEnabled(true)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
-                .withColumnStatsTimeout("1s")
+                .withColumnStatsTimeout("10s")
                 .build();
         MaterializedResult totalRes = getQueryRunner().execute(session, "SELECT * FROM " + table);
         MaterializedResult prunedRes = getQueryRunner().execute(session, "SELECT * FROM " + table


### PR DESCRIPTION
…flaky tests (#68)

### Change Logs

Followup PR for: https://github.com/apache/hudi/pull/13787

Our current index are loaded asynchronously. If it fails to load in 1s, it will fallback doing a full load so as to not block split generation. When testing for correctness in our tests, we require indexes to be loaded fully. If the server that is running the test is busy or overloaded, it will increase the likelihood of the test failing.

While this is not a permanent fix, it should reduce the probability of tests failing. The permanent fix should be adding a synchronous flag so that index metadata is loaded synchronously to remove these timing issues entirely.

### Impact

Reduce probability of async metadata tests failing.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
