### PR TITLE
[HUDI-9158] Rename heartbeat poll secs to lock renewal secs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -183,7 +183,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
       Logger logger,
       HoodieLockMetrics hoodieLockMetrics) {
     StorageBasedLockConfig config = new StorageBasedLockConfig.Builder().fromProperties(properties).build();
-    long heartbeatPollSeconds = config.getHeartbeatPollSeconds();
+    long heartbeatPollSeconds = config.getRenewIntervalSecs();
     this.lockValiditySecs = config.getValiditySeconds();
     this.basePath = config.getHudiTableBasePath();
     String lockFolderPath = StorageLockClient.getLockFolderPath(basePath);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/StorageBasedLockConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/StorageBasedLockConfig.java
@@ -42,11 +42,12 @@ public class StorageBasedLockConfig extends HoodieConfig {
               + "The lock provider will attempt to renew its lock until it successfully extends the lock lease period "
               + "or the validity timeout is reached.");
 
-  public static final ConfigProperty<Long> HEARTBEAT_POLL_SECONDS = ConfigProperty
-      .key(STORAGE_BASED_LOCK_PROPERTY_PREFIX + "heartbeat.poll.secs")
+  public static final ConfigProperty<Long> RENEW_INTERVAL_SECS = ConfigProperty
+      .key(STORAGE_BASED_LOCK_PROPERTY_PREFIX + "renew.interval.secs")
       .defaultValue(30L)
       .markAdvanced()
       .sinceVersion(SINCE_VERSION_1_0_2)
+      .withAlternatives(STORAGE_BASED_LOCK_PROPERTY_PREFIX + "heartbeat.poll.secs")
       .withDocumentation(
           "For storage-based lock provider, the amount of time in seconds to wait before renewing the lock. "
               + "Defaults to 30 seconds.");
@@ -55,8 +56,8 @@ public class StorageBasedLockConfig extends HoodieConfig {
     return getLong(VALIDITY_TIMEOUT_SECONDS);
   }
 
-  public long getHeartbeatPollSeconds() {
-    return getLong(HEARTBEAT_POLL_SECONDS);
+  public long getRenewIntervalSecs() {
+    return getLong(RENEW_INTERVAL_SECS);
   }
 
   public String getHudiTableBasePath() {
@@ -82,18 +83,18 @@ public class StorageBasedLockConfig extends HoodieConfig {
       if (!lockConfig.contains(BASE_PATH)) {
         throw new IllegalArgumentException(BASE_PATH.key() + notExistsMsg);
       }
-      if (lockConfig.getLongOrDefault(VALIDITY_TIMEOUT_SECONDS) < lockConfig.getLongOrDefault(HEARTBEAT_POLL_SECONDS)
+      if (lockConfig.getLongOrDefault(VALIDITY_TIMEOUT_SECONDS) < lockConfig.getLongOrDefault(RENEW_INTERVAL_SECS)
           * 10) {
         throw new IllegalArgumentException(
-            VALIDITY_TIMEOUT_SECONDS.key() + " should be greater than or equal to 10x " + HEARTBEAT_POLL_SECONDS.key());
+            VALIDITY_TIMEOUT_SECONDS.key() + " should be greater than or equal to 10x " + RENEW_INTERVAL_SECS.key());
       }
       if (lockConfig.getLongOrDefault(VALIDITY_TIMEOUT_SECONDS) < 10) {
         throw new IllegalArgumentException(
             VALIDITY_TIMEOUT_SECONDS.key() + " should be greater than or equal to 10 seconds.");
       }
-      if (lockConfig.getLongOrDefault(HEARTBEAT_POLL_SECONDS) < 1) {
+      if (lockConfig.getLongOrDefault(RENEW_INTERVAL_SECS) < 1) {
         throw new IllegalArgumentException(
-            HEARTBEAT_POLL_SECONDS.key() + " should be greater than or equal to 1 second.");
+            RENEW_INTERVAL_SECS.key() + " should be greater than or equal to 1 second.");
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProviderTestBase.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProviderTestBase.java
@@ -92,7 +92,7 @@ public abstract class StorageBasedLockProviderTestBase {
   @Test
   void testLockThreadKilledShouldNotCauseOrphanedHeartbeat() throws InterruptedException {
     providerProperties.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), 10);
-    providerProperties.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), 1);
+    providerProperties.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), 1);
 
     AtomicReference<StorageBasedLockProvider> lp = new AtomicReference<>();
     // Create a thread with a new lock provider to acquire the lock

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -94,7 +94,7 @@ class TestStorageBasedLockProvider {
     when(mockLockService.readObject(anyString(), anyBoolean())).thenReturn(Option.empty());
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
 
     lockProvider = spy(new StorageBasedLockProvider(
@@ -669,7 +669,7 @@ class TestStorageBasedLockProvider {
     // Create test configuration
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
     LockConfiguration lockConfiguration = new LockConfiguration(props);
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
@@ -715,7 +715,7 @@ class TestStorageBasedLockProvider {
     // Create test configuration
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
     LockConfiguration lockConfiguration = new LockConfiguration(props);
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
@@ -758,7 +758,7 @@ class TestStorageBasedLockProvider {
     // Test that lock provider works correctly when audit config is not present
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-audit-test");
 
     // Mock client that returns empty for audit config
@@ -802,7 +802,7 @@ class TestStorageBasedLockProvider {
     // Test that lock provider works correctly when audit is explicitly disabled
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-audit-disabled");
 
     // Mock client that returns disabled config
@@ -847,7 +847,7 @@ class TestStorageBasedLockProvider {
     // Test that lock provider works correctly when audit is enabled
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-audit-enabled");
 
     // Mock client that returns enabled config

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestStorageBasedLockConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestStorageBasedLockConfig.java
@@ -41,7 +41,7 @@ class TestStorageBasedLockConfig {
         .build();
 
     assertEquals(5 * 60, config.getValiditySeconds(), "Default lock validity should be 5 minutes");
-    assertEquals(30, config.getHeartbeatPollSeconds(), "Default heartbeat poll time should be 30 seconds");
+    assertEquals(30, config.getRenewIntervalSecs(), "Default heartbeat poll time should be 30 seconds");
   }
 
   @Test
@@ -49,7 +49,7 @@ class TestStorageBasedLockConfig {
     // Testing that custom values which differ from defaults can be read properly
     TypedProperties props = new TypedProperties();
     props.setProperty(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "120");
-    props.setProperty(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "10");
+    props.setProperty(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "10");
     props.setProperty(BASE_PATH.key(), "/hudi/table/basepath");
 
     StorageBasedLockConfig config = new StorageBasedLockConfig.Builder()
@@ -57,7 +57,7 @@ class TestStorageBasedLockConfig {
         .build();
 
     assertEquals(120, config.getValiditySeconds());
-    assertEquals(10, config.getHeartbeatPollSeconds());
+    assertEquals(10, config.getRenewIntervalSecs());
     assertEquals("/hudi/table/basepath", config.getHudiTableBasePath());
   }
 
@@ -81,7 +81,7 @@ class TestStorageBasedLockConfig {
     props.setProperty(BASE_PATH.key(), "/hudi/table/basepath");
     // Invalid config case: validity timeout is less than 10x of heartbeat poll period
     props.setProperty(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "5");
-    props.setProperty(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "3");
+    props.setProperty(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "3");
     StorageBasedLockConfig.Builder propsBuilder = new StorageBasedLockConfig.Builder();
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
@@ -89,13 +89,13 @@ class TestStorageBasedLockConfig {
     assertTrue(exception.getMessage().contains(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key()));
     // Invalid config case: validity timeout is less than 10 seconds
     props.setProperty(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "9");
-    props.setProperty(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "1");
+    props.setProperty(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
     exception = assertThrows(IllegalArgumentException.class, () -> propsBuilder.fromProperties(props));
     assertTrue(exception.getMessage().contains(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key()));
     // Invalid config case: heartbeat poll period is less than 1 second
     props.setProperty(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.setProperty(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key(), "0");
+    props.setProperty(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "0");
     exception = assertThrows(IllegalArgumentException.class, () -> propsBuilder.fromProperties(props));
-    assertTrue(exception.getMessage().contains(StorageBasedLockConfig.HEARTBEAT_POLL_SECONDS.key()));
+    assertTrue(exception.getMessage().contains(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key()));
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

As suggested by @vinothchandar , should rename heartbeat poll secs to lock renewal secs

### Summary and Changelog

`hoodie.write.lock.storage.heartbeat.poll.secs` -> `hoodie.write.lock.storage.renew.interval.secs`
- will still keep heartbeat poll as alternative

### Impact

No impact

### Risk Level

None, maintains default behavior.

### Documentation Update

None

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
