### PR TITLE
refactor: Consolidate file writer side interfaces for new file format integrations

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
@@ -65,6 +65,24 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
     };
   }
 
+  /**
+   * Alternate constructor that takes taskPartitionId directly instead of requiring TaskContextSupplier.
+   * This is useful when the partition ID is known upfront (e.g., in bulk insert scenarios).
+   */
+  public HoodieSparkParquetWriter(StoragePath file,
+                                  HoodieRowParquetConfig parquetConfig,
+                                  String instantTime,
+                                  int taskPartitionId,
+                                  boolean populateMetaFields) throws IOException {
+    super(file, parquetConfig);
+    this.writeSupport = parquetConfig.getWriteSupport();
+    this.fileName = UTF8String.fromString(file.getName());
+    this.instantTime = UTF8String.fromString(instantTime);
+    this.populateMetaFields = populateMetaFields;
+    this.seqIdGenerator = recordIndex ->
+        HoodieRecord.generateSequenceId(instantTime, taskPartitionId, recordIndex);
+  }
+
   @Override
   public void writeRowWithMetadata(HoodieKey key, InternalRow row) throws IOException {
     if (populateMetaFields) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriter.java
@@ -25,7 +25,12 @@ import java.io.IOException;
 
 /**
  * Abstraction to assist in writing {@link InternalRow}s to be used in datasource implementation.
+ *
+ * @deprecated Use {@link org.apache.hudi.io.storage.HoodieSparkFileWriter} instead.
+ *             This interface is deprecated and will be removed in a future release.
+ *             HoodieSparkFileWriter provides the same functionality with built-in metadata population support.
  */
+@Deprecated
 public interface HoodieInternalRowFileWriter {
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
@@ -38,7 +38,13 @@ import static org.apache.hudi.common.util.ParquetUtils.getCompressionCodecName;
 
 /**
  * Factory to assist in instantiating a new {@link HoodieInternalRowFileWriter}.
+ *
+ * @deprecated Use {@link org.apache.hudi.io.storage.HoodieSparkFileWriterFactory#newParquetFileWriter(
+ *             StoragePath, org.apache.hudi.storage.StorageConfiguration, org.apache.hudi.common.config.HoodieConfig,
+ *             org.apache.spark.sql.types.StructType, String, int)} instead.
+ *             This factory is deprecated and will be removed in a future release.
  */
+@Deprecated
 public class HoodieInternalRowFileWriterFactory {
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowParquetWriter.java
@@ -29,7 +29,12 @@ import java.io.IOException;
 
 /**
  * Parquet's impl of {@link HoodieInternalRowFileWriter} to write {@link InternalRow}s.
+ *
+ * @deprecated Use {@link org.apache.hudi.io.storage.HoodieSparkParquetWriter} instead.
+ *             This class is deprecated and will be removed in a future release.
+ *             HoodieSparkParquetWriter provides the same functionality with built-in metadata population support.
  */
+@Deprecated
 public class HoodieInternalRowParquetWriter extends HoodieBaseParquetWriter<InternalRow>
     implements HoodieInternalRowFileWriter {
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Currently in hudi today we have many abstractions for doing file writing, as seen during the integration with lance https://github.com/apache/hudi/discussions/14128. The main goal is if we should try to consolidate these interfaces and their implementation so it is easier to add new file formats in the future.

Here are some of the core interfaces I have encountered thus far:

* HoodieFileWriter (highest level interface for writing) 
* HoodieSparkFileWriter (impl of the above for spark side)
* HoodieInternalRowWriter(duplicate interface that seems to be used only for bulk insert, potentially can be consolidated with top level interface)

### Summary and Changelog

* consolidate the logic from `HoodieInternalRowWriter` and its impl `HoodieInternalRowParquetWriter` into the `HoodieSparkParquetWriter`
* Mark classes as deprecated
* Port original test logic to use `HoodieSparkFileWriter`

### Impact

Low impact, marking older interfaces as deprecated

### Risk Level

medium, as we want to ensure that now operations work correctly when removing this `HoodieInternalRowWriter` interface which has been used for bulk insert flow. We should ensure CI which has many bulk inserts tests is passsing.

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
