### PR TITLE
fix: Fix the mismatch between operation metrics and the actual operation in the compaction plan

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
@@ -132,18 +132,18 @@ public abstract class BaseHoodieCompactionPlanGenerator<T extends HoodieRecordPa
         .getLatestFileSlicesStateless(partitionPath)
         .filter(slice -> filterFileSlice(slice, lastCompletedInstantTime, fgIdsInPendingCompactionAndClustering, instantRange))
         .map(s -> {
-              // ==============================================================
-              // IMPORTANT
-              // ==============================================================
-              // Currently, our filesystem view could return a file slice with pending log files there,
-              // these files should be excluded from the plan, let's say we have such a sequence of actions
+          // ==============================================================
+          // IMPORTANT
+          // ==============================================================
+          // Currently, our filesystem view could return a file slice with pending log files there,
+          // these files should be excluded from the plan, let's say we have such a sequence of actions
 
-              // t10: a delta commit starts,
-              // t20: the compaction is scheduled and the t10 delta commit is still pending, and the "fg_10.log" is included in the plan
-              // t25: the delta commit 10 finishes,
-              // t30: the compaction execution starts, now the reader considers the log file "fg_10.log" as valid.
+          // t10: a delta commit starts,
+          // t20: the compaction is scheduled and the t10 delta commit is still pending, and the "fg_10.log" is included in the plan
+          // t25: the delta commit 10 finishes,
+          // t30: the compaction execution starts, now the reader considers the log file "fg_10.log" as valid.
 
-              // for both OCC and NB-CC, this is in-correct.
+          // for both OCC and NB-CC, this is in-correct.
           return s.filterLogFiles(logFile -> completionTimeQueryView.isCompletedBefore(compactionInstant, logFile.getDeltaCommitTime()));
         })
         .filter(FileSlice::hasLogFiles) // compaction is not needed if there is no log file.

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/FileSlice.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.model;
 
-import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.util.Option;


### PR DESCRIPTION


### Describe the issue this Pull Request addresses

closes #14361 

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

1. Fix the mismatch between operation metrics and the actual operation in the compaction plan

### Impact

as above

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
