### PR TITLE
chore: update CSP setting to allow kapa.ai (INFRA-27242)

### DIFF
--- a/website/static/.htaccess
+++ b/website/static/.htaccess
@@ -1,3 +1,3 @@
 # CSP permissions for hudi.apache.org - https://issues.apache.org/jira/browse/INFRA-27242
 # Ref https://docs.kapa.ai/integrations/understanding-csp-cors
-SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app https://www.google.com/recaptcha/ https://hcaptcha.com https://*.hcaptcha.com"
+SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com https://*.hcaptcha.com"


### PR DESCRIPTION
Additional required URL to whitelist for kapa