### PR TITLE
feat(schema): Add support for time, fixed length byte arrays, and local timestamps to ParquetToSparkSchemaUtils

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestParquetToSparkSchemaUtils.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestParquetToSparkSchemaUtils.java
@@ -18,8 +18,14 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.sync.common.util.Parquet2SparkSchemaUtils;
 
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.HoodieAvroParquetSchemaConverter;
+import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.execution.SparkSqlParser;
 import org.apache.spark.sql.execution.datasources.parquet.SparkToParquetSchemaConverter;
 import org.apache.spark.sql.internal.SQLConf;
@@ -31,6 +37,9 @@ import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -52,35 +61,65 @@ public class TestParquetToSparkSchemaUtils {
   }
 
   @Test
-  public void testConvertPrimitiveType() {
+  public void testConvertBasicTypes() {
     StructType sparkSchema = parser.parseTableSchema(
-            "f0 int, f1 string, f3 bigint,"
-                    + " f4 decimal(5,2), f5 timestamp, f6 date,"
-                    + " f7 short, f8 float, f9 double, f10 byte,"
-                    + " f11 tinyint, f12 smallint, f13 binary, f14 boolean");
+            "f0 int NOT NULL, f1 string NOT NULL, f2 bigint NOT NULL, f3 float, f4 double, f5 boolean, f6 binary, f7 binary NOT NULL,"
+                    + " f8 decimal(5,2) NOT NULL, f9 decimal(5,2), f10 timestamp, f11 timestamp NOT NULL, f12 timestamp_ntz NOT NULL, f13 timestamp_ntz,"
+                    + " f14 date NOT NULL, f15 int NOT NULL, f16 bigint NOT NULL, f17 string NOT NULL, f18 string");
 
-    String sparkSchemaJson = Parquet2SparkSchemaUtils.convertToSparkSchemaJson(
-            sparkToParquetConverter.convert(sparkSchema).asGroupType());
+    Schema schemaWithSupportedTypes =
+        Schema.createRecord("root", null, null, false, Arrays.asList(
+            new Schema.Field("f0", Schema.create(Schema.Type.INT), null, null),
+            new Schema.Field("f1", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("f2", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("f3", AvroSchemaUtils.createNullableSchema(Schema.Type.FLOAT), null, null),
+            new Schema.Field("f4", AvroSchemaUtils.createNullableSchema(Schema.Type.DOUBLE), null, null),
+            new Schema.Field("f5", AvroSchemaUtils.createNullableSchema(Schema.Type.BOOLEAN), null, null),
+            new Schema.Field("f6", AvroSchemaUtils.createNullableSchema(Schema.Type.BYTES), null, null),
+            new Schema.Field("f7", Schema.createFixed("fixed", null, null, 10), null, null),
+            new Schema.Field("f8", LogicalTypes.decimal(5, 2).addToSchema(Schema.createFixed("decimal", null, null, 16)), null, null),
+            new Schema.Field("f9", AvroSchemaUtils.createNullableSchema(LogicalTypes.decimal(5, 2).addToSchema(Schema.create(Schema.Type.BYTES))), null, null),
+            new Schema.Field("f10", AvroSchemaUtils.createNullableSchema(LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG))), null, null),
+            new Schema.Field("f11", LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG)), null, null),
+            new Schema.Field("f12", LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG)), null, null),
+            new Schema.Field("f13", AvroSchemaUtils.createNullableSchema(LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG))), null, null),
+            new Schema.Field("f14", LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT)), null, null),
+            new Schema.Field("f15", LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)), null, null),
+            new Schema.Field("f16", LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG)), null, null),
+            new Schema.Field("f17", Schema.createEnum("enum", null, null, Arrays.asList("A", "B", "C")), null, null),
+            new Schema.Field("f18", AvroSchemaUtils.createNullableSchema(LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING))), null, null)
+        ));
+    MessageType parquetSchema = HoodieAvroParquetSchemaConverter.getAvroSchemaConverter(new Configuration()).convert(schemaWithSupportedTypes);
+    String sparkSchemaJson = Parquet2SparkSchemaUtils.convertToSparkSchemaJson(parquetSchema);
     StructType convertedSparkSchema = (StructType) StructType.fromJson(sparkSchemaJson);
     assertEquals(sparkSchema.json(), convertedSparkSchema.json());
