### PR TITLE
[MINOR] Enable HFile block cache by default

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -92,7 +92,7 @@ public class HoodieReaderConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> HFILE_BLOCK_CACHE_ENABLED = ConfigProperty
       .key("hoodie.hfile.block.cache.enabled")
-      .defaultValue(false)
+      .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.1.0")
       .withDocumentation("Enable HFile block-level caching for metadata files. This caches frequently "


### PR DESCRIPTION
### Change Logs

Enable HFile block cache by default as to test stability.

### Impact

Faster MDT reads potentially.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Configurations for this should be automatically generated.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
