### PR TITLE
[MINOR] Adding back PRECOMBINE_FIELD Config property in DataSourceReadOptions

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -418,6 +418,9 @@ object DataSourceWriteOptions {
    */
   val ORDERING_FIELDS = HoodieWriteConfig.PRECOMBINE_FIELD_NAME
 
+  // for b/w compatibility
+  val PRECOMBINE_FIELD = HoodieWriteConfig.PRECOMBINE_FIELD_NAME
+
   /**
    * Payload class used. Override this, if you like to roll your own merge logic, when upserting/inserting.
    * This will render any value set for `PRECOMBINE_FIELD_OPT_VAL` in-effective


### PR DESCRIPTION
### Change Logs

Adding back PRECOMBINE_FIELD Config property in DataSourceReadOptions. When we renamed the precombine field 
https://github.com/apache/hudi/pull/13718/ here, we removed the config property. This could be used by users in their pipeline scripts for setting writer properties. atleast this is one of the 3 basic properties for creating a hudi table. 

### Impact

Existing user scripts will not break. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
