### PR TITLE
fix: MIT spill records to disk with incorrect schema

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/StreamingFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/StreamingFileGroupRecordBufferLoader.java
@@ -66,7 +66,7 @@ public class StreamingFileGroupRecordBufferLoader<T> implements FileGroupRecordB
                                                                             List<String> orderingFieldNames, HoodieTableMetaClient hoodieTableMetaClient,
                                                                             TypedProperties props, ReaderParameters readerParameters, HoodieReadStats readStats,
                                                                             Option<BaseFileUpdateCallback<T>> fileGroupUpdateCallback) {
-    Schema recordSchema = AvroSchemaCache.intern(HoodieAvroUtils.removeMetadataFields(readerContext.getSchemaHandler().getRequestedSchema()));
+    Schema recordSchema = AvroSchemaCache.intern(getRecordSchema(readerContext, props));
     HoodieTableConfig tableConfig = hoodieTableMetaClient.getTableConfig();
     Option<PartialUpdateMode> partialUpdateModeOpt = tableConfig.getPartialUpdateMode();
     UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.emitDeletes(), fileGroupUpdateCallback, props);
@@ -107,5 +107,15 @@ public class StreamingFileGroupRecordBufferLoader<T> implements FileGroupRecordB
       }
     }
     return Pair.of(recordBuffer, Collections.emptyList());
+  }
+
+  private static <T> Schema getRecordSchema(HoodieReaderContext<T> readerContext, TypedProperties props) {
+    Option<Pair<String, String>> payloadClasses = readerContext.getPayloadClasses(props);
+    if (payloadClasses.isPresent() && payloadClasses.get().getRight().equals("org.apache.spark.sql.hudi.command.payload.ExpressionPayload")) {
+      String schemaStr = props.getString("hoodie.payload.record.schema");
+      return new Schema.Parser().parse(schemaStr);
+    } else {
+      return HoodieAvroUtils.removeMetadataFields(readerContext.getSchemaHandler().getRequestedSchema());
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
https://github.com/apache/hudi/issues/13966

### Summary and Changelog

In the StreamingFileGroupRecordBufferLoader we check if it's expression payload, and if so, we use the schema set in the configs instead of using the requested schema

### Impact

MIT does not fail with index oob

### Risk Level

low
added a test

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
