### PR TITLE
fix: Make HFile block size configurable for metadata table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -224,6 +224,7 @@ public class HoodieMetadataWriteUtils {
             .logFileMaxSize(maxLogFileSizeBytes)
             // Keeping the log blocks as large as the log files themselves reduces the number of HFile blocks to be checked for
             // presence of keys
+            .hfileBlockSize(writeConfig.getHFileBlockSize())
             .logFileDataBlockMaxSize(maxLogFileSizeBytes)
                                .withBloomFilterType(writeConfig.getMetadataConfig().getBloomFilterType())
                                .withBloomFilterNumEntries(writeConfig.getMetadataConfig().getBloomFilterNumEntries())


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17448

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
