### PR TITLE
fix: Fix Flink profiles and modules for release version change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <module>packaging/hudi-trino-bundle</module>
     <module>hudi-examples</module>
     <module>hudi-flink-datasource</module>
-    <module>hudi-flink-datasource/${hudi.flink.module}</module>
     <module>hudi-kafka-connect</module>
     <module>packaging/hudi-flink-bundle</module>
     <module>packaging/hudi-kafka-connect-bundle</module>
@@ -2664,6 +2663,9 @@
         <flink.format.parquet.version>1.14.4</flink.format.parquet.version>
         <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility</flink.hadoop.compatibility.artifactId>
       </properties>
+      <modules>
+        <module>hudi-flink-datasource/hudi-flink2.0.x</module>
+      </modules>
       <activation>
         <property>
           <name>flink2.0</name>
@@ -2682,6 +2684,9 @@
         <flink.connector.kafka.version>3.3.0-1.20</flink.connector.kafka.version>
         <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility_2.12</flink.hadoop.compatibility.artifactId>
       </properties>
+      <modules>
+        <module>hudi-flink-datasource/hudi-flink1.20.x</module>
+      </modules>
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
@@ -2701,6 +2706,9 @@
         <flink.connector.kafka.version>3.2.0-1.19</flink.connector.kafka.version>
         <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility_2.12</flink.hadoop.compatibility.artifactId>
       </properties>
+      <modules>
+        <module>hudi-flink-datasource/hudi-flink1.19.x</module>
+      </modules>
       <activation>
         <property>
           <name>flink1.19</name>
@@ -2719,6 +2727,9 @@
         <flink.connector.kafka.version>3.2.0-1.18</flink.connector.kafka.version>
         <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility_2.12</flink.hadoop.compatibility.artifactId>
       </properties>
+      <modules>
+        <module>hudi-flink-datasource/hudi-flink1.18.x</module>
+      </modules>
       <activation>
         <property>
           <name>flink1.18</name>
@@ -2737,6 +2748,9 @@
         <flink.connector.kafka.version>${flink1.17.version}</flink.connector.kafka.version>
         <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility_2.12</flink.hadoop.compatibility.artifactId>
       </properties>
+      <modules>
+        <module>hudi-flink-datasource/hudi-flink1.17.x</module>
+      </modules>
       <activation>
         <property>
           <name>flink1.17</name>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

After running `mvn versions:set -DnewVersion=1.3.0-SNAPSHOT -DdeployArtifacts=true`, the Flink version-specific modules do not have their versions updated in:
```
hudi-flink-datasource/hudi-flink1.17.x/pom.xml
hudi-flink-datasource/hudi-flink1.18.x/pom.xml
hudi-flink-datasource/hudi-flink1.19.x/pom.xml
hudi-flink-datasource/hudi-flink1.20.x/pom.xml
hudi-flink-datasource/hudi-flink2.0.x/pom.xml
```

This happens because these modules are not properly attached to the root POM. The main modules section contained `<module>hudi-flink-datasource/${hudi.flink.module}</module>`, which uses a property reference that cannot be resolved when running `mvn versions:set` without activating specific Flink profiles. Unlike Spark modules, which declare version-specific modules explicitly within their respective profiles, Flink modules relied on this property-based approach, which breaks during release version changes.

### Summary and Changelog

This PR aligns Flink module configuration with the Spark module pattern to ensure proper version management during releases.
- Removes property-based module reference `<module>hudi-flink-datasource/${hudi.flink.module}</module>` from the main modules section;
- Adds explicit `<modules>` section to all Flink profiles.

### Impact

Smooth release version change. 

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable