### PR TITLE
refactor: Adapt delete handling with DeleteContext for HoodieFlinkRecord

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.table.format.FlinkRecordContext;
 import org.apache.hudi.util.RowDataAvroQueryContexts;
 import org.apache.hudi.util.RowDataAvroQueryContexts.RowDataQueryContext;
 import org.apache.hudi.util.RowProjection;
@@ -218,24 +219,11 @@ public class HoodieFlinkRecord extends HoodieRecord<RowData> {
 
   @Override
   protected boolean checkIsDelete(DeleteContext deleteContext, Properties props) {
-    if (data == null) {
+    if (data == null || HoodieOperation.isDelete(getOperation())) {
       return true;
     }
 
-    if (HoodieOperation.isDelete(getOperation())) {
-      return true;
-    }
-
-    // Use data field to decide.
-    Schema.Field deleteField = deleteContext.getReaderSchema().getField(HOODIE_IS_DELETED_FIELD);
-    if (deleteField != null && data.getBoolean(deleteField.pos())) {
-      return true;
-    }
-    // check custom delete marker
-    return deleteContext.getCustomDeleteMarkerKeyValue().map(markerKeyValue -> {
-      Object fieldValue = getColumnValueAsJava(deleteContext.getReaderSchema(), markerKeyValue.getKey(), props, true);
-      return markerKeyValue.getValue().equals(fieldValue);
-    }).orElse(false);
+    return FlinkRecordContext.getFieldAccessorInstance(props).isDeleteRecord(data, deleteContext);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
@@ -223,7 +223,7 @@ public class HoodieFlinkRecord extends HoodieRecord<RowData> {
       return true;
     }
 
-    return FlinkRecordContext.getFieldAccessorInstance(props).isDeleteRecord(data, deleteContext);
+    return FlinkRecordContext.getDeleteCheckingInstance().isDeleteRecord(data, deleteContext);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
@@ -49,9 +49,12 @@ import org.apache.flink.types.RowKind;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.UnaryOperator;
 
 public class FlinkRecordContext extends RecordContext<RowData> {
+  private static final FlinkRecordContext FIELD_ACCESSOR_INSTANCE_WITH_UTC_ENABLE = new FlinkRecordContext(true);
+  private static final FlinkRecordContext FIELD_ACCESSOR_INSTANCE_WITH_UTC_DISABLE = new FlinkRecordContext(false);
 
   private final boolean utcTimezone;
   // the converter is used to create a RowData contains primary key fields only
@@ -63,6 +66,16 @@ public class FlinkRecordContext extends RecordContext<RowData> {
   public FlinkRecordContext(HoodieTableConfig tableConfig, StorageConfiguration<?> storageConf) {
     super(tableConfig, new DefaultJavaTypeConverter());
     this.utcTimezone = storageConf.getBoolean("read.utc-timezone",true);
+  }
+
+  private FlinkRecordContext(boolean utcTimezone) {
+    super(new DefaultJavaTypeConverter());
+    this.utcTimezone = utcTimezone;
+  }
+
+  public static FlinkRecordContext getFieldAccessorInstance(Properties props) {
+    boolean utcTimezone = Boolean.parseBoolean(props.getProperty("read.utc-timezone","true"));
+    return utcTimezone ? FIELD_ACCESSOR_INSTANCE_WITH_UTC_ENABLE : FIELD_ACCESSOR_INSTANCE_WITH_UTC_DISABLE;
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
@@ -49,12 +49,10 @@ import org.apache.flink.types.RowKind;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.function.UnaryOperator;
 
 public class FlinkRecordContext extends RecordContext<RowData> {
-  private static final FlinkRecordContext FIELD_ACCESSOR_INSTANCE_WITH_UTC_ENABLE = new FlinkRecordContext(true);
-  private static final FlinkRecordContext FIELD_ACCESSOR_INSTANCE_WITH_UTC_DISABLE = new FlinkRecordContext(false);
+  private static final FlinkRecordContext DELETE_CHECKING_INSTANCE = new FlinkRecordContext(true);
 
   private final boolean utcTimezone;
   // the converter is used to create a RowData contains primary key fields only
@@ -73,9 +71,8 @@ public class FlinkRecordContext extends RecordContext<RowData> {
     this.utcTimezone = utcTimezone;
   }
 
-  public static FlinkRecordContext getFieldAccessorInstance(Properties props) {
-    boolean utcTimezone = Boolean.parseBoolean(props.getProperty("read.utc-timezone","true"));
-    return utcTimezone ? FIELD_ACCESSOR_INSTANCE_WITH_UTC_ENABLE : FIELD_ACCESSOR_INSTANCE_WITH_UTC_DISABLE;
+  public static FlinkRecordContext getDeleteCheckingInstance() {
+    return DELETE_CHECKING_INSTANCE;
   }
 
   @Override


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix issue: https://github.com/apache/hudi/issues/13969

### Summary and Changelog

Adapt delete handling with `DeleteContext` for `HoodieFlinkRecord`

### Impact

none.

### Risk Level

low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
