### PR TITLE
test: Disable failing test testFiltersInFileFormat to unblock CI

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestFiltersInFileGroupReader.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestFiltersInFileGroupReader.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.internal.SQLConf;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -40,6 +41,7 @@ import java.util.Map;
 @Tag("functional")
 public class TestFiltersInFileGroupReader extends TestBootstrapReadBase {
 
+  @Disabled("issues/14222")
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testFiltersInFileFormat(boolean mergeUseRecordPositions) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

As above.  Failing test is tracked by #14222.

### Summary and Changelog

This PR temporarily disables failing test `TestFiltersInFileGroupReader#testFiltersInFileFormat` to unblock CI.

### Impact

Unblocks CI for other PRs

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
