### PR TITLE
(perf) Avoid repeated work in HFile reads and writes

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReaderImplBase.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReaderImplBase.java
@@ -19,19 +19,21 @@
 
 package org.apache.hudi.io.storage;
 
-import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.BinaryDecoder;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.avro.HoodieAvroUtils.getBinaryDecoder;
 import static org.apache.hudi.common.util.CollectionUtils.toStream;
 import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 
@@ -83,32 +85,23 @@ public abstract class HoodieAvroHFileReaderImplBase extends HoodieAvroFileReader
     }
   }
 
-  protected static GenericRecord deserialize(final byte[] keyBytes,
-                                             final byte[] valueBytes,
-                                             Schema writerSchema,
-                                             Schema readerSchema) throws IOException {
-    return deserialize(
-        keyBytes, 0, keyBytes.length, valueBytes, 0, valueBytes.length, writerSchema, readerSchema);
-  }
-
   protected static GenericRecord deserialize(final byte[] keyBytes, int keyOffset, int keyLength,
                                              final byte[] valueBytes, int valueOffset, int valueLength,
-                                             Schema writerSchema,
-                                             Schema readerSchema) throws IOException {
-    GenericRecord record = HoodieAvroUtils.bytesToAvro(
-        valueBytes, valueOffset, valueLength, writerSchema, readerSchema);
-
-    getKeySchema(readerSchema).ifPresent(keyFieldSchema -> {
-      final Object keyObject = record.get(keyFieldSchema.pos());
-      if (keyObject != null && keyObject.toString().isEmpty()) {
-        record.put(keyFieldSchema.pos(), fromUTF8Bytes(keyBytes, keyOffset, keyLength));
-      }
-    });
-
-    return record;
+                                             GenericDatumReader<GenericRecord> datumReader,
+                                             Schema.Field keyFieldSchema) throws IOException {
+    BinaryDecoder binaryDecoder = getBinaryDecoder(valueBytes, valueOffset, valueLength);
+    GenericRecord avroRecord = datumReader.read(null, binaryDecoder);
+    if (keyFieldSchema == null) {
+      return avroRecord;
+    }
+    final Object keyObject = avroRecord.get(keyFieldSchema.pos());
+    if (keyObject != null && keyObject.toString().isEmpty()) {
+      avroRecord.put(keyFieldSchema.pos(), fromUTF8Bytes(keyBytes, keyOffset, keyLength));
+    }
+    return avroRecord;
   }
 
-  private static Option<Schema.Field> getKeySchema(Schema schema) {
+  static Option<Schema.Field> getKeySchema(Schema schema) {
     return Option.ofNullable(schema.getField(KEY_FIELD_NAME));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -41,6 +41,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.Lazy;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.slf4j.Logger;
@@ -269,14 +270,14 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
   }
 
   private static GenericRecord getRecordFromKeyValue(KeyValue keyValue,
-                                                     Schema writerSchema,
-                                                     Schema readerSchema) throws IOException {
+                                                     GenericDatumReader<GenericRecord> datumReader,
+                                                     Schema.Field keyFieldSchema) throws IOException {
     byte[] bytes = keyValue.getBytes();
     return deserialize(
         bytes, keyValue.getKeyContentOffset(), keyValue.getKeyContentLength(),
         bytes, keyValue.getValueOffset(), keyValue.getValueLength(),
-        writerSchema,
-        readerSchema);
+        datumReader,
+        keyFieldSchema);
   }
 
   private byte[] getHFileMetaInfoFromCache(String key) throws IOException {
@@ -332,17 +333,16 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   private static class RecordIterator implements ClosableIterator<IndexedRecord> {
     private final HFileReader reader;
-
-    private final Schema writerSchema;
-    private final Schema readerSchema;
+    private final GenericDatumReader<GenericRecord> datumReader;
+    private final Schema.Field keyFieldSchema;
 
     private IndexedRecord next = null;
     private boolean eof = false;
 
     RecordIterator(HFileReader reader, Schema writerSchema, Schema readerSchema) {
       this.reader = reader;
-      this.writerSchema = writerSchema;
-      this.readerSchema = readerSchema;
+      this.datumReader = new GenericDatumReader<>(writerSchema, readerSchema);
+      this.keyFieldSchema = getKeySchema(readerSchema).orElse(null);
     }
 
     @Override
@@ -369,7 +369,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
           return false;
         }
 
-        this.next = getRecordFromKeyValue(reader.getKeyValue().get(), writerSchema, readerSchema);
+        this.next = getRecordFromKeyValue(reader.getKeyValue().get(), datumReader, keyFieldSchema);
         return true;
       } catch (IOException io) {
         throw new HoodieIOException("unable to read next record from hfile ", io);
@@ -395,12 +395,10 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
   private static class RecordByKeyIterator implements ClosableIterator<IndexedRecord> {
     private final Iterator<String> sortedKeyIterator;
-
     private final HFileReader reader;
-
-    private final Schema readerSchema;
-    private final Schema writerSchema;
     private final Option<BloomFilter> bloomFilterOption;
+    private final GenericDatumReader<GenericRecord> datumReader;
+    private final Schema.Field keyFieldSchema;
 
     private IndexedRecord next = null;
 
@@ -410,8 +408,6 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
       this.reader = reader;
       this.reader.seekTo(); // position at the beginning of the file
 
-      this.writerSchema = writerSchema;
-      this.readerSchema = readerSchema;
       BloomFilter bloomFilter = null;
       if (useBloomFilter) {
         try {
@@ -421,6 +417,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
         }
       }
       this.bloomFilterOption = Option.ofNullable(bloomFilter);
+      this.datumReader = new GenericDatumReader<>(writerSchema, readerSchema);
+      this.keyFieldSchema = getKeySchema(readerSchema).orElse(null);
     }
 
     @Override
@@ -445,7 +443,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
             next = deserialize(
                 key.getBytes(), key.getContentOffset(), key.getContentLength(),
                 keyValue.getBytes(), keyValue.getValueOffset(), keyValue.getValueLength(),
-                writerSchema, readerSchema);
+                datumReader, keyFieldSchema);
             return true;
           }
         }
@@ -575,6 +573,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
           }
         }
       }
+      GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(writerSchema, readerSchema);
+      Schema.Field keyFieldSchema = getKeySchema(readerSchema).orElse(null);
 
       class KeyPrefixIterator implements Iterator<IndexedRecord> {
         private IndexedRecord next = null;
@@ -600,7 +600,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
                 deserialize(
                     bytes, keyValue.getKeyContentOffset(), keyValue.getKeyContentLength(),
                     bytes, keyValue.getValueOffset(), keyValue.getValueLength(),
-                    writerSchema, readerSchema);
+                    datumReader, keyFieldSchema);
             // In case scanner is not able to advance, it means we reached EOF
             eof = !reader.next();
           } catch (IOException e) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
The HFile read performance is critical for good query performance for Hudi users. As part of auditing that code path, I discovered that we do a few steps per record that can be done once per file read. The writer path had similar issues.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
In both the reader and writer path, this PR aims to only check if the key field exists once for a given file or batch of records.

Only the reader path, the DatumReader is also reused to avoid recreating this object per record.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
In local testing against a 4.5Mb col stats HFile, I saw a 20% reduction in time taken to deserialize the file.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
