### PR TITLE
fix: Ignore field nullability while checking whether record should be…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -175,10 +175,17 @@ public class AvroSchemaUtils {
    * </ol>
    */
   public static boolean isStrictProjectionOf(Schema sourceSchema, Schema targetSchema) {
-    return isProjectionOfInternal(sourceSchema, targetSchema, AvroSchemaUtils::isAtomicTypeEquals);
+    return isProjectionOfInternal(sourceSchema, targetSchema, AvroSchemaUtils::isAtomicTypeProjectable);
   }
 
-  private static boolean isAtomicTypeEquals(Schema source, Schema target) {
+  private static boolean isAtomicTypeProjectable(Schema source, Schema target) {
+    // ignore nullability for projectable checking
+    source = resolveNullableSchema(source);
+    target = resolveNullableSchema(target);
+    if (source.getType() == Schema.Type.ENUM && target.getType() == Schema.Type.STRING
+        || source.getType() == Schema.Type.STRING && target.getType() == Schema.Type.ENUM) {
+      return true;
+    }
     // ignore name/namespace for FIXED type
     if (source.getType() == Schema.Type.FIXED && target.getType() == Schema.Type.FIXED) {
       return source.getLogicalType().equals(target.getLogicalType())


### PR DESCRIPTION
… rewritten in COW write path

### Describe the issue this Pull Request addresses

Ignore field nullability while checking whether record should be rewritten in COW write path, https://github.com/apache/hudi/issues/14093

### Summary and Changelog

Ignore field nullability in `AvroSchemaUtils#isStrictProjectionOf`.

### Impact

Avoid unnecessary record rewritten in COW write path.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
