### PR TITLE
chore: move disk space cleanup in integration-test CI module

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1199,8 +1199,6 @@ jobs:
           architecture: x64
       - name: Check disk space
         run: df -h
-      - name: Check disk space 2
-        run: df -h /usr/share
       - name: 'Free space'
         run: |
           sudo rm -rf /usr/share/dotnet
@@ -1208,7 +1206,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
           docker system prune --all --force --volumes
-      - name: Check disk space 3
+      - name: Check disk space after cleanup
         run: df -h
       - name: Build Project
         env:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
All PRs are failing on the integration-tests running out of disk space. There is a step to reclaim some disk space but it happens after the step that is now failing.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Move the cleanup and add another step to check its effectiveness for ease of debugging in the future

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Unblocks other PRs

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
