### PR TITLE
perf: [Flink] Introduce a Flink Clustering Plan Strategy to Eliminate Redundant Small-File Merges

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/FlinkSkipSingleFileClusteringPlanStrategy.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/FlinkSkipSingleFileClusteringPlanStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.clustering.plan.strategy;
+
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An extension of {@link FlinkSizeBasedClusteringPlanStrategy} that skips clustering
+ * for partitions containing only one small file.
+ */
+public class FlinkSkipSingleFileClusteringPlanStrategy<T>
+    extends FlinkSizeBasedClusteringPlanStrategy<T> {
+
+  public FlinkSkipSingleFileClusteringPlanStrategy(HoodieTable table,
+                                              HoodieEngineContext engineContext,
+                                              HoodieWriteConfig writeConfig) {
+    super(table, engineContext, writeConfig);
+  }
+
+  @Override
+  protected Stream<FileSlice> getFileSlicesEligibleForClustering(final String partition) {
+    List<FileSlice> fileSlices = super.getFileSlicesEligibleForClustering(partition)
+            .collect(Collectors.toList());
+
+    //  if some special sort columns are declared, we can not skip the clustering.
+    if (!StringUtils.isNullOrEmpty(getWriteConfig().getClusteringSortColumns())) {
+      return fileSlices.stream();
+    }
+
+    if (fileSlices.size() > 1) {
+      return fileSlices.stream();
+    }
+    return Stream.empty();
+  }
+}


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR introduces an adaptive clustering strategy to improve FlinkSizeBasedClusteringPlanStrategy, preventing repeated tail small-file (smaller than small.file.limit) rewrites and enhancing clustering efficiency and downstream query stability.

### How to reproduce

**1.** To reproduce the issue, prepare a partition whose total data size is around 720 MB, and configure the following parameter:
`'clustering.plan.strategy.target.file.max.bytes' = '650000000'`

**2.** Before clustering, the partition (p_date=20251029) contains around 10 Parquet files, each ranging from 8 MB to 120 MB in size.

<img width="695" height="82" alt="1" src="https://github.com/user-attachments/assets/ccee85e4-3064-412f-856a-facc6bf13b20" />


**3.** After running the first clustering, one large file (~680 MB) and one small file (~50 MB) are generated.This satisfies the configured file size target, and no further merging should be necessary.

**4.** However, as clustering continues to run periodically, the small file (~50 MB) keeps being rewritten repeatedly — each new clustering execution produces a new version of this small file.

**5.** Because of the clean-retain-commits configuration, multiple historical versions of this small file are retained,
leading to unnecessary file growth and redundant commits.

<img width="1392" height="389" alt="2" src="https://github.com/user-attachments/assets/d33eb678-25ad-4f72-9aab-5c2d9a7fea53" />

In production environments, partition data sizes can vary widely.Even with careful tuning of the minimum and maximum file size limits, it’s impossible to ensure that all partitions are evenly split into large files.

As a result, small “tail” files are inevitable. When these small files are repeatedly rewritten during clustering, they lead to unnecessary resource consumption and may cause unstable query performance.

### What problem does this PR solve?
In the current `FlinkSizeBasedClusteringPlanStrategy`, the clustering plan selects small files based solely on their size 
threshold (`small.file.limit`) without considering whether a partition contains only one such small file. 

As a result, the same file is repeatedly included in clustering plans, causing redundant clustering operations and unnecessary commits, which can lead to temporary missing files or unstable read results for downstream queries.

Therefore, a mechanism is needed to detect and skip partitions that contain only one small file, to avoid redundant clustering cycles.

### What is the improvement?

This change introduces org.apache.hudi.client.clustering.plan.strategy.FlinkSizeBasedClusteringPlanStrategy to improve FlinkSizeBasedClusteringPlanStrategy.

This strategy can be freely enabled via the clustering.plan.strategy.class parameter, ensuring flexibility and backward compatibility.

### Does this change affect other components?
No. The logic is applied only in the plan-building phase and does not modify commit or execution flows.

### How was this patch tested?
- This change only adds an early-exit condition in the clustering plan phase. 
- Verified manually on a local Flink cluster that partitions with only one small file are skipped as expected (observed from INFO logs).
- No functional change to existing clustering logic.

### Issue
https://github.com/apache/hudi/issues/14086