### PR TITLE
[HUDI-9799] Add metric of totalCorruptLogFiles when stream read

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.read.buffer.HoodieFileGroupRecordBuffer;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -122,6 +123,10 @@ public abstract class BaseHoodieLogRecordReader<T> {
   private AtomicLong totalRollbacks = new AtomicLong(0);
   // Total number of corrupt blocks written across all log files
   private AtomicLong totalCorruptBlocks = new AtomicLong(0);
+  // Total number of corrupt log files - for metrics
+  private AtomicLong totalCorruptLogFiles = new AtomicLong(0);
+  // Corrupt log files list - for debug
+  private List<String> corruptLogFilesList;
   // Store the last instant log blocks (needed to implement rollback)
   private Deque<HoodieLogBlock> currentInstantLogBlocks = new ArrayDeque<>();
   // Enables full scan of log records
@@ -385,6 +390,13 @@ public abstract class BaseHoodieLogRecordReader<T> {
 
       // Done
       progress = 1.0f;
+      totalCorruptLogFiles.set(logFilePaths.size() - scannedLogFiles.size());
+      if (totalCorruptLogFiles.get() > 0) {
+        List<String> scannedLogFilesNames = scannedLogFiles.stream().map(HoodieLogFile::getPath)
+            .map(StoragePath::getName).collect(Collectors.toList());
+        corruptLogFilesList = CollectionUtils.diff(logFilePaths, scannedLogFilesNames);
+        LOG.info("Corrupt Log Files: {}", corruptLogFilesList);
+      }
       totalLogRecords.set(recordBuffer.getTotalLogRecords());
     } catch (IOException e) {
       LOG.error("Got IOException when reading log file", e);
@@ -787,6 +799,10 @@ public abstract class BaseHoodieLogRecordReader<T> {
 
   public long getTotalCorruptBlocks() {
     return totalCorruptBlocks.get();
+  }
+
+  public long getTotalCorruptLogFiles() {
+    return totalCorruptLogFiles.get();
   }
 
   public boolean isWithOperationField() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -324,8 +324,15 @@ public final class HoodieFileGroupReader<T> implements Closeable {
   public static class HoodieFileGroupReaderIterator<T> implements ClosableIterator<BufferedRecord<T>> {
     private HoodieFileGroupReader<T> reader;
 
+    private final HoodieReadStats readStats;
+
     public HoodieFileGroupReaderIterator(HoodieFileGroupReader<T> reader) {
       this.reader = reader;
+      this.readStats = reader.readStats;
+    }
+
+    public HoodieReadStats getReadStats() {
+      return this.readStats;
     }
 
     @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieReadStats.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieReadStats.java
@@ -52,6 +52,8 @@ public class HoodieReadStats implements Serializable {
   protected long totalCorruptLogBlock;
   // Total number of rollback blocks seen in a compaction operation
   protected long totalRollbackBlocks;
+  // Total number of corrupt log files
+  protected long totalCorruptLogFiles;
 
   public HoodieReadStats() {
   }
@@ -106,6 +108,10 @@ public class HoodieReadStats implements Serializable {
     return totalRollbackBlocks;
   }
 
+  public long getTotalCorruptLogFiles() {
+    return totalCorruptLogFiles;
+  }
+
   public void incrementNumInserts() {
     numInserts++;
   }
@@ -148,5 +154,9 @@ public class HoodieReadStats implements Serializable {
 
   public void setTotalRollbackBlocks(long totalRollbackBlocks) {
     this.totalRollbackBlocks = totalRollbackBlocks;
+  }
+
+  public void setTotalCorruptLogFiles(long totalCorruptLogFiles) {
+    this.totalCorruptLogFiles = totalCorruptLogFiles;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/LogScanningRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/LogScanningRecordBufferLoader.java
@@ -58,6 +58,7 @@ abstract class LogScanningRecordBufferLoader {
       readStats.setTotalLogBlocks(logRecordReader.getTotalLogBlocks());
       readStats.setTotalCorruptLogBlock(logRecordReader.getTotalCorruptBlocks());
       readStats.setTotalRollbackBlocks(logRecordReader.getTotalRollbacks());
+      readStats.setTotalCorruptLogFiles(logRecordReader.getTotalCorruptLogFiles());
       return logRecordReader.getValidBlockInstants();
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -819,7 +819,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     return actualRecordList;
   }
 
-  private HoodieFileGroupReader<T> getHoodieFileGroupReader(StorageConfiguration<?> storageConf,
+  protected HoodieFileGroupReader<T> getHoodieFileGroupReader(StorageConfiguration<?> storageConf,
                                                             String tablePath,
                                                             HoodieTableMetaClient metaClient,
                                                             Schema avroSchema,
@@ -883,7 +883,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     return actualRecordList;
   }
 
-  private TypedProperties buildProperties(HoodieTableMetaClient metaClient, RecordMergeMode recordMergeMode) {
+  protected TypedProperties buildProperties(HoodieTableMetaClient metaClient, RecordMergeMode recordMergeMode) {
     TypedProperties props = new TypedProperties();
     props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));
     props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
@@ -60,6 +60,10 @@ public class FlinkStreamReadMetrics extends HoodieFlinkMetrics {
    * Duration between splitLatestCommit and now.
    */
   private long splitLatestCommitDelay;
+  /**
+   * Number of corrupt log file which will be skipped when stream read
+   */
+  private long totalCorruptLogFiles;
 
   public FlinkStreamReadMetrics(MetricGroup metricGroup) {
     super(metricGroup);
@@ -71,6 +75,7 @@ public class FlinkStreamReadMetrics extends HoodieFlinkMetrics {
     metricGroup.gauge("issuedInstant", () -> issuedInstant);
     metricGroup.gauge("splitLatestCommit", () -> splitLatestCommit);
     metricGroup.gauge("splitLatestCommitDelay", () -> splitLatestCommitDelay);
+    metricGroup.gauge("totalCorruptLogFiles", () -> totalCorruptLogFiles);
   }
 
   public void setIssuedInstant(String issuedInstant) {
@@ -91,6 +96,10 @@ public class FlinkStreamReadMetrics extends HoodieFlinkMetrics {
     } catch (ParseException e) {
       LOG.warn("Invalid input latest commit" + splitLatestCommit);
     }
+  }
+
+  public void setTotalCorruptLogFiles(long totalCorruptLogFiles) {
+    this.totalCorruptLogFiles = totalCorruptLogFiles;
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -168,6 +168,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
       // there is only one log message for one data bucket.
       LOG.info("Processing input split : {}", split);
       format.open(split);
+      readMetrics.setTotalCorruptLogFiles(format.getLogReadStats().getTotalCorruptLogFiles());
       readMetrics.setSplitLatestCommit(split.getLatestCommit());
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.read.HoodieReadStats;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -202,6 +203,10 @@ public class MergeOnReadInputFormat
   public BaseStatistics getStatistics(BaseStatistics baseStatistics) {
     // statistics not supported yet.
     return null;
+  }
+
+  public HoodieReadStats getLogReadStats() {
+    return ((HoodieFileGroupReader.HoodieFileGroupReaderIterator)this.iterator).getReadStats();
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Corrupt log files will be skipped when stream read, which may cause data loss(first data block with broken magic number while later data blocks are also skipped).

This PR add metric totalCorruptLogFiles when stream read which indicates this potential data loss. 


### Impact

hudi-common、hudi-flink

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist
