### PR TITLE
perf: Increase HFile prefetch threshold

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -521,7 +521,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Integer> METADATA_FILE_CACHE_MAX_SIZE_MB = ConfigProperty
       .key(METADATA_PREFIX + ".file.cache.max.size.mb")
-      .defaultValue(0)
+      .defaultValue(50)
       .markAdvanced()
       .sinceVersion("1.1.0")
       .withDocumentation("Max size in MB below which metadata file (HFile) will be downloaded "


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

For queries that run short, e.g., a few seconds, the impact of reading Hudi metadata table could be huge on the query latency. We have observed that the metadata read latency could be higher than that of the data read itself.  Therefore, reducing the latency of reading Hudi metadata is important for these short running queries. 

### Summary and Changelog

Previously the hfile reader could trigger multiple read for a single hfile in the MDT, e.g., one read is triggered when a data block of a hfile is requested. When the hfile becomes bigger, this could be become a huge problem. An feature that Hudi introduces to alleviate this problem is caching the entire hfile before reading it if hfile size is below a certain threshold. By default the threshold is 0MB. 

This change Increases the threshold from 0 MB to 50 MB, which enables hfile prefetching and caching.

### Impact

Reduce the MDT read latency, that improves the query performance.

### Risk Level

Low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
