### PR TITLE
fix: show_index command output had incorrect order of column names

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -72,8 +72,8 @@ case class ShowIndexes(table: LogicalPlan,
 object ShowIndexes {
   def getOutputAttrs: Seq[Attribute] = Seq(
     AttributeReference("index_name", StringType, nullable = false)(),
-    AttributeReference("col_name", StringType, nullable = false)(),
-    AttributeReference("index_type", StringType, nullable = false)()
+    AttributeReference("index_type", StringType, nullable = false)(),
+    AttributeReference("col_name", StringType, nullable = false)()
   )
 }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Before the fix:

scala> spark.sql(s"SHOW INDEXES FROM hudi_indexed_table").show(false);
| index_name                 | col_name        | index_type |
|-----------------------------|-----------------|-------------|
| column_stats               | column_stats    |             |
| partition_stats            | partition_stats |             |
| expr_index_idx_bloom_driver| bloom_filters   | driver      |



### Summary and Changelog

After fix: 

scala> spark.sql(s"SHOW INDEXES FROM hudi_indexed_table").show(false);
|index_name                 |index_type|col_name     |
|---------------------------|--------|---------------|
| column_stats               | column_stats    |             |
| partition_stats            | partition_stats |             |
| expr_index_idx_bloom_driver| bloom_filters   | driver      |


### Impact

Fix a minor bug.

### Risk Level

None.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
