### PR TITLE
fix(metadata): propagate timeline server config from main dataset to metadata

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -192,7 +192,7 @@ public class HoodieMetadataWriteUtils {
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false)
             .withFileListingParallelism(writeConfig.getFileListingParallelism()).build())
         .withAvroSchemaValidate(false)
-        .withEmbeddedTimelineServerEnabled(false)
+        .withEmbeddedTimelineServerEnabled(writeConfig.isEmbeddedTimelineServerEnabled())
         .withMarkersType(MarkerType.DIRECT.name())
         .withRollbackUsingMarkers(false)
         .withPath(HoodieTableMetadata.getMetadataTableBasePath(writeConfig.getBasePath()))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes a configuration inconsistency where the embedded timeline server configuration from the main dataset was not being propagated to the metadata table. Previously, the metadata table writer was hardcoded to disable the embedded timeline server (`withEmbeddedTimelineServerEnabled(false)`), regardless of the main dataset's configuration. This could lead to inconsistent behavior between the main dataset and metadata table.

### Summary and Changelog

**Summary:** This fix ensures that the embedded timeline server configuration is properly propagated from the main dataset write config to the metadata table write config.

**Changelog:**
- Modified `HoodieMetadataWriteUtils.java` to use `writeConfig.isEmbeddedTimelineServerEnabled()` instead of hardcoded `false` value
- This ensures metadata table respects the same timeline server configuration as the main dataset

### Impact

This change affects the metadata table's timeline server configuration behavior:
- The metadata table will now honor the embedded timeline server setting from the main dataset
- No public API changes
- No user-facing feature changes
- Potential performance impact: If the main dataset has embedded timeline server enabled, the metadata table will now also use it, which could improve timeline access performance in distributed environments

### Risk Level

**Low** - This is a configuration propagation fix that aligns the metadata table behavior with the main dataset. The change is minimal (1 line) and makes the behavior more consistent. The embedded timeline server feature itself is well-tested in the main dataset context.

### Documentation Update

None - This is an internal configuration fix with no new configs or user-facing changes. The existing embedded timeline server configuration documentation already applies to both main and metadata tables.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable