### PR TITLE
fix: tracking partition names correctly during secondary index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -90,7 +89,16 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
     Set<String> indexesInflightOrCompleted = getInflightAndCompletedMetadataPartitions(table.getMetaClient().getTableConfig());
     InstantGenerator instantGenerator = table.getMetaClient().getInstantGenerator();
 
-    Set<String> requestedPartitions = new HashSet<>(partitionPaths);
+    HoodieMetadataConfig metadataConfig = config.getMetadataConfig();
+    Set<String> requestedPartitions = partitionIndexTypes.stream().map(p -> {
+      if (MetadataPartitionType.EXPRESSION_INDEX.equals(p)) {
+        return getSecondaryOrExpressionIndexName(metadataConfig::getExpressionIndexName, PARTITION_NAME_EXPRESSION_INDEX_PREFIX, metadataConfig.getExpressionIndexColumn());
+      } else if (MetadataPartitionType.SECONDARY_INDEX.equals(p)) {
+        return getSecondaryOrExpressionIndexName(metadataConfig::getSecondaryIndexName, PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataConfig.getSecondaryIndexColumn());
+      }
+      return p.getPartitionPath();
+    }).collect(Collectors.toSet());
+    requestedPartitions.addAll(partitionPaths);
     requestedPartitions.removeAll(indexesInflightOrCompleted);
 
     if (!requestedPartitions.isEmpty()) {
@@ -101,7 +109,17 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
       return Option.empty();
     }
     List<MetadataPartitionType> finalPartitionsToIndex = partitionIndexTypes.stream()
-        .filter(p -> requestedPartitions.contains(p.getPartitionPath())).collect(Collectors.toList());
+        .filter(p -> {
+          String partitionName;
+          if (MetadataPartitionType.EXPRESSION_INDEX.equals(p)) {
+            partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getExpressionIndexName, PARTITION_NAME_EXPRESSION_INDEX_PREFIX, metadataConfig.getExpressionIndexColumn());
+          } else if (MetadataPartitionType.SECONDARY_INDEX.equals(p)) {
+            partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getSecondaryIndexName, PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataConfig.getSecondaryIndexColumn());
+          } else {
+            partitionName = p.getPartitionPath();
+          }
+          return requestedPartitions.contains(partitionName);
+        }).collect(Collectors.toList());
     final HoodieInstant indexInstant = instantGenerator.getIndexRequestedInstant(instantTime);
     try {
       // get last completed instant

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -89,7 +89,15 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
     Set<String> indexesInflightOrCompleted = getInflightAndCompletedMetadataPartitions(table.getMetaClient().getTableConfig());
     InstantGenerator instantGenerator = table.getMetaClient().getInstantGenerator();
 
-    Set<String> requestedPartitions = partitionIndexTypes.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toSet());
+    Set<String> requestedPartitions = partitionIndexTypes.stream().map(p -> {
+      HoodieMetadataConfig metadataConfig = config.getMetadataConfig();
+      if (MetadataPartitionType.EXPRESSION_INDEX.equals(p)) {
+        return getSecondaryOrExpressionIndexName(metadataConfig::getExpressionIndexName, PARTITION_NAME_EXPRESSION_INDEX_PREFIX, metadataConfig.getExpressionIndexColumn());
+      } else if (MetadataPartitionType.SECONDARY_INDEX.equals(p)) {
+        return getSecondaryOrExpressionIndexName(metadataConfig::getSecondaryIndexName, PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataConfig.getSecondaryIndexColumn());
+      }
+      return p.getPartitionPath();
+    }).collect(Collectors.toSet());
     requestedPartitions.addAll(partitionPaths);
     requestedPartitions.removeAll(indexesInflightOrCompleted);
 
@@ -101,7 +109,18 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
       return Option.empty();
     }
     List<MetadataPartitionType> finalPartitionsToIndex = partitionIndexTypes.stream()
-        .filter(p -> requestedPartitions.contains(p.getPartitionPath())).collect(Collectors.toList());
+        .filter(p -> {
+          HoodieMetadataConfig metadataConfig = config.getMetadataConfig();
+          String partitionName;
+          if (MetadataPartitionType.EXPRESSION_INDEX.equals(p)) {
+            partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getExpressionIndexName, PARTITION_NAME_EXPRESSION_INDEX_PREFIX, metadataConfig.getExpressionIndexColumn());
+          } else if (MetadataPartitionType.SECONDARY_INDEX.equals(p)) {
+            partitionName = getSecondaryOrExpressionIndexName(metadataConfig::getSecondaryIndexName, PARTITION_NAME_SECONDARY_INDEX_PREFIX, metadataConfig.getSecondaryIndexColumn());
+          } else {
+            partitionName = p.getPartitionPath();
+          }
+          return requestedPartitions.contains(partitionName);
+        }).collect(Collectors.toList());
     final HoodieInstant indexInstant = instantGenerator.getIndexRequestedInstant(instantTime);
     try {
       // get last completed instant


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When scheduling secondary or expression indexes, the code was incorrectly using the partition type prefix (`secondary_index_` or `expr_index_`) along with computed partition names (e.x `secondary_index_idx_rider`). It is later filtered out but the logs in between are getting improper results

### Summary and Changelog

Fixed `ScheduleIndexActionExecutor` to update the evaluation correctly

### Impact

No much impact, just cleaner way

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
