### PR TITLE
fix(cli): Use long type when sorting based on file status modification time

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
@@ -56,6 +56,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -101,7 +102,7 @@ public class ExportCommand {
     List<StoragePathInfo> pathInfoList =
         HoodieStorageUtils.getStorage(basePath, HoodieCLI.conf).globEntries(archivePath);
     List<StoragePathInfo> archivedPathInfoList = pathInfoList.stream()
-        .sorted((f1, f2) -> (int) (f1.getModificationTime() - f2.getModificationTime()))
+        .sorted(Comparator.comparingLong(StoragePathInfo::getModificationTime))
         .collect(Collectors.toList());
 
     if (descending) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes a potential integer overflow issue when sorting files based on modification time in the ExportCommand. The original code cast the result of subtracting two long values to int, which could cause incorrect sorting behavior when modification times differ by more than Integer.MAX_VALUE milliseconds.

Related to JIRA HUDI-3391

### Summary and Changelog

**Summary**: Updated file sorting logic in CLI ExportCommand to use `Comparator.comparingLong()` instead of casting long subtraction to int, preventing potential integer overflow.

**Changelog**:
- Changed sorting comparator in `ExportCommand.java` from `(f1, f2) -> (int) (f1.getModificationTime() - f2.getModificationTime())` to `Comparator.comparingLong(StoragePathInfo::getModificationTime)`
- This ensures correct sorting behavior even when modification times have large differences

### Impact

This is a bug fix with no API changes. Users will experience correct chronological ordering of archived instants when using the `export instants` CLI command.

### Risk Level

**Low** - This is a minor bug fix in sorting logic. The change uses a more appropriate comparison method that prevents potential overflow. The functionality remains the same for normal use cases while fixing edge cases with large time differences.

### Documentation Update

None - No new features, configs, or user-facing changes. This is an internal implementation fix.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable