### PR TITLE
fix(spark): Update merge into command to check if ordering field is set for EventTimeOrdering

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable.scala
@@ -1613,6 +1613,52 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
     }
   }
 
+  test("Test missing ordering columns in Merge Into statement") {
+    Seq("cow", "mor").foreach { tableType =>
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        // Create a partitioned table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  dt string,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (primaryKey = 'id', type = '$tableType', preCombineField = 'ts')
+             | partitioned by (dt)
+             | location '${tmp.getCanonicalPath}'
+             | """.stripMargin)
+
+        spark.sql(
+          s"""
+             | insert into $tableName partition(dt = '2024-01-14')
+             | select 1 as id, 'a1' as name, 10 as price, 1000 as ts
+             | union
+             | select 2 as id, 'a2' as name, 20 as price, 1002 as ts
+             | """.stripMargin)
+
+        // Update statement is missing ordering column 'ts'
+        val sqlStatement1 =
+          s"""
+             | merge into $tableName
+             | using (
+             |  select 2 as id, '2024-01-14' as dt, 'a2_new' as name, 25 as price, 1005 as ts
+             |  union
+             |  select 3 as id, '2024-01-14' as dt, 'a3' as name, 30 as price, 1003 as ts
+             | ) s0
+             | on s0.id = $tableName.id
+             | when matched then update set
+             | id = s0.id, dt = s0.dt, price = s0.price
+             | """.stripMargin
+
+        checkExceptionContain(sqlStatement1)("No matching assignment found for target table ordering field `ts`")
+      }
+    }
+  }
+
   test("Test no schema evolution in MERGE INTO") {
     Seq("cow", "mor").foreach { tableType =>
       withTempDir { tmp =>

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -936,6 +936,17 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     if (hoodieCatalogTable.orderingFields.isEmpty && updateActions.nonEmpty) {
       logWarning(s"Updates without precombine can have nondeterministic behavior")
     }
+    if (isEventTimeOrdering(props)) {
+      // validate ordering fields are set for update
+      updateActions.foreach(action =>
+        validateTargetTableAttrExistsInAssignments(
+          sparkSession.sessionState.conf.resolver,
+          mergeInto.targetTable,
+          hoodieCatalogTable.orderingFields.asScala.toSeq,
+          "ordering field",
+          action.assignments)
+      )
+    }
     updateActions.foreach(update =>
       assert(update.assignments.length <= targetTableSchema.length,
         s"The number of update assignments[${update.assignments.length}] must be less than or equal to the " +


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

If the target of a MergeInto command is a table with `EventTimeOrdering` the update statements should include the ordering field to ensure proper ordering of the updates. Today, there is no check at runtime for this which allows users to run an invalid command.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Add assertion for update actions to check for event time ordering fields when the target is an event time ordered table
- Add test case for issue

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
- Improves end user experience

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
