### PR TITLE
docs: Fixing the CSP Directive issues for google fonts and at-ui fonts

### DIFF
--- a/website/static/.htaccess
+++ b/website/static/.htaccess
@@ -4,4 +4,4 @@
 # CSP permissions for Algolia: https://issues.apache.org/jira/browse/INFRA-27279
 # Ref https://support.algolia.com/hc/en-us/articles/8947249849873-How-do-I-fix-Content-Security-Policy-CSP-errors-on-my-site
 # CSP permissions for YouTube: https://privacy.apache.org/examples/youtube-html/with-youtube-api.html
-SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com/ https://*.hcaptcha.com/ https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://www.youtube-nocookie.com https://www.youtube.com https://fonts.googleapis.com https://at-ui.github.io"
+SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app/ https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com/ https://*.hcaptcha.com/ https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://www.youtube-nocookie.com https://www.youtube.com https://fonts.googleapis.com/ https://at-ui.github.io/"


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The website is experiencing Content Security Policy (CSP) violations related to loading external stylesheets, resulting in blocked resources and degraded user experience (missing fonts and icons).

Specifically, the style-src directive in the CSP header is blocking two external resources:
* Google Fonts (https://fonts.googleapis.com).
* Feather Font/Icon library (https://at-ui.github.io/feather-font/css/iconfont.css).

<img width="619" height="636" alt="Screenshot 2025-11-24 at 6 11 10 PM" src="https://github.com/user-attachments/assets/fbd4838b-681c-49b4-bc64-175387d7d9ac" />

This PR updates the CSP to permit loading these necessary third-party styles.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

This PR updates the style-src directive in the Content Security Policy to explicitly whitelist the required domains.

**Changelog:**

* Whitelisted https://fonts.googleapis.com for loading Google Fonts CSS.
* Whitelisted https://at-ui.github.io for loading the Feather Icon stylesheet.

These changes are implemented by updating the Apache .htaccess file (or equivalent CSP configuration).

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
### Impact
None
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
Low

The risk is low as we are only expanding the style-src to include well-known CDNs for fonts and icons. This does not permit script-src from these domains.

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

This PR does not require a change to user documentation, as it addresses a site infrastructure issue.

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable