### PR TITLE
fix: Fix failing CI caused by multiple definition of IncompatibleSchemaExc…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -242,5 +242,3 @@ object HoodieSparkSchemaConverters {
       }
   }
 }
-
-private[avro] class IncompatibleSchemaException(msg: String, ex: Throwable = null) extends Exception(msg, ex)


### PR DESCRIPTION
…eption

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Spark CIs are failing due to the following error:

```log
Error:  /home/runner/work/hudi/hudi/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala:245: error: IncompatibleSchemaException is already defined as class IncompatibleSchemaException
Error:  private[avro] class IncompatibleSchemaException(msg: String, ex: Throwable = null) extends Exception(msg, ex)
Error:                      ^
Error: [ERROR] one error found
```

`IncompatibleSchemaException` was defined in:
1. `SchemaConverters`
2. `HoodieSparkSchemaConverters` [#17475](https://github.com/apache/hudi/pull/17475)

This PR fixes the CI.

Failing CI link:
https://github.com/apache/hudi/actions/runs/20123663494/job/57748838723?pr=17535#step:4:1132

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Remove `IncompatibleSchemaException` declaration in `HoodieSparkSchemaConverters`.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

None

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
