### PR TITLE
fix: Upgrade parquet-avro version to 1.15.1 in trino bundle and plugin

### DIFF
--- a/hudi-trino-plugin/pom.xml
+++ b/hudi-trino-plugin/pom.xml
@@ -418,6 +418,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
+            <version>${trino.parquet.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -202,7 +202,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
+      <version>${trino.parquet.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
     <presto.bundle.bootstrap.shade.prefix>org.apache.hudi.</presto.bundle.bootstrap.shade.prefix>
     <presto.commons-lang3.version>3.18.0</presto.commons-lang3.version>
     <presto.parquet.version>1.15.1</presto.parquet.version>
+    <trino.parquet.version>1.15.1</trino.parquet.version>
     <trino.bundle.bootstrap.scope>compile</trino.bundle.bootstrap.scope>
     <trino.bundle.bootstrap.shade.prefix>org.apache.hudi.</trino.bundle.bootstrap.shade.prefix>
     <twitter.chill.version>0.10.0</twitter.chill.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/14129

### Summary and Changelog

https://github.com/advisories/GHSA-2c59-37c4-qrx5 is fixed by parquet-avro version 1.15.1. Upgrading parquet-avro version to 1.15.1 in trino bundle and plugin to handle the CVE.

### Impact

Handles CVE https://github.com/advisories/GHSA-2c59-37c4-qrx5 in trino plugin

### Risk Level

medium

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
