### PR TITLE
feat(schema): Add types for decimal, date, timestamp, time, and uuid

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaType.java
@@ -143,7 +143,8 @@ public enum HoodieSchemaType {
         return DECIMAL;
       } else if (logicalType instanceof LogicalTypes.TimeMillis || logicalType instanceof LogicalTypes.TimeMicros) {
         return TIME;
-      } else if (logicalType instanceof LogicalTypes.TimestampMillis || logicalType instanceof LogicalTypes.TimestampMicros) {
+      } else if (logicalType instanceof LogicalTypes.TimestampMillis || logicalType instanceof LogicalTypes.TimestampMicros
+          || logicalType instanceof LogicalTypes.LocalTimestampMillis || logicalType instanceof LogicalTypes.LocalTimestampMicros) {
         return TIMESTAMP;
       } else if (logicalType instanceof LogicalTypes.Date) {
         return DATE;
@@ -200,20 +201,7 @@ public enum HoodieSchemaType {
    * @return true if this type is a primitive type (not RECORD, ENUM, ARRAY, MAP, or UNION)
    */
   public boolean isPrimitive() {
-    switch (this) {
-      case STRING:
-      case BYTES:
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-      case BOOLEAN:
-      case NULL:
-      case FIXED:
-        return true;
-      default:
-        return false;
-    }
+    return !isComplex();
   }
 
   /**
@@ -222,7 +210,16 @@ public enum HoodieSchemaType {
    * @return true if this type is a complex type (RECORD, ENUM, ARRAY, MAP, or UNION)
    */
   public boolean isComplex() {
-    return !isPrimitive();
+    switch (this) {
+      case RECORD:
+      case ENUM:
+      case ARRAY:
+      case MAP:
+      case UNION:
+        return true;
+      default:
+        return false;
+    }
   }
 
   /**
@@ -236,6 +233,7 @@ public enum HoodieSchemaType {
       case LONG:
       case FLOAT:
       case DOUBLE:
+      case DECIMAL:
         return true;
       default:
         return false;

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaType.java
@@ -24,6 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,27 +37,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test class for {@link HoodieSchemaType}.
  */
 public class TestHoodieSchemaType {
+  private static final Map<HoodieSchemaType, Schema> TEST_SCHEMAS = buildSampleSchemasForType();
 
   @ParameterizedTest
   @EnumSource(HoodieSchemaType.class)
   public void testAvroTypeRoundTripConversion(HoodieSchemaType hoodieType) {
     // Test conversion from Hudi to Avro and back
-    Schema.Type avroType = hoodieType.toAvroType();
-    HoodieSchemaType convertedBack = HoodieSchemaType.fromAvro(Schema.create(avroType));
+    HoodieSchemaType convertedBack = HoodieSchemaType.fromAvro(TEST_SCHEMAS.get(hoodieType));
 
     assertEquals(hoodieType, convertedBack,
         "Round-trip conversion should preserve type: " + hoodieType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(Schema.Type.class)
-  public void testFromAvroTypeMapping(Schema.Type avroType) {
-    // Test that all Avro types can be converted to Hudi types
-    HoodieSchemaType hoodieType = HoodieSchemaType.fromAvro(Schema.create(avroType));
-    Schema.Type convertedBack = hoodieType.toAvroType();
-
-    assertEquals(avroType, convertedBack,
-        "Avro type conversion should be consistent: " + avroType);
   }
 
   @Test
@@ -152,7 +145,7 @@ public class TestHoodieSchemaType {
   }
 
   @Test
-  public void testFromAvroTypeSpecificMappings() {
+  public void testFromAvro() {
     // Test reverse mappings
     assertEquals(HoodieSchemaType.STRING, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.STRING)));
     assertEquals(HoodieSchemaType.INT, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.INT)));
@@ -162,20 +155,51 @@ public class TestHoodieSchemaType {
     assertEquals(HoodieSchemaType.BOOLEAN, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.BOOLEAN)));
     assertEquals(HoodieSchemaType.BYTES, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.BYTES)));
     assertEquals(HoodieSchemaType.NULL, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.NULL)));
