### PR TITLE
fix: Partition stats and Col stats should be on the same index version

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -324,6 +324,7 @@ public class HoodieTableMetaClient implements Serializable {
       // Ensure we write out valid index metadata.
       indexMetadata.getIndexDefinitions().values().forEach(d ->
           ValidationUtils.checkArgument(isValidIndexDefinition(tableVersion, d), "Found invalid index definition " + d));
+      HoodieIndexMetadata.validateIndexMetadata(indexMetadata);
       // TODO[HUDI-9094]: should not write byte array directly
       FileIOUtils.createFileInPath(storage, new StoragePath(indexDefinitionPath),
           Option.of(HoodieInstantWriter.convertByteArrayToWriter(getUTF8Bytes(indexMetadata.toJson()))));

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2867,7 +2867,20 @@ public class HoodieTableMetadataUtil {
         .orElseThrow(() -> new HoodieIndexException("Expression Index definition is not present for index: " + indexName));
   }
 
-  public static Option<HoodieIndexVersion> getIndexVersionOption(String metadataPartitionPath, HoodieTableMetaClient metaClient) {
+  @VisibleForTesting
+  static Option<HoodieIndexVersion> getIndexVersionOption(String metadataPartitionPath, HoodieTableMetaClient metaClient) {
+    if (PARTITION_NAME_COLUMN_STATS.equals(metadataPartitionPath)) {
+      return getIndexVersionOptionHelper(PARTITION_NAME_COLUMN_STATS, metaClient)
+          .or(getIndexVersionOptionHelper(PARTITION_NAME_PARTITION_STATS, metaClient));
+    } else if (PARTITION_NAME_PARTITION_STATS.equals(metadataPartitionPath)) {
+      return getIndexVersionOptionHelper(PARTITION_NAME_PARTITION_STATS, metaClient)
+          .or(getIndexVersionOptionHelper(PARTITION_NAME_COLUMN_STATS, metaClient));
+    } else {
+      return getIndexVersionOptionHelper(metadataPartitionPath, metaClient);
+    }
+  }
+
+  private static Option<HoodieIndexVersion> getIndexVersionOptionHelper(String metadataPartitionPath, HoodieTableMetaClient metaClient) {
     Option<HoodieIndexMetadata> indexMetadata = metaClient.getIndexMetadata();
     if (indexMetadata.isEmpty()) {
       return Option.empty();

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -19,11 +19,26 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.function.SerializableBiFunction;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getIndexVersionOption;
 import static org.apache.hudi.metadata.SecondaryIndexKeyUtils.constructSecondaryIndexKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestHoodieTableMetadataUtil {
 
@@ -49,5 +64,100 @@ public class TestHoodieTableMetadataUtil {
 
     // Both should hash the secondary key portion so read and write paths are consistent.
     assertEquals(result1, result2);
+  }
+
+  @Test
+  void testGetIndexVersionNoMetadata() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+
+    Option<HoodieIndexVersion> result = getIndexVersionOption(PARTITION_NAME_COLUMN_STATS, metaClient);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void testGetIndexVersionNoPartitions() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.emptyMap()); // empty map
+
+    Option<HoodieIndexVersion> result = getIndexVersionOption(PARTITION_NAME_COLUMN_STATS, metaClient);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void testGetColStatsVersionPartitionStatsExists() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexVersion version = HoodieIndexVersion.V1;
+    HoodieIndexDefinition def = mock(HoodieIndexDefinition.class);
+    when(def.getVersion()).thenReturn(version);
+    Map<String, HoodieIndexDefinition> indexDefs = Collections.singletonMap(PARTITION_NAME_PARTITION_STATS, def);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(indexDefs);
+    Option<HoodieIndexVersion> result = getIndexVersionOption(PARTITION_NAME_COLUMN_STATS, metaClient);
+    assertTrue(result.isPresent());
+    assertEquals(version, result.get());
+  }
+
+  @Test
+  void testGetPartitionStatsVersionColStatsExists() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexVersion version = HoodieIndexVersion.V1;
+    HoodieIndexDefinition def = mock(HoodieIndexDefinition.class);
+    when(def.getVersion()).thenReturn(version);
+    Map<String, HoodieIndexDefinition> indexDefs = Collections.singletonMap(PARTITION_NAME_COLUMN_STATS, def);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(indexDefs);
+
+    Option<HoodieIndexVersion> result = getIndexVersionOption(PARTITION_NAME_PARTITION_STATS, metaClient);
+    assertTrue(result.isPresent());
+    assertEquals(version, result.get());
+  }
+
+  @Test
+  void testGetColAndPartitionStatsIndexBothExist() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexVersion version = HoodieIndexVersion.V1;
+    HoodieIndexDefinition defColStats = mock(HoodieIndexDefinition.class);
+    when(defColStats.getVersion()).thenReturn(version);
+    // NOTE: this is intentionally set to a different version than col stats
+    // but should never happen outside of this test.
+    HoodieIndexVersion otherVersion = HoodieIndexVersion.V2;
+    HoodieIndexDefinition defPartStats = mock(HoodieIndexDefinition.class);
+    when(defPartStats.getVersion()).thenReturn(otherVersion);
+    Map<String, HoodieIndexDefinition> indexDefs = new HashMap<>(2);
+    indexDefs.put(PARTITION_NAME_COLUMN_STATS, defColStats);
+    indexDefs.put(PARTITION_NAME_PARTITION_STATS, defPartStats);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(indexDefs);
+
+    Option<HoodieIndexVersion> result = getIndexVersionOption(PARTITION_NAME_COLUMN_STATS, metaClient);
+    assertTrue(result.isPresent());
+    assertEquals(version, result.get());
+
+    result = getIndexVersionOption(PARTITION_NAME_PARTITION_STATS, metaClient);
+    assertTrue(result.isPresent());
+    assertEquals(otherVersion, result.get());
+  }
+
+  @Test
+  void testGetArbitraryIndexVersion() {
+    String indexName = "asdf";
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexVersion version = HoodieIndexVersion.V1;
+    HoodieIndexDefinition def = mock(HoodieIndexDefinition.class);
+    when(def.getVersion()).thenReturn(version);
+    Map<String, HoodieIndexDefinition> indexDefs = Collections.singletonMap(indexName, def);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(indexDefs);
+
+    Option<HoodieIndexVersion> result = getIndexVersionOption(indexName, metaClient);
+    assertTrue(result.isPresent());
+    assertEquals(version, result.get());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/14012

### Summary and Changelog

We have a util method to get the index version or use the highest index version for the corresponding table version. Now, this util method will return the index version of the other index if either col stats or partition stats doesn't exist. Additionally, I have added validation on hoodie index definition to ensure that they match. This should not be required with the other fix, but it is negligible perf cost and will protect us in the future if that util method is not always used.

### Impact
Prevent index corruption scenario

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
