### PR TITLE
feat: Make ctor of TypedProperties public for better customization

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -39,7 +39,7 @@ public class TypedProperties extends Properties implements Serializable {
     super(null);
   }
 
-  protected TypedProperties(Properties defaults) {
+  public TypedProperties(Properties defaults) {
     if (Objects.nonNull(defaults)) {
       for (Enumeration<?> e = defaults.propertyNames(); e.hasMoreElements(); ) {
         Object k = e.nextElement();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
The current constructor of TypedProperties is protected. Making it public will make it more flexible for downstream apps to use Hudi props with zero side-effect.
### Summary and Changelog
- Change the ctor of `TypedProperties` from protected to public 
<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
None
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
None
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
None
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
