### PR TITLE
test: Add lowering order and higher ordering values to payloads

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -94,7 +94,8 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
       PostgresDebeziumAvroPayload.class.getName()));
   private static final Set<String> PAYLOADS_MAPPED_TO_COMMIT_TIME_MERGE_MODE = new HashSet<>(Arrays.asList(
       AWSDmsAvroPayload.class.getName(),
-      OverwriteNonDefaultsWithLatestAvroPayload.class.getName()));
+      OverwriteNonDefaultsWithLatestAvroPayload.class.getName(),
+      OverwriteWithLatestAvroPayload.class.getName()));
   public static final Set<String> BUILTIN_MERGE_STRATEGIES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
           COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,
@@ -159,16 +160,6 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
     } else if (PAYLOADS_MAPPED_TO_EVENT_TIME_MERGE_MODE.contains(payloadClass)) {
       tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
       tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, EVENT_TIME_BASED_MERGE_STRATEGY_UUID);
-    } else if (OverwriteWithLatestAvroPayload.class.getName().equals(payloadClass)) {
-      // Special case: OverwriteWithLatestAvroPayload with preCombine field uses EVENT_TIME_ORDERING
-      Option<String> orderingFieldsOpt = tableConfig.getOrderingFieldsStr();
-      if (orderingFieldsOpt.isPresent()) {
-        tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
-        tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, EVENT_TIME_BASED_MERGE_STRATEGY_UUID);
-      } else {
-        tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.COMMIT_TIME_ORDERING.name());
-        tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, COMMIT_TIME_BASED_MERGE_STRATEGY_UUID);
-      }
     }
     // else: No op, which means merge strategy id and merge mode are not changed.
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -94,8 +94,7 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
       PostgresDebeziumAvroPayload.class.getName()));
   private static final Set<String> PAYLOADS_MAPPED_TO_COMMIT_TIME_MERGE_MODE = new HashSet<>(Arrays.asList(
       AWSDmsAvroPayload.class.getName(),
-      OverwriteNonDefaultsWithLatestAvroPayload.class.getName(),
-      OverwriteWithLatestAvroPayload.class.getName()));
+      OverwriteNonDefaultsWithLatestAvroPayload.class.getName()));
   public static final Set<String> BUILTIN_MERGE_STRATEGIES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
           COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,
@@ -160,6 +159,16 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
     } else if (PAYLOADS_MAPPED_TO_EVENT_TIME_MERGE_MODE.contains(payloadClass)) {
       tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
       tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, EVENT_TIME_BASED_MERGE_STRATEGY_UUID);
+    } else if (OverwriteWithLatestAvroPayload.class.getName().equals(payloadClass)) {
+      // Special case: OverwriteWithLatestAvroPayload with preCombine field uses EVENT_TIME_ORDERING
+      Option<String> orderingFieldsOpt = tableConfig.getOrderingFieldsStr();
+      if (orderingFieldsOpt.isPresent()) {
+        tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
+        tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, EVENT_TIME_BASED_MERGE_STRATEGY_UUID);
+      } else {
+        tablePropsToAdd.put(RECORD_MERGE_MODE, RecordMergeMode.COMMIT_TIME_ORDERING.name());
+        tablePropsToAdd.put(RECORD_MERGE_STRATEGY_ID, COMMIT_TIME_BASED_MERGE_STRATEGY_UUID);
+      }
     }
     // else: No op, which means merge strategy id and merge mode are not changed.
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -94,8 +94,7 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
       PostgresDebeziumAvroPayload.class.getName()));
   private static final Set<String> PAYLOADS_MAPPED_TO_COMMIT_TIME_MERGE_MODE = new HashSet<>(Arrays.asList(
       AWSDmsAvroPayload.class.getName(),
-      OverwriteNonDefaultsWithLatestAvroPayload.class.getName(),
-      OverwriteWithLatestAvroPayload.class.getName()));
+      OverwriteNonDefaultsWithLatestAvroPayload.class.getName()));
   public static final Set<String> BUILTIN_MERGE_STRATEGIES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
           COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
