### PR TITLE
refactor: change access level of flushRemaining for flink-cdc require…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -381,7 +381,7 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     return true;
   }
 
-  private void flushRemaining(boolean endInput) {
+  public void flushRemaining(boolean endInput) {
     writeMetrics.startDataFlush();
     this.currentInstant = instantToWrite(hasData());
     if (this.currentInstant == null) {


### PR DESCRIPTION
…ments

### Describe the issue this Pull Request addresses

Adding required (pre-requisites) for Hudi support on Flink-CDC. Flink-CDC requires `flushRemaining` to be public. 


### Summary and Changelog

Change private access `flushRemaining` method to public.

### Impact

None

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
