### PR TITLE
fix empty byte array translation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/SerializableIndexedRecord.java
@@ -68,6 +68,9 @@ public class SerializableIndexedRecord implements GenericRecord, KryoSerializabl
   }
 
   public static SerializableIndexedRecord fromAvroBytes(Schema schema, byte[] bytes) {
+    if (bytes.length == 0) {
+      return null;
+    }
     return new SerializableIndexedRecord(schema, bytes);
   }
 
@@ -83,7 +86,7 @@ public class SerializableIndexedRecord implements GenericRecord, KryoSerializabl
 
   @Override
   public Schema getSchema() {
-    return schema != null ? schema : getData().getSchema();
+    return schema != null ? schema : record.getSchema();
   }
 
   byte[] encodeRecord() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
In the legacy payload path when the record is meant to be null, an empty byte array is used. The translation from payload to SerializableIndexedRecord does not account for this.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
Change `SerializableIndexedRecord.fromAvroBytes` to return `null` when the byte array has 0 length.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Fixes bug with payload translation

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
