### PR TITLE
docs: Add Maven artifacts for Hudi release 1.0.2

### DIFF
--- a/website/releases/download.md
+++ b/website/releases/download.md
@@ -9,6 +9,12 @@ last_modified_at: 2022-12-27T15:59:57-04:00
 ### Release 1.0.2
 * Source Release : [Apache Hudi 1.0.2 Source Release](https://downloads.apache.org/hudi/1.0.2/hudi-1.0.2.src.tgz) ([asc](https://downloads.apache.org/hudi/1.0.2/hudi-1.0.2.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/1.0.2/hudi-1.0.2.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 1.0.2](/releases/release-1.0.2))
+* Maven Artifacts :
+    * [hudi-spark3.5-bundle](https://repository.apache.org/content/repositories/releases/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.0.2/hudi-spark3.5-bundle_2.12-1.0.2.jar)
+    * [hudi-utilities-slim-bundle](https://repository.apache.org/content/repositories/releases/org/apache/hudi/hudi-utilities-slim-bundle_2.12/1.0.2/hudi-utilities-slim-bundle_2.12-1.0.2.jar)
+    * [hudi-hive-sync-bundle](https://repository.apache.org/content/repositories/releases/org/apache/hudi/hudi-hive-sync-bundle/1.0.2/hudi-hive-sync-bundle-1.0.2.jar)
+    * [hudi-flink1.19-bundle](https://repository.apache.org/content/repositories/releases/org/apache/hudi/hudi-flink1.19-bundle/1.0.2/hudi-flink1.19-bundle-1.0.2.jar)
+    * [hudi-cli-bundle](https://repository.apache.org/content/repositories/releases/org/apache/hudi/hudi-cli-bundle_2.12/1.0.2/hudi-cli-bundle_2.12-1.0.2.jar)
 
 ### Release 1.0.1
 * Source Release : [Apache Hudi 1.0.1 Source Release](https://downloads.apache.org/hudi/1.0.1/hudi-1.0.1.src.tgz) ([asc](https://downloads.apache.org/hudi/1.0.1/hudi-1.0.1.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/1.0.1/hudi-1.0.1.src.tgz.sha512))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR adds the Maven artifacts corresponding to the Apache Hudi 1.0.2 release.

### Summary and Changelog

Adds Maven artifacts for Hudi release 1.0.2

### Impact

None

### Risk Level

none

### Documentation Update

This PR updates existing release documentation to include Maven artifacts for version 1.0.2.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