-    assertEquals(HoodieSchemaType.RECORD, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.RECORD)));
-    assertEquals(HoodieSchemaType.ENUM, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.ENUM)));
-    assertEquals(HoodieSchemaType.ARRAY, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.ARRAY)));
-    assertEquals(HoodieSchemaType.MAP, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.MAP)));
-    assertEquals(HoodieSchemaType.UNION, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.UNION)));
-    assertEquals(HoodieSchemaType.FIXED, HoodieSchemaType.fromAvro(Schema.create(Schema.Type.FIXED)));
+    assertEquals(HoodieSchemaType.RECORD, HoodieSchemaType.fromAvro(Schema.createRecord("record", null, null, false)));
+    assertEquals(HoodieSchemaType.ENUM, HoodieSchemaType.fromAvro(Schema.createEnum("enum", null, null, Arrays.asList("A", "B", "C"))));
+    assertEquals(HoodieSchemaType.ARRAY, HoodieSchemaType.fromAvro(Schema.createArray(Schema.create(Schema.Type.STRING))));
+    assertEquals(HoodieSchemaType.MAP, HoodieSchemaType.fromAvro(Schema.createMap(Schema.create(Schema.Type.STRING))));
+    assertEquals(HoodieSchemaType.UNION, HoodieSchemaType.fromAvro(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT))));
+    assertEquals(HoodieSchemaType.FIXED, HoodieSchemaType.fromAvro(Schema.createFixed("fixed", null, null, 10)));
     assertEquals(HoodieSchemaType.TIMESTAMP, HoodieSchemaType.fromAvro(LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG))));
     assertEquals(HoodieSchemaType.TIMESTAMP, HoodieSchemaType.fromAvro(LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG))));
     assertEquals(HoodieSchemaType.TIMESTAMP, HoodieSchemaType.fromAvro(LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG))));
     assertEquals(HoodieSchemaType.TIMESTAMP, HoodieSchemaType.fromAvro(LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))));
     assertEquals(HoodieSchemaType.TIME, HoodieSchemaType.fromAvro(LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG))));
     assertEquals(HoodieSchemaType.TIME, HoodieSchemaType.fromAvro(LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT))));
-    assertEquals(HoodieSchemaType.DECIMAL, HoodieSchemaType.fromAvro(LogicalTypes.decimal(2, 5).addToSchema(Schema.create(Schema.Type.BYTES))));
+    assertEquals(HoodieSchemaType.DECIMAL, HoodieSchemaType.fromAvro(LogicalTypes.decimal(10, 5).addToSchema(Schema.create(Schema.Type.BYTES))));
     assertEquals(HoodieSchemaType.DATE, HoodieSchemaType.fromAvro(LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))));
     assertEquals(HoodieSchemaType.UUID, HoodieSchemaType.fromAvro(LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING))));
+  }
+
+  private static Map<HoodieSchemaType, Schema> buildSampleSchemasForType() {
+    Map<HoodieSchemaType, Schema> map = new EnumMap<>(HoodieSchemaType.class);
+    // Standard types
+    map.put(HoodieSchemaType.STRING, Schema.create(Schema.Type.STRING));
+    map.put(HoodieSchemaType.INT, Schema.create(Schema.Type.INT));
+    map.put(HoodieSchemaType.LONG, Schema.create(Schema.Type.LONG));
+    map.put(HoodieSchemaType.FLOAT, Schema.create(Schema.Type.FLOAT));
+    map.put(HoodieSchemaType.DOUBLE, Schema.create(Schema.Type.DOUBLE));
+    map.put(HoodieSchemaType.BOOLEAN, Schema.create(Schema.Type.BOOLEAN));
+    map.put(HoodieSchemaType.BYTES, Schema.create(Schema.Type.BYTES));
+    map.put(HoodieSchemaType.NULL, Schema.create(Schema.Type.NULL));
+    map.put(HoodieSchemaType.RECORD, Schema.createRecord("record", null, null, false));
+    map.put(HoodieSchemaType.ENUM, Schema.createEnum("enum", null, null, Arrays.asList("A", "B", "C")));
+    map.put(HoodieSchemaType.ARRAY, Schema.createArray(Schema.create(Schema.Type.STRING)));
+    map.put(HoodieSchemaType.MAP, Schema.createMap(Schema.create(Schema.Type.STRING)));
+    map.put(HoodieSchemaType.UNION, Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+    map.put(HoodieSchemaType.FIXED, Schema.createFixed("fixed", null, null, 10));
+    // Logical types
+    map.put(HoodieSchemaType.TIMESTAMP,
+        LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG)));
+    map.put(HoodieSchemaType.TIME,
+        LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)));
+    map.put(HoodieSchemaType.DECIMAL,
+        LogicalTypes.decimal(10, 5).addToSchema(Schema.create(Schema.Type.BYTES)));
+    map.put(HoodieSchemaType.DATE,
+        LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT)));
+    map.put(HoodieSchemaType.UUID,
+        LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING)));
+    return map;
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Addresses https://github.com/apache/hudi/issues/14302
The new `HoodieSchema` does not cover the logical types that Avro currently provides. The types need to be expanded to handle Decimal, Date, Time, Timestamp, and UUID types

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Add types for Decimal, Date, Time, Timestamp, and UUID
- Extend HoodieSchema for the Time, Timestamp, and Decimal schemas which require additional context for how to interpret the field values
- Adds factory methods for generating these new types

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Enables the migration to HoodieSchema

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
