### PR TITLE
feat: update dependencies and to make trino-hudi-plugin compatible with trino 478.

### DIFF
--- a/hudi-trino-plugin/pom.xml
+++ b/hudi-trino-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>478</version>
         <!-- Stop looking for the parent on local file system -->
         <relativePath />
     </parent>
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
         </dependency>
 
         <dependency>
@@ -279,6 +280,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
         </dependency>
@@ -463,6 +470,20 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules>
+                        <bannedDependencies>
+                            <includes combine.children="append">
+                                <!-- Legacy HDFS file system uses AWS S3 SDK v1 -->
+                                <include>com.amazonaws:*:*</include>
+                            </includes>
+                        </bannedDependencies>
+                    </rules>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
                 <configuration>
@@ -470,6 +491,8 @@
                         <!-- org.apache.hudi:hudi-client-common and org.apache.hudi:hudi-java-client log4j.properties duplicates -->
                         <ignoredResourcePattern>log4j.properties</ignoredResourcePattern>
                         <ignoredResourcePattern>log4j-surefire.properties</ignoredResourcePattern>
+                        <!-- Jersey and Jetty about.html duplicates -->
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
                     </ignoredResourcePatterns>
                 </configuration>
             </plugin>

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiBaseFileOnlyPageSource.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiBaseFileOnlyPageSource.java
@@ -19,6 +19,7 @@ import io.trino.plugin.hudi.util.SynthesizedColumnHandler;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -84,9 +85,10 @@ public class HudiBaseFileOnlyPageSource
     }
 
     @Override
-    public Page getNextPage()
+    public SourcePage getNextSourcePage()
     {
-        Page physicalSourcePage = dataPageSource.getNextPage();
+        //TODO hudi can have it's own lazy loading Implementation for further optimization of data scan
+        SourcePage physicalSourcePage = dataPageSource.getNextSourcePage();
         if (physicalSourcePage == null) {
             return null;
         }
@@ -108,7 +110,7 @@ public class HudiBaseFileOnlyPageSource
                 outputBlocks[i] = synthesizedColumnHandler.createRleSynthesizedBlock(outputColumn, positionCount);
             }
         }
-        return new Page(outputBlocks);
+        return SourcePage.create(new Page(outputBlocks));
     }
 
     @Override

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -276,7 +276,7 @@ public class HudiMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableHandle tableHandle)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         HudiTableHandle table = (HudiTableHandle) tableHandle;
         return Optional.of(new HudiTableInfo(table.getSchemaTableName(), table.getTableType().name(), table.getBasePath()));

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiModule.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiModule.java
@@ -26,7 +26,6 @@ import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HideDeltaLakeTables;
 import io.trino.plugin.hive.HiveNodePartitioningProvider;
 import io.trino.plugin.hive.HiveTransactionHandle;
-import io.trino.plugin.hive.metastore.thrift.TranslateHiveViews;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.hudi.cache.HudiCacheKeyProvider;
@@ -59,7 +58,6 @@ public class HudiModule
 
         configBinder(binder).bindConfig(HudiConfig.class);
 
-        binder.bind(boolean.class).annotatedWith(TranslateHiveViews.class).toInstance(false);
         binder.bind(boolean.class).annotatedWith(HideDeltaLakeTables.class).toInstance(false);
 
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(HudiSessionProperties.class).in(Scopes.SINGLETON);

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiPageSource.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiPageSource.java
@@ -20,6 +20,7 @@ import io.trino.plugin.hudi.util.SynthesizedColumnHandler;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Metrics;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hudi.common.table.read.HoodieFileGroupReader;
@@ -88,7 +89,7 @@ public class HudiPageSource
     }
 
     @Override
-    public Page getNextPage()
+    public SourcePage getNextSourcePage()
     {
         checkState(pageBuilder.isEmpty(), "PageBuilder is not empty at the beginning of a new page");
         try {
@@ -102,7 +103,7 @@ public class HudiPageSource
 
         Page newPage = pageBuilder.build();
         pageBuilder.reset();
-        return newPage;
+        return SourcePage.create(newPage);
     }
 
     @Override

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiSplit.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/HudiSplit.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hudi.file.HudiBaseFile;
@@ -28,7 +27,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -78,16 +76,6 @@ public class HudiSplit
         this.partitionKeys = ImmutableList.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
         this.cachingHostAddresses = requireNonNull(cachingHostAddresses, "cachingHostAddresses is null");
-    }
-
-    @Override
-    public Map<String, String> getSplitInfo()
-    {
-        return ImmutableMap.<String, String>builder()
-                .put("baseFile", baseFile.toString())
-                .put("logFiles", logFiles.toString())
-                .put("commitTime", commitTime)
-                .buildOrThrow();
     }
 
     @JsonProperty

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/reader/HudiTrinoReaderContext.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/reader/HudiTrinoReaderContext.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hudi.util.HudiAvroSerializer;
 import io.trino.plugin.hudi.util.SynthesizedColumnHandler;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
@@ -104,7 +105,8 @@ public class HudiTrinoReaderContext
                     }
 
                     // Get next page and reset currentPosition
