### PR TITLE
[MINOR[] Fixing record size estimator for avro record

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordSizeEstimator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordSizeEstimator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.avro;
 
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.util.ObjectSizeCalculator;
 import org.apache.hudi.common.util.SizeEstimator;
@@ -26,15 +27,49 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificRecord;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * An implementation of {@link SizeEstimator} for Avro {@link BufferedRecord}, which estimates the size of
  * Avro record excluding the internal {@link Schema}.
  */
 public class AvroRecordSizeEstimator implements SizeEstimator<BufferedRecord<IndexedRecord>> {
   private final long sizeOfSchema;
+  private final long sizeOfSchemaWithoutMeta;
 
   public AvroRecordSizeEstimator(Schema recordSchema) {
     sizeOfSchema = ObjectSizeCalculator.getObjectSize(recordSchema);
+    if (recordSchema.getFields().get(0).name().equals(HoodieRecord.COMMIT_TIME_METADATA_FIELD)) {
+      sizeOfSchemaWithoutMeta = ObjectSizeCalculator.getObjectSize(schemaWithoutMeta(recordSchema));
+    } else {
+      sizeOfSchemaWithoutMeta = sizeOfSchema;
+    }
+  }
+
+  private Schema schemaWithoutMeta(Schema originalSchema) {
+    List<Schema.Field> originalFields = originalSchema.getFields();
+    List<Schema.Field> remainingFields = new ArrayList<>();
+    int startIndex = originalSchema.getFields().get(5).name().equals(HoodieRecord.OPERATION_METADATA_FIELD) ? 6 : 5;
+    for (int i = startIndex; i < originalFields.size(); i++) {
+      Schema.Field originalField = originalFields.get(i);
+      Schema.Field copiedField = new Schema.Field(
+          originalField.name(),
+          originalField.schema(),
+          originalField.doc(),
+          originalField.defaultVal(),
+          originalField.order()
+      );
+      remainingFields.add(copiedField);
+    }
+    Schema newSchema = Schema.createRecord(
+        originalSchema.getName() + "_Subset",
+        originalSchema.getDoc(),
+        originalSchema.getNamespace(),
+        false
+    );
+    newSchema.setFields(remainingFields);
+    return newSchema;
   }
 
   @Override
@@ -45,6 +80,11 @@ public class AvroRecordSizeEstimator implements SizeEstimator<BufferedRecord<Ind
       return sizeOfRecord;
     }
     // do not contain size of Avro schema as the schema is reused among records
-    return sizeOfRecord - sizeOfSchema + 8;
+    long toReturn =  sizeOfRecord - sizeOfSchema + 8;
+    if (toReturn < 0) {
+       return sizeOfRecord - sizeOfSchemaWithoutMeta + 8;
+    } else {
+      return toReturn;
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

Fixing record size estimator for avro record. Sometimes we might use records w/o meta fields while deserializing (COW merge paths), while compaction might use it w/ meta fields. We happened to instantiate AvroRecordSizeEstimator with a schema containing meta fields, but `SizeEstimator.sizeEstimate()` is invoked for a BufferedRecord w/o meta fields which could lead to negative size estimations

### Impact

Robust record size estimation for avro records.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
