### PR TITLE
chore: keep collaborators <= 10

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,8 +52,6 @@ github:
     - vamsikarnika
     - rahil-c
     - lokeshj1703
-    - CTTY
-    - mansipp
     - hudi-bot
 notifications:
   commits:      commits@hudi.apache.org


### PR DESCRIPTION

> You can only have a maximum of 10 external triage collaborators, please contact [vp-infra@apache.org](mailto:vp-infra@apache.org) to request an exception.
