### PR TITLE
fix: Converting ordering value with timestamp millis type properly fo…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
@@ -20,7 +20,6 @@ package org.apache.hudi.util;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ArrayComparable;
 
@@ -53,9 +52,12 @@ public class OrderingValueEngineTypeConverter {
     }
     return orderingFieldNames.stream().map(f -> {
       Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f);
-      ValidationUtils.checkArgument(fieldSchemaOpt.isPresent(), "ordering field " + f + " should be included in data schema: " + dataSchema);
-      DataType fieldType =  AvroSchemaConverter.convertToDataType(fieldSchemaOpt.get());
-      return RowDataUtils.flinkValFunc(fieldType.getLogicalType(), utcTimezone);
+      if (fieldSchemaOpt.isEmpty()) {
+        return Function.<Comparable>identity();
+      } else {
+        DataType fieldType =  AvroSchemaConverter.convertToDataType(fieldSchemaOpt.get());
+        return RowDataUtils.flinkValFunc(fieldType.getLogicalType(), utcTimezone);
+      }
     }).collect(Collectors.toList());
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
@@ -51,7 +51,7 @@ public class OrderingValueEngineTypeConverter {
       return Collections.singletonList(Function.identity());
     }
     return orderingFieldNames.stream().map(f -> {
-      Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f);
+      Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f, true);
       if (fieldSchemaOpt.isEmpty()) {
         return Function.<Comparable>identity();
       } else {

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestOrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestOrderingValueEngineTypeConverter.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * Unit tests for {@link OrderingValueEngineTypeConverter}.
  */
-public class OrderingValueEngineTypeConverterTest {
+public class TestOrderingValueEngineTypeConverter {
 
   @Test
   public void testCreateWithMultipleOrderingFields() {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
@@ -181,6 +181,20 @@ object AvroConversionUtils {
   }
 
   /**
+   * Converts Avro's [[Schema]] to Catalyst's [[DataType]]
+   */
+  def convertAvroSchemaToDataType(avroSchema: Schema): DataType = {
+    try {
+      val schemaConverters = sparkAdapter.getAvroSchemaConverters
+      schemaConverters.toSqlType(avroSchema) match {
+        case (dataType, _) => dataType
+      }
+    } catch {
+      case e: Exception => throw new HoodieSchemaException("Failed to convert avro schema to DataType: " + avroSchema, e)
+    }
+  }
+
+  /**
    *
    * Method to add default value of null to nullable fields in given avro schema
    *

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.hudi;
 
-import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieReaderContext;
@@ -100,8 +99,6 @@ public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderCont
     // init ordering value converter: java -> engine type
     List<String> orderingFieldNames = HoodieRecordUtils.getOrderingFieldNames(getMergeMode(), tableConfig);
     Schema schema = schemaHandler.getRequiredSchema();
-    if (orderingFieldNames.stream().allMatch(f -> AvroSchemaUtils.findNestedField(schema, f).isPresent())) {
-      ((BaseSparkInternalRecordContext) recordContext).initOrderingValueConverter(schema, orderingFieldNames);
-    }
+    ((BaseSparkInternalRecordContext) recordContext).initOrderingValueConverter(schema, orderingFieldNames);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
@@ -64,7 +64,7 @@ public class OrderingValueEngineTypeConverter {
       return Collections.singletonList(Function.identity());
     }
     return orderingFieldNames.stream().map(f -> {
-      Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f);
+      Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f, true);
       if (fieldSchemaOpt.isEmpty()) {
         return Function.<Comparable>identity();
       } else {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.ArrayComparable;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A converter that converts ordering value from native Java type to Spark type.
+ */
+public class OrderingValueEngineTypeConverter {
+  private final List<Function<Comparable, Comparable>> converters;
+  private OrderingValueEngineTypeConverter(Schema dataSchema, List<String> orderingFieldNames) {
+    this.converters = createConverters(dataSchema, orderingFieldNames);
+  }
+
+  public Comparable convert(Comparable value) {
+    return value instanceof ArrayComparable
+        ? ((ArrayComparable) value).apply(this.converters)
+        : this.converters.get(0).apply(value);
+  }
+
+  public static OrderingValueEngineTypeConverter create(Schema dataSchema, List<String> orderingFieldNames) {
+    return new OrderingValueEngineTypeConverter(dataSchema, orderingFieldNames);
+  }
+
+  private static List<Function<Comparable, Comparable>> createConverters(Schema dataSchema, List<String> orderingFieldNames) {
+    if (orderingFieldNames.isEmpty()) {
+      return Collections.singletonList(Function.identity());
+    }
+    return orderingFieldNames.stream().map(f -> {
+      Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f);
+      ValidationUtils.checkArgument(fieldSchemaOpt.isPresent(), "ordering field " + f + " should be included in data schema: " + dataSchema);
+      DataType fieldType = AvroConversionUtils.convertAvroSchemaToDataType(fieldSchemaOpt.get());
+      return createConverter(fieldType, fieldSchemaOpt.get());
+    }).collect(Collectors.toList());
+  }
+
+  public static Function<Comparable, Comparable> createConverter(DataType fieldType, Schema fieldSchema) {
+    if (fieldType instanceof TimestampType) {
+      LogicalType logicalType = fieldSchema.getLogicalType();
+      if (logicalType == null || logicalType instanceof LogicalTypes.TimestampMillis) {
+        return comparable -> formatAsMicros((long) comparable);
+      }
+    } else if (fieldType instanceof StringType) {
+      // Spark reads String field values as UTF8String.
+      // To foster value comparison, if the value is of String type, e.g., from
+      // the delete record, we convert it to UTF8String type.
+      return comparable -> comparable instanceof String
+          ? SparkAdapterSupport$.MODULE$.sparkAdapter().getUTF8StringFactory().wrapUTF8String(UTF8String.fromString((String) comparable))
+          : comparable;
+    } else if (fieldType instanceof DecimalType) {
+      return comparable -> comparable instanceof BigDecimal ? Decimal.apply((BigDecimal) comparable) : comparable;
+    }
+    return comparable -> comparable;
+  }
+
+  /**
+   * Since the value can be either milliseconds or microseconds (from 1.1), we normalize the value into millis' form.
+   */
+  private static long formatAsMicros(long value) {
+    // since millis for 2286/11/21 is 9_999_999_999_999L, the check logic is safe enough.
+    if (value <= 9_999_999_999_999L) {
+      // convert to microseconds to align with internal representation of spark timestamp
+      return value * 1000;
+    }
+    return value;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/OrderingValueEngineTypeConverter.java
@@ -22,7 +22,6 @@ import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.SparkAdapterSupport$;
 import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ArrayComparable;
 
 import org.apache.avro.LogicalType;
@@ -66,9 +65,12 @@ public class OrderingValueEngineTypeConverter {
     }
     return orderingFieldNames.stream().map(f -> {
       Option<Schema> fieldSchemaOpt = AvroSchemaUtils.findNestedFieldSchema(dataSchema, f);
-      ValidationUtils.checkArgument(fieldSchemaOpt.isPresent(), "ordering field " + f + " should be included in data schema: " + dataSchema);
-      DataType fieldType = AvroConversionUtils.convertAvroSchemaToDataType(fieldSchemaOpt.get());
-      return createConverter(fieldType, fieldSchemaOpt.get());
+      if (fieldSchemaOpt.isEmpty()) {
+        return Function.<Comparable>identity();
+      } else {
+        DataType fieldType = AvroConversionUtils.convertAvroSchemaToDataType(fieldSchemaOpt.get());
+        return createConverter(fieldType, fieldSchemaOpt.get());
+      }
     }).collect(Collectors.toList());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -224,7 +224,7 @@ public class AvroSchemaUtils {
     return atomicTypeEqualityPredicate.apply(sourceSchema, targetSchema);
   }
 
-  public static Option<Schema> findNestedFieldSchema(Schema schema, String fieldName) {
+  public static Option<Schema> findNestedFieldSchema(Schema schema, String fieldName, boolean allowsMissingField) {
     if (StringUtils.isNullOrEmpty(fieldName)) {
       return Option.empty();
     }
@@ -233,6 +233,9 @@ public class AvroSchemaUtils {
     for (String part : parts) {
       Schema.Field foundField = resolveNullableSchema(schema).getField(part);
       if (foundField == null) {
+        if (allowsMissingField) {
+          return Option.empty();
+        }
         throw new HoodieAvroSchemaException(fieldName + " not a field in " + schema);
       }
       schema = foundField.schema();
@@ -241,7 +244,7 @@ public class AvroSchemaUtils {
   }
 
   public static Option<Schema.Type> findNestedFieldType(Schema schema, String fieldName) {
-    return findNestedFieldSchema(schema, fieldName).map(Schema::getType);
+    return findNestedFieldSchema(schema, fieldName, false).map(Schema::getType);
   }
 
   /**


### PR DESCRIPTION
…r DeleteRecord in spark file group reader

### Describe the issue this Pull Request addresses

Fix issue https://github.com/apache/hudi/issues/13997

### Summary and Changelog

Converting ordering value with timestamp millis type properly for DeleteRecord in spark file group reader

### Impact

none.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
