### PR TITLE
chore: Update Content Security Policy to allow Algolia

### DIFF
--- a/website/static/.htaccess
+++ b/website/static/.htaccess
@@ -1,3 +1,4 @@
 # CSP permissions for hudi.apache.org - https://issues.apache.org/jira/browse/INFRA-27242
 # Ref https://docs.kapa.ai/integrations/understanding-csp-cors
-SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com/ https://*.hcaptcha.com/"
+# CSP permissions for hudi.apache.org - Adding 3rd party service Algolia. Approved by VP Data Privacy (https://infra.apache.org/tools/csp.html)
+SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com/ https://*.hcaptcha.com/ https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/"


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This pull request adds the necessary Content Security Policy (CSP) rules to enable Algolia-based search on the Apache Hudi website.

### Summary and Changelog

This pull request updates the Content Security Policy (CSP) for the Apache Hudi website to allow the necessary connections to Algolia's domains. By adding Algolia's domains to the policy, the PR ensures the search bar will function correctly for all users.

**Not working:**

<img width="563" height="393" alt="Screenshot 2025-09-25 at 9 31 09 AM" src="https://github.com/user-attachments/assets/73a3610f-775c-4674-bbc7-892ff1f30863" />

**Working:**

<img width="561" height="515" alt="Screenshot 2025-09-25 at 9 32 04 AM" src="https://github.com/user-attachments/assets/1e41a563-95af-4487-804e-b3ce661ea626" />


### Impact

Low

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
