### PR TITLE
[INFRA-27242] chore: add .htaccess with CSP update to allow Kapa.ai widget

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,7 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See https://docs.kapa.ai/integrations/understanding-csp-cors and https://issues.apache.org/jira/browse/INFRA-26638
-<IfModule mod_headers.c>
-    Header set Content-Security-Policy "default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/ https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ https://www.recaptcha.net/; script-src-elem 'self' 'unsafe-inline' https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ https://www.recaptcha.net/ https://analytics.apache.org/ https://widget.kapa.ai/; style-src 'self' 'unsafe-inline' https://*.kapa.ai/ data:; frame-ancestors 'self'; frame-src 'self' data: blob: https://www.google.com/ https://www.recaptcha.net/; connect-src 'self' https://analytics.apache.org proxy.kapa.ai kapa-widget-proxy-la7.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai www.google.com recaptcha.net; img-src 'self' data: https://*.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/ https://www.google.com https://*.gstatic.com/; worker-src 'self' data: blob:;"
-</IfModule>
+# https://infra.apache.org/tools/csp.html and https://issues.apache.org/jira/browse/INFRA-27242
+SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://widget.kapa.ai/ proxy.kapa.ai kapa-widget-proxy-la7.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai"


### PR DESCRIPTION
### Change Logs

This PR introduces a new .htaccess file to configure the Content Security Policy (CSP) and allow the Kapa.ai widget to load correctly.

Without this change, browsers block the script with the following error:

```sh
(index):1 Refused to load the script 'https://widget.kapa.ai/kapa-widget.bundle.js' 
because it violates the following Content Security Policy directive: 
"script-src 'self' data: blob: 'unsafe-inline' 'unsafe-eval' https://www.apachecon.com/ 
https://www.communityovercode.org/ https://*.apache.org/ https://apache.org/ https://*.scarf.sh/".
```

### Impact

Enable kapa widget. Infra ticket https://issues.apache.org/jira/browse/INFRA-27242

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