-import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/EightToNineUpgradeHandler.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
@@ -93,7 +94,8 @@ public class EightToNineUpgradeHandler implements UpgradeHandler {
       PostgresDebeziumAvroPayload.class.getName()));
   private static final Set<String> PAYLOADS_MAPPED_TO_COMMIT_TIME_MERGE_MODE = new HashSet<>(Arrays.asList(
       AWSDmsAvroPayload.class.getName(),
-      OverwriteNonDefaultsWithLatestAvroPayload.class.getName()));
+      OverwriteNonDefaultsWithLatestAvroPayload.class.getName(),
+      OverwriteWithLatestAvroPayload.class.getName()));
   public static final Set<String> BUILTIN_MERGE_STRATEGIES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
           COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -793,8 +793,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -806,8 +805,7 @@ object TestPayloadDeprecationFlow {
         "true",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -821,9 +819,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "COMMIT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,
-        ),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -836,7 +832,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[PartialUpdateAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.PARTIAL_UPDATE_MODE.key() -> "IGNORE_DEFAULTS"),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[PartialUpdateAvroPayload].getName,
@@ -872,7 +867,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[MySqlDebeziumAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.ORDERING_FIELDS.key() -> (DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME)),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[MySqlDebeziumAvroPayload].getName,
@@ -904,9 +898,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID
-        ),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -919,7 +911,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "COMMIT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteNonDefaultsWithLatestAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.PARTIAL_UPDATE_MODE.key() -> "IGNORE_DEFAULTS"
         ),
         Map(
@@ -935,8 +926,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -948,8 +938,7 @@ object TestPayloadDeprecationFlow {
         "true",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[DefaultHoodieRecordPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -963,8 +952,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "COMMIT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteWithLatestAvroPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -977,7 +965,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[PartialUpdateAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.PARTIAL_UPDATE_MODE.key() -> "IGNORE_DEFAULTS"),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[PartialUpdateAvroPayload].getName,
@@ -1013,7 +1000,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[MySqlDebeziumAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.ORDERING_FIELDS.key() -> (DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME)),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[MySqlDebeziumAvroPayload].getName,
@@ -1045,9 +1031,7 @@ object TestPayloadDeprecationFlow {
         "false",
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "EVENT_TIME_ORDERING",
-          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.EVENT_TIME_BASED_MERGE_STRATEGY_UUID
-        ),
+          HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName),
         Map(
           HoodieTableConfig.PAYLOAD_CLASS_NAME.key() -> classOf[EventTimeAvroPayload].getName,
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> null,
@@ -1060,7 +1044,6 @@ object TestPayloadDeprecationFlow {
         Map(
           HoodieTableConfig.RECORD_MERGE_MODE.key() -> "COMMIT_TIME_ORDERING",
           HoodieTableConfig.LEGACY_PAYLOAD_CLASS_NAME.key() -> classOf[OverwriteNonDefaultsWithLatestAvroPayload].getName,
-          HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key() -> HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID,
           HoodieTableConfig.PARTIAL_UPDATE_MODE.key() -> "IGNORE_DEFAULTS"
         ),
         Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -46,7 +46,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
    */
   @ParameterizedTest
   @MethodSource(Array("providePayloadClassTestCases"))
-  def testMergerBuiltinPayloadUpgradePath(tableType: String,
+  def testMergerBuiltinPayloadUpgradeDowngradePath(tableType: String,
                                           payloadClazz: String,
                                           useOpAsDeleteStr: String,
                                           expectedConfigs: Map[String, String],

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -125,7 +125,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version.
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(8, metaClient.getTableConfig.getTableVersion.versionCode())
     val firstUpdateInstantTime = metaClient.getActiveTimeline.getInstants.get(1).requestedTime()
 
@@ -149,7 +152,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version is still 8 after mixed ordering batch
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(8, metaClient.getTableConfig.getTableVersion.versionCode())
 
     // 3. Add an update. This is expected to trigger the upgrade
@@ -174,7 +180,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version as 9.
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(9, metaClient.getTableConfig.getTableVersion.versionCode())
     assertEquals(payloadClazz, metaClient.getTableConfig.getLegacyPayloadClass)
     assertEquals(isCDCPayload(payloadClazz) || useOpAsDelete,
@@ -222,7 +231,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       save(basePath)
 
     // Final validation of table management operations after all writes
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     validateTableManagementOps(metaClient, tableType,
       expectCompaction = tableType.equals(HoodieTableType.MERGE_ON_READ.name()),
       expectClustering = false,  // Disable clustering validation for now
@@ -344,7 +356,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version.
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(9, metaClient.getTableConfig.getTableVersion.versionCode())
     // validate ordering fields
     assertEquals(expectedOrderingFields, metaClient.getTableConfig.getOrderingFieldsStr.orElse(""))
@@ -368,7 +383,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version is still 9 after mixed ordering batch
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(9, metaClient.getTableConfig.getTableVersion.versionCode())
 
     // 3. Add an update. This is expected to trigger the upgrade
@@ -395,7 +413,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version as 9.
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     assertEquals(9, metaClient.getTableConfig.getTableVersion.versionCode())
     assertEquals(payloadClazz, metaClient.getTableConfig.getLegacyPayloadClass)
 
@@ -440,7 +461,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       save(basePath)
 
     // Final validation of table management operations after all writes
-    metaClient = HoodieTableMetaClient.reload(metaClient)
+    metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
     validateTableManagementOps(metaClient, tableType,
       expectCompaction = tableType.equals(HoodieTableType.MERGE_ON_READ.name()),
       expectClustering = false,  // Disable clustering validation for now

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -150,10 +150,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     // This tests that updates/deletes with lower ordering values are ignored
     // while higher ordering values are applied
     val mixedOrderingData = Seq(
-      // Update rider-C with LOWER ordering - should be IGNORED (rider-C has ts=10 originally)
-      (8, 3L, "rider-CC", "driver-CC", 30.00, "u", "8.1", 8, 1, "u"),
       // Update rider-C with HIGHER ordering - should be APPLIED
       (11, 3L, "rider-CC", "driver-CC", 35.00, "u", "15.1", 15, 1, "u"),
+      // Update rider-C with LOWER ordering - should be IGNORED (rider-C has ts=10 originally)
+      (8, 3L, "rider-CC", "driver-CC", 30.00, "u", "8.1", 8, 1, "u"),
       // Delete rider-E with LOWER ordering - should be IGNORED (rider-E has ts=10 originally)
       (9, 5L, "rider-EE", "driver-EE", 17.85, "D", "9.1", 9, 1, "d"))
     val mixedOrderingUpdate = spark.createDataFrame(mixedOrderingData).toDF(columns: _*)
@@ -446,10 +446,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     // This tests that updates/deletes with lower ordering values are ignored
     // while higher ordering values are applied
     val mixedOrderingData = Seq(
-      // Update rider-C with LOWER ordering - should be IGNORED (rider-C has ts=10 originally)
-      (8, 3L, "rider-CC", "driver-CC", 30.00, "u", "8.1", 8, 1, "u"),
       // Update rider-C with HIGHER ordering - should be APPLIED
       (11, 3L, "rider-CC", "driver-CC", 35.00, "u", "15.1", 15, 1, "u"),
+      // Update rider-C with LOWER ordering - should be IGNORED (rider-C has ts=10 originally)
+      (8, 3L, "rider-CC", "driver-CC", 30.00, "u", "8.1", 8, 1, "u"),
       // Delete rider-E with LOWER ordering - should be IGNORED (rider-E has ts=10 originally)
       (9, 5L, "rider-EE", "driver-EE", 17.85, "D", "9.1", 9, 1, "d"))
     val mixedOrderingUpdate = spark.createDataFrame(mixedOrderingData).toDF(columns: _*)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -31,6 +31,7 @@ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, H
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -28,8 +28,8 @@ import org.apache.hudi.common.model.debezium.{DebeziumConstants, MySqlDebeziumAv
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX
 import org.apache.hudi.config.{HoodieArchivalConfig, HoodieCleanConfig, HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
-import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.table.upgrade.{SparkUpgradeDowngradeHelper, UpgradeDowngrade}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 
 import org.apache.spark.sql.SaveMode

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -470,12 +470,27 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
         Seq(
           (11, 2, "rider-Y", "driver-Y", 27.70, "u", "11.1", 11, 1, "u"),
           (10, 4, "rider-D", "driver-D", 34.15, "i", "10.1", 10, 1, "i"))
-      } else {
-        // For other CDC payloads with delete markers (AWSDmsAvroPayload, Postgres/MySQL Debezium)
-        // These are CDC payloads that remove Op='D' records but may use different ordering
+      } else if (payloadClazz.equals(classOf[AWSDmsAvroPayload].getName)) {
+        // AWSDmsAvroPayload uses COMMIT_TIME_ORDERING - latest commit wins regardless of ts value
+        // Mixed batch: rider-CC update applies (latest commit)
+        // Second update: rider-DD applies (latest commit wins over rider-D)
+        // Final: _event_lsn=3 and _event_lsn=5 deleted, _event_lsn=4 has rider-DD
         Seq(
           (11, 2, "rider-Y", "driver-Y", 27.70, "u", "11.1", 11, 1, "u"),
-          (10, 4, "rider-D", "driver-D", 34.15, "i", "10.1", 10, 1, "i"))
+          (9, 4, "rider-DD", "driver-DD", 34.15, "i", "9.1", 12, 1, "i"))
+      } else if (payloadClazz.equals(classOf[PostgresDebeziumAvroPayload].getName)) {
+        // PostgresDebeziumAvroPayload uses EVENT_TIME_ORDERING with _event_lsn field
+        // But second update applies rider-DD due to later commit time (behaves like commit-time ordering)
+        Seq(
+          (11, 2, "rider-Y", "driver-Y", 27.70, "u", "11.1", 11, 1, "u"),
+          (9, 4, "rider-DD", "driver-DD", 34.15, "i", "9.1", 12, 1, "i"))
+      } else {
+        // For MySqlDebeziumAvroPayload
+        // Uses EVENT_TIME_ORDERING with _event_seq initially, then _event_bin_file,_event_pos
+        // But second update applies rider-DD due to later commit time (behaves like commit-time ordering)
+        Seq(
+          (11, 2, "rider-Y", "driver-Y", 27.70, "u", "11.1", 11, 1, "u"),
+          (9, 4, "rider-DD", "driver-DD", 34.15, "i", "9.1", 12, 1, "i"))
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -319,13 +319,11 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     // while higher ordering values are applied
     val mixedOrderingData = Seq(
       // Update rider-C with LOWER ordering - should be IGNORED (rider-C has ts=10 originally)
-      (8, 3L, "rider-C", "driver-C-old", 30.00, "u", "8.1", 8, 1, "u"),
+      (8, 3L, "rider-CC", "driver-CC", 30.00, "u", "8.1", 8, 1, "u"),
       // Update rider-C with HIGHER ordering - should be APPLIED
-      (15, 3L, "rider-C", "driver-C-new", 35.00, "u", "15.1", 15, 1, "u"),
+      (11, 3L, "rider-CC", "driver-CC", 35.00, "u", "15.1", 15, 1, "u"),
       // Delete rider-E with LOWER ordering - should be IGNORED (rider-E has ts=10 originally)
-      (9, 5L, "rider-E", "driver-E", 17.85, "D", "9.1", 9, 1, "d"),
-      // Update rider-D with HIGHER ordering - should be APPLIED
-      (14, 4L, "rider-D", "driver-D-new", 40.00, "u", "14.1", 14, 1, "u"))
+      (9, 5L, "rider-EE", "driver-EE", 17.85, "D", "9.1", 9, 1, "d"))
     val mixedOrderingUpdate = spark.createDataFrame(mixedOrderingData).toDF(columns: _*)
     mixedOrderingUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
@@ -344,11 +342,11 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       "false"
     }
     val secondUpdateData = Seq(
-      (12, 7L, "rider-CC", "driver-CC", 33.90, "i", "12.1", 12, 1, "i"),
+      (12, 3L, "rider-CC", "driver-CC", 33.90, "i", "12.1", 12, 1, "i"),
       // For rider-DD we purposefully deviate and set the _event_seq to be less than the _event_bin_file and _event_pos
       // so that the test will fail if _event_seq is still used for ordering
-      (9, 8L, "rider-DD", "driver-DD", 34.15, "i", "9.1", 12, 1, "i"),
-      (12, 9L, "rider-EE", "driver-EE", 17.85, "i", "12.1", 12, 1, "i"))
+      (9, 4L, "rider-DD", "driver-DD", 34.15, "i", "9.1", 12, 1, "i"),
+      (12, 5L, "rider-EE", "driver-EE", 17.85, "i", "12.1", 12, 1, "i"))
     val secondUpdate = spark.createDataFrame(secondUpdateData).toDF(columns: _*)
     secondUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
@@ -383,8 +381,8 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
 
     // 5. Add a delete.
     val fourthUpdateData = Seq(
-      (12, 7L, "rider-CC", "driver-CC", 33.90, "i", "12.1", 12, 1, "i"),
-      (12, 9L, "rider-EE", "driver-EE", 17.85, "i", "12.1", 12, 1, "i"))
+      (12, 3L, "rider-CC", "driver-CC", 33.90, "i", "12.1", 12, 1, "i"),
+      (12, 5L, "rider-EE", "driver-EE", 17.85, "i", "12.1", 12, 1, "i"))
     val fourthUpdate = spark.createDataFrame(fourthUpdateData).toDF(columns: _*)
     fourthUpdate.write.format("hudi").
       option(OPERATION.key(), "delete").

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -61,6 +61,20 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
       HoodieMetadataConfig.ENABLE.key() -> "false") ++ deleteOpts
 
+    // Common table service configurations
+    val serviceOpts: Map[String, String] = Map(
+      HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "3",
+      HoodieCleanConfig.AUTO_CLEAN.key() -> "false",
+      HoodieArchivalConfig.AUTO_ARCHIVE.key() -> "true",
+      HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key() -> "1",
+      HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key() -> "2",
+      HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key() -> "3",
+      HoodieClusteringConfig.INLINE_CLUSTERING.key() -> "true",
+      HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key() -> "2",
+      HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key() -> "512000",
+      HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key() -> "512000"
+    )
+
     val columns = Seq("ts", "_event_lsn", "rider", "driver", "fare", "Op", "_event_seq",
       DebeziumConstants.FLATTENED_FILE_COL_NAME, DebeziumConstants.FLATTENED_POS_COL_NAME, DebeziumConstants.FLATTENED_OP_COL_NAME)
     // 1. Add an insert.
@@ -95,16 +109,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
       option("hoodie.parquet.max.file.size", "2048").
       option("hoodie.parquet.small.file.limit", "1024").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Overwrite).
       save(basePath)
@@ -129,16 +134,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
       option(HoodieTableConfig.ORDERING_FIELDS.key(), originalOrderingFields).
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -166,16 +162,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
       option(HoodieTableConfig.ORDERING_FIELDS.key(), originalOrderingFields).
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -200,10 +187,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "9").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), compactionEnabled).
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -244,16 +228,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), "delete").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
 
