### PR TITLE
perf: Remove the eager loading of CompletionTimeQueryView

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
@@ -40,6 +40,4 @@ public abstract class TimelineFactory implements Serializable {
   public abstract HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, boolean applyLayoutFilter);
 
   public abstract CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient);
-
-  public abstract CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient, String eagerInstant);
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
@@ -78,9 +78,4 @@ public class TimelineV1Factory extends TimelineFactory {
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV1(metaClient);
   }
-
-  @Override
-  public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient, String eagerInstant) {
-    return new CompletionTimeQueryViewV1(metaClient, eagerInstant);
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
@@ -78,9 +78,4 @@ public class TimelineV2Factory extends TimelineFactory {
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV2(metaClient);
   }
-
-  @Override
-  public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient, String eagerInstant) {
-    return new CompletionTimeQueryViewV2(metaClient, eagerInstant);
-  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
@@ -83,9 +83,4 @@ public class TestTimelineFactory extends TimelineFactory {
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV2(metaClient);
   }
-
-  @Override
-  public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient, String eagerInstant) {
-    return new CompletionTimeQueryViewV2(metaClient, eagerInstant);
-  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix issue https://github.com/apache/hudi/issues/14018

### Summary and Changelog

Remove the eager loading of CompletionTimeQueryView

### Impact

Improve performance for CompletionTimeQueryView

### Risk Level

low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
