### PR TITLE
feat: Partition predicate fix for Databricks runtime support

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -260,7 +260,7 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
           ctor.newInstance(transformedPredicate).asInstanceOf[BasePredicate]
         } catch {
           case _: NoSuchMethodException | _: IllegalArgumentException =>
-            // Fallback: Try using 2-arg constructor
+            // Fallback: Try using 2-arg constructor for certain Spark runtime
             val clazz = Class.forName("org.apache.spark.sql.catalyst.expressions.InterpretedPredicate")
             val ctor = clazz.getConstructor(classOf[Expression], classOf[Boolean])
             ctor.newInstance(transformedPredicate, java.lang.Boolean.FALSE)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Fixes https://github.com/apache/hudi/issues/14058

While running hudi on databricks, the code failed as InterpretedPredicate was expecting two parameters in the constructor

### Summary and Changelog

We can use Hudi with Databricks Runtime seemlessly. Before we were facing issues while adding partition predicate to hudi reads with Databricks runtime

### Impact

none

### Risk Level

none

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
