### PR TITLE
perf: Avoid materializing into intermediate list in metadata table path

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/data/HoodieListData.java
@@ -25,6 +25,9 @@ import org.apache.hudi.common.function.SerializablePairFunction;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -60,6 +63,7 @@ import static org.apache.hudi.common.function.FunctionWrapper.throwingMapWrapper
  * @param <T> type of object.
  */
 public class HoodieListData<T> extends HoodieBaseListData<T> implements HoodieData<T> {
+  private static Logger LOG = LoggerFactory.getLogger(HoodieListData.class);
 
   private HoodieListData(List<T> data, boolean lazy) {
     super(data, lazy);
@@ -89,6 +93,27 @@ public class HoodieListData<T> extends HoodieBaseListData<T> implements HoodieDa
    */
   public static <T> HoodieListData<T> lazy(List<T> listData) {
     return new HoodieListData<>(listData, true);
+  }
+
+  /**
+   * Creates instance of {@link HoodieListData} bearing *lazy* execution semantic on top of an iterator.
+   * If the iterator is {@link java.io.Closeable}, it will be closed when the stream is closed.
+   * @param iterator a {@link Iterator} of objects in type T
+   * @return a new instance that will process the iterator lazily
+   * @param <T> the type of object
+   */
+  public static <T> HoodieListData<T> lazy(Iterator<T> iterator) {
+    Stream<T> stream = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), true).onClose(() -> {
+          if (iterator instanceof AutoCloseable) {
+            try {
+              ((AutoCloseable) iterator).close();
+            } catch (Exception ex) {
+              LOG.warn("Failed to close the iterator", ex);
+            }
+          }
+        });
+    return new HoodieListData<>(stream, true);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -574,11 +574,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
                                                                                            Collection<String> sortedKeys,
                                                                                            FileSlice fileSlice,
                                                                                            boolean isFullKey) {
-    List<HoodieRecord<HoodieMetadataPayload>> res = new ArrayList<>();
-    try (ClosableIterator<HoodieRecord<HoodieMetadataPayload>> iterator = lookupRecordsItr(partitionName, sortedKeys, fileSlice, isFullKey)) {
-      iterator.forEachRemaining(res::add);
-    }
-    return HoodieListData.lazy(res);
+    return HoodieListData.lazy(lookupRecordsItr(partitionName, sortedKeys, fileSlice, isFullKey));
   }
 
   private ClosableIterator<Pair<String, HoodieRecord<HoodieMetadataPayload>>> readSliceAndFilterByKeys(String partitionName,

--- a/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListData.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/data/TestHoodieListData.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.common.data;
 
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,8 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class TestHoodieListData {
 
@@ -94,6 +97,16 @@ class TestHoodieListData {
 
     emptyListData = HoodieListData.lazy(Collections.emptyList());
     assertTrue(emptyListData.isEmpty());
+  }
+
+  @Test
+  void testCloseableIterator() {
+    ClosableIterator<String> iterator = spy(ClosableIterator.wrap(Arrays.asList("value1", "value2").iterator()));
+    HoodieData<String> listData = HoodieListData.lazy(iterator);
+    List<String> values = listData.collectAsList();
+    assertEquals(Arrays.asList("value1", "value2"), values);
+    // Ensure the iterator is closed after use
+    verify(iterator).close();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
There is one path in the metadata table that is not properly leveraging iterators and needs a fix

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Added a new method for `HoodieListData` that takes in an iterator. This method will convert to a stream and add the proper hook to close the iterator if required.
- Updates the `readSliceAndFilterByKeysIntoList` to use the above constructor

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Avoids reading data into a list just to create an iterator

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
