### PR TITLE
fix: update docker compose file name for mac arm in the stop script

### DIFF
--- a/docker/stop_demo.sh
+++ b/docker/stop_demo.sh
@@ -22,7 +22,7 @@ HUDI_DEMO_ENV=$1
 WS_ROOT=`dirname $SCRIPT_PATH`
 COMPOSE_FILE_NAME="docker-compose_hadoop284_hive233_spark353_amd64.yml"
 if [ "$HUDI_DEMO_ENV" = "--mac-aarch64" ]; then
-  COMPOSE_FILE_NAME="docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml"
+  COMPOSE_FILE_NAME="docker-compose_hadoop284_hive233_spark353_arm64.yml"
 fi
 # shut down cluster
 HUDI_WS=${WS_ROOT} docker compose -f ${SCRIPT_PATH}/compose/${COMPOSE_FILE_NAME} down


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/13929

The stop demo script with the mac flag is currently wrong, it was never updated when the compose filename was changed

### Summary and Changelog

change the filename to the correct name

### Impact

can properly stop docker demo

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
