### PR TITLE
perf: Reduce unnecessary FSDataOutputStream#hsync to enhance append performance

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -147,6 +147,8 @@ public interface HoodieLogFormat {
     private String suffix;
     // file creation hook
     private LogFileCreationCallback fileCreationCallback;
+    // When flushing, should `FSDataOutputStream#hsync` be called simultaneously
+    private boolean syncDuringFlush;
 
     private HoodieTableVersion tableVersion;
 
@@ -212,6 +214,11 @@ public interface HoodieLogFormat {
 
     public WriterBuilder withTableVersion(HoodieTableVersion writeTableVersion) {
       this.tableVersion = writeTableVersion;
+      return this;
+    }
+
+    public WriterBuilder withSyncDuringFlush(boolean sync) {
+      this.syncDuringFlush = sync;
       return this;
     }
 
@@ -287,8 +294,8 @@ public interface HoodieLogFormat {
       }
       return (Writer) ReflectionUtils.loadClass(
           DEFAULT_LOG_FORMAT_WRITER,
-          new Class[] {HoodieStorage.class, HoodieLogFile.class, Integer.class, Short.class, Long.class, String.class, LogFileCreationCallback.class},
-          storage, logFile, bufferSize, null, sizeThreshold, logWriteToken, fileCreationCallback
+          new Class[] {HoodieStorage.class, HoodieLogFile.class, Integer.class, Short.class, Long.class, String.class, LogFileCreationCallback.class, boolean.class},
+          storage, logFile, bufferSize, null, sizeThreshold, logWriteToken, fileCreationCallback, syncDuringFlush
       );
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -85,6 +85,17 @@ public interface HoodieLogFormat {
     AppendResult appendBlocks(List<HoodieLogBlock> blocks) throws IOException, InterruptedException;
 
     long getCurrentSize() throws IOException;
+
+    /**
+     * Force previously appended blocks to durable storage so that downstream
+     * readers can observe them before this writer is closed.
+     *
+     * <p>Production code paths typically rely on {@link #close()} for
+     * commit-level visibility and do not need to call this. It is exposed
+     * mainly for tests that assert per-append visibility on the underlying
+     * file system.
+     */
+    void sync() throws IOException;
   }
 
   /**
@@ -147,8 +158,6 @@ public interface HoodieLogFormat {
     private String suffix;
     // file creation hook
     private LogFileCreationCallback fileCreationCallback;
-    // When flushing, should `FSDataOutputStream#hsync` be called simultaneously
-    private boolean syncDuringFlush;
 
     private HoodieTableVersion tableVersion;
 
@@ -214,11 +223,6 @@ public interface HoodieLogFormat {
 
     public WriterBuilder withTableVersion(HoodieTableVersion writeTableVersion) {
       this.tableVersion = writeTableVersion;
-      return this;
-    }
-
-    public WriterBuilder withSyncDuringFlush(boolean sync) {
-      this.syncDuringFlush = sync;
       return this;
     }
 
@@ -294,8 +298,8 @@ public interface HoodieLogFormat {
       }
       return (Writer) ReflectionUtils.loadClass(
           DEFAULT_LOG_FORMAT_WRITER,
-          new Class[] {HoodieStorage.class, HoodieLogFile.class, Integer.class, Short.class, Long.class, String.class, LogFileCreationCallback.class, boolean.class},
-          storage, logFile, bufferSize, null, sizeThreshold, logWriteToken, fileCreationCallback, syncDuringFlush
+          new Class[] {HoodieStorage.class, HoodieLogFile.class, Integer.class, Short.class, Long.class, String.class, LogFileCreationCallback.class},
+          storage, logFile, bufferSize, null, sizeThreshold, logWriteToken, fileCreationCallback
       );
     }
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -58,6 +58,9 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
   private final LogFileCreationCallback fileCreationHook;
   private boolean closed = false;
   private transient Thread shutdownThread = null;
+  // NOTE: For 1.x, we should set this parameter to false by default.
+  // However, since some unit tests simulate the behavior of the block appending in 0.x, this parameter needs to be used to provide the logic for calling `hsync` during flush
+  private final boolean syncDuringFlush;
 
   public HoodieLogFormatWriter(
       HoodieStorage storage,
@@ -66,7 +69,8 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       Short replication,
       Long sizeThreshold,
       String rolloverLogWriteToken,
-      LogFileCreationCallback fileCreationHook) {
+      LogFileCreationCallback fileCreationHook,
+      boolean syncDuringFlush) {
     this.storage = storage;
     this.logFile = logFile;
     this.sizeThreshold = sizeThreshold;
@@ -74,6 +78,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     this.replication = replication != null ? replication : storage.getDefaultReplication(logFile.getPath().getParent());
     this.rolloverLogWriteToken = rolloverLogWriteToken;
     this.fileCreationHook = fileCreationHook;
+    this.syncDuringFlush = syncDuringFlush;
     addShutDownHook();
   }
 
@@ -237,11 +242,8 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
 
   private void closeStream() throws IOException {
     if (output != null) {
-      flush();
-      // Before closing the stream, call `FSDataOutputStream#hsync` to manually request DataNodes to perform data flushing to enhance the data persistence capability
-      // NOTE : the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
-      // See more details here : https://issues.apache.org/jira/browse/HDFS-744
-      output.hsync();
+      // Call flush and `FSDataOutputStream#hsync` to persist all the data to DataNodes
+      flush(true);
       output.close();
       output = null;
       closed = true;
@@ -249,10 +251,19 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
   }
 
   private void flush() throws IOException {
+    flush(syncDuringFlush);
+  }
+
+  private void flush(boolean sync) throws IOException {
     if (output == null) {
       return; // Presume closed
     }
     output.flush();
+    if (sync) {
+      // NOTE : the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
+      // See more details here : https://issues.apache.org/jira/browse/HDFS-744
+      output.hsync();
+    }
   }
 
   @Override

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -58,9 +58,6 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
   private final LogFileCreationCallback fileCreationHook;
   private boolean closed = false;
   private transient Thread shutdownThread = null;
-  // NOTE: For 1.x, we should set this parameter to false by default.
-  // However, since some unit tests simulate the behavior of the block appending in 0.x, this parameter needs to be used to provide the logic for calling `hsync` during flush
-  private final boolean syncDuringFlush;
 
   public HoodieLogFormatWriter(
       HoodieStorage storage,
@@ -69,8 +66,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       Short replication,
       Long sizeThreshold,
       String rolloverLogWriteToken,
-      LogFileCreationCallback fileCreationHook,
-      boolean syncDuringFlush) {
+      LogFileCreationCallback fileCreationHook) {
     this.storage = storage;
     this.logFile = logFile;
     this.sizeThreshold = sizeThreshold;
@@ -78,7 +74,6 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     this.replication = replication != null ? replication : storage.getDefaultReplication(logFile.getPath().getParent());
     this.rolloverLogWriteToken = rolloverLogWriteToken;
     this.fileCreationHook = fileCreationHook;
-    this.syncDuringFlush = syncDuringFlush;
     addShutDownHook();
   }
 
@@ -184,9 +179,10 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       }
       sizeWritten +=  outputStream.size() - startSize;
     }
-    // Flush all blocks
-    // Only the stream flush, not guarantee that the data has been thoroughly persisted
-    flush();
+    // No flush/hsync here: append-time visibility is not part of the contract.
+    // Downstream readers only need commit-level visibility, which is provided
+    // when the writer is closed (see closeStream) or when callers explicitly
+    // invoke sync().
 
     AppendResult result = new AppendResult(logFile, startPos, sizeWritten);
     // roll over if size is past the threshold
@@ -242,28 +238,24 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
 
   private void closeStream() throws IOException {
     if (output != null) {
-      // Call flush and `FSDataOutputStream#hsync` to persist all the data to DataNodes
-      flush(true);
+      // Persist all buffered data to DataNodes before closing so downstream
+      // readers can observe a fully-written log file at commit-level visibility.
+      sync();
       output.close();
       output = null;
       closed = true;
     }
   }
 
-  private void flush() throws IOException {
-    flush(syncDuringFlush);
-  }
-
-  private void flush(boolean sync) throws IOException {
+  @Override
+  public void sync() throws IOException {
     if (output == null) {
       return; // Presume closed
     }
     output.flush();
-    if (sync) {
-      // NOTE : the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
-      // See more details here : https://issues.apache.org/jira/browse/HDFS-744
-      output.hsync();
-    }
+    // NOTE: the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
+    // See more details here: https://issues.apache.org/jira/browse/HDFS-744
+    output.hsync();
   }
 
   @Override

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -179,7 +179,8 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       }
       sizeWritten +=  outputStream.size() - startSize;
     }
-    // Flush all blocks to disk
+    // Flush all blocks
+    // Only the stream flush, not guarantee that the data has been thoroughly persisted
     flush();
 
     AppendResult result = new AppendResult(logFile, startPos, sizeWritten);
@@ -237,6 +238,10 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
   private void closeStream() throws IOException {
     if (output != null) {
       flush();
+      // Before closing the stream, call `FSDataOutputStream#hsync` to manually request DataNodes to perform data flushing to enhance the data persistence capability
+      // NOTE : the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
+      // See more details here : https://issues.apache.org/jira/browse/HDFS-744
+      output.hsync();
       output.close();
       output = null;
       closed = true;
@@ -248,9 +253,6 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       return; // Presume closed
     }
     output.flush();
-    // NOTE : the following API call makes sure that the data is flushed to disk on DataNodes (akin to POSIX fsync())
-    // See more details here : https://issues.apache.org/jira/browse/HDFS-744
-    output.hsync();
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -208,7 +208,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testEmptyLog() throws IOException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     assertEquals(0, writer.getCurrentSize(), "Just created this log, size should be 0");
@@ -221,7 +221,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testBasicAppend(HoodieLogBlockType dataBlockType) throws IOException, InterruptedException, URISyntaxException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -245,7 +245,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testRollover() throws IOException, InterruptedException, URISyntaxException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -264,7 +264,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Create a writer with the size threshold as the size we just wrote - so this has to roll
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(size - 1).build();
@@ -306,11 +306,11 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
   private void testConcurrentAppend(boolean logFileExists, boolean newLogFileFormat) throws Exception {
     HoodieLogFormat.WriterBuilder builder1 =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
             .withInstantTime("100").withStorage(storage);
     HoodieLogFormat.WriterBuilder builder2 =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
             .withInstantTime("100").withStorage(storage);
 
@@ -350,7 +350,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testMultipleAppend(HoodieLogBlockType dataBlockType) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -364,7 +364,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -382,7 +382,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Close and Open again and append 100 more records
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -438,7 +438,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @ValueSource(ints = {6, 8})
   public void testBasicWriteAndScan(int tableVersion) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withTableVersion(HoodieTableVersion.fromVersionCode(tableVersion))
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
@@ -473,7 +473,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testHugeLogFileWrite() throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(3L * 1024 * 1024 * 1024)
@@ -523,7 +523,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testBasicAppendAndRead(HoodieLogBlockType dataBlockType) throws IOException, URISyntaxException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath)
+        .onParentPath(partitionPath).withSyncDuringFlush(true)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -541,7 +541,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.close();
 
     writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath)
+        .onParentPath(partitionPath).withSyncDuringFlush(true)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -560,7 +560,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Close and Open again and append 100 more records
     writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath)
+        .onParentPath(partitionPath).withSyncDuringFlush(true)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -612,7 +612,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testCDCBlock() throws IOException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath)
+        .onParentPath(partitionPath).withSyncDuringFlush(true)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -1060,7 +1060,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
   private HoodieLogFile addValidBlock(String fileId, String commitTime, int numRecords) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime(commitTime).withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, numRecords);
@@ -1077,7 +1077,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
                                          int numRecords)
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime(commitTime).withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -1095,7 +1095,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testValidateCorruptBlockEndPosition() throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -1151,7 +1151,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(500).build();
@@ -1195,7 +1195,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1258,7 +1258,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1295,7 +1295,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     // Write 3
@@ -1328,7 +1328,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1469,7 +1469,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Set a small threshold so that every block is a new version
     String fileId = "test-fileid111";
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime("100").withStorage(storage).build();
 
@@ -1577,7 +1577,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1710,7 +1710,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1779,7 +1779,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1831,7 +1831,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1868,7 +1868,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1922,7 +1922,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<String> deleteKeyListInV2Block = Arrays.asList(
@@ -2045,7 +2045,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2105,7 +2105,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2149,7 +2149,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2169,7 +2169,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     // Write 1 rollback block for the last commit instant
@@ -2200,7 +2200,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2272,7 +2272,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -2402,7 +2402,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       List<IndexedRecord> records2 = new ArrayList<>(records);
 
       // Write1 with numRecordsInLog1 records written to log.1
-      Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+      Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
           .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
           .withInstantTime("100").withStorage(storage).build();
 
@@ -2416,7 +2416,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       writer.close();
 
       // write2 with numRecordsInLog2 records written to log.2
-      Writer writer2 = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+      Writer writer2 = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
           .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
           .withInstantTime("100").withStorage(storage).withSizeThreshold(size - 1).build();
 
@@ -2496,7 +2496,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testBasicAppendAndReadInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2566,7 +2566,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testAppendAndReadOnCorruptedLogInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2599,7 +2599,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Should be able to append a new block
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -2628,7 +2628,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testBasicAppendAndTraverseInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2715,7 +2715,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       HoodieLogBlockType dataBlockType
   ) throws IOException, URISyntaxException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath)
+        .onParentPath(partitionPath).withSyncDuringFlush(true)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -2860,7 +2860,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   private HoodieLogFormat.Reader createCorruptedFile(String fileId) throws Exception {
     // block is corrupted, but check is skipped.
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -208,7 +208,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testEmptyLog() throws IOException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     assertEquals(0, writer.getCurrentSize(), "Just created this log, size should be 0");
@@ -221,7 +221,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testBasicAppend(HoodieLogBlockType dataBlockType) throws IOException, InterruptedException, URISyntaxException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -234,8 +234,9 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     long size = writer.getCurrentSize();
     assertTrue(size > 0, "We just wrote a block - size should be > 0");
+    writer.sync();
     assertEquals(size, storage.getPathInfo(writer.getLogFile().getPath()).getLength(),
-        "Write should be auto-flushed. The size reported by FileStatus and the writer should match");
+        "After explicit sync, FileStatus length should match the writer's reported size");
     assertEquals(size, result.size());
     assertEquals(writer.getLogFile(), result.logFile());
     assertEquals(0, result.offset());
@@ -245,7 +246,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testRollover() throws IOException, InterruptedException, URISyntaxException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -264,7 +265,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Create a writer with the size threshold as the size we just wrote - so this has to roll
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(size - 1).build();
@@ -306,11 +307,11 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
   private void testConcurrentAppend(boolean logFileExists, boolean newLogFileFormat) throws Exception {
     HoodieLogFormat.WriterBuilder builder1 =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
             .withInstantTime("100").withStorage(storage);
     HoodieLogFormat.WriterBuilder builder2 =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
             .withInstantTime("100").withStorage(storage);
 
@@ -350,7 +351,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testMultipleAppend(HoodieLogBlockType dataBlockType) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -364,7 +365,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -376,13 +377,14 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     long size2 = writer.getCurrentSize();
     assertTrue(size2 > size1, "We just wrote a new block - size2 should be > size1");
+    writer.sync();
     assertEquals(size2, storage.getPathInfo(writer.getLogFile().getPath()).getLength(),
-        "Write should be auto-flushed. The size reported by FileStatus and the writer should match");
+        "After explicit sync, FileStatus length should match the writer's reported size");
     writer.close();
 
     // Close and Open again and append 100 more records
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withLogVersion(1).withInstantTime("100")
             .withStorage(storage).build();
@@ -394,8 +396,9 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.appendBlock(dataBlock);
     long size3 = writer.getCurrentSize();
     assertTrue(size3 > size2, "We just wrote a new block - size3 should be > size2");
+    writer.sync();
     assertEquals(size3, storage.getPathInfo(writer.getLogFile().getPath()).getLength(),
-        "Write should be auto-flushed. The size reported by FileStatus and the writer should match");
+        "After explicit sync, FileStatus length should match the writer's reported size");
     writer.close();
 
     // Cannot get the current size after closing the log
@@ -438,7 +441,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @ValueSource(ints = {6, 8})
   public void testBasicWriteAndScan(int tableVersion) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withTableVersion(HoodieTableVersion.fromVersionCode(tableVersion))
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
@@ -473,7 +476,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testHugeLogFileWrite() throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(3L * 1024 * 1024 * 1024)
@@ -523,7 +526,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @EnumSource(names = {"AVRO_DATA_BLOCK", "HFILE_DATA_BLOCK", "PARQUET_DATA_BLOCK"})
   public void testBasicAppendAndRead(HoodieLogBlockType dataBlockType) throws IOException, URISyntaxException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath).withSyncDuringFlush(true)
+        .onParentPath(partitionPath)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -541,7 +544,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     writer.close();
 
     writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath).withSyncDuringFlush(true)
+        .onParentPath(partitionPath)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -560,7 +563,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Close and Open again and append 100 more records
     writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath).withSyncDuringFlush(true)
+        .onParentPath(partitionPath)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -612,7 +615,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testCDCBlock() throws IOException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath).withSyncDuringFlush(true)
+        .onParentPath(partitionPath)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -1060,7 +1063,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
   private HoodieLogFile addValidBlock(String fileId, String commitTime, int numRecords) throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime(commitTime).withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, numRecords);
@@ -1077,7 +1080,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
                                          int numRecords)
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime(commitTime).withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -1095,7 +1098,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   @Test
   public void testValidateCorruptBlockEndPosition() throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
@@ -1151,7 +1154,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage)
             .withSizeThreshold(500).build();
@@ -1195,7 +1198,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1258,7 +1261,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1295,7 +1298,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     // Write 3
@@ -1328,7 +1331,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1469,7 +1472,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Set a small threshold so that every block is a new version
     String fileId = "test-fileid111";
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime("100").withStorage(storage).build();
 
@@ -1577,7 +1580,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1710,7 +1713,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1779,7 +1782,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1831,7 +1834,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1868,7 +1871,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -1922,7 +1925,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     List<String> deleteKeyListInV2Block = Arrays.asList(
@@ -2045,7 +2048,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2105,7 +2108,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2149,7 +2152,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2169,7 +2172,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     // Write 1 rollback block for the last commit instant
@@ -2200,7 +2203,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(getSimpleSchema());
     // Set a small threshold so that every block is a new version
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
 
@@ -2272,7 +2275,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.close();
 
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -2402,7 +2405,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       List<IndexedRecord> records2 = new ArrayList<>(records);
 
       // Write1 with numRecordsInLog1 records written to log.1
-      Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+      Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
           .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
           .withInstantTime("100").withStorage(storage).build();
 
@@ -2416,7 +2419,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       writer.close();
 
       // write2 with numRecordsInLog2 records written to log.2
-      Writer writer2 = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+      Writer writer2 = HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
           .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId("test-fileid1")
           .withInstantTime("100").withStorage(storage).withSizeThreshold(size - 1).build();
 
@@ -2496,7 +2499,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testBasicAppendAndReadInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2566,7 +2569,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testAppendAndReadOnCorruptedLogInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2599,7 +2602,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     // Should be able to append a new block
     writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     ((HoodieLogFormatWriter) writer).withOutputStream(
@@ -2628,7 +2631,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   public void testBasicAppendAndTraverseInReverse()
       throws IOException, URISyntaxException, InterruptedException {
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId("test-fileid1").withInstantTime("100").withStorage(storage).build();
     HoodieSchema schema = getSimpleSchema();
@@ -2715,7 +2718,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
       HoodieLogBlockType dataBlockType
   ) throws IOException, URISyntaxException, InterruptedException {
     Writer writer = HoodieLogFormat.newWriterBuilder()
-        .onParentPath(partitionPath).withSyncDuringFlush(true)
+        .onParentPath(partitionPath)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
         .withFileId("test-fileid1")
         .withInstantTime("100")
@@ -2860,7 +2863,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
   private HoodieLogFormat.Reader createCorruptedFile(String fileId) throws Exception {
     // block is corrupted, but check is skipped.
     Writer writer =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withSyncDuringFlush(true)
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath)
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
             .withFileId(fileId).withInstantTime("100").withStorage(storage).build();
     List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);


### PR DESCRIPTION
Before this optimization：
The average throughput on one of our real writer is 127k：
<img width="2424" height="596" alt="image" src="https://github.com/user-attachments/assets/4b6a872b-12e7-4165-8519-aaf94aac6e3a" />
After this optimization:
160k!
<img width="2432" height="602" alt="image" src="https://github.com/user-attachments/assets/4337a459-0983-4b07-9bb7-280c5caf0937" />
We have conducted stress tests in multiple scenarios, and the performance can be significantly increased by 20% to 40%


### Describe the issue this Pull Request addresses

closes #17516 

### Summary and Changelog

1. Reduce unnecessary `FSDataOutputStream#hsync` to enhance append performance

### Impact

write performance improvement

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
