### PR TITLE
fix: Log info keygen missing

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorType.java
@@ -150,7 +150,7 @@ public enum KeyGeneratorType {
       return keyGeneratorType.getClassName();
     }
     // No key generator information is provided.
-    LOG.warn("No key generator type is set properly");
+    LOG.info("No key generator type is set properly");
     return null;
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

If keygen is missing log.info instead of log.warn

### Summary and Changelog

If keygen is missing log.info instead of log.warn

### Impact

remove noisy log warn

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
