### PR TITLE
docs: [DNM] Adding known regressions to 1.1.0 release

### DIFF
--- a/website/releases/release-1.1.0.md
+++ b/website/releases/release-1.1.0.md
@@ -372,6 +372,13 @@ For more details, see the [community discussion](https://github.com/apache/hudi/
 
 ---
 
+## Known Regressions
+Streaming writes to metadata support was added in 1.1.0 release to speed up metadata table writes. Even though we ran benchmarks at large scale to ensure
+the feature meets the performance expectations, the new spark DAG written has behavior difference based on spark runtimes used. 
+EMR spark seems to be in good shape, but EKS and other spark runtimes could face severe performance impact. For users using spark engine to write to Hudi, 
+we recommend disabling this feature until 1.1.1 is released via `hoodie.metadata.streaming.write.enabled=false`. 
+[tracking issue](https://github.com/apache/hudi/issues/17476)
+
 ## Contributors
 
 Hudi 1.1.0 is the result of contributions from the entire Hudi community. We thank all contributors who made this release possible.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adding known regressions to 1.1.0 release wrt streaming writes to metadata table in spark engine. 

### Summary and Changelog

Doc updated to 1.1.0 release. 

### Impact

Caution users of known regression in 1.1.0.

### Risk Level

doc update. low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
