### PR TITLE
fix: Set credentials for Hive metastore based lock provider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
@@ -42,18 +42,13 @@ public class TransactionManager implements Serializable {
   protected Option<HoodieInstant> currentTxnOwnerInstant = Option.empty();
   private Option<HoodieInstant> lastCompletedTxnOwnerInstant = Option.empty();
 
-  public TransactionManager(HoodieWriteConfig config, FileSystem fs) {
-    this(createLockManager(config, fs), config.isLockRequired());
+  public TransactionManager(HoodieWriteConfig config, HoodieStorage storage) {
+    this(new LockManager(config, (FileSystem) storage.getFileSystem()), config.isLockRequired());
   }
 
   protected TransactionManager(LockManager lockManager, boolean isLockRequired) {
     this.lockManager = lockManager;
     this.isLockRequired = isLockRequired;
-  }
-
-  private static LockManager createLockManager(HoodieWriteConfig config, FileSystem fs) {
-    fs.getConf().addResource(fs.getConf());
-    return new LockManager(config, fs);
   }
 
   public void beginTransaction(Option<HoodieInstant> newTxnOwnerInstant,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add credentials to hive metastore based lock provider.

### Summary and Changelog

Add the extra configurations, e.g., credentials, to the storage conf before the lock provider creation.

### Impact

In this case, the extra configurations could take effect. 

### Risk Level

Low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
