### PR TITLE
perf: reduce unnecessary row group metadata loading

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -115,7 +115,7 @@ public class ParquetUtils extends FileFormatUtils {
     return readMetadata(storage, parquetFilePath, NO_FILTER);
   }
 
-  public static ParquetMetadata readMetadataWithSkipRowGroups(HoodieStorage storage, StoragePath parquetFilePath) {
+  public static ParquetMetadata readFileMetadataOnly(HoodieStorage storage, StoragePath parquetFilePath) {
     return readMetadata(storage, parquetFilePath, SKIP_ROW_GROUPS);
   }
 
@@ -244,7 +244,7 @@ public class ParquetUtils extends FileFormatUtils {
    * Get the schema of the given parquet file.
    */
   public MessageType readSchema(HoodieStorage storage, StoragePath parquetFilePath) {
-    return readMetadataWithSkipRowGroups(storage, parquetFilePath).getFileMetaData().getSchema();
+    return readFileMetadataOnly(storage, parquetFilePath).getFileMetaData().getSchema();
   }
   
   /**
@@ -266,7 +266,7 @@ public class ParquetUtils extends FileFormatUtils {
   public Map<String, String> readFooter(HoodieStorage storage, boolean required,
                                         StoragePath filePath, String... footerNames) {
     Map<String, String> footerVals = new HashMap<>();
-    ParquetMetadata footer = readMetadataWithSkipRowGroups(storage, filePath);
+    ParquetMetadata footer = readFileMetadataOnly(storage, filePath);
     Map<String, String> metadata = footer.getFileMetaData().getKeyValueMetaData();
     for (String footerName : footerNames) {
       if (metadata.containsKey(footerName)) {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -517,7 +517,7 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     writeParquetFile(BloomFilterTypeCode.SIMPLE.name(), filePath, rowKeys);
 
     ParquetMetadata metadata = parquetUtils.readMetadata(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath));
-    ParquetMetadata metadataWithSkipRowGroups = parquetUtils.readMetadataWithSkipRowGroups(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath));
+    ParquetMetadata metadataWithSkipRowGroups = parquetUtils.readFileMetadataOnly(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath));
     assertTrue(metadata.getFileMetaData() != null);
     assertTrue(metadataWithSkipRowGroups.getFileMetaData() != null);
     assertFalse(metadata.getBlocks().isEmpty());


### PR DESCRIPTION

### Describe the issue this Pull Request addresses

closes #14207 

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

1. reduce unnecessary row group metadata loading

### Impact

enhance parquet metadata related performance

### Risk Level

none

### Documentation Update

none

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
