### PR TITLE
docs: Fix home page buttons

### DIFF
--- a/website/src/components/HomepageHeader/index.js
+++ b/website/src/components/HomepageHeader/index.js
@@ -52,11 +52,11 @@ function HomepageHeader() {
               </h1>
               <FeatureRender/>
               <div className={styles.buttons}>
-                <LinkButton to="/releases/release-1.1.0">
+                <LinkButton to="/docs/quick-start-guide">
                   Get Started
                 </LinkButton>
-                <LinkButton type="secondary" to="/docs/quick-start-guide">
-                  Read Docs
+                <LinkButton type="secondary" to="/community/get-involved">
+                  Community
                 </LinkButton>
               </div>
             </div>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The navigation links on the Hudi website homepage are currently mismatched: the 'Get Started' button incorrectly links to the Release page, and the 'Read Docs' button incorrectly links to the Getting Started page. This inverted functionality creates a confusing user experience. We need to either correct the target URLs to their semantically appropriate pages or update the button labels to reflect their actual destinations.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

Getting Started now pointing to the Getting Started home page and Read Docs renamed to Community and it is redirecting to Getting involved.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
Low.

UI page redirection only.
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
None
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
None
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
