### PR TITLE
[MINOR] Preload file listing for partitions in BloomIndex to avoid repeated listings

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -139,7 +139,6 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
     // Preload the partitions so that each parallel op does not have to perform listing.
     // This is only needed when the embedded timeline server is not enabled, as TLS caches file listings.
     if (!config.isEmbeddedTimelineServerEnabled()) {
-      hoodieTable.getHoodieView().sync();
       affectedPartitionPathList.forEach(partition -> hoodieTable.getBaseFileOnlyView().getAllBaseFiles(partition));
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieBloomIndex.java
@@ -659,6 +659,66 @@ public class TestHoodieBloomIndex extends TestHoodieMetadataBase {
     }
   }
 
+  @Test
+  public void testPreloadPartitionsWhenTimelineServerDisabled() throws Exception {
+    // This test verifies that when TLS is disabled, file listings are preloaded
+    // to avoid redundant listings by parallel operations
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withEmbeddedTimelineServerEnabled(false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .bloomIndexPruneByRanges(true)
+            .bloomIndexUseMetadata(false)
+            .build())
+        .build();
+
+    HoodieBloomIndex index = new HoodieBloomIndex(config, SparkHoodieBloomIndexHelper.getInstance());
+    metadataWriter = SparkHoodieBackedTableMetadataWriter.create(storageConf, config, context);
+    HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(metaClient, SCHEMA, metadataWriter, Option.of(context));
+
+    // Create partitions with files
+    final String partition1 = "2016/01/31";
+    final String partition2 = "2015/01/31";
+    testTable.withPartitionMetaFiles(partition1, partition2);
+
+    HoodieRecord record1 = createSimpleRecord("000", "2016-01-31T03:16:41.415Z", 12);
+    HoodieRecord record2 = createSimpleRecord("001", "2015-01-31T03:16:41.415Z", 15);
+
+    final Map<String, List<Pair<String, Integer>>> partitionToFilesNameLengthMap = new HashMap<>();
+    String commitTime = "20160131010101";
+    StoragePath baseFilePath = testTable.forCommit(commitTime)
+        .withInserts(partition1, "file1", Collections.singletonList(record1));
+    long baseFileLength = storage.getPathInfo(baseFilePath).getLength();
+    partitionToFilesNameLengthMap.put(partition1,
+        Collections.singletonList(Pair.of("file1", (int) baseFileLength)));
+    testTable.doWriteOperation(commitTime, WriteOperationType.UPSERT,
+        Collections.singletonList(partition1), partitionToFilesNameLengthMap, false, false);
+
+    commitTime = "20150131010101";
+    partitionToFilesNameLengthMap.clear();
+    baseFilePath = testTable.forCommit(commitTime)
+        .withInserts(partition2, "file2", Collections.singletonList(record2));
+    baseFileLength = storage.getPathInfo(baseFilePath).getLength();
+    partitionToFilesNameLengthMap.put(partition2,
+        Collections.singletonList(Pair.of("file2", (int) baseFileLength)));
+    testTable.doWriteOperation(commitTime, WriteOperationType.UPSERT,
+        Collections.singletonList(partition2), partitionToFilesNameLengthMap, false, false);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
+
+    // Load column ranges - this should work correctly with preloading
+    List<String> partitions = Arrays.asList(partition1, partition2);
+    List<Pair<String, BloomIndexFileInfo>> filesList = index.loadColumnRangesFromFiles(partitions, context, hoodieTable);
+
+    // Verify files were loaded for both partitions
+    assertEquals(2, filesList.size());
+    Set<String> loadedPartitions = filesList.stream()
+        .map(Pair::getLeft)
+        .collect(Collectors.toSet());
+    assertTrue(loadedPartitions.contains(partition1));
+    assertTrue(loadedPartitions.contains(partition2));
+  }
+
   private static String genRandomUUID() {
     return genPseudoRandomUUID(RANDOM).toString();
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR addresses a performance optimization for HoodieBloomIndex when `config.getBloomIndexPruneByRanges()` is enabled. Currently, when finding the latest parquet file for each fileID to read footers for min/max record keys, the partition is listed multiple times by different executors. This creates unnecessary overhead.

### Summary and Changelog

**Summary:**
This change preloads the file listing for each partition into the FileSystemView before distributing work to executors. This allows the cached file listing to be serialized and sent to executors, eliminating the need for each executor to perform redundant partition listings.

**Detailed Changes:**
- Added preloading logic in `HoodieBloomIndex.loadColumnRangesFromMetadataTable()` that:
  - Syncs the HoodieView
  - Preloads base files for all affected partitions using `getAllBaseFiles(partition)`
- This ensures the FileSystemView cache is populated before parallel operations begin
- The cached data is then serialized and distributed to executors, avoiding repeated listings

### Impact

**Performance Impact:**
- Positive: Reduces redundant partition listing operations when using bloom index with range pruning enabled
- Improves query performance by eliminating duplicate filesystem operations across executors

**Public API/User-facing changes:**
- None. This is an internal optimization with no API or configuration changes.

### Risk Level

**Low**

The change is a caching optimization that preloads data that would be retrieved anyway during execution. The risk is minimal because:
1. It only affects the bloom index code path when range pruning is enabled
2. The data being cached (file listings) is the same data that would be retrieved by executors
3. The sync() and getAllBaseFiles() methods are existing, well-tested APIs
4. The change does not modify any core logic, only when the data is loaded

### Documentation Update

None. This is an internal performance optimization that does not introduce any new features, configs, or user-facing changes.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable