### PR TITLE
fix: avoid overwriting hoodie.properities file for MDT during downgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/NineToEightDowngradeHandler.java
@@ -85,9 +85,6 @@ public class NineToEightDowngradeHandler implements DowngradeHandler {
         && isComplexKeyGeneratorWithSingleRecordKeyField(metaClient.getTableConfig())) {
       throw new HoodieUpgradeDowngradeException(getComplexKeygenErrorMessage("downgrade"));
     }
-    // Handle index Changes
-    UpgradeDowngradeUtils.dropNonV1IndexPartitions(
-        config, context, table, upgradeDowngradeHelper, "downgrading from table version nine to eight");
     // Update table properties.
     Set<ConfigProperty> propertiesToRemove = new HashSet<>();
     Map<ConfigProperty, String> propertiesToAdd = new HashMap<>();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngradeUtils.java
@@ -287,12 +287,13 @@ public class UpgradeDowngradeUtils {
    *
    * @param config        Write config
    * @param context       Engine context
-   * @param table         Hoodie table
+   * @param metaClient    Hoodie table meta client
    * @param operationType Type of operation (upgrade/downgrade)
    */
   public static void dropNonV1IndexPartitions(HoodieWriteConfig config, HoodieEngineContext context,
-                                              HoodieTable table, SupportsUpgradeDowngrade upgradeDowngradeHelper, String operationType) {
-    HoodieTableMetaClient metaClient = table.getMetaClient();
+                                              HoodieTableMetaClient metaClient,
+                                              SupportsUpgradeDowngrade upgradeDowngradeHelper,
+                                              String operationType) {
     try (BaseHoodieWriteClient writeClient = upgradeDowngradeHelper.getWriteClient(config, context)) {
       List<String> mdtPartitions = metaClient.getTableConfig().getMetadataPartitions()
           .stream()

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestNineToEightDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestNineToEightDowngradeHandler.java
@@ -19,15 +19,12 @@
 
 package org.apache.hudi.table.upgrade;
 
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
-import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
@@ -37,11 +34,8 @@ import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.metadata.HoodieIndexVersion;
-import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,17 +43,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,10 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TestNineToEightDowngradeHandler {
@@ -248,81 +233,6 @@ class TestNineToEightDowngradeHandler {
       assertEquals(1, propertiesToChange.propertiesToDelete().size());
       assertTrue(propertiesToChange.propertiesToDelete().contains(PARTIAL_UPDATE_MODE));
       assertEquals(0, propertiesToChange.propertiesToUpdate().size());
-    }
-  }
-
-  @Test
-  void testDowngradeDropsOnlyV2OrAboveIndexes() {
-    // Use try-with-resources to ensure the static mock is closed
-    try (MockedStatic<UpgradeDowngradeUtils> mockedUtils = Mockito.mockStatic(UpgradeDowngradeUtils.class)) {
-      // Mock the static method to do nothing - avoid NPE
-      mockedUtils.when(() -> UpgradeDowngradeUtils.rollbackFailedWritesAndCompact(
-          any(HoodieTable.class), 
-          any(HoodieEngineContext.class), 
-          any(HoodieWriteConfig.class), 
-          any(SupportsUpgradeDowngrade.class),
-          anyBoolean(),
-          any(HoodieTableVersion.class)
-      )).thenAnswer(invocation -> null); // Do nothing
-      
-      // Mock the dropNonV1SecondaryIndexPartitions to simulate dropping V2 indexes
-      mockedUtils.when(() -> UpgradeDowngradeUtils.dropNonV1IndexPartitions(
-          eq(config),
-          eq(context),
-          eq(table),
-          eq(upgradeDowngradeHelper),
-          any(String.class)
-      )).thenAnswer(invocation -> {
-        // Get the write client and call dropIndex with expected partitions
-        BaseHoodieWriteClient writeClient = upgradeDowngradeHelper.getWriteClient(config, context);
-        List<String> partitionsToDrop = Arrays.asList("secondary_index_v2");
-        writeClient.dropIndex(partitionsToDrop);
-        return null;
-      });
-
-      // Arrange
-      // Mock index definitions: one V1, one V2, one V3
-      Map<String, HoodieIndexDefinition> indexDefs = new HashMap<>();
-      indexDefs.put(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath() + "v1", HoodieIndexDefinition.newBuilder()
-          .withIndexName(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath() + "v1")
-          .withIndexType(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath())
-          .withVersion(HoodieIndexVersion.V1)
-          .build());
-      indexDefs.put(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath() + "v2", HoodieIndexDefinition.newBuilder()
-          .withIndexName(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath() + "v2")
-          .withIndexType(MetadataPartitionType.SECONDARY_INDEX.getPartitionPath())
-          .withVersion(HoodieIndexVersion.V2)
-          .build());
-      indexDefs.put(MetadataPartitionType.FILES.getPartitionPath(), HoodieIndexDefinition.newBuilder()
-          .withIndexName(MetadataPartitionType.FILES.getPartitionPath())
-          .withIndexType(MetadataPartitionType.FILES.getPartitionPath())
-          .withVersion(HoodieIndexVersion.V2)
-          .build());
-      indexDefs.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), HoodieIndexDefinition.newBuilder()
-          .withIndexName(MetadataPartitionType.COLUMN_STATS.getPartitionPath())
-          .withIndexType(MetadataPartitionType.COLUMN_STATS.getPartitionPath())
-          .withVersion(HoodieIndexVersion.V2)
-          .build());
-      HoodieIndexMetadata metadata = new HoodieIndexMetadata(indexDefs);
-
-      when(table.getMetaClient()).thenReturn(metaClient);
-      when(metaClient.getIndexMetadata()).thenReturn(Option.of(metadata));
-      when(metaClient.getTableConfig()).thenReturn(tableConfig);
-      Set<String> mdtPartitions = new HashSet<>(indexDefs.keySet());
-      when(tableConfig.getMetadataPartitions()).thenReturn(mdtPartitions);
-
-      // Mock write client
-      BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
-      when(upgradeDowngradeHelper.getWriteClient(config, context)).thenReturn(writeClient);
-
-      // Act
-      handler.downgrade(config, context, "20240101120000", upgradeDowngradeHelper);
-
-      // Assert: dropIndex should be called with only index with version v2 or higher.
-      ArgumentCaptor<List<String>> argumentCaptor = ArgumentCaptor.forClass(List.class);
-      verify(writeClient, times(1)).dropIndex(argumentCaptor.capture());
-      List<String> capturedIndexes = argumentCaptor.getValue();
-      assertEquals(new HashSet<>(Arrays.asList("secondary_index_v2")), new HashSet<>(capturedIndexes));
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngradeUtils.java
@@ -18,19 +18,38 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieIndexVersion;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 import static org.apache.hudi.table.upgrade.UpgradeDowngradeUtils.convertCompletionTimeToEpoch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-public class TestUpgradeDowngradeUtils {
+class TestUpgradeDowngradeUtils {
 
   @Test
   void testConvertCompletionTimeToEpoch() {
@@ -52,5 +71,98 @@ public class TestUpgradeDowngradeUtils {
     HoodieInstant inValidInstant = new HoodieInstant(HoodieInstant.State.COMPLETED, "dummy_action", "20231112153045678", invalidCompletionTime, InstantComparatorV2.COMPLETION_TIME_BASED_COMPARATOR);
 
     assertEquals(-1, convertCompletionTimeToEpoch(inValidInstant), "Epoch time for invalid input should be -1.");
+  }
+
+  @Test
+  void testDropNonV1IndexPartitions() {
+    // Test scenario: No metadata partitions exist
+    testDropNonV1IndexPartitionsNoPartitions();
+    // Test scenario: Mixed V1 and V2+ partitions
+    testDropNonV1IndexPartitionsMixedVersions();
+    // Test scenario: Exception handling
+    testDropNonV1IndexPartitionsExceptionHandling();
+  }
+
+  private void testDropNonV1IndexPartitionsNoPartitions() {
+    // Setup mocks
+    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    SupportsUpgradeDowngrade upgradeDowngradeHelper = mock(SupportsUpgradeDowngrade.class);
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+
+    // Mock behavior - no metadata partitions
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getMetadataPartitions()).thenReturn(new HashSet<>());
+    when(upgradeDowngradeHelper.getWriteClient(config, context)).thenReturn(writeClient);
+
+    // Execute
+    UpgradeDowngradeUtils.dropNonV1IndexPartitions(
+        config, context, metaClient, upgradeDowngradeHelper, "upgrade");
+
+    // Verify - dropIndex should not be called when no partitions exist
+    verify(writeClient, times(0)).dropIndex(any());
+  }
+
+  private void testDropNonV1IndexPartitionsMixedVersions() {
+    // Setup mocks
+    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    SupportsUpgradeDowngrade upgradeDowngradeHelper = mock(SupportsUpgradeDowngrade.class);
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    HoodieIndexDefinition v1IndexDef = mock(HoodieIndexDefinition.class);
+    HoodieIndexDefinition v2IndexDef = mock(HoodieIndexDefinition.class);
+
+    // Mock behavior - mixed V1 and V2+ partitions
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getMetadataPartitions()).thenReturn(new HashSet<>(Arrays.asList("v1_partition", "v2_partition")));
+    when(metaClient.getIndexForMetadataPartition("v1_partition")).thenReturn(Option.of(v1IndexDef));
+    when(metaClient.getIndexForMetadataPartition("v2_partition")).thenReturn(Option.of(v2IndexDef));
+    when(v1IndexDef.getVersion()).thenReturn(HoodieIndexVersion.V1);
+    when(v2IndexDef.getVersion()).thenReturn(HoodieIndexVersion.V2);
+    when(upgradeDowngradeHelper.getWriteClient(config, context)).thenReturn(writeClient);
+
+    // Execute
+    UpgradeDowngradeUtils.dropNonV1IndexPartitions(
+        config, context, metaClient, upgradeDowngradeHelper, "upgrade");
+
+    // Verify - dropIndex should be called only with V2+ partitions
+    ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+    verify(writeClient, times(1)).dropIndex(captor.capture());
+    List<String> droppedPartitions = captor.getValue();
+    assertEquals(1, droppedPartitions.size());
+    assertTrue(droppedPartitions.contains("v2_partition"));
+    assertFalse(droppedPartitions.contains("v1_partition"));
+  }
+
+  private void testDropNonV1IndexPartitionsExceptionHandling() {
+    // Setup mocks
+    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    SupportsUpgradeDowngrade upgradeDowngradeHelper = mock(SupportsUpgradeDowngrade.class);
+    HoodieIndexDefinition v2IndexDef = mock(HoodieIndexDefinition.class);
+
+    // Mock behavior - V2 partition but exception when getting write client
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getMetadataPartitions()).thenReturn(new HashSet<>(Arrays.asList("partition1")));
+    when(metaClient.getIndexForMetadataPartition("partition1")).thenReturn(Option.of(v2IndexDef));
+    when(v2IndexDef.getVersion()).thenReturn(HoodieIndexVersion.V2);
+    when(upgradeDowngradeHelper.getWriteClient(config, context)).thenThrow(
+        new RuntimeException("Write client creation failed"));
+
+    // Execute and verify exception is propagated
+    try {
+      UpgradeDowngradeUtils.dropNonV1IndexPartitions(
+          config, context, metaClient, upgradeDowngradeHelper, "upgrade");
+      // If we reach here, the test should fail
+      assert false : "Expected RuntimeException to be thrown";
+    } catch (RuntimeException e) {
+      assertEquals("Write client creation failed", e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`NineToEightDowngradeHandler` contains an operation of removing non-V1 index partitions. This operation first drops these non-V1 partitions, meanwhile updates the `hoodie.properties` file for MDT.

This behavior causes incorrect downgrade result because MDT downgrade happens before DT. After MDT has been downgrade from v9 to v8, the dropping non-V1 partitions would rewrite the table version of MDT to v9 again since it uses V9 table meta client. Basically it overwrites the `hoodie.properties` file for MDT table.

### Summary and Changelog

Move function `UpgradeDowngradeUtils.dropNonV1IndexPartitions` from `NineToEightDowngradeHandler` to `UpgradeDowngrade` class before MDT upgrade/downgrade operations, such that no overwrites should happen.

### Tests

- Added unit tests for `UpgradeDowngradeUtils.dropNonV1IndexPartitions`.
- Manually tested downgrading a table from v9 to v8, and confirmed that the MDT version was v8, not v9. 
  - Note that the secondary index has to be enabled in order to trigger the dropping of non-v1 index partitions.


### Impact

Fixed an incorrect downgrade behavior.

### Risk Level

Medium.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
