### PR TITLE
refactor: remove buildx option in docker build for notebooks

### DIFF
--- a/hudi-notebooks/build.sh
+++ b/hudi-notebooks/build.sh
@@ -37,7 +37,7 @@ docker build \
 echo "Building Hive Docker image using Hive version: $HIVE_VERSION"
 
 export TARGET_PLATFORM=linux/amd64
-docker buildx build \
+docker build \
     --platform $TARGET_PLATFORM \
     --build-arg HIVE_VERSION="$HIVE_VERSION" \
     -t apachehudi/hive:latest \


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR addresses build issues and warnings related to docker buildx build usage in the Hudi notebook image build script.

### Summary and Changelog

Replaced `docker buildx build` with `docker build` in `hudi-notebooks/build.sh`

### Impact

None

### Risk Level

none

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
