### PR TITLE
fix: INSERT INTO should preserve duplication with hoodie.spark.sql.insert.into.operation=insert

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -215,10 +215,15 @@ trait ProvidesHoodieConfig extends Logging {
     val insertDupPolicy = combinedOpts.getOrElse(INSERT_DUP_POLICY.key(), INSERT_DUP_POLICY.defaultValue())
     val isNonStrictMode = insertMode == InsertMode.NON_STRICT
     val isPartitionedTable = hoodieCatalogTable.partitionFields.nonEmpty
-    val combineBeforeInsert = if (sparkSqlInsertIntoOperationSet && sparkSqlInsertIntoOperation == "insert") {
-      false
-    } else {
-      !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+    val combineBeforeInsert = combinedOpts.get(HoodieWriteConfig.COMBINE_BEFORE_INSERT.key()) match {
+      case Some(value) =>
+        value.toBoolean
+      case None =>
+        if (sparkSqlInsertIntoOperationSet && sparkSqlInsertIntoOperation.equals(INSERT_OPERATION_OPT_VAL)) {
+          false
+        } else {
+          !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+        }
     }
 
     /*

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -215,7 +215,11 @@ trait ProvidesHoodieConfig extends Logging {
     val insertDupPolicy = combinedOpts.getOrElse(INSERT_DUP_POLICY.key(), INSERT_DUP_POLICY.defaultValue())
     val isNonStrictMode = insertMode == InsertMode.NON_STRICT
     val isPartitionedTable = hoodieCatalogTable.partitionFields.nonEmpty
-    val combineBeforeInsert = !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+    val combineBeforeInsert = if (sparkSqlInsertIntoOperationSet && sparkSqlInsertIntoOperation == "insert") {
+      false
+    } else {
+      !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+    }
 
     /*
      * The sql write operation has higher precedence than the legacy insert mode.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
@@ -3076,12 +3076,12 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
           Seq(2, "a2_2", 30.0, "2021-07-18")
         )
       } else if (isExplicitInsertOperation) {
-        // When INSERT operation is explicitly set, duplicates should be preserved (our fix)
+        // When INSERT operation is explicitly set, duplicates should be preserved
         if (insertDupPolicy == NONE_INSERT_DUP_POLICY) {
           checkAnswer(s"select id, name, price, dt from $tableName order by id")(
             Seq(1, "a1", 10.0, "2021-07-18"),
             Seq(1, "a1_1", 10.0, "2021-07-18"),
-            Seq(2, "a2", 20.0, "2021-07-18"), // same-batch duplicates preserved with explicit INSERT
+            Seq(2, "a2", 20.0, "2021-07-18"),
             Seq(2, "a2_2", 30.0, "2021-07-18")
           )
         } else if (insertDupPolicy == DROP_INSERT_DUP_POLICY) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

INSERT INTO operations silently deduplicate records when tables have preCombineField defined, even when explicitly setting `hoodie.spark.sql.insert.into.operation=insert`. This violates spark-sql writes expected behavior when sql.insert.into.operation is explicitly set to "insert". The root cause is that the presence of preCombineField automatically sets `combineBeforeInsert=true`, overriding INSERT operation semantics.

deduplication can be happen by explicitly setting `hoodie.combine.before.insert=true` if need be. 

fixes: https://github.com/apache/hudi/issues/14049

### Summary and Changelog

Fixed INSERT INTO operations to preserve duplicates when `hoodie.spark.sql.insert.into.operation=insert` is set.

### Impact

User control - INSERT operations now correctly preserve duplicates when `hoodie.spark.sql.insert.into.operation=insert` is set

### Risk Level

low

### Documentation Update

Update 1.1 doc for interaction with `hoodie.spark.sql.insert.into.operation`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
