### PR TITLE
refactor: Add required setter methods for Flink-CDC

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -127,7 +127,7 @@ public class StreamWriteOperatorCoordinator
   /**
    * Coordinator context.
    */
-  private final Context context;
+  protected final Context context;
 
   /**
    * Gateways for sending events to sub-tasks.
@@ -167,12 +167,12 @@ public class StreamWriteOperatorCoordinator
   /**
    * A single-thread executor to handle all the write metadata events.
    */
-  private NonThrownExecutor executor;
+  protected NonThrownExecutor executor;
 
   /**
    * A single-thread executor to handle the instant time request.
    */
-  private NonThrownExecutor instantRequestExecutor;
+  protected NonThrownExecutor instantRequestExecutor;
 
   /**
    * A single-thread executor to handle asynchronous hive sync.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -88,7 +88,7 @@ public abstract class AbstractStreamWriteFunction<I>
   /**
    * Correspondent to request the instant time.
    */
-  private transient Correspondent correspondent;
+  protected transient Correspondent correspondent;
 
   /**
    * Gateway to send operator events to the operator coordinator.
@@ -183,8 +183,16 @@ public abstract class AbstractStreamWriteFunction<I>
     this.correspondent = correspondent;
   }
 
+  public Correspondent getCorrespondent() {
+    return correspondent;
+  }
+
   public void setOperatorEventGateway(OperatorEventGateway operatorEventGateway) {
     this.eventGateway = operatorEventGateway;
+  }
+
+  public OperatorEventGateway getOperatorEventGateway() {
+    return eventGateway;
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/Correspondent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/Correspondent.java
@@ -71,6 +71,14 @@ public class Correspondent {
     }
   }
 
+  public OperatorID getOperatorID() {
+    return operatorID;
+  }
+
+  public TaskOperatorEventGateway getGateway() {
+    return gateway;
+  }
+
   /**
    * A request for instant time with a given checkpoint id.
    */


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adding required (pre-requisites) for Hudi support on Flink-CDC.

### Summary and Changelog

Changing access level and adding correspondent getter/setters to allow required fields to be accessed from wrapper functions.

### Impact

None.

### Risk Level

None

### Documentation Update

None.
- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
