### PR TITLE
fix: disable embedded timeline service for flink upgrade

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/upgrade/FlinkUpgradeDowngradeHelper.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/upgrade/FlinkUpgradeDowngradeHelper.java
@@ -54,6 +54,10 @@ public class FlinkUpgradeDowngradeHelper implements SupportsUpgradeDowngrade {
 
   @Override
   public BaseHoodieWriteClient getWriteClient(HoodieWriteConfig config, HoodieEngineContext context) {
+    // Because flink enables reusing of embedded timeline service by default, disable the embedded time service to avoid closing of the reused timeline server.
+    // The write config inherits from the info of the currently running timeline server started in coordinator, even though the flag is disabled, it still can
+    // access the remote timeline server started before.
+    config.setValue(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
     return new HoodieFlinkWriteClient(context, config);
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Disable embedded timeline serice for flink upgrade


### Summary and Changelog

Disable embedded timeline service for flink upgrade, since the upgrading runs in standalone mode on coordinator.

### Impact

Improve performance of fs view operation in flink writers, since embedded time service on coordinator may be closed after upgrading.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
