### PR TITLE
(docs) Removed FAQ from Docs starting from 1.0.0

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -138,20 +138,6 @@ module.exports = {
                     ],
                 },
             ],
-        },
-        {
-            type: 'category',
-            label: 'Frequently Asked Questions(FAQs)',
-            items: [
-                'faq',
-                'faq_general',
-                'faq_design_and_concepts',
-                'faq_writing_tables',
-                'faq_reading_tables',
-                'faq_table_services',
-                'faq_storage',
-                'faq_integrations',
-            ],
         }
     ],
     quick_links: [

--- a/website/versioned_sidebars/version-1.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-1.0.0-sidebars.json
@@ -132,20 +132,6 @@
         }
       ]
     },
-    {
-      "type": "category",
-      "label": "Frequently Asked Questions(FAQs)",
-      "items": [
-        "faq",
-        "faq_general",
-        "faq_design_and_concepts",
-        "faq_writing_tables",
-        "faq_reading_tables",
-        "faq_table_services",
-        "faq_storage",
-        "faq_integrations"
-      ]
-    },
     "privacy"
   ],
   "quick_links": [

--- a/website/versioned_sidebars/version-1.0.1-sidebars.json
+++ b/website/versioned_sidebars/version-1.0.1-sidebars.json
@@ -132,20 +132,6 @@
         }
       ]
     },
-    {
-      "type": "category",
-      "label": "Frequently Asked Questions(FAQs)",
-      "items": [
-        "faq",
-        "faq_general",
-        "faq_design_and_concepts",
-        "faq_writing_tables",
-        "faq_reading_tables",
-        "faq_table_services",
-        "faq_storage",
-        "faq_integrations"
-      ]
-    },
     "privacy"
   ],
   "quick_links": [

--- a/website/versioned_sidebars/version-1.0.2-sidebars.json
+++ b/website/versioned_sidebars/version-1.0.2-sidebars.json
@@ -132,20 +132,6 @@
         }
       ]
     },
-    {
-      "type": "category",
-      "label": "Frequently Asked Questions(FAQs)",
-      "items": [
-        "faq",
-        "faq_general",
-        "faq_design_and_concepts",
-        "faq_writing_tables",
-        "faq_reading_tables",
-        "faq_table_services",
-        "faq_storage",
-        "faq_integrations"
-      ]
-    },
     "privacy"
   ],
   "quick_links": [


### PR DESCRIPTION
### Change Logs

Removed FAQ from Docs starting from 1.0.0

**Before:**
<img width="1230" height="488" alt="image" src="https://github.com/user-attachments/assets/0f1a6939-fb8c-42d1-98c9-2858bd8a6fdf" />

**After:**
<img width="1220" height="452" alt="image" src="https://github.com/user-attachments/assets/e7339084-349d-4de3-82d2-7303493ade76" />



### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

Removed FAQ from Docs starting from 1.0.0

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
