### PR TITLE
fix: make sure blog links redirect opens a new tab

### DIFF
--- a/website/src/theme/BlogPostItem/BlogPostBox.js
+++ b/website/src/theme/BlogPostItem/BlogPostBox.js
@@ -19,9 +19,10 @@ export default function BlogPostBox({metadata = {}, assets, frontMatter}) {
 
     const image = assets.image ?? frontMatter.image ?? '/assets/images/hudi-logo-medium.png';
 
-    const manageVideoOpen = (videoLink) => {
-        if(videoLink) {
-            window.open(videoLink, '_blank', 'noopener noreferrer');
+    const openResourceInNewTab = (e, resource_url) => {
+        e.preventDefault()
+        if(resource_url) {
+            window.open(resource_url, '_blank', 'noopener noreferrer');
         }
     }
 
@@ -68,14 +69,14 @@ export default function BlogPostBox({metadata = {}, assets, frontMatter}) {
                         <div className="col blogThumbnail" itemProp="blogThumbnail">
                             {
                                 location.pathname.startsWith('/blog') ? <Link itemProp="url" to={permalink}>
-                                        <img
+                                        <img onClick={(e) => openResourceInNewTab(e, permalink)}
                                             src={withBaseUrl(image, {
                                                 absolute: true,
                                             })}
                                             className="blog-image"
                                         />
                                     </Link> :
-                                    <img onClick={() => manageVideoOpen(frontMatter?.navigate)}
+                                    <img onClick={(e) => openResourceInNewTab(e, frontMatter?.navigate)}
                                          src={withBaseUrl(image, {
                                              absolute: true,
                                          })}
@@ -87,16 +88,13 @@ export default function BlogPostBox({metadata = {}, assets, frontMatter}) {
                     )}
                     <TitleHeading className={styles.blogPostTitle} itemProp="headline">
                         {location.pathname.startsWith('/blog') ?
-                                <Link itemProp="url" to={permalink} onClick={(e) => {
-                                        e.preventDefault();
-                                        window.open(permalink, '_blank', 'noopener,noreferrer');
-                                    }}>
+                                <Link itemProp="url" to={permalink} onClick={(e) => openResourceInNewTab(e, permalink)}>
                                     <TitleHeading className={styles.blogPostTitle} itemProp="headline">
                                         {title}
                                     </TitleHeading>
                                 </Link>
                                 :
-                                <TitleHeading onClick={() => manageVideoOpen(frontMatter?.navigate)}
+                                <TitleHeading onClick={(e) => openResourceInNewTab(e, frontMatter?.navigate)}
                                               className={styles.blogPostTitle} itemProp="headline">
                                     {title}
                                 </TitleHeading>


### PR DESCRIPTION
### Change Logs

When a blog link redirects to an external page, it opens in the same tab. As a result, the browser's back button doesn't return users to the blog list—it jumps back to the redirect page and then immediately back to the external blog, which creates a frustrating loop. Users are forced to manually open a new tab and navigate back to the blog list from the Hudi homepage.

To improve the experience, external blog links should open in a new tab—just like the video guide links do.

### Impact

Minor

### Risk level (write none, low medium or high below)

None

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed