### PR TITLE
test: optimize the debug loggings for Flink local test

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.client.transaction.lock;
 
+import org.apache.hudi.client.transaction.lock.metrics.HoodieLockMetrics;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
@@ -89,6 +90,10 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     if (!customSupportedFSs.contains(this.storage.getScheme()) && !StorageSchemes.isAtomicCreationSupported(this.storage.getScheme())) {
       throw new HoodieLockException("Unsupported scheme :" + this.storage.getScheme() + ", since this fs can not support atomic creation");
     }
+  }
+
+  public FileSystemBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> configuration, final HoodieLockMetrics lockMetrics) {
+    this(lockConfiguration, configuration);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -115,9 +115,8 @@ public class LockManager implements Serializable, AutoCloseable {
       if (ReflectionUtils.hasConstructor(writeConfig.getLockProviderClass(), metricsConstructorTypes)) {
         lockProvider = (LockProvider) ReflectionUtils.loadClass(writeConfig.getLockProviderClass(),
             metricsConstructorTypes, lockConfiguration, storageConf, metrics);
-        LOG.debug("Successfully loaded LockProvider with HoodieLockMetrics support");
       } else {
-        LOG.debug("LockProvider does not support HoodieLockMetrics constructor, falling back to standard constructor");
+        LOG.debug("LockProvider does not support HoodieLockMetrics param in constructor, falling back to standard constructor");
         // Fallback to original constructor without metrics
         lockProvider = (LockProvider) ReflectionUtils.loadClass(writeConfig.getLockProviderClass(),
                 new Class<?>[] {LockConfiguration.class, StorageConfiguration.class},


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

I see a lot of verbose debugging logs for Flink local tests, just eliminate it because Flink by default uses the fs based lock provider now.

### Summary and Changelog

add a new constructor to `FileSystemBasedLockProvider` to support `HoodieLockMetrics` as a param.

### Impact

no impact

### Risk Level

none

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
