### PR TITLE
Fix: Show underline for links on Get Involved page

### DIFF
--- a/website/src/components/GetInvolvedGrid/styles.module.css
+++ b/website/src/components/GetInvolvedGrid/styles.module.css
@@ -18,18 +18,9 @@
 
 .card p,
 .card a {
-    color: #1e293b;
+    color: var(--ifm-blue-900);
     font-size: 0.95rem;
     line-height: 1.6;
-}
-
-.card a {
-    color: #0078e7;
-    text-decoration: none;
-}
-
-.card a:hover {
-    text-decoration: underline;
 }
 
 .getInvloved {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<img width="1920" height="912" alt="Screenshot 2025-12-05 at 10 55 05" src="https://github.com/user-attachments/assets/2f6258f3-bdc2-49b0-b942-523d84b97bbc" />


<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
