### PR TITLE
perf: Improvements to CompletionTimeQueryViewV2

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -33,6 +33,7 @@ import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -149,17 +150,15 @@ public class LSMTimeline {
    */
   public static int latestSnapshotVersion(HoodieTableMetaClient metaClient, StoragePath archivePath) throws IOException {
     StoragePath versionFilePath = getVersionFilePath(archivePath);
-    if (metaClient.getStorage().exists(versionFilePath)) {
-      try {
-        Option<byte[]> content =
-            FileIOUtils.readDataFromPath(metaClient.getStorage(), versionFilePath);
-        if (content.isPresent()) {
-          return Integer.parseInt(fromUTF8Bytes(content.get()));
-        }
-      } catch (Exception e) {
-        // fallback to manifest file listing.
-        LOG.warn("Error reading version file {}", versionFilePath, e);
+    try {
+      Option<byte[]> content =
+          FileIOUtils.readDataFromPath(metaClient.getStorage(), versionFilePath, true);
+      if (content.isPresent()) {
+        return Integer.parseInt(fromUTF8Bytes(content.get()));
       }
+    } catch (Exception e) {
+      // fallback to manifest file listing.
+      LOG.warn("Error reading version file {}", versionFilePath, e);
     }
 
     return allSnapshotVersions(metaClient, archivePath).stream().max(Integer::compareTo).orElse(-1);
@@ -169,15 +168,17 @@ public class LSMTimeline {
    * Returns all the valid snapshot versions.
    */
   public static List<Integer> allSnapshotVersions(HoodieTableMetaClient metaClient, StoragePath archivePath) throws IOException {
-    if (!metaClient.getStorage().exists(archivePath)) {
+    try {
+      return metaClient.getStorage().listDirectEntries(archivePath,
+              getManifestFilePathFilter())
+          .stream()
+          .map(fileStatus -> fileStatus.getPath().getName())
+          .map(LSMTimeline::getManifestVersion)
+          .collect(Collectors.toList());
+    } catch (FileNotFoundException ex) {
+      LOG.debug("Archive path {} does not exist", archivePath);
       return Collections.emptyList();
     }
-    return metaClient.getStorage().listDirectEntries(archivePath,
-            getManifestFilePathFilter())
-        .stream()
-        .map(fileStatus -> fileStatus.getPath().getName())
-        .map(LSMTimeline::getManifestVersion)
-        .collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Currently, the CompletionTimeQueryViewV2 implementation will eagerly load up to 3 days of history data from the archived timeline. This data may never be used so this read operation just introduces extra overhead and should be avoided.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
The initialization of the `CompletionTimeQueryViewV2` will now only consider the active timeline when creating the instance. It will then load from the archived timeline when there is a request for a completion time that is not in the active timeline with the same approach as before where we will eagerly fetch the last 3 days by default. 

Changes:
- Makes the archived timeline read lazy
- Adds optimizations to avoid extra `exists` checks

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Improves performance by reducing IO and listing calls

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
