### PR TITLE
docs: Blogs page redirection

### DIFF
--- a/website/src/components/BlogsSlider/BlogCard.js
+++ b/website/src/components/BlogsSlider/BlogCard.js
@@ -19,7 +19,7 @@ const BlogCard = ({ blog }) => {
 
   return (
     <div className={styles.blogsWrapper}>
-      <Link itemProp="url" to={permalink} className={styles.link}>
+      <Link itemProp="url" to={permalink} className={styles.link} target="_blank" rel="noopener noreferrer">
         <div className={styles.cardBlogs}>
           <div>
             <div className={styles.blogImgWrapper}>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Hudi Blog section on the project's home page contains links to individual blog posts. The current behavior is to open these links in the same browser tab. This interrupts the user's flow and causes them to navigate away from the main site.

This Pull Request addresses this by ensuring a better user experience, where clicking any blog link opens the destination in a new browser tab or window.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog
This change implements a minor but significant user experience improvement. By adding the target="_blank" attribute to the blog link elements, all links within the Hudi Blog section will now open in a new tab.
<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
Low. This is purely a front-end user experience (UX) change.
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
none
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
none
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
