### PR TITLE
fix(spark): Add clearJobStatus() calls after setJobStatus() operations

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -165,7 +165,7 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
         .collect(toList());
 
     context.setJobStatus(this.getClass().getName(), "Obtain key ranges for file slices (range pruning=on): " + config.getTableName());
-    return context.map(partitionPathFileIDList, pf -> {
+    List<Pair<String, BloomIndexFileInfo>> result = context.map(partitionPathFileIDList, pf -> {
       try {
         HoodieRangeInfoHandle rangeInfoHandle = new HoodieRangeInfoHandle(config, hoodieTable, Pair.of(pf.getKey(), pf.getValue().getKey()));
         String[] minMaxKeys = rangeInfoHandle.getMinMaxKeys(pf.getValue().getValue());
@@ -175,6 +175,8 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
         return Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue().getKey()));
       }
     }, Math.max(partitionPathFileIDList.size(), 1));
+    context.clearJobStatus();
+    return result;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -104,6 +104,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
       Option<HoodieInstant> earliestInstant = planner.getEarliestCommitToRetain();
       context.setJobStatus(this.getClass().getSimpleName(), "Obtaining list of partitions to be cleaned: " + config.getTableName());
       List<String> partitionsToClean = planner.getPartitionPathsToClean(earliestInstant);
+      context.clearJobStatus();
 
       if (partitionsToClean.isEmpty()) {
         log.info("Nothing to clean here. It is already clean");
@@ -145,6 +146,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
         partitionsToDelete.addAll(cleanOpsWithPartitionMeta.entrySet().stream().filter(entry -> entry.getValue().getKey()).map(Map.Entry::getKey)
             .collect(Collectors.toList()));
       }
+      context.clearJobStatus();
 
       return new HoodieCleanerPlan(
           earliestInstant.map(x -> new HoodieActionInstant(x.requestedTime(), x.getAction(), x.getState().name())).orElse(null),

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -204,6 +204,11 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public void clearJobStatus() {
+    // no operation for now
+  }
+
+  @Override
   public void putCachedDataIds(HoodieDataCacheKey cacheKey, int... ids) {
     // no operation for now
   }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
@@ -163,6 +163,11 @@ public class HoodieJavaEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public void clearJobStatus() {
+    // no operation for now
+  }
+
+  @Override
   public void putCachedDataIds(HoodieDataCacheKey cacheKey, int... ids) {
     // no operation for now
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -210,6 +210,11 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public void clearJobStatus() {
+    javaSparkContext.setJobDescription(null);
+  }
+
+  @Override
   public void putCachedDataIds(HoodieDataCacheKey cacheKey, int... ids) {
     synchronized (cachedRddIds) {
       cachedRddIds.putIfAbsent(cacheKey, new ArrayList<>());

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
@@ -111,6 +111,8 @@ public abstract class HoodieEngineContext {
 
   public abstract void setJobStatus(String activeModule, String activityDescription);
 
+  public abstract void clearJobStatus();
+
   public abstract void putCachedDataIds(HoodieDataCacheKey cacheKey, int... ids);
 
   public abstract List<Integer> getCachedDataIds(HoodieDataCacheKey cacheKey);

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
@@ -159,6 +159,11 @@ public final class HoodieLocalEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public void clearJobStatus() {
+    // no operation for now
+  }
+
+  @Override
   public void putCachedDataIds(HoodieDataCacheKey cacheKey, int... ids) {
     // no operation for now
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -683,6 +683,7 @@ public class FSUtils {
       result = hoodieEngineContext.mapToPair(subPaths,
           subPath -> new ImmutablePair<>(subPath, pairFunction.apply(new ImmutablePair<>(subPath, storageConf))),
           actualParallelism);
+      hoodieEngineContext.clearJobStatus();
     }
     return result;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -170,6 +170,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         }
       }, listingParallelism);
       pathsToList.clear();
+      engineContext.clearJobStatus();
 
       // if current dictionary contains PartitionMetadata, add it to result
       // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
@@ -200,6 +201,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
                   }
                   return Pair.of(Option.empty(), Option.empty());
                 }, fileListingParallelism);
+        engineContext.clearJobStatus();
 
         partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
             .map(entry -> entry.getKey().get())
@@ -255,6 +257,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
               return Pair.of(partitionPathStr,
                   FSUtils.getAllDataFilesInPartition(getStorage(), partitionPath));
             }, parallelism);
+    engineContext.clearJobStatus();
 
     return partitionToFiles.stream().collect(Collectors.toMap(pair -> pair.getLeft(),
         pair -> pair.getRight()));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

After a job completes, its job group and description continues to show on the Spark history server UI for following jobs which may not be setting their own job status correctly. This causes confusion as stale job descriptions persist in the UI.

### Summary and Changelog

Added `clearJobStatus()` API to `HoodieEngineContext` and corresponding calls after parallel operations complete.

**Changes:**
- Added abstract `clearJobStatus()` method to `HoodieEngineContext`
- Added implementations in `HoodieSparkEngineContext` (clears via `javaSparkContext.setJobDescription(null)`), `HoodieFlinkEngineContext`, `HoodieJavaEngineContext`, and `HoodieLocalEngineContext` (no-op)
- Added `clearJobStatus()` calls after parallel operations in:
  - `HoodieBloomIndex.java` - after range pruning
  - `CleanPlanActionExecutor.java` - after partition listing and file slice generation
  - `BaseSparkCommitActionExecutor.java` - after clustering handle, write operations, workload profile, and commit
  - `FSUtils.java` - after parallel path listing
  - `FileSystemBackedTableMetadata.java` - after partition and file listing

### Impact

Enhancement to the Spark History Server UI. Job descriptions will now be properly cleared after operations complete, preventing stale status from appearing on subsequent jobs.

### Risk Level

Low. This is a cosmetic change limited to the Spark History Server UI display.
- No functional changes to data processing
- Only cleanup operations added after existing parallel operations
- Existing unit and integration tests should pass

### Documentation Update

None required. This is an internal implementation detail that improves UI clarity.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable