### PR TITLE
feat: Support data skipping based on record index for flink reader

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -236,7 +236,7 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
                                                                                             SerializableFunction<Iterator<V>, Iterator<R>> processFunc,
                                                                                             List<K> keySpace,
                                                                                             boolean preservesPartitioning) {
-    throw new UnsupportedOperationException("processKeyGroups() is not supported in FlinkEngineContext");
+    return super.mapGroupsByKey(data, processFunc, keySpace, preservesPartitioning);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -417,6 +417,19 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Enables data-skipping allowing queries to leverage indexes to reduce the search space by "
           + "skipping over files");
 
+  @AdvancedConfig
+  public static final ConfigOption<Integer> RECORD_INDEX_KEYS_MAX_COUNT = ConfigOptions
+      .key("read.record.index.keys.max.count")
+      .intType()
+      .defaultValue(8)
+      .withDescription("Record Level index statistics will be read from metadata table (MDT) for data skipping optimization,\n"
+          + "and currently the index statistics are collected by a single process, i.e., flink client for batch query or\n"
+          + "split monitor operator for streaming query. This config is used to constrain the maximum number of hoodie\n"
+          + "keys that can be read from MDT without sacrificing any performance. If the number of hoodie keys from query\n"
+          + "predicate is bigger than the maximum value, the query will fallback to not using record level index.\n"
+          + "E.g., given query: SELECT * FROM T WHERE `uuid` IN (1,2,3,4,5,6,7,8,9), the number of hoodie keys is 9, and\n"
+          + "the maximum value is 8, so the source will not perform data skipping based on record level index.");
+
   // ------------------------------------------------------------------------
   //  Write Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -418,17 +418,16 @@ public class FlinkOptions extends HoodieConfig {
           + "skipping over files");
 
   @AdvancedConfig
-  public static final ConfigOption<Integer> RECORD_INDEX_KEYS_MAX_COUNT = ConfigOptions
-      .key("read.record.index.keys.max.count")
+  public static final ConfigOption<Integer> READ_DATA_SKIPPING_RLI_KEYS_MAX_NUM = ConfigOptions
+      .key("read.data.skipping.rli.keys.max.num")
       .intType()
       .defaultValue(8)
       .withDescription("Record Level index statistics will be read from metadata table (MDT) for data skipping optimization,\n"
-          + "and currently the index statistics are collected by a single process, i.e., flink client for batch query or\n"
-          + "split monitor operator for streaming query. This config is used to constrain the maximum number of hoodie\n"
-          + "keys that can be read from MDT without sacrificing any performance. If the number of hoodie keys from query\n"
-          + "predicate is bigger than the maximum value, the query will fallback to not using record level index.\n"
+          + "and currently the index statistics are collected by a single process. This config is used to constrain the maximum \n"
+          + " number of hoodie keys that can be read from MDT without sacrificing any performance. If the number of hoodie keys from query\n"
+          + "predicate is greater than the maximum value, the query will fallback to skip the record level index filtering.\n"
           + "E.g., given query: SELECT * FROM T WHERE `uuid` IN (1,2,3,4,5,6,7,8,9), the number of hoodie keys is 9, and\n"
-          + "the maximum value is 8, so the source will not perform data skipping based on record level index.");
+          + "the maximum value is 8, so the source will not perform record level index filtering.");
 
   // ------------------------------------------------------------------------
   //  Write Options

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
@@ -221,7 +221,7 @@ public class RowDataKeyGen implements Serializable {
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordKey
-  public static String getRecordKey(Object recordKeyValue, String recordKeyField,boolean consistentLogicalTimestampEnabled) {
+  public static String getRecordKey(Object recordKeyValue, String recordKeyField, boolean consistentLogicalTimestampEnabled) {
     recordKeyValue = getTimestampValue(consistentLogicalTimestampEnabled, recordKeyValue);
     String recordKey = StringUtils.objToString(recordKeyValue);
     if (recordKey == null || recordKey.isEmpty()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionEvaluators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionEvaluators.java
@@ -194,6 +194,10 @@ public class ExpressionEvaluators {
           "Can not find column " + this.name);
       return columnStats;
     }
+
+    public String getName() {
+      return this.name;
+    }
   }
 
   /**
@@ -242,6 +246,10 @@ public class ExpressionEvaluators {
         return false;
       }
       return compare(maxVal, val, type) >= 0;
+    }
+
+    public Object getVal() {
+      return this.val;
     }
   }
 
@@ -424,6 +432,10 @@ public class ExpressionEvaluators {
     public void bindVals(Object... vals) {
       this.vals = vals;
     }
+
+    public Object[] getVals() {
+      return this.vals;
+    }
   }
 
   /**
@@ -520,6 +532,10 @@ public class ExpressionEvaluators {
     public Evaluator bindEvaluator(Evaluator... evaluators) {
       this.evaluators = evaluators;
       return this;
+    }
+
+    public Evaluator[] getEvaluators() {
+      return this.evaluators;
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -94,8 +94,7 @@ public class FileIndex implements Serializable {
     this.fileStatsIndex = new FileStatsIndex(path.toString(), rowType, conf, metaClient);
     this.partitionBucketIdFunc = partitionBucketIdFunc;
     List<ExpressionEvaluators.Evaluator> evaluators = Option.ofNullable(colStatsProbe).map(ColumnStatsProbe::getEvaluators).orElse(Collections.emptyList());
-    boolean consistentLogicalTimestampEnabled = OptionsResolver.isConsistentLogicalTimestampEnabled(conf);
-    this.recordLevelIndex = RecordLevelIndex.create(path.toString(), conf, metaClient, evaluators, rowType, consistentLogicalTimestampEnabled);
+    this.recordLevelIndex = RecordLevelIndex.create(path.toString(), conf, metaClient, evaluators, rowType);
     this.metaClient = metaClient;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
-import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.source.prune.ColumnStatsProbe;
 import org.apache.hudi.source.prune.PartitionPruners;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/ColumnStatsProbe.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/ColumnStatsProbe.java
@@ -73,6 +73,10 @@ public class ColumnStatsProbe implements Serializable {
     return referencedCols;
   }
 
+  public List<ExpressionEvaluators.Evaluator> getEvaluators() {
+    return evaluators;
+  }
+
   @Nullable
   public static ColumnStatsProbe newInstance(List<ResolvedExpression> filters) {
     if (filters.isEmpty()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PartitionPruners.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PartitionPruners.java
@@ -50,12 +50,16 @@ import java.util.stream.Stream;
  */
 public class PartitionPruners {
 
-  public interface PartitionPruner extends Serializable {
+  public interface PartitionPruner extends Serializable, AutoCloseable {
 
     /**
      * Applies partition pruning on the given partition list, return remained partitions.
      */
     Set<String> filter(Collection<String> partitions);
+
+    default void close() {
+      // do nothing.
+    }
   }
 
   /**
@@ -163,6 +167,11 @@ public class PartitionPruners {
       }
       return partitions.stream().filter(candidatePartitions::contains).collect(Collectors.toSet());
     }
+
+    @Override
+    public void close() {
+      this.partitionStatsIndex.close();
+    }
   }
 
   /**
@@ -182,6 +191,11 @@ public class PartitionPruners {
         partitions = pruner.filter(partitions);
       }
       return new HashSet<>(partitions);
+    }
+
+    @Override
+    public void close() {
+      pruners.forEach(PartitionPruner::close);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndex.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * Base support that leverages Metadata Table's indexes, such as Column Stats Index
  * and Partition Stats Index, to prune files and partitions.
  */
-public interface ColumnStatsIndex extends FlinkBaseIndex {
+public interface ColumnStatsIndex extends FlinkMetadataIndex {
   /**
    * Computes the filtered files with given candidates.
    *

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndex.java
@@ -20,7 +20,6 @@ package org.apache.hudi.source.stats;
 
 import org.apache.hudi.source.prune.ColumnStatsProbe;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 
@@ -28,13 +27,7 @@ import java.util.Set;
  * Base support that leverages Metadata Table's indexes, such as Column Stats Index
  * and Partition Stats Index, to prune files and partitions.
  */
-public interface ColumnStatsIndex extends Serializable {
-
-  /**
-   * Returns the partition name of the index.
-   */
-  String getIndexPartitionName();
-
+public interface ColumnStatsIndex extends FlinkBaseIndex {
   /**
    * Computes the filtered files with given candidates.
    *

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FileStatsIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FileStatsIndex.java
@@ -420,4 +420,16 @@ public class FileStatsIndex implements ColumnStatsIndex {
     ).collect(Collectors.toList());
     return projectNestedColStatsColumns(rows);
   }
+
+  @Override
+  public void close() {
+    if (this.metadataTable == null) {
+      return;
+    }
+    try {
+      this.metadataTable.close();
+    } catch (Exception e) {
+      throw new HoodieException("Exception happened during close metadata table.", e);
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkBaseIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkBaseIndex.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.stats;
+
+import java.io.Serializable;
+
+/**
+ * Base support that leverages Metadata Table's indexes, such as Column Stats Index,
+ * Partition Stats Index, Record Level Index to prune files, file slice and partitions.
+ */
+public interface FlinkBaseIndex extends Serializable {
+  /**
+   * Returns the partition name of the index.
+   */
+  String getIndexPartitionName();
+
+  /**
+   * Returns whether the metadata partition is available for the current table;
+   */
+  boolean isIndexAvailable();
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkMetadataIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkMetadataIndex.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
  * Base support that leverages Metadata Table's indexes, such as Column Stats Index,
  * Partition Stats Index, Record Level Index to prune files, file slice and partitions.
  */
-public interface FlinkMetadataIndex extends Serializable {
+public interface FlinkMetadataIndex extends Serializable, AutoCloseable {
   /**
    * Returns the partition name of the index.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkMetadataIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FlinkMetadataIndex.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
  * Base support that leverages Metadata Table's indexes, such as Column Stats Index,
  * Partition Stats Index, Record Level Index to prune files, file slice and partitions.
  */
-public interface FlinkBaseIndex extends Serializable {
+public interface FlinkMetadataIndex extends Serializable {
   /**
    * Returns the partition name of the index.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/PartitionStatsIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/PartitionStatsIndex.java
@@ -51,6 +51,12 @@ public class PartitionStatsIndex extends FileStatsIndex {
   }
 
   @Override
+  public boolean isIndexAvailable() {
+    return getMetaClient().getTableConfig().isMetadataTableAvailable()
+        && getMetaClient().getTableConfig().getMetadataPartitions().contains(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS);
+  }
+
+  @Override
   public Set<String> computeCandidateFiles(ColumnStatsProbe probe, List<String> allFiles) {
     throw new UnsupportedOperationException("This method is not supported by " + this.getClass().getSimpleName());
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.stats;
+
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.HoodieDataUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.keygen.KeyGenUtils;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.source.ExpressionEvaluators;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.flink.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An index support implementation that leverages Record Level Index to prune file slices.
+ */
+public class RecordLevelIndex implements FlinkBaseIndex {
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(RecordLevelIndex.class);
+
+  private final String basePath;
+  private final Configuration conf;
+  private final List<String> hoodieKeysFromFilter;
+  private final HoodieTableMetaClient metaClient;
+  private HoodieTableMetadata metadataTable;
+
+  private RecordLevelIndex(
+      String basePath,
+      Configuration conf,
+      HoodieTableMetaClient metaClient,
+      List<String> hoodieKeysFromFilter) {
+    this.basePath = basePath;
+    this.conf = conf;
+    this.metaClient = metaClient;
+    this.hoodieKeysFromFilter = hoodieKeysFromFilter;
+  }
+
+  @Override
+  public String getIndexPartitionName() {
+    return HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX;
+  }
+
+  @Override
+  public boolean isIndexAvailable() {
+    return metaClient.getTableConfig().isMetadataTableAvailable()
+        && metaClient.getTableConfig().getMetadataPartitions().contains(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX);
+  }
+
+  public HoodieTableMetadata getMetadataTable() {
+    // initialize the metadata table lazily
+    if (this.metadataTable == null) {
+      this.metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
+          HoodieFlinkEngineContext.DEFAULT,
+          metaClient.getStorage(),
+          StreamerUtil.metadataConfig(conf),
+          basePath);
+    }
+    return this.metadataTable;
+  }
+
+  public List<FileSlice> computeCandidateFileSlices(List<FileSlice> fileSlices) {
+    if (!isIndexAvailable()) {
+      return fileSlices;
+    }
+    HoodiePairData<String, HoodieRecordGlobalLocation> recordIndexData =
+        getMetadataTable().readRecordIndexLocationsWithKeys(HoodieListData.eager(hoodieKeysFromFilter));
+    try {
+      List<Pair<String, HoodieRecordGlobalLocation>> recordIndexLocations = HoodieDataUtils.dedupeAndCollectAsList(recordIndexData);
+      Set<String> fileIds = recordIndexLocations.stream()
+          .map(pair -> pair.getValue().getFileId()).collect(Collectors.toSet());
+      return fileSlices.stream().filter(fileSlice -> fileIds.contains(fileSlice.getFileId())).collect(Collectors.toList());
+    } finally {
+      // Clean up the RDD to avoid memory leaks
+      recordIndexData.unpersistWithDependencies();
+    }
+  }
+
+  public static Option<RecordLevelIndex> create(String basePath, Configuration conf, HoodieTableMetaClient metaClient, List<ExpressionEvaluators.Evaluator> evaluators) {
+    if (evaluators.isEmpty() || !FlinkOptions.QUERY_TYPE_SNAPSHOT.equalsIgnoreCase(conf.get(FlinkOptions.QUERY_TYPE))) {
+      return Option.empty();
+    }
+    if (metaClient == null) {
+      metaClient = StreamerUtil.createMetaClient(conf);
+    }
+    if (KeyGenUtils.mayUseNewEncodingForComplexKeyGen(metaClient.getTableConfig())) {
+      return Option.empty();
+    }
+
+    String[] recordKeyFields = metaClient.getTableConfig().getRecordKeyFields().orElse(new String[0]);
+    if (recordKeyFields.length == 0) {
+      return Option.empty();
+    }
+    List<String> hoodieKeysFromFilter = computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    if (hoodieKeysFromFilter.isEmpty() || hoodieKeysFromFilter.size() > conf.get(FlinkOptions.RECORD_INDEX_KEYS_MAX_COUNT)) {
+      LOG.info("Hoodie keys from query predicate: {}, key number: {}, maximum value: {}.",
+          hoodieKeysFromFilter, hoodieKeysFromFilter.size(), conf.get(FlinkOptions.RECORD_INDEX_KEYS_MAX_COUNT));
+      return Option.empty();
+    }
+    return Option.of(new RecordLevelIndex(basePath, conf, metaClient, hoodieKeysFromFilter));
+  }
+
+  /**
+   * Given query filters, it filters the EqualTo and IN queries on record key columns and
+   * returns the list of record key literals present in the query, for example:
+   * <p>
+   * filter1: `key1` = 'val1', returns {"val1"}
+   * filter2: `key1` in ('val1', 'val2', 'val3'), returns {"val1", "vale", "val3"}
+   * filter2: `key1` = 'val1' AND `key2` in ('val2', 'val3'), returns {"key1:val1,key2:val2", "key1:val1,key2:val3"}
+   */
+  @VisibleForTesting
+  public static List<String> computeHoodieKeyFromFilters(
+      Configuration conf, HoodieTableMetaClient metaClient, List<ExpressionEvaluators.Evaluator> evaluators, String[] keyFields) {
+    String[] partitionFields = metaClient.getTableConfig().getPartitionFields().orElse(new String[0]);
+    // align with the check logic in RowDataKeyGen
+    boolean isComplexRecordKey = keyFields.length > 1 || partitionFields.length > 1 && !OptionsResolver.useComplexKeygenNewEncoding(conf);
+    List<String> hoodieKeys = new ArrayList<>();
+    for (String keyField: keyFields) {
+      List<String> recordKeys = new ArrayList<>();
+      for (ExpressionEvaluators.Evaluator evaluator: evaluators) {
+        // if there exists multiple ref fields in an evaluator, ignore this evaluator, e.g., key = 'key1' or age = 20
+        List<Object> literals = collectLiterals(evaluator, keyField);
+        literals.forEach(val -> recordKeys.add(isComplexRecordKey ? keyField + KeyGenerator.DEFAULT_COLUMN_VALUE_SEPARATOR + val : val.toString()));
+      }
+      if (recordKeys.isEmpty()) {
+        LOG.info("No literals found for the record key: {}, therefore filtering can not be performed", keyField);
+        return Collections.emptyList();
+      } else if (!isComplexRecordKey || hoodieKeys.isEmpty()) {
+        hoodieKeys = recordKeys;
+      } else {
+        // Combine literals for this configured record key with literals for the other configured record keys
+        // If there are two literals for rk1, rk2, rk3 each. A total of 8 combinations will be generated
+        List<String> tmpHoodieKeys = new ArrayList<>();
+        for (String compositeKey: hoodieKeys) {
+          for (String recordKey: recordKeys) {
+            tmpHoodieKeys.add(compositeKey + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + recordKey);
+          }
+        }
+        hoodieKeys = tmpHoodieKeys;
+      }
+    }
+    return hoodieKeys;
+  }
+
+  /**
+   * Collect literal values for record key fields from the predicate.
+   */
+  private static List<Object> collectLiterals(ExpressionEvaluators.Evaluator evaluator, String refName) {
+    if (evaluator instanceof ExpressionEvaluators.LeafEvaluator
+        && !((ExpressionEvaluators.LeafEvaluator) evaluator).getName().equalsIgnoreCase(refName)) {
+      return Collections.emptyList();
+    }
+    if (evaluator instanceof ExpressionEvaluators.EqualTo) {
+      Object valueLiteral = ((ExpressionEvaluators.EqualTo) evaluator).getVal();
+      return valueLiteral == null ? Collections.emptyList() : Collections.singletonList(valueLiteral);
+    } else if (evaluator instanceof ExpressionEvaluators.In) {
+      Object[] valueLiterals = ((ExpressionEvaluators.In) evaluator).getVals();
+      if (valueLiterals.length < 1 || Arrays.stream(valueLiterals).anyMatch(Objects::isNull)) {
+        return Collections.emptyList();
+      }
+      return Arrays.stream(valueLiterals).collect(Collectors.toList());
+    } else if (evaluator instanceof ExpressionEvaluators.Or) {
+      List<List<Object>> literalsList = Arrays.stream(((ExpressionEvaluators.Or) evaluator).getEvaluators())
+          .map(eval -> collectLiterals(eval, refName)).collect(Collectors.toList());
+      // if any child expr do not contain predicate on the key, just return empty list
+      if (literalsList.stream().anyMatch(List::isEmpty)) {
+        return Collections.emptyList();
+      }
+      return literalsList.stream().flatMap(List::stream).distinct().collect(Collectors.toList());
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
@@ -257,6 +257,7 @@ public class RecordLevelIndex implements FlinkMetadataIndex {
       default:
         break;
     }
+    // to align with the hoodie key generating logic in writer side.
     return RowDataKeyGen.getRecordKey(value, keyField, consistentLogicalTimestampEnabled);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/RecordLevelIndex.java
@@ -124,8 +124,7 @@ public class RecordLevelIndex implements FlinkMetadataIndex {
       Configuration conf,
       HoodieTableMetaClient metaClient,
       List<ExpressionEvaluators.Evaluator> evaluators,
-      RowType rowType,
-      boolean consistentLogicalTimestampEnabled) {
+      RowType rowType) {
     if (evaluators.isEmpty() || !FlinkOptions.QUERY_TYPE_SNAPSHOT.equalsIgnoreCase(conf.get(FlinkOptions.QUERY_TYPE))) {
       return Option.empty();
     }
@@ -141,6 +140,7 @@ public class RecordLevelIndex implements FlinkMetadataIndex {
       LOG.warn("The table do not have record keys, skipping the rli pruning.");
       return Option.empty();
     }
+    boolean consistentLogicalTimestampEnabled = OptionsResolver.isConsistentLogicalTimestampEnabled(conf);
     List<String> hoodieKeysFromFilter = computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields, rowType, consistentLogicalTimestampEnabled);
     if (hoodieKeysFromFilter.isEmpty()) {
       LOG.warn("The number of keys from query predicate is empty, skipping the rli pruning.");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestFileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestFileIndex.java
@@ -59,6 +59,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
@@ -317,6 +318,16 @@ public class TestFileIndex {
         DataTypes.BOOLEAN());
     ColumnStatsProbe probeTimestamp = ColumnStatsProbe.newInstance(Collections.singletonList(equalExprTimestamp));
 
+    // TIME data type tests - using the TIME config with appropriate record key
+    CallExpression equalExprTime = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(
+            new FieldReferenceExpression("f_time", DataTypes.TIME(), 0, 0),
+            new ValueLiteralExpression(LocalTime.ofSecondOfDay(1), DataTypes.TIME().notNull())
+        ),
+        DataTypes.BOOLEAN());
+    ColumnStatsProbe probeTime = ColumnStatsProbe.newInstance(Collections.singletonList(equalExprTime));
+
     // DATE data type tests - using the date config with appropriate record key
     CallExpression equalExprDate = CallExpression.permanent(
         BuiltInFunctionDefinitions.EQUALS,
@@ -349,6 +360,8 @@ public class TestFileIndex {
         {TestData.DATA_SET_INSERT, TestConfigurations.ROW_DATA_TYPE, "uuid,name", probe2, 2, 4},
         // key type is TIMESTAMP
         {TestData.DATA_SET_WITH_SPECIAL_KEY, TestConfigurations.PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, "f_timestamp", probeTimestamp, 8, 1},
+        // key type is TIME
+        {TestData.DATA_SET_WITH_SPECIAL_KEY, TestConfigurations.PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, "f_time", probeTime, 8, 1},
         // key type is DATE
         {TestData.DATA_SET_WITH_SPECIAL_KEY, TestConfigurations.PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, "f_date", probeDate, 8, 1},
         // key type is DECIMAL

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -40,6 +40,7 @@ import org.apache.hudi.sink.partitioner.profile.WriteProfiles;
 import org.apache.hudi.source.prune.ColumnStatsProbe;
 import org.apache.hudi.source.prune.PartitionPruners;
 import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
 import org.apache.hudi.utils.TestData;
 
@@ -359,6 +360,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     Configuration conf = TestConfigurations.getDefaultConf(basePath);
     conf.set(FlinkOptions.READ_AS_STREAMING, true);
     conf.set(FlinkOptions.READ_DATA_SKIPPING_ENABLED, true);
+    conf.set(FlinkOptions.METADATA_ENABLED, true);
     conf.set(FlinkOptions.TABLE_TYPE, tableType.name());
     conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     if (tableType == HoodieTableType.MERGE_ON_READ) {
@@ -366,8 +368,8 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
       // which will be used to construct partition stats then.
       conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     }
-    metaClient = HoodieTestUtils.init(basePath, tableType);
     TestData.writeData(TestData.DATA_SET_INSERT, conf);
+    metaClient = StreamerUtil.createMetaClient(conf);
 
     // uuid > 'id5' and age < 30, only column stats of 'par3' matches the filter.
     ColumnStatsProbe columnStatsProbe =

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -360,7 +360,6 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     Configuration conf = TestConfigurations.getDefaultConf(basePath);
     conf.set(FlinkOptions.READ_AS_STREAMING, true);
     conf.set(FlinkOptions.READ_DATA_SKIPPING_ENABLED, true);
-    conf.set(FlinkOptions.METADATA_ENABLED, true);
     conf.set(FlinkOptions.TABLE_TYPE, tableType.name());
     conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
     if (tableType == HoodieTableType.MERGE_ON_READ) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestRecordLevelIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestRecordLevelIndex.java
@@ -22,11 +22,13 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.sink.bulk.RowDataKeyGen;
 import org.apache.hudi.source.ExpressionEvaluators;
 import org.apache.hudi.utils.TestConfigurations;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -223,8 +225,8 @@ public class TestRecordLevelIndex {
     RowType rowType = (RowType) ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getLogicalType();
     List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(
         conf, metaClient, ExpressionEvaluators.fromExpression(expressions), recordKeyFields, rowType, consistentLogicalTimestampEnabled);
-    String expectedTimestamp = consistentLogicalTimestampEnabled ? "1970-01-01T00:00:00.001" : "-28799999";
-    assertEquals(Arrays.asList("f_timestamp:" + expectedTimestamp + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "f_decimal:1.10"), result,
+    String expectedTimestampVal = RowDataKeyGen.getRecordKey(TimestampData.fromEpochMillis(1), "f_timestamp", consistentLogicalTimestampEnabled);
+    assertEquals(Arrays.asList("f_timestamp:" + expectedTimestampVal + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "f_decimal:1.10"), result,
         "Should return composite key with complex record keys");
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestRecordLevelIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestRecordLevelIndex.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.stats;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.source.ExpressionEvaluators;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link RecordLevelIndex}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestRecordLevelIndex {
+  private final HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+  private final HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+  private List<ExpressionEvaluators.Evaluator> createColumnStatsProbe(BuiltInFunctionDefinition func, String refName, List<String> vals) {
+    List<ResolvedExpression> args = vals.stream().map(
+        val -> new ValueLiteralExpression(val, DataTypes.STRING().notNull())).collect(Collectors.toList());
+    args.add(0, new FieldReferenceExpression(refName, DataTypes.STRING(), 0, 0));
+    CallExpression callExpression = CallExpression.permanent(func, args, DataTypes.BOOLEAN());
+    return ExpressionEvaluators.fromExpression(Collections.singletonList(callExpression));
+  }
+
+  private List<ExpressionEvaluators.Evaluator> createOrColumnStatsProbe(String refName, List<String> vals) {
+    // Create multiple EQUALS expressions and join them with OR
+    CallExpression outerExpr = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(new FieldReferenceExpression(refName, DataTypes.STRING(), 0, 0),
+            new ValueLiteralExpression(vals.get(0), DataTypes.STRING().notNull())),
+        DataTypes.BOOLEAN());
+    CallExpression leftExpr = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(new FieldReferenceExpression(refName, DataTypes.STRING(), 0, 0),
+            new ValueLiteralExpression(vals.get(1), DataTypes.STRING().notNull())),
+        DataTypes.BOOLEAN());
+    CallExpression rightExpr = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(new FieldReferenceExpression(refName, DataTypes.STRING(), 0, 0),
+            new ValueLiteralExpression(vals.get(2), DataTypes.STRING().notNull())),
+        DataTypes.BOOLEAN());
+
+    CallExpression orExpression = CallExpression.permanent(
+        BuiltInFunctionDefinitions.OR,
+        Arrays.asList(leftExpr, rightExpr),
+        DataTypes.BOOLEAN());
+    CallExpression outerOrExpression = CallExpression.permanent(
+        BuiltInFunctionDefinitions.OR,
+        Arrays.asList(outerExpr, orExpression),
+        DataTypes.BOOLEAN());
+    return ExpressionEvaluators.fromExpression(Collections.singletonList(outerOrExpression));
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithSimpleRecordKey() {
+    // Setup mock table config with single record key field
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"uuid"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with EqualTo evaluator on record key
+    List<ExpressionEvaluators.Evaluator> evaluators = createColumnStatsProbe(
+        BuiltInFunctionDefinitions.EQUALS, "uuid", Collections.singletonList("id1"));
+    String[] recordKeyFields = {"uuid"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    assertEquals(Collections.singletonList("id1"), result, "Should return the simple record key value");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithInOperator() {
+    // Setup mock table config with single record key field
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"uuid"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with IN operator
+    List<ExpressionEvaluators.Evaluator> evaluators = createColumnStatsProbe(BuiltInFunctionDefinitions.IN, "uuid", Arrays.asList("id1", "id2", "id3"));
+    String[] recordKeyFields = {"uuid"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    assertEquals(Arrays.asList("id1", "id2", "id3"), result, "Should return all the IN operator values");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithOrOperator() {
+    // Setup mock table config with single record key field
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"uuid"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with OR operator (which should be converted to IN)
+    List<ExpressionEvaluators.Evaluator> evaluators = createOrColumnStatsProbe("uuid", Arrays.asList("id1", "id2", "id3"));
+    String[] recordKeyFields = {"uuid"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    // Note: OR with two values "id1" and "id2" should result in the literals from both evaluators
+    assertEquals(Arrays.asList("id1", "id2", "id3"), result, "Should return values from OR operator");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithComplexRecordKey() {
+    // Setup mock table config with multiple record key fields
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"key1", "key2"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with filters on multiple record key fields
+    List<ResolvedExpression> expressions = Arrays.asList(
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.EQUALS,
+            Arrays.asList(new FieldReferenceExpression("key1", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("val1", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN()),
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.EQUALS,
+            Arrays.asList(new FieldReferenceExpression("key2", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("val2", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN())
+    );
+    String[] recordKeyFields = {"key1", "key2"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, ExpressionEvaluators.fromExpression(expressions), recordKeyFields);
+    // For complex keys, the format should be key1:val1,key2:val2
+    assertEquals(Arrays.asList("key1:val1" + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "key2:val2"), result,
+        "Should return composite key with complex record keys");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithMultipleSimpleKeys() {
+    // Setup mock table config with single record key field
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"uuid"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with multiple equal filters on same record key field
+    // This scenario might not be typical, but testing the method behavior
+    List<ResolvedExpression> expressions = Arrays.asList(
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.EQUALS,
+            Arrays.asList(new FieldReferenceExpression("uuid", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("id1", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN()),
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.EQUALS,
+            Arrays.asList(new FieldReferenceExpression("uuid", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("id2", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN())
+    );
+    String[] recordKeyFields = {"uuid"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, ExpressionEvaluators.fromExpression(expressions), recordKeyFields);
+    // This should return both values
+    assertEquals(Arrays.asList("id1", "id2"), result, "Should return multiple values for same field");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithEmptyResult() {
+    // Setup mock table config with single record key field
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"uuid"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with filter on non-record key field - should return empty list
+    List<ExpressionEvaluators.Evaluator> evaluators = createColumnStatsProbe(
+        BuiltInFunctionDefinitions.EQUALS, "nonKeyField", Collections.singletonList("val1"));
+    String[] recordKeyFields = {"uuid"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    assertEquals(Collections.emptyList(), result, "Should return empty list when filtering on non-record key field");
+
+    CallExpression keyExpr = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(new FieldReferenceExpression("uuid", DataTypes.STRING(), 0, 0),
+            new ValueLiteralExpression("key1", DataTypes.STRING().notNull())),
+        DataTypes.BOOLEAN());
+    CallExpression nonKeyExpr = CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(new FieldReferenceExpression("name", DataTypes.STRING(), 0, 0),
+            new ValueLiteralExpression("Bob", DataTypes.STRING().notNull())),
+        DataTypes.BOOLEAN());
+    CallExpression orExpression = CallExpression.permanent(
+        BuiltInFunctionDefinitions.OR,
+        Arrays.asList(keyExpr, nonKeyExpr),
+        DataTypes.BOOLEAN());
+
+    evaluators = ExpressionEvaluators.fromExpression(Collections.singletonList(orExpression));
+    result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, evaluators, recordKeyFields);
+    assertEquals(Collections.emptyList(), result, "Should return empty list when filtering on or predicate including multiple fields");
+  }
+
+  @Test
+  public void testComputeHoodieKeyFromFiltersWithComplexRecordKeyMultipleValues() {
+    // Setup mock table config with multiple record key fields
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"key1", "key2"}));
+    when(tableConfig.getPartitionFields()).thenReturn(Option.of(new String[]{"partition"}));
+
+    Configuration conf = new Configuration();
+
+    // Test with multiple values for each record key field to test combinations
+    // key1 in ['val1', 'val2'] AND key2 in ['val3', 'val4'] should produce 4 combinations
+    List<ResolvedExpression> expressions = Arrays.asList(
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.IN,
+            Arrays.asList(new FieldReferenceExpression("key1", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("val1", DataTypes.STRING().notNull()),
+                new ValueLiteralExpression("val2", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN()),
+        CallExpression.permanent(
+            BuiltInFunctionDefinitions.IN,
+            Arrays.asList(new FieldReferenceExpression("key2", DataTypes.STRING(), 0, 0),
+                new ValueLiteralExpression("val3", DataTypes.STRING().notNull()),
+                new ValueLiteralExpression("val4", DataTypes.STRING().notNull())),
+            DataTypes.BOOLEAN())
+    );
+    String[] recordKeyFields = {"key1", "key2"};
+    List<String> result = RecordLevelIndex.computeHoodieKeyFromFilters(conf, metaClient, ExpressionEvaluators.fromExpression(expressions), recordKeyFields);
+    // Should have 4 combinations: (val1,val3), (val1,val4), (val2,val3), (val2,val4)
+    List<String> expected = Arrays.asList(
+        "key1:val1" + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "key2:val3",
+        "key1:val1" + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "key2:val4",
+        "key1:val2" + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "key2:val3",
+        "key1:val2" + KeyGenerator.DEFAULT_RECORD_KEY_PARTS_SEPARATOR + "key2:val4"
+    );
+    assertEquals(expected, result, "Should return all combinations of complex record keys");
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -2804,10 +2804,8 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = "create table t1(\n"
         + "  _hoodie_commit_time STRING METADATA VIRTUAL,\n"
-        + "  _hoodie_commit_seqno STRING METADATA VIRTUAL,\n"
         + "  _hoodie_record_key STRING METADATA VIRTUAL,\n"
         + "  _hoodie_partition_path STRING METADATA VIRTUAL,\n"
-        + "  _hoodie_file_name STRING METADATA VIRTUAL,\n"
         + "  uuid varchar(20),\n"
         + "  name varchar(10),\n"
         + "  age int,\n"
@@ -2840,8 +2838,8 @@ public class ITTestHoodieDataSource {
 
     // select metadata columns
     rows = CollectionUtil.iterableToList(
-        () -> streamTableEnv.sqlQuery("select _hoodie_commit_time, _hoodie_commit_seqno, _hoodie_record_key, _hoodie_partition_path, _hoodie_file_name from t1").execute().collect());
-    rows.forEach(row -> IntStream.range(0, 5).forEach(idx -> assertNotNull(row.getField(idx))));
+        () -> streamTableEnv.sqlQuery("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path from t1").execute().collect());
+    rows.forEach(row -> IntStream.range(0, 3).forEach(idx -> assertNotNull(row.getField(idx))));
 
     // select metadata and data columns
     rows = CollectionUtil.iterableToList(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -2804,8 +2804,10 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = "create table t1(\n"
         + "  _hoodie_commit_time STRING METADATA VIRTUAL,\n"
+        + "  _hoodie_commit_seqno STRING METADATA VIRTUAL,\n"
         + "  _hoodie_record_key STRING METADATA VIRTUAL,\n"
         + "  _hoodie_partition_path STRING METADATA VIRTUAL,\n"
+        + "  _hoodie_file_name STRING METADATA VIRTUAL,\n"
         + "  uuid varchar(20),\n"
         + "  name varchar(10),\n"
         + "  age int,\n"
@@ -2838,8 +2840,8 @@ public class ITTestHoodieDataSource {
 
     // select metadata columns
     rows = CollectionUtil.iterableToList(
-        () -> streamTableEnv.sqlQuery("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path from t1").execute().collect());
-    rows.forEach(row -> IntStream.range(0, 3).forEach(idx -> assertNotNull(row.getField(idx))));
+        () -> streamTableEnv.sqlQuery("select _hoodie_commit_time, _hoodie_commit_seqno, _hoodie_record_key, _hoodie_partition_path, _hoodie_file_name from t1").execute().collect());
+    rows.forEach(row -> IntStream.range(0, 5).forEach(idx -> assertNotNull(row.getField(idx))));
 
     // select metadata and data columns
     rows = CollectionUtil.iterableToList(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
@@ -304,7 +304,7 @@ public class TestHoodieTableSource {
 
     // test timestamp filtering
     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf1);
-    HoodieTableSource tableSource1 = createHoodieTableSource(conf1);
+    HoodieTableSource tableSource1 = createHoodieTableSource(conf1, TestConfigurations.TABLE_SCHEMA_KEY_SPECIAL_DATA_TYPE);
     tableSource1.applyFilters(Collections.singletonList(
         createLitEquivalenceExpr(f1, 0, DataTypes.TIMESTAMP(3).notNull(),
             LocalDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneId.of("UTC")))));
@@ -321,7 +321,7 @@ public class TestHoodieTableSource {
     conf2.set(FlinkOptions.RECORD_KEY_FIELD, f2);
     conf2.set(FlinkOptions.ORDERING_FIELDS, f2);
     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf2);
-    HoodieTableSource tableSource2 = createHoodieTableSource(conf2);
+    HoodieTableSource tableSource2 = createHoodieTableSource(conf2, TestConfigurations.TABLE_SCHEMA_KEY_SPECIAL_DATA_TYPE);
     tableSource2.applyFilters(Collections.singletonList(
         createLitEquivalenceExpr(f2, 1, DataTypes.DATE().notNull(), LocalDate.ofEpochDay(1))));
 
@@ -337,7 +337,8 @@ public class TestHoodieTableSource {
     conf3.set(FlinkOptions.RECORD_KEY_FIELD, f3);
     conf3.set(FlinkOptions.ORDERING_FIELDS, f3);
     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf3);
-    HoodieTableSource tableSource3 = createHoodieTableSource(conf3);
+    HoodieTableSource tableSource3 = createHoodieTableSource(conf3, TestConfigurations.TABLE_SCHEMA_KEY_SPECIAL_DATA_TYPE);
+
     tableSource3.applyFilters(Collections.singletonList(
         createLitEquivalenceExpr(f3, 1, DataTypes.DECIMAL(3, 2).notNull(),
             new BigDecimal("1.11"))));
@@ -538,6 +539,15 @@ public class TestHoodieTableSource {
 
   private HoodieTableSource createHoodieTableSource(Configuration conf) {
     return createHoodieTableSource(conf, TestConfigurations.TABLE_SCHEMA);
+  }
+
+  private HoodieTableSource createHoodieTableSource(Configuration conf, ResolvedSchema resolvedSchema) {
+    return new HoodieTableSource(
+        SerializableSchema.create(resolvedSchema),
+        new StoragePath(conf.get(FlinkOptions.PATH)),
+        Arrays.asList(conf.get(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
+        "default-par",
+        conf);
   }
 
   private HoodieTableSource createHoodieTableSource(Configuration conf, ResolvedSchema resolvedSchema) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
@@ -550,15 +550,6 @@ public class TestHoodieTableSource {
         conf);
   }
 
-  private HoodieTableSource createHoodieTableSource(Configuration conf, ResolvedSchema resolvedSchema) {
-    return new HoodieTableSource(
-        SerializableSchema.create(resolvedSchema),
-        new StoragePath(conf.get(FlinkOptions.PATH)),
-        Arrays.asList(conf.get(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
-        "default-par",
-        conf);
-  }
-
   private ResolvedExpression createLitEquivalenceExpr(String fieldName, int fieldIdx, DataType dataType, Object val) {
     FieldReferenceExpression ref = new FieldReferenceExpression(fieldName, dataType, fieldIdx, fieldIdx);
     ValueLiteralExpression literal = new ValueLiteralExpression(val, dataType);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -190,6 +190,7 @@ public class TestConfigurations {
 
   public static final DataType PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = DataTypes.ROW(
           DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
+          DataTypes.FIELD("f_time", DataTypes.TIME()),
           DataTypes.FIELD("f_date", DataTypes.DATE()),
           DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(38, 18)),
           DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -188,15 +188,23 @@ public class TestConfigurations {
       .fields(ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getFieldNames(), ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getChildren())
       .build();
 
-  public static final DataType PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = DataTypes.ROW(
+  public static final DataType ROW_DATA_TYPE_WITH_ATOMIC_TYPES = DataTypes.ROW(
+          DataTypes.FIELD("f_bool", DataTypes.BOOLEAN()),
+          DataTypes.FIELD("f_tinyint", DataTypes.TINYINT()),
+          DataTypes.FIELD("f_smallint", DataTypes.SMALLINT()),
+          DataTypes.FIELD("f_int", DataTypes.INT()),
+          DataTypes.FIELD("f_bigint", DataTypes.BIGINT()),
+          DataTypes.FIELD("f_float", DataTypes.FLOAT()),
+          DataTypes.FIELD("f_double", DataTypes.DOUBLE()),
           DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
           DataTypes.FIELD("f_time", DataTypes.TIME()),
           DataTypes.FIELD("f_date", DataTypes.DATE()),
           DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(38, 18)),
+          DataTypes.FIELD("f_str", DataTypes.STRING()),
           DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
       .notNull();
 
-  public static final RowType PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = (RowType) PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getLogicalType();
+  public static final RowType ROW_TYPE_WITH_ATOMIC_TYPES = (RowType) ROW_DATA_TYPE_WITH_ATOMIC_TYPES.getLogicalType();
 
   public static final RowType ROW_TYPE_EVOLUTION_AFTER = (RowType) ROW_DATA_TYPE_EVOLUTION_AFTER.getLogicalType();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -184,6 +184,19 @@ public class TestConfigurations {
 
   public static final RowType ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = (RowType) ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getLogicalType();
 
+  public static final ResolvedSchema TABLE_SCHEMA_KEY_SPECIAL_DATA_TYPE  = SchemaBuilder.instance()
+      .fields(ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getFieldNames(), ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getChildren())
+      .build();
+
+  public static final DataType PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = DataTypes.ROW(
+          DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
+          DataTypes.FIELD("f_date", DataTypes.DATE()),
+          DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(38, 18)),
+          DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
+      .notNull();
+
+  public static final RowType PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = (RowType) PARTITIONED_ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getLogicalType();
+
   public static final RowType ROW_TYPE_EVOLUTION_AFTER = (RowType) ROW_DATA_TYPE_EVOLUTION_AFTER.getLogicalType();
 
   public static final DataType ROW_DATA_TYPE_BIGINT = DataTypes.ROW(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -426,13 +426,13 @@ public class TestData {
           TimestampData.fromEpochMillis(2), StringData.fromString("par1"))
   );
 
-  public static List<RowData> DATA_SET_WITH_SPECIAL_KEY = Arrays.asList(
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(1), 1000, 1,
-          DecimalData.fromBigDecimal(new BigDecimal("1.11"), 38, 18), StringData.fromString("par1")),
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(2), 2000, 2,
-          DecimalData.fromBigDecimal(new BigDecimal("2.22"), 38, 18), StringData.fromString("par2")),
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(3), 3000, 3,
-          DecimalData.fromBigDecimal(new BigDecimal("3.33"), 38, 18), StringData.fromString("par3")));
+  public static List<RowData> DATA_SET_WITH_ATOMIC_TYPES = Arrays.asList(
+      insertRow(TestConfigurations.ROW_TYPE_WITH_ATOMIC_TYPES, true, (byte) 1, (short) 11, 111, 1111L, 10.11f, 11.111, TimestampData.fromEpochMillis(1),
+          1000, 1, DecimalData.fromBigDecimal(new BigDecimal("1.11"), 38, 18), StringData.fromString("str1"), StringData.fromString("par1")),
+      insertRow(TestConfigurations.ROW_TYPE_WITH_ATOMIC_TYPES, true, (byte) 2, (short) 22, 222, 2222L, 20.22f, 22.222, TimestampData.fromEpochMillis(2),
+          2000, 2, DecimalData.fromBigDecimal(new BigDecimal("2.22"), 38, 18), StringData.fromString("str2"), StringData.fromString("par2")),
+      insertRow(TestConfigurations.ROW_TYPE_WITH_ATOMIC_TYPES, true, (byte) 3, (short) 33, 333, 3333L, 30.33f, 33.333, TimestampData.fromEpochMillis(3),
+          3000, 3, DecimalData.fromBigDecimal(new BigDecimal("3.33"), 38, 18), StringData.fromString("str3"), StringData.fromString("par3")));
 
   // data types handled specifically for Hoodie Key
   public static List<RowData> DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE = new ArrayList<>();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -426,6 +426,14 @@ public class TestData {
           TimestampData.fromEpochMillis(2), StringData.fromString("par1"))
   );
 
+  public static List<RowData> DATA_SET_WITH_SPECIAL_KEY = Arrays.asList(
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(1), 1,
+          DecimalData.fromBigDecimal(new BigDecimal("1.11"), 38, 18), StringData.fromString("par1")),
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(2), 2,
+          DecimalData.fromBigDecimal(new BigDecimal("2.22"), 38, 18), StringData.fromString("par2")),
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(3), 3,
+          DecimalData.fromBigDecimal(new BigDecimal("3.33"), 38, 18), StringData.fromString("par3")));
+
   // data types handled specifically for Hoodie Key
   public static List<RowData> DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE = new ArrayList<>();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -427,11 +427,11 @@ public class TestData {
   );
 
   public static List<RowData> DATA_SET_WITH_SPECIAL_KEY = Arrays.asList(
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(1), 1,
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(1), 1000, 1,
           DecimalData.fromBigDecimal(new BigDecimal("1.11"), 38, 18), StringData.fromString("par1")),
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(2), 2,
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(2), 2000, 2,
           DecimalData.fromBigDecimal(new BigDecimal("2.22"), 38, 18), StringData.fromString("par2")),
-      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(3), 3,
+      insertRow(TestConfigurations.PARTITIONED_ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE, TimestampData.fromEpochMillis(3), 3000, 3,
           DecimalData.fromBigDecimal(new BigDecimal("3.33"), 38, 18), StringData.fromString("par3")));
 
   // data types handled specifically for Hoodie Key


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Support data skipping based on record index for flink reader, fixes https://github.com/apache/hudi/issues/17594

### Summary and Changelog

Support data skipping based on record index for flink reader
* Add RecordLevelIndex to support reading RLI from MDT and prune file slices.
* The reading of RLI from MDT is accomplished in single process now, and config `read.record.index.keys.max.count` is added to limit the number of hoodie keys inferred from query predicate, once exceeded, the reader will fallback to not using RLI.

### Impact

Improve performance for flink queries with record key predicate

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
