### PR TITLE
fix: Fix the buffer overflow issue for hfile writer

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
@@ -26,6 +26,7 @@ import com.google.protobuf.CodedOutputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -89,7 +90,6 @@ public abstract class HFileBlock {
   // Write properties
   private long startOffsetInBuffForWrite = -1;
   private long previousBlockOffsetForWrite = -1;
-  protected int longestEntrySize = 0;
 
   /**
    * Initialize HFileBlock for read.
@@ -257,12 +257,7 @@ public abstract class HFileBlock {
    * Returns serialized "data" part of the block.
    * This function must be implemented by each block type separately.
    */
-  protected abstract ByteBuffer getUncompressedBlockDataToWrite();
-
-  /**
-   * Calculate the capacity of the buffer for each piece of data.
-   */
-  protected abstract int calculateBufferCapacity();
+  protected abstract ByteBuffer getUncompressedBlockDataToWrite() throws IOException;
 
   /**
    * Return serialized block including header, data, checksum.
@@ -273,40 +268,44 @@ public abstract class HFileBlock {
     // Compress if specified.
     ByteBuffer compressedBlockData = context.getCompressor().compress(uncompressedBlockData);
     // Buffer for building block.
-    ByteBuffer buf = ByteBuffer.allocate(Math.max(
-        context.getBlockSize() * 2,
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(
+        context.getBlockSize(),
         compressedBlockData.limit() + HFILEBLOCK_HEADER_SIZE * 2));
+    try (DataOutputStream dataOutputStream = new DataOutputStream(baos)) {
+      // Block header
+      // 1. Magic is always 8 bytes.
+      dataOutputStream.write(blockType.getMagic(), 0, 8);
+      // 2. onDiskSizeWithoutHeader.
+      int compressedDataSize = compressedBlockData.limit();
+      int onDiskDataSizeWithHeader = HFileBlock.HFILEBLOCK_HEADER_SIZE + compressedDataSize;
+      int numChecksumBytes = numChecksumBytes(onDiskDataSizeWithHeader, DEFAULT_BYTES_PER_CHECKSUM);
+      dataOutputStream.writeInt(compressedDataSize + numChecksumBytes);
+      // 3. uncompressedSizeWithoutHeader.
+      dataOutputStream.writeInt(uncompressedBlockData.limit());
+      // 4. Previous block offset.
+      dataOutputStream.writeLong(previousBlockOffsetForWrite);
+      // 5. Checksum type.
+      dataOutputStream.write(context.getChecksumType().getCode());
+      // 6. Bytes covered per checksum.
+      // Note that: Default value is 16K. There is a check on
+      // onDiskSizeWithoutHeader = uncompressedSizeWithoutHeader + Checksum.
+      // For compatibility with both HBase and native reader, the size of checksum bytes is
+      // calculated based on this and the checksum is appended at the end of the block
+      dataOutputStream.writeInt(DEFAULT_BYTES_PER_CHECKSUM);
+      // 7. onDiskDataSizeWithHeader
+      dataOutputStream.writeInt(onDiskDataSizeWithHeader);
+      // 8. Payload.
+      dataOutputStream.write(
+          compressedBlockData.array(),
+          compressedBlockData.position(), compressedBlockData.remaining());
+      // 9. Checksum.
+      dataOutputStream.write(
+          generateChecksumBytes(context.getChecksumType(), numChecksumBytes));
+    }
 
-    // Block header
-    // 1. Magic is always 8 bytes.
-    buf.put(blockType.getMagic(), 0, 8);
-    // 2. onDiskSizeWithoutHeader.
-    int compressedDataSize = compressedBlockData.limit();
-    int onDiskDataSizeWithHeader = HFileBlock.HFILEBLOCK_HEADER_SIZE + compressedDataSize;
-    int numChecksumBytes = numChecksumBytes(onDiskDataSizeWithHeader, DEFAULT_BYTES_PER_CHECKSUM);
-    buf.putInt(compressedDataSize + numChecksumBytes);
-    // 3. uncompressedSizeWithoutHeader.
-    buf.putInt(uncompressedBlockData.limit());
-    // 4. Previous block offset.
-    buf.putLong(previousBlockOffsetForWrite);
-    // 5. Checksum type.
-    buf.put(context.getChecksumType().getCode());
-    // 6. Bytes covered per checksum.
-    // Note that: Default value is 16K. There is a check on
-    // onDiskSizeWithoutHeader = uncompressedSizeWithoutHeader + Checksum.
-    // For compatibility with both HBase and native reader, the size of checksum bytes is
-    // calculated based on this and the checksum is appended at the end of the block
-    buf.putInt(DEFAULT_BYTES_PER_CHECKSUM);
-    // 7. onDiskDataSizeWithHeader
-    buf.putInt(onDiskDataSizeWithHeader);
-    // 8. Payload.
-    buf.put(compressedBlockData);
-    // 9. Checksum.
-    buf.put(generateChecksumBytes(context.getChecksumType(), numChecksumBytes));
-
-    // Update sizes
-    buf.flip();
-    return buf;
+    // Convert to ByteBuffer for return
+    byte[] result = baos.toByteArray();
+    return ByteBuffer.wrap(result);
   }
 
   /**

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
@@ -89,6 +89,7 @@ public abstract class HFileBlock {
   // Write properties
   private long startOffsetInBuffForWrite = -1;
   private long previousBlockOffsetForWrite = -1;
+  protected int longestEntrySize = 0;
 
   /**
    * Initialize HFileBlock for read.
@@ -257,6 +258,11 @@ public abstract class HFileBlock {
    * This function must be implemented by each block type separately.
    */
   protected abstract ByteBuffer getUncompressedBlockDataToWrite();
+
+  /**
+   * Calculate the capacity of the buffer for each piece of data.
+   */
+  protected abstract int calculateBufferCapacity();
 
   /**
    * Return serialized block including header, data, checksum.

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileIndexBlock.java
@@ -43,8 +43,6 @@ public abstract class HFileIndexBlock extends HFileBlock {
   public void add(byte[] firstKey, long offset, int size) {
     Key key = new Key(firstKey);
     entries.add(new BlockIndexEntry(key, Option.empty(), offset, size));
-    // 8 bytes for offset, 4 bytes for size.
-    longestEntrySize = Math.max(longestEntrySize, key.getContentLength() + 12);
   }
 
   public int getNumOfEntries() {

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileIndexBlock.java
@@ -43,6 +43,8 @@ public abstract class HFileIndexBlock extends HFileBlock {
   public void add(byte[] firstKey, long offset, int size) {
     Key key = new Key(firstKey);
     entries.add(new BlockIndexEntry(key, Option.empty(), offset, size));
+    // 8 bytes for offset, 4 bytes for size.
+    longestEntrySize = Math.max(longestEntrySize, key.getContentLength() + 12);
   }
 
   public int getNumOfEntries() {

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileLeafIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileLeafIndexBlock.java
@@ -54,6 +54,11 @@ public class HFileLeafIndexBlock extends HFileBlock {
     throw new HoodieException("HFile writer does not support leaf index block");
   }
 
+  @Override
+  protected int calculateBufferCapacity() {
+    throw new HoodieException("HFile writer does not support leaf index block");
+  }
+
   /**
    * Reads the index block and returns the block index entries.
    */

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileLeafIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileLeafIndexBlock.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,12 +51,7 @@ public class HFileLeafIndexBlock extends HFileBlock {
   }
 
   @Override
-  protected ByteBuffer getUncompressedBlockDataToWrite() {
-    throw new HoodieException("HFile writer does not support leaf index block");
-  }
-
-  @Override
-  protected int calculateBufferCapacity() {
+  protected ByteBuffer getUncompressedBlockDataToWrite() throws IOException {
     throw new HoodieException("HFile writer does not support leaf index block");
   }
 

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaBlock.java
@@ -56,8 +56,13 @@ public class HFileMetaBlock extends HFileBlock {
   }
 
   @Override
+  protected int calculateBufferCapacity() {
+    return entryToWrite.value.length;
+  }
+
+  @Override
   public ByteBuffer getUncompressedBlockDataToWrite() {
-    ByteBuffer dataBuf = ByteBuffer.allocate(context.getBlockSize());
+    ByteBuffer dataBuf = ByteBuffer.allocate(calculateBufferCapacity());
     // Note that: only value should be store in the block.
     // The key is stored in the meta index block.
     dataBuf.put(entryToWrite.value);

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaBlock.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.io.hfile;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
@@ -56,17 +57,9 @@ public class HFileMetaBlock extends HFileBlock {
   }
 
   @Override
-  protected int calculateBufferCapacity() {
-    return entryToWrite.value.length;
-  }
-
-  @Override
-  public ByteBuffer getUncompressedBlockDataToWrite() {
-    ByteBuffer dataBuf = ByteBuffer.allocate(calculateBufferCapacity());
+  public ByteBuffer getUncompressedBlockDataToWrite() throws IOException {
     // Note that: only value should be store in the block.
     // The key is stored in the meta index block.
-    dataBuf.put(entryToWrite.value);
-    dataBuf.flip();
-    return dataBuf;
+    return ByteBuffer.wrap(entryToWrite.value);
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaIndexBlock.java
@@ -33,8 +33,14 @@ public class HFileMetaIndexBlock extends HFileIndexBlock {
   }
 
   @Override
+  protected int calculateBufferCapacity() {
+    // Use 5 since the keyLength could use 5 bytes maximally.
+    return longestEntrySize + 5;
+  }
+
+  @Override
   public ByteBuffer getUncompressedBlockDataToWrite() {
-    ByteBuffer buf = ByteBuffer.allocate(context.getBlockSize() * 2);
+    ByteBuffer buf = ByteBuffer.allocate(calculateBufferCapacity());
     for (BlockIndexEntry entry : entries) {
       buf.putLong(entry.getOffset());
       buf.putInt(entry.getSize());

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileMetaIndexBlock.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.io.hfile;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -33,33 +35,29 @@ public class HFileMetaIndexBlock extends HFileIndexBlock {
   }
 
   @Override
-  protected int calculateBufferCapacity() {
-    // Use 5 since the keyLength could use 5 bytes maximally.
-    return longestEntrySize + 5;
-  }
-
-  @Override
-  public ByteBuffer getUncompressedBlockDataToWrite() {
-    ByteBuffer buf = ByteBuffer.allocate(calculateBufferCapacity());
-    for (BlockIndexEntry entry : entries) {
-      buf.putLong(entry.getOffset());
-      buf.putInt(entry.getSize());
-      // Key length.
-      try {
-        byte[] keyLength = getVariableLengthEncodedBytes(entry.getFirstKey().getLength());
-        buf.put(keyLength);
-      } catch (IOException e) {
-        throw new RuntimeException(
-            "Failed to serialize number: " + entry.getFirstKey().getLength());
+  public ByteBuffer getUncompressedBlockDataToWrite() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(context.getBlockSize());
+    try (DataOutputStream outputStream = new DataOutputStream(baos)) {
+      for (BlockIndexEntry entry : entries) {
+        outputStream.writeLong(entry.getOffset());
+        outputStream.writeInt(entry.getSize());
+        // Key length.
+        try {
+          byte[] keyLength = getVariableLengthEncodedBytes(entry.getFirstKey().getLength());
+          outputStream.write(keyLength);
+        } catch (IOException e) {
+          throw new RuntimeException(
+              "Failed to serialize number: " + entry.getFirstKey().getLength());
+        }
+        // Note that: NO two-bytes for encoding key length.
+        // Key.
+        outputStream.write(entry.getFirstKey().getBytes());
       }
-      // Note that: NO two-bytes for encoding key length.
-      // Key.
-      buf.put(entry.getFirstKey().getBytes());
     }
-    buf.flip();
 
     // Set metrics.
-    blockDataSize = buf.limit();
-    return buf;
+    byte[] allData = baos.toByteArray();
+    blockDataSize = allData.length;
+    return ByteBuffer.wrap(allData);
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileRootIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileRootIndexBlock.java
@@ -22,6 +22,7 @@ package org.apache.hudi.io.hfile;
 import org.apache.hudi.common.util.Option;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -100,37 +101,27 @@ public class HFileRootIndexBlock extends HFileIndexBlock {
   }
 
   @Override
-  protected int calculateBufferCapacity() {
-    // 2 bytes for length of key length.
-    // 5 bytes for maximal key length.
-    return longestEntrySize + 2 + 5;
-  }
+  public ByteBuffer getUncompressedBlockDataToWrite() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(context.getBlockSize());
+    try (DataOutputStream outputStream = new DataOutputStream(baos)) {
+      for (BlockIndexEntry entry : entries) {
+        outputStream.writeLong(entry.getOffset());
+        outputStream.writeInt(entry.getSize());
 
-  @Override
-  public ByteBuffer getUncompressedBlockDataToWrite() {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    ByteBuffer buf = ByteBuffer.allocate(calculateBufferCapacity());
-    for (BlockIndexEntry entry : entries) {
-      buf.putLong(entry.getOffset());
-      buf.putInt(entry.getSize());
-
-      // Key length + 2.
-      try {
-        byte[] keyLength = getVariableLengthEncodedBytes(
-            entry.getFirstKey().getLength() + SIZEOF_INT16);
-        buf.put(keyLength);
-      } catch (IOException e) {
-        throw new RuntimeException(
-            "Failed to serialize number: " + entry.getFirstKey().getLength() + SIZEOF_INT16);
+        // Key length + 2.
+        try {
+          byte[] keyLength = getVariableLengthEncodedBytes(
+              entry.getFirstKey().getLength() + SIZEOF_INT16);
+          outputStream.write(keyLength);
+        } catch (IOException e) {
+          throw new RuntimeException(
+              "Failed to serialize number: " + entry.getFirstKey().getLength() + SIZEOF_INT16);
+        }
+        // Key length.
+        outputStream.writeShort((short) entry.getFirstKey().getLength());
+        // Key.
+        outputStream.write(entry.getFirstKey().getBytes());
       }
-      // Key length.
-      buf.putShort((short) entry.getFirstKey().getLength());
-      // Key.
-      buf.put(entry.getFirstKey().getBytes());
-      // Copy to output stream.
-      baos.write(buf.array(), 0, buf.position());
-      // Clear the buffer.
-      buf.clear();
     }
 
     // Output all data in a buffer.

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileRootIndexBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileRootIndexBlock.java
@@ -100,9 +100,16 @@ public class HFileRootIndexBlock extends HFileIndexBlock {
   }
 
   @Override
+  protected int calculateBufferCapacity() {
+    // 2 bytes for length of key length.
+    // 5 bytes for maximal key length.
+    return longestEntrySize + 2 + 5;
+  }
+
+  @Override
   public ByteBuffer getUncompressedBlockDataToWrite() {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    ByteBuffer buf = ByteBuffer.allocate(context.getBlockSize());
+    ByteBuffer buf = ByteBuffer.allocate(calculateBufferCapacity());
     for (BlockIndexEntry entry : entries) {
       buf.putLong(entry.getOffset());
       buf.putInt(entry.getSize());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/13978

When HFile writer serializes an entry, e.g., a key value pair for data block or an index for index block, a ByteBuffer is used to allocate memory to keep serialized data. Since the capacity of the ByteBuffer cannot be changed once allocated and this buffer is used to serialize all entries for a block, its capacity should be set properly.

Previously the capacity of the buffer equals the HFile data block size (1MB by default) with the assumption that the key value pair should not be larger than the block size. However, we found that in fact the above assumption is not true. When this happened, `java.nio.BufferOverflowException` exception was thrown.

### Summary and Changelog

To solve the above problem, we remove the usage of ByteBuffer, and instead we use `DataOutputStream` + `ByteArrayOutputStream` to keep the data into memory before flush to the disk. Since ByteArrayOutputStream can extends its capacity automatically, overflow issue should not happen anymore.


### Impact

Simplify the logic of writing data for hfile; remove the risk of overflow.

### Risk Level

Medium.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