-                    currentPage = pageSource.getNextPage();
+                    SourcePage sourcePage = pageSource.getNextSourcePage();
+                    currentPage = sourcePage != null ? sourcePage.getPage() : null;
                     currentPosition = 0;
 
                     // If no more pages are available

--- a/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
+++ b/hudi-trino-plugin/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
@@ -135,7 +135,7 @@ public class HudiAvroSerializer
 
     public Object getValue(Page sourcePage, int channel, int position)
     {
-        return columnTypes.get(channel).getObjectValue(null, sourcePage.getBlock(channel), position);
+        return columnTypes.get(channel).getObjectValue(sourcePage.getBlock(channel), position);
     }
 
     public void buildRecordInPage(PageBuilder pageBuilder, IndexedRecord record)

--- a/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
+++ b/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
@@ -20,6 +20,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_LIMIT_PUSHDOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHudiConnectorTest
@@ -49,6 +50,7 @@ public class TestHudiConnectorTest
                  SUPPORTS_DELETE,
                  SUPPORTS_DEREFERENCE_PUSHDOWN,
                  SUPPORTS_INSERT,
+                 SUPPORTS_LIMIT_PUSHDOWN,
                  SUPPORTS_MERGE,
                  SUPPORTS_RENAME_COLUMN,
                  SUPPORTS_RENAME_TABLE,

--- a/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -1302,7 +1302,7 @@ public class TestHudiSmokeTest
                 hudiSplit,
                 new LocalInputFile(parquetFile),
                 new FileFormatDataSourceStats(),
-                new ParquetReaderOptions(),
+                ParquetReaderOptions.builder().build(),
                 DateTimeZone.UTC, DynamicFilter.EMPTY, true)) {
             MaterializedResult result = materializeSourceDataStream(session, pageSource, List.of(columnType)).toTestTypes();
             assertThat(result.getMaterializedRows())


### PR DESCRIPTION
# Pull Request #14299 - Trino 478 Compatibility Update

## Describe the issue this Pull Request addresses

This PR updates the Hudi Trino plugin to be compatible with Trino version 478, upgrading from version 472. The changes address API compatibility issues and dependency updates required by the newer Trino version.

## Summary and Changelog

### Summary
Users can now use the Hudi Trino plugin with Trino 478, benefiting from the latest Trino features, performance improvements, and bug fixes. This update ensures continued compatibility with the Trino ecosystem.

### Detailed Changelog

#### 1. Dependency Updates
- Upgraded Trino parent version from 472 to 478
- Added `classifier` attribute to Guice dependency to use the `classes` classifier
- Added `io.airlift:configuration-testing` test dependency
- Added Maven enforcer plugin configuration to allow AWS S3 SDK v1 dependencies (required for legacy HDFS file system)
- Added ignored resource pattern for Jersey and Jetty `about.html` duplicates

#### 2. API Compatibility Changes
- **HudiConnectorFactory**: Refactored to use new `ConnectorContextModule` instead of manually binding context components (OpenTelemetry, Tracer, NodeVersion, NodeManager, TypeManager, CatalogName)
- **HudiConnectorFactory**: Updated `HiveMetastoreModule` constructor to include new boolean parameter
- **HudiConnectorFactory**: Updated `FileSystemModule` constructor to accept `ConnectorContext` instead of individual `NodeManager` and `OpenTelemetry` parameters
- **HudiBaseFileOnlyPageSource**: Updated method signatures for compatibility with new Trino APIs
- **HudiPageSource**: Updated method signatures for compatibility with new Trino APIs
- **HudiPageSourceProvider**: Simplified code by leveraging new Trino utility methods
- **HudiMetadata**: Minor API adjustments
- **HudiModule**: Removed deprecated bindings
- **HudiSplit**: Removed deprecated methods/fields
- **HudiTrinoReaderContext**: Updated to use new Trino reader APIs
- **HudiAvroSerializer**: Minor API adjustments

#### 3. Test Updates
- Updated test cases to align with new Trino testing framework
- Added necessary test configurations

## Impact

### Public API Changes
- No changes to Hudi's public APIs or user-facing features
- Internal Trino plugin APIs updated to match Trino 478 requirements

### Performance Impact
- No expected performance degradation
- Potential performance improvements from Trino 478 optimizations

### User-Facing Changes
- Users running Trino 478 can now use the Hudi connector
- No breaking changes for existing Hudi table operations

## Risk Level

**Low**

### Rationale
- Changes are primarily dependency upgrades and API compatibility updates
- No modifications to core Hudi functionality or data processing logic
- The plugin maintains the same functionality with updated Trino APIs

### Verification
- All existing test cases have been updated and should pass
- The changes follow Trino's migration patterns from version 472 to 478
- No changes to Hudi table format or data storage

## Documentation Update

**Config Changes:** None - No new configurations added or default values changed

**Feature Documentation:** None required - This is an internal compatibility update with no new user-facing features

**Website Update:** Not required - This is a maintenance update for Trino compatibility

## Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable *(Note: Existing tests updated for compatibility; no new tests needed as functionality unchanged)*