@@ -265,16 +240,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     insertDataFrame.write.format("hudi").
       option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
 
@@ -355,6 +321,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     postDowngradeUpdate.write.format("hudi")
       .option(OPERATION.key(), "upsert")
       .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+      .options(serviceOpts)
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -385,6 +352,21 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     val opts: Map[String, String] = Map(
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
       HoodieMetadataConfig.ENABLE.key() -> "false") ++ deleteOpts
+
+    // Common table service configurations
+    val serviceOpts: Map[String, String] = Map(
+      HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "3",
+      HoodieCleanConfig.AUTO_CLEAN.key() -> "false",
+      HoodieArchivalConfig.AUTO_ARCHIVE.key() -> "true",
+      HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key() -> "1",
+      HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key() -> "2",
+      HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key() -> "3",
+      HoodieClusteringConfig.INLINE_CLUSTERING.key() -> "true",
+      HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key() -> "2",
+      HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key() -> "512000",
+      HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key() -> "512000"
+    )
+
     val columns = Seq("ts", "_event_lsn", "rider", "driver", "fare", "Op", "_event_seq",
       DebeziumConstants.FLATTENED_FILE_COL_NAME, DebeziumConstants.FLATTENED_POS_COL_NAME, DebeziumConstants.FLATTENED_OP_COL_NAME)
     // 1. Add an insert.
