### PR TITLE
chore: Fix logging when file is not found

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -32,6 +32,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -236,6 +237,12 @@ public class FileIOUtils {
   public static Option<byte[]> readDataFromPath(HoodieStorage storage, StoragePath detailPath, boolean ignoreIOE) {
     try (InputStream is = storage.open(detailPath)) {
       return Option.of(FileIOUtils.readAsByteArray(is));
+    } catch (FileNotFoundException fnfe) {
+      if (!ignoreIOE) {
+        throw new HoodieIOException("Could not find commit details from " + detailPath, fnfe);
+      }
+      LOG.debug("No file found at path {}", detailPath);
+      return Option.empty();
     } catch (IOException e) {
       LOG.warn("Could not read commit details from {}", detailPath, e);
       if (!ignoreIOE) {

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -238,9 +238,6 @@ public class FileIOUtils {
     try (InputStream is = storage.open(detailPath)) {
       return Option.of(FileIOUtils.readAsByteArray(is));
     } catch (FileNotFoundException fnfe) {
-      if (!ignoreIOE) {
-        throw new HoodieIOException("Could not find commit details from " + detailPath, fnfe);
-      }
       LOG.debug("No file found at path {}", detailPath);
       return Option.empty();
     } catch (IOException e) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Currently we log at warn level in `readDataFromPath` when the file is not found but we should handle that at debug level and return an empty result

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
Handle FileNotFoundException on its own instead of treating it as a more general IOException

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Improves logging

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