-    // Test type with nullable
-    StructField field0 = new StructField("f0", StringType$.MODULE$, false, Metadata.empty());
-    StructField field1 = new StructField("f1", StringType$.MODULE$, true, Metadata.empty());
-    StructType sparkSchemaWithNullable = new StructType(new StructField[]{field0, field1});
-    String sparkSchemaWithNullableJson = Parquet2SparkSchemaUtils.convertToSparkSchemaJson(
-            sparkToParquetConverter.convert(sparkSchemaWithNullable).asGroupType());
-    StructType convertedSparkSchemaWithNullable = (StructType) StructType.fromJson(sparkSchemaWithNullableJson);
-    assertEquals(sparkSchemaWithNullable.json(), convertedSparkSchemaWithNullable.json());
   }
 
   @Test
   public void testConvertComplexType() {
     StructType sparkSchema = parser.parseTableSchema(
             "f0 int, f1 map<string, int>, f2 array<decimal(10,2)>"
-                    + ",f3 map<array<date>, bigint>, f4 array<array<double>>"
+                    + ",f3 map<string, struct<nested: struct<double_nested: int>>>, f4 array<array<double>>"
                     + ",f5 struct<id:int, name:string>");
-    String sparkSchemaJson = Parquet2SparkSchemaUtils.convertToSparkSchemaJson(
-            sparkToParquetConverter.convert(sparkSchema).asGroupType());
+    Schema schemaWithSupportedTypes =
+        Schema.createRecord("root", null, null, false, Arrays.asList(
+            new Schema.Field("f0", AvroSchemaUtils.createNullableSchema(Schema.Type.INT), null, null),
+            new Schema.Field("f1", AvroSchemaUtils.createNullableSchema(Schema.createMap(AvroSchemaUtils.createNullableSchema(Schema.Type.INT))), null, null),
+            new Schema.Field("f2", AvroSchemaUtils.createNullableSchema(Schema.createArray(
+                    LogicalTypes.decimal(10, 2).addToSchema(Schema.create(Schema.Type.BYTES)))), null, null),
+            new Schema.Field("f3", AvroSchemaUtils.createNullableSchema(Schema.createMap(AvroSchemaUtils.createNullableSchema(Schema.createRecord(
+                    "struct", null, null, false, Collections.singletonList(
+                        new Schema.Field("nested", AvroSchemaUtils.createNullableSchema(Schema.createRecord(
+                            "double_nested_struct", null, null, false, Collections.singletonList(
+                                new Schema.Field("double_nested", AvroSchemaUtils.createNullableSchema(Schema.Type.INT), null, null)))), null, null)))))), null, null),
+            new Schema.Field("f4", AvroSchemaUtils.createNullableSchema(Schema.createArray(Schema.createArray(Schema.create(Schema.Type.DOUBLE)))), null, null),
+            new Schema.Field("f5", AvroSchemaUtils.createNullableSchema(Schema.createRecord("struct",
+                    null, null, false, Arrays.asList(
+                    new Schema.Field("id", AvroSchemaUtils.createNullableSchema(Schema.Type.INT), null, null),
+                    new Schema.Field("name", AvroSchemaUtils.createNullableSchema(Schema.Type.STRING), null, null)
+            ))), null, null)));
+    MessageType parquetSchema = HoodieAvroParquetSchemaConverter.getAvroSchemaConverter(new Configuration()).convert(schemaWithSupportedTypes);
+    String sparkSchemaJson = Parquet2SparkSchemaUtils.convertToSparkSchemaJson(parquetSchema);
     StructType convertedSparkSchema = (StructType) StructType.fromJson(sparkSchemaJson);
     assertEquals(sparkSchema.json(), convertedSparkSchema.json());
     // Test complex type with nullable


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Resolves https://github.com/apache/hudi/issues/17474 - there are bugs in how the schema translation is handled today

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
In preparation for more schema related changes, we decided to make sure the Parquet MessageType to Spark StructType conversion util was well tested so it is easy to ensure the migration to HoodieSchema does not break anything.

The change updates the testing to cover all types supported by Hudi today and removes types not supported.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Fixes bugs in current schema translation, ensures testing is more robust

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