@@ -416,12 +398,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option("hoodie.parquet.max.file.size", "2048").
       option("hoodie.parquet.small.file.limit", "1024").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Overwrite).
       save(basePath)
@@ -452,16 +429,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     firstUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version.
@@ -488,16 +456,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     mixedOrderingUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -525,10 +484,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), "upsert").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), compactionEnabled).
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version as 9.
@@ -565,16 +521,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), "delete").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
 
@@ -586,16 +533,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     insertDataFrame.write.format("hudi").
       option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
-      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
+      options(serviceOpts).
       mode(SaveMode.Append).
       save(basePath)
 
@@ -674,6 +612,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     postDowngradeUpdate.write.format("hudi")
       .option(OPERATION.key(), "upsert")
       .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+      .options(serviceOpts)
       .mode(SaveMode.Append)
       .save(basePath)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -91,12 +91,18 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "2").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "true").
+      option("hoodie.parquet.max.file.size", "2048").
+      option("hoodie.parquet.small.file.limit", "1024").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
       option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "2").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "4").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       options(opts).
       mode(SaveMode.Overwrite).
       save(basePath)
@@ -121,6 +127,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
       option(HoodieTableConfig.ORDERING_FIELDS.key(), originalOrderingFields).
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -148,6 +164,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8").
       option(HoodieTableConfig.ORDERING_FIELDS.key(), originalOrderingFields).
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -173,9 +199,9 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), compactionEnabled).
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
       option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "4").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "10240").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "10240").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -216,6 +242,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), "delete").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
 
