### PR TITLE
fix: fixing hivesync tool in docker

### DIFF
--- a/docker/hoodie/hadoop/sparkadhoc/Dockerfile
+++ b/docker/hoodie/hadoop/sparkadhoc/Dockerfile
@@ -50,4 +50,8 @@ RUN set -x \
     ## trino-cli
     && wget -q -O /usr/local/bin/trino ${BASE_URL}/io/trino/trino-cli/${TRINO_VERSION}/trino-cli-${TRINO_VERSION}-executable.jar \
     && chmod +x /usr/local/bin/trino
+
+RUN cp /opt/hive/lib/calcite-core*.jar $HADOOP_HOME/share/hadoop/common/lib/
+RUN cp /opt/hive/lib/libfb*.jar $HADOOP_HOME/share/hadoop/common/lib/
+
 CMD ["/bin/bash", "/opt/spark/adhoc.sh"]

--- a/docker/hoodie/hadoop/sparkadhoc/Dockerfile
+++ b/docker/hoodie/hadoop/sparkadhoc/Dockerfile
@@ -53,5 +53,4 @@ RUN set -x \
 
 RUN cp /opt/hive/lib/calcite-core*.jar $HADOOP_HOME/share/hadoop/common/lib/
 RUN cp /opt/hive/lib/libfb*.jar $HADOOP_HOME/share/hadoop/common/lib/
-
 CMD ["/bin/bash", "/opt/spark/adhoc.sh"]


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes #13938

- The original Docker image did not support copying necessary Hive dependencies like calcite-core and libfb303, causing Hive sync failures at runtime.
- This PR fixes an issue with running the HiveSyncTool inside a Docker container.

### Summary and Changelog

Fixed HiveSyncTool runtime failure by updating Docker runtime script to inject required Hive dependencies.

### Impact

None

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
