### PR TITLE
fix: Fix flaky TestHoodieIndex#testCheckIfValidCommit test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
@@ -548,6 +548,10 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     String checkInstantTimestamp = checkInstantTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT;
     Thread.sleep(2010); // sleep required so that new timestamp differs in the seconds rather than msec
     String newTimestamp = WriteClientTestUtils.createNewInstantTime();
+    // Ensure newTimestamp doesn't end with DEFAULT_MILLIS_EXT to avoid collision with instant6
+    while (newTimestamp.endsWith(HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT)) {
+      newTimestamp = WriteClientTestUtils.createNewInstantTime();
+    }
     String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
     final HoodieInstant instant5 = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
     timeline = TIMELINE_FACTORY.createDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The test below is flaky and is failing from time to time:

#### Error 2
```log
TestHoodieIndex.testCheckIfValidCommit:562 expected: <false> but was: <true>
```

- `String newTimestamp = WriteClientTestUtils.createNewInstantTime();`
  - e.g. generates: "20251204065739123"
- Strip millisecondsString `newTimestampSec = "20251204065739"`
- Create `instant6` with `newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT`
  - "20251204065739" + "999" = "20251204065739999"
- `assertFalse(timeline.containsInstant(newTimestamp));`
  - Expects timeline does **NOT** contain newTimestamp (which is "20251204065739123")

**Edge case, root cause of flakiness**:
If newTimestamp happens to end with "999" (milliseconds = 999), then:
- newTimestamp = "20251204065739999"
- instant6 timestamp = "20251204065739999"
- They are **EQUAL**
- `timeline.containsInstant(newTimestamp)` returns true
  - Assertion **FAILS**

**Fix**
Add retry to ensure `newTimestamp` does not end with `999`/`DEFAULT_MILLIS_EXT`.
 

### Summary and Changelog

#### Error 2
- Add retry mechanism to creation of `newTimestamp` to ensure that it does not end with "999".



### Impact

CI is less likely to fail due to flaky `testPartitionStatsWithRestore`

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
