### PR TITLE
chore: Exclude hudi-trino-plugin from RAT checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -614,6 +614,7 @@
               <!-- local files not in version control -->
               <exclude>**/*.iml</exclude>
               <exclude>.mvn/**</exclude>
+              <exclude>hudi-trino-plugin/**</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR addresses issue https://github.com/apache/hudi/issues/14066 by excluding `hudi-trino-plugin` from RAT checks.

### Summary and Changelog

1. Exclude `hudi-trino-plugin` from RAT checks.

### Impact

None

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
