### PR TITLE
feat(schema): Migrate BigQuery schema converter to use HoodieSchema

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
@@ -128,6 +128,7 @@ public class BigQuerySchemaResolver {
         break;
       case STRING:
       case ENUM:
+      case UUID:
         standardSQLTypeName = StandardSQLTypeName.STRING;
         break;
       case BOOLEAN:

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySchemaResolver.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySchemaResolver.java
@@ -194,7 +194,8 @@ public class TestBigQuerySchemaResolver {
         + "{\"name\":\"long_timestamp_micros\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}},"
         + "{\"name\":\"long_timestamp_millis_local\",\"type\":{\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}},"
         + "{\"name\":\"long_timestamp_micros_local\",\"type\":{\"type\":\"long\",\"logicalType\":\"local-timestamp-micros\"}},"
-        + "{\"name\":\"bytes_decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\", \"precision\": 4, \"scale\": 2}}]}";
+        + "{\"name\":\"bytes_decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\", \"precision\": 4, \"scale\": 2}},"
+        + "{\"name\":\"uuid_field\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}}]}";
     HoodieSchema input = HoodieSchema.parse(schemaString);
 
     Schema expected = Schema.of(
@@ -205,7 +206,8 @@ public class TestBigQuerySchemaResolver {
         Field.newBuilder("long_timestamp_micros", StandardSQLTypeName.TIMESTAMP).setMode(Field.Mode.REQUIRED).build(),
         Field.newBuilder("long_timestamp_millis_local", StandardSQLTypeName.INT64).setMode(Field.Mode.REQUIRED).build(),
         Field.newBuilder("long_timestamp_micros_local", StandardSQLTypeName.INT64).setMode(Field.Mode.REQUIRED).build(),
-        Field.newBuilder("bytes_decimal", StandardSQLTypeName.NUMERIC).setMode(Field.Mode.REQUIRED).build());
+        Field.newBuilder("bytes_decimal", StandardSQLTypeName.NUMERIC).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("uuid_field", StandardSQLTypeName.STRING).setMode(Field.Mode.REQUIRED).build());
 
     Assertions.assertEquals(expected, SCHEMA_RESOLVER.convertSchema(input));
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Migrates the Avro to BigQuery Schema converter to use HoodieSchema as part of our migration to our own type system.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Updates the converter to operate on the HoodieSchema
- Updates test objects to avoid usage of Avro

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Continues migration towards our own type system

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low, this is covered pretty extensively by unit testing

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