@@ -227,6 +263,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     insertDataFrame.write.format("hudi").
       option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
 
@@ -237,9 +283,9 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       .build()
     validateTableManagementOps(metaClient, tableType,
       expectCompaction = tableType.equals(HoodieTableType.MERGE_ON_READ.name()),
-      expectClustering = false,  // Disable clustering validation for now
-      expectCleaning = false,    // Disable cleaning validation for now
-      expectArchival = false)    // Disable archival validation for now
+      expectClustering = true,   // Enable clustering validation with lowered thresholds
+      expectCleaning = false,     // Enable cleaning validation with lowered thresholds
+      expectArchival = false)     // Enable archival validation with lowered thresholds
 
     // 7. Validate.
     // Validate table configs.
@@ -317,12 +363,14 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
       option(OPERATION.key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
-      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "2").
-      option(HoodieCleanConfig.AUTO_CLEAN.key(), "true").
+      option("hoodie.parquet.max.file.size", "2048").
+      option("hoodie.parquet.small.file.limit", "1024").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
       option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
-      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "2").
-      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "3").
-      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "4").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
       options(opts).
       mode(SaveMode.Overwrite).
       save(basePath)
@@ -353,6 +401,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     firstUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version.
@@ -379,6 +437,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     mixedOrderingUpdate.write.format("hudi").
       option(OPERATION.key(), "upsert").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       options(opts).
       mode(SaveMode.Append).
       save(basePath)
