### PR TITLE
feat: Bump spark version to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <spark.version>${spark3.version}</spark.version>
     <spark3.version>${spark35.version}</spark3.version>
-    <spark4.version>4.0.0</spark4.version>
+    <spark4.version>4.0.1</spark4.version>
     <sparkbundle.version></sparkbundle.version>
     <flink2.0.version>2.0.0</flink2.0.version>
     <flink1.20.version>1.20.1</flink1.20.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark 4.0.1 is released. This PR adopts Spark 4.0.1.

### Summary and Changelog

As above

### Impact

Use the latest Spark 4.0.x version.

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
