### PR TITLE
docs: update Hudi table version mapping and downgrade examples in CLI

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -621,31 +621,33 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `EIGHT` or `8`     | 1.0.x                   |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `EIGHT`(`8`) (current version) to `SIX`(`6`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion SIX --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 6 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=6
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-0.14.0/cli.md
+++ b/website/versioned_docs/version-0.14.0/cli.md
@@ -617,31 +617,32 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `SIX`(`6`) (current version) to `FIVE`(`5`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion FIVE --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 5 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=5
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-0.14.1/cli.md
+++ b/website/versioned_docs/version-0.14.1/cli.md
@@ -617,31 +617,32 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `SIX`(`6`) (current version) to `FIVE`(`5`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion FIVE --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 5 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=5
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-0.15.0/cli.md
+++ b/website/versioned_docs/version-0.15.0/cli.md
@@ -617,31 +617,32 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `SIX`(`6`) (current version) to `FIVE`(`5`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion FIVE --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 5 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=5
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-1.0.0/cli.md
+++ b/website/versioned_docs/version-1.0.0/cli.md
@@ -616,31 +616,33 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `EIGHT` or `8`     | 1.0.x                   |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `EIGHT`(`8`) (current version) to `SIX`(`6`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion SIX --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 6 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=6
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-1.0.1/cli.md
+++ b/website/versioned_docs/version-1.0.1/cli.md
@@ -616,31 +616,33 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `EIGHT` or `8`     | 1.0.x                   |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `EIGHT`(`8`) (current version) to `SIX`(`6`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion SIX --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 6 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=6
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:

--- a/website/versioned_docs/version-1.0.2/cli.md
+++ b/website/versioned_docs/version-1.0.2/cli.md
@@ -621,31 +621,33 @@ The following table shows the Hudi table versions corresponding to the Hudi rele
 
 | Hudi Table Version | Hudi Release Version(s) |
 |:-------------------|:------------------------|
-| `FIVE` or `5`      | 0.12.x                  |
+| `EIGHT` or `8`     | 1.0.x                   |
+| `SIX` or `6`       | 0.14.x - 0.15.x         |
+| `FIVE` or `5`      | 0.12.x - 0.13.x         |
 | `FOUR` or `4`      | 0.11.x                  |
 | `THREE` or `3`     | 0.10.x                  |
 | `TWO` or `2`       | 0.9.x                   |
 | `ONE` or `1`       | 0.6.x - 0.8.x           |
 | `ZERO` or `0`      | 0.5.x and below         |
 
-For example, to downgrade a table from version `FIVE`(`5`) (current version) to `TWO`(`2`), you should run (use proper Spark master based
+For example, to downgrade a table from version `EIGHT`(`8`) (current version) to `SIX`(`6`), you should run (use proper Spark master based
 on your environment)
 
 ```shell
-downgrade table --toVersion TWO --sparkMaster local[2]
+downgrade table --toVersion SIX --sparkMaster local[2]
 ```
 
 or
 
 ```shell
-downgrade table --toVersion 2 --sparkMaster local[2]
+downgrade table --toVersion 6 --sparkMaster local[2]
 ```
 
 You can verify the table version by looking at the `hoodie.table.version` property in `.hoodie/hoodie.properties` under
 the table path:
 
 ```properties
-hoodie.table.version=2
+hoodie.table.version=6
 ```
 
 Hudi CLI also provides the ability to manually upgrade a Hudi table.  To upgrade a Hudi table through CLI:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The documentation for Hudi's CLI table downgrade functionality contained outdated and potentially confusing examples. Specifically, the examples used old and unrealistic target table versions (like version TWO) that are unlikely to be relevant for users of recent Hudi releases (0.14.x, 0.15.x, 1.0.x).

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

This PR clarifies and updates the Hudi CLI documentation regarding table versioning, ensuring the provided examples reflect current best practices and available versions.

**Summary:**

Updated Hudi CLI documentation files to include the latest table version mappings (up to version EIGHT) and revised all downgrade examples to target realistic, modern Hudi versions. This prevents user confusion and makes the documentation more practical.

**Changelog:**

The changes include:
- Added missing table versions SIX (0.14.x-0.15.x) and EIGHT (1.0.x)
- Updated downgrade examples to use realistic target versions:
    - 1.0.x → downgrade to SIX (6) instead of TWO (2)
    - 0.14.x/0.15.x → downgrade to FIVE (5) instead of TWO (2)
- Updated properties examples to match the downgrade targets
- Applied changes across all versioned documentation files

<img width="404" height="468" alt="Screenshot 2025-10-24 at 10 08 54 PM" src="https://github.com/user-attachments/assets/d80f35e8-297f-4920-9d5f-295f0e4848d2" />

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

The impact is strictly related to the clarity and accuracy of the Hudi website documentation.
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

none

This change is purely a documentation update to correct misleading information and add missing context. It does not touch any source code or configuration that affects runtime behavior.
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

This PR completes the necessary documentation update by correcting the existing CLI documentation files related to table versioning and downgrade commands.
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