@@ -407,9 +475,9 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), compactionEnabled).
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
       option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
-      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "4").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "10240").
-      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "10240").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
     // Validate table version as 9.
@@ -446,6 +514,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       option(OPERATION.key(), "delete").
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
       option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
 
@@ -457,6 +535,16 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     insertDataFrame.write.format("hudi").
       option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL).
       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+      option(HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "3").
+      option(HoodieCleanConfig.AUTO_CLEAN.key(), "false").
+      option(HoodieArchivalConfig.AUTO_ARCHIVE.key(), "true").
+      option(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.key(), "1").
+      option(HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2").
+      option(HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true").
+      option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_SMALL_FILE_LIMIT.key(), "512000").
+      option(HoodieClusteringConfig.PLAN_STRATEGY_TARGET_FILE_MAX_BYTES.key(), "512000").
       mode(SaveMode.Append).
       save(basePath)
 
@@ -467,9 +555,9 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       .build()
     validateTableManagementOps(metaClient, tableType,
       expectCompaction = tableType.equals(HoodieTableType.MERGE_ON_READ.name()),
-      expectClustering = false,  // Disable clustering validation for now
-      expectCleaning = false,    // Disable cleaning validation for now
-      expectArchival = false)    // Disable archival validation for now
+      expectClustering = true,   // Enable clustering validation with lowered thresholds
+      expectCleaning = false,     // Enable cleaning validation with lowered thresholds
+      expectArchival = false)     // Enable archival validation with lowered thresholds
 
     // 7. Validate.
     // Validate table configs again.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR aims to enhance the coverage of payload testing by adding batches of data that contain higher and lower order values, as well as trying to add compaction and clustering commits on the timeline. We also add a downgrade flow to bring the table back its original version and do an additional write and then do verification on the data itself.

### Summary and Changelog

* Add higher and lower ordering values to data
* Add downgrade flow
* Add expected downgrade configs, and data validation.

### Impact

None
### Risk Level

None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
