### PR TITLE
fix: creating warehouse bucket automatically

### DIFF
--- a/hudi-notebooks/docker-compose.yml
+++ b/hudi-notebooks/docker-compose.yml
@@ -69,7 +69,7 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c " 
-      until (/usr/bin/mc alias set add minio http://minio:9000 admin password --api S3v4) do echo '...waiting...' && sleep 1; done; 
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password --api S3v4) do echo '...waiting...' && sleep 1; done; 
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

- This PR addresses the issue where the expected S3 bucket `warehouse` is not automatically created if it doesn’t already exist. This causes failures in workflows that assume the warehouse bucket is always available.
- The fix ensures that the required S3 bucket is created programmatically if it does not already exist,

### Summary and Changelog

- This change adds logic to automatically create the warehouse S3 bucket if it does not already exist. 
- This eliminates the need for manual bucket creation.

### Impact

None

### Risk Level

none

### Documentation Update

This is an internal change related to setup automation.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
