### PR TITLE
minor: Enabling streaming writes to metadata code paths only when eligible metadata partitions

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -101,7 +101,7 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
       HoodieWriteMetadata<HoodieData<WriteStatus>> writeMetadata,
       String instantTime,
       WriteOperationType writeOperationType) {
-    if (isStreamingWriteToMetadataEnabled(table)) {
+    if (isStreamingWriteToMetadataEnabled(table, config)) {
       boolean enforceCoalesceWithRepartition = writeOperationType == WriteOperationType.CLUSTER; // for other table services, enforceCoalesceWithRepartition will be false.
       if (enforceCoalesceWithRepartition) {
         enforceCoalesceWithRepartition = computeEnforceCoalesceWithRepartitionForClustering(table, instantTime);
@@ -128,7 +128,7 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
 
   @Override
   protected void writeToMetadataTable(HoodieTable table, String instantTime, HoodieCommitMetadata metadata, List<HoodieWriteStat> partialMetadataWriteStats) {
-    if (isStreamingWriteToMetadataEnabled(table)) {
+    if (isStreamingWriteToMetadataEnabled(table, config)) {
       streamingMetadataWriteHandler.commitToMetadataTable(table, instantTime, metadata, partialMetadataWriteStats);
     } else {
       writeTableMetadata(table, instantTime, metadata);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -107,7 +107,7 @@ public class SparkRDDWriteClient<T> extends
     // write to metadata table if streaming writes are enabled.
     HoodieTable table = createTable(config);
     final JavaRDD<WriteStatus> writeStatuses;
-    if (WriteOperationType.streamingWritesToMetadataSupported((getOperationType())) && isStreamingWriteToMetadataEnabled(table)) {
+    if (WriteOperationType.streamingWritesToMetadataSupported((getOperationType())) && isStreamingWriteToMetadataEnabled(table, config)) {
       // this code block is expected to create a new Metadata Writer, start a new commit in metadata table and trigger streaming write to metadata table.
       boolean enforceCoalesceWithRepartition = getOperationType() == WriteOperationType.BULK_INSERT && config.getBulkInsertSortMode() == BulkInsertSortMode.NONE;
       writeStatuses = HoodieJavaRDD.getJavaRDD(streamingMetadataWriteHandler.streamWriteToMetadataTable(table, HoodieJavaRDD.of(rawWriteStatuses), instantTime,
@@ -161,7 +161,7 @@ public class SparkRDDWriteClient<T> extends
                                       List<HoodieWriteStat> partialMetadataTableWriteStats,
                                       HoodieCommitMetadata metadata) {
     if (!skipStreamingWritesToMetadataTable
-        && isStreamingWriteToMetadataEnabled(table)
+        && isStreamingWriteToMetadataEnabled(table, config)
         && WriteOperationType.streamingWritesToMetadataSupported(getOperationType())) {
       streamingMetadataWriteHandler.commitToMetadataTable(table, instantTime, metadata, partialMetadataTableWriteStats);
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -1042,6 +1042,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
+    public Builder withEnableRecordLevelIndex(boolean enabled) {
+      metadataConfig.setValue(RECORD_LEVEL_INDEX_ENABLE_PROP, String.valueOf(enabled));
+      return this;
+    }
+
     public Builder withRecordIndexGrowthFactor(float factor) {
       metadataConfig.setValue(RECORD_INDEX_GROWTH_FACTOR_PROP, String.valueOf(factor));
       return this;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

We added streaming writes to metadata table in 1.1.0. Not all partitions in mdt supports streaming writes as of now. So, fixing writes to leverage streaming writes to metadata table only when eligible metadata partitions are enabled. 

### Summary and Changelog

- Leverage streaming writes to metadata table in spark only when either of RLI (global or non global) or secondary index is enabled. 

### Impact

- Avoids the new dag if not really required. Down the line, when we move col stats and other partitions to streaming flow, probably we will get rid of this optimization. 

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
