### PR TITLE
fix: Fixing unions for partitioned RLI bootstrap

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -793,7 +793,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     HoodieTimer partitionInitTimer = HoodieTimer.start();
 
     // Generate the file groups
-    HoodieData<HoodieRecord> records = engineContext.emptyHoodieData();
+    List<HoodieData<HoodieRecord>> hoodieDataList = new ArrayList<>();
     clearExistingMetadataPartition(RECORD_INDEX.getPartitionPath());
     TreeMap<String, Integer> partitionSizes = new TreeMap<>();
     for (String dataPartition : fileGroupCountAndRecordsPairMap.keySet()) {
@@ -801,9 +801,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       ValidationUtils.checkArgument(fileGroupCountAndRecordsPair.getKey() > 0, "FileGroup count for partitioned RLI data partition " + dataPartition + " should be > 0");
       partitionSizes.put(dataPartition, fileGroupCountAndRecordsPair.getKey());
       initializeFileGroups(dataMetaClient, RECORD_INDEX, commitTimeForPartition, fileGroupCountAndRecordsPair.getKey(), RECORD_INDEX.getPartitionPath(), Option.of(dataPartition));
-      records = records.union(fileGroupCountAndRecordsPair.getValue());
+      hoodieDataList.add(fileGroupCountAndRecordsPair.getValue());
     }
-
+    HoodieData<HoodieRecord> records = engineContext.union(hoodieDataList);
     // Perform the commit using bulkCommit
     bulkCommit(commitTimeForPartition, RECORD_INDEX.getPartitionPath(), records,  new BucketizedMetadataTableFileGroupIndexParser(partitionSizes));
     dataMetaClient.getTableConfig().setMetadataPartitionState(dataMetaClient, RECORD_INDEX.getPartitionPath(), true);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -52,6 +52,7 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.util.FlinkClientUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -110,6 +111,13 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> parallelize(List<T> data, int parallelism) {
     return HoodieListData.eager(data);
+  }
+
+  @Override
+  public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
+    List<T> allData = new ArrayList<>();
+    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    return HoodieListData.eager(allData);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -116,7 +116,7 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
     List<T> allData = new ArrayList<>();
-    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
     return HoodieListData.eager(allData);
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -52,7 +52,6 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.util.FlinkClientUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -115,9 +114,9 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
 
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
-    List<T> allData = new ArrayList<>();
-    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
-    return HoodieListData.eager(allData);
+    return HoodieListData.eager(dataList.stream()
+        .flatMap(hoodieData -> hoodieData.collectAsList().stream())
+        .collect(Collectors.toList()));
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.common;
 
+import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 
 import org.junit.jupiter.api.Assertions;
@@ -29,6 +30,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit test against HoodieFlinkEngineContext.
@@ -47,8 +52,8 @@ public class TestHoodieFlinkEngineContext {
     List<Integer> result = context.map(mapList, x -> x + 1, 2);
     result.removeAll(mapList);
 
-    Assertions.assertEquals(1, result.size());
-    Assertions.assertEquals(11, result.get(0));
+    assertEquals(1, result.size());
+    assertEquals(11, result.get(0));
   }
 
   @Test
@@ -64,7 +69,7 @@ public class TestHoodieFlinkEngineContext {
 
     List<String> result = context.flatMap(inputList, Collection::stream, 2);
 
-    Assertions.assertEquals(9, result.size());
+    assertEquals(9, result.size());
   }
 
   @Test
@@ -73,7 +78,7 @@ public class TestHoodieFlinkEngineContext {
     List<Integer> result = new ArrayList<>(10);
     context.foreach(mapList, result::add, 2);
 
-    Assertions.assertEquals(result.size(), mapList.size());
+    assertEquals(result.size(), mapList.size());
     Assertions.assertTrue(result.containsAll(mapList));
   }
 
@@ -86,7 +91,21 @@ public class TestHoodieFlinkEngineContext {
       return new ImmutablePair<>(splits[0], splits[1]);
     }, 2);
 
-    Assertions.assertEquals(resultMap.get("spark"), resultMap.get("flink"));
+    assertEquals(resultMap.get("spark"), resultMap.get("flink"));
   }
 
+  @Test
+  public void testUnion() {
+    List<HoodieData<Integer>> dataList = new ArrayList<>();
+    for (int i = 0;i < 50;i++) {
+      dataList.add(context.parallelize(
+          IntStream.rangeClosed(i * 100, (i * 100) + 99).boxed().collect(Collectors.toList()), 6));
+    }
+
+    List<Integer> expected = context.parallelize(
+        IntStream.rangeClosed(0, 50 * 100 - 1).boxed().collect(Collectors.toList()), 6).collectAsList();
+
+    List<Integer> actual = context.union(dataList).collectAsList();
+    assertEquals(expected, actual);
+  }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
@@ -102,7 +102,7 @@ public class HoodieJavaEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
     List<T> allData = new ArrayList<>();
-    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
     return HoodieListData.eager(allData);
   }
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
@@ -48,7 +48,6 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -101,9 +100,9 @@ public class HoodieJavaEngineContext extends HoodieEngineContext {
 
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
-    List<T> allData = new ArrayList<>();
-    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
-    return HoodieListData.eager(allData);
+    return HoodieListData.eager(dataList.stream()
+        .flatMap(hoodieData -> hoodieData.collectAsList().stream())
+        .collect(Collectors.toList()));
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
@@ -48,6 +48,7 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -96,6 +97,13 @@ public class HoodieJavaEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> parallelize(List<T> data, int parallelism) {
     return HoodieListData.eager(data);
+  }
+
+  @Override
+  public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
+    List<T> allData = new ArrayList<>();
+    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    return HoodieListData.eager(allData);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -136,6 +136,16 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
+    List<JavaRDD<T>> javaRDDList = dataList.stream().map(hoodieData -> HoodieJavaRDD.getJavaRDD(hoodieData)).collect(Collectors.toList());
+    if (javaRDDList.isEmpty()) {
+      return HoodieJavaRDD.of(javaSparkContext.emptyRDD());
+    } else {
+      return HoodieJavaRDD.of(javaSparkContext.union(javaRDDList.toArray(new JavaRDD[0])));
+    }
+  }
+
+  @Override
   public <I, O> List<O> map(List<I> data, SerializableFunction<I, O> func, int parallelism) {
     final Map<String, Registry> registries = DISTRIBUTED_REGISTRY_MAP;
     return javaSparkContext.parallelize(data, parallelism).map(i -> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -137,7 +137,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
 
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
-    List<JavaRDD<T>> javaRDDList = dataList.stream().map(hoodieData -> HoodieJavaRDD.getJavaRDD(hoodieData)).collect(Collectors.toList());
+    List<JavaRDD<T>> javaRDDList = dataList.stream().map(HoodieJavaRDD::getJavaRDD).collect(Collectors.toList());
     if (javaRDDList.isEmpty()) {
       return HoodieJavaRDD.of(javaSparkContext.emptyRDD());
     } else {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineContext.java
@@ -61,6 +61,21 @@ public class TestHoodieSparkEngineContext extends SparkClientFunctionalTestHarne
   }
 
   @Test
+  public void testUnion() {
+    List<HoodieData<Integer>> dataList = new ArrayList<>();
+    for (int i = 0;i < 50;i++) {
+      dataList.add(context.parallelize(
+          IntStream.rangeClosed(i * 100, (i * 100) + 99).boxed().collect(Collectors.toList()), 6));
+    }
+
+    List<Integer> expected = context.parallelize(
+        IntStream.rangeClosed(0, 50 * 100 - 1).boxed().collect(Collectors.toList()), 6).collectAsList();
+
+    List<Integer> actual = context.union(dataList).collectAsList();
+    assertEquals(expected, actual);
+  }
+
+  @Test
   void testSetJobStatus() {
     // Test data
     String jobGroupId = "jobGroupId";

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/ExecutorServiceBasedEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/ExecutorServiceBasedEngineContext.java
@@ -149,6 +149,13 @@ public class ExecutorServiceBasedEngineContext extends HoodieEngineContext {
   }
 
   @Override
+  public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
+    return HoodieListData.eager(dataList.stream()
+        .flatMap(hoodieData -> hoodieData.collectAsList().stream())
+        .collect(Collectors.toList()));
+  }
+
+  @Override
   public <I, O> List<O> map(List<I> data, SerializableFunction<I, O> func, int parallelism) {
     return mapAsync(data, FunctionWrapper.throwingMapWrapper(func));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
@@ -80,6 +80,8 @@ public abstract class HoodieEngineContext {
     }
   }
 
+  public abstract <T> HoodieData<T> union(List<HoodieData<T>> dataList);
+
   public abstract <T> HoodieData<T> parallelize(List<T> data, int parallelism);
 
   public abstract <I, O> List<O> map(List<I> data, SerializableFunction<I, O> func, int parallelism);

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
@@ -42,6 +42,7 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -89,6 +90,13 @@ public final class HoodieLocalEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> parallelize(List<T> data, int parallelism) {
     return HoodieListData.eager(data);
+  }
+
+  @Override
+  public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
+    List<T> allData = new ArrayList<>();
+    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    return HoodieListData.eager(allData);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
@@ -42,7 +42,6 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -94,9 +93,9 @@ public final class HoodieLocalEngineContext extends HoodieEngineContext {
 
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
-    List<T> allData = new ArrayList<>();
-    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
-    return HoodieListData.eager(allData);
+    return HoodieListData.eager(dataList.stream()
+        .flatMap(hoodieData -> hoodieData.collectAsList().stream())
+        .collect(Collectors.toList()));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
@@ -95,7 +95,7 @@ public final class HoodieLocalEngineContext extends HoodieEngineContext {
   @Override
   public <T> HoodieData<T> union(List<HoodieData<T>> dataList) {
     List<T> allData = new ArrayList<>();
-    dataList.forEach(entry -> allData.addAll(entry.collectAsList()));
+    dataList.forEach(hoodieData -> allData.addAll(hoodieData.collectAsList()));
     return HoodieListData.eager(allData);
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/engine/TestExecutorServiceBasedEngineContext.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/engine/TestExecutorServiceBasedEngineContext.java
@@ -18,12 +18,14 @@
 
 package org.apache.hudi.common.engine;
 
+import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.HoodieStorage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -108,5 +110,20 @@ public class TestExecutorServiceBasedEngineContext {
     }, 1);
     assertEquals(ExecutorServiceBasedEngineContext.class.getClassLoader(), captured[0],
         "Worker threads must use ExecutorServiceBasedEngineContext classloader to avoid ClassNotFoundException on Java 11+");
+  }
+
+  @Test
+  void testUnion() {
+    List<HoodieData<Integer>> dataList = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      dataList.add(context.parallelize(
+          IntStream.rangeClosed(i * 100, (i * 100) + 99).boxed().collect(Collectors.toList()), 6));
+    }
+
+    List<Integer> expected = context.parallelize(
+        IntStream.rangeClosed(0, 50 * 100 - 1).boxed().collect(Collectors.toList()), 6).collectAsList();
+
+    List<Integer> actual = context.union(dataList).collectAsList();
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixing unions of rdd for partitioned RLI bootstrap.
For partitioned RLI bootstrap, we create N rdd's for N table partitions and union them all before we trigger bulk insert in MDT RLI partition. At TB scale, we are running into StackOverFlow error.

17760 [main] INFO  org.apache.spark.SparkContext [] - Starting job: count at DeepLineageRepro.java:53
Exception in thread "dag-scheduler-event-loop" java.lang.StackOverflowError
	at scala.Option.flatMap(Option.scala:271)
	at org.apache.spark.rdd.RDD.checkpointRDD(RDD.scala:247)
	at org.apache.spark.rdd.RDD.dependencies(RDD.scala:254)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)
	at org.apache.spark.rdd.RDD.isBarrier(RDD.scala:2050)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.$anonfun$isBarrier_$2$adapted(RDD.scala:2055)
	at scala.collection.IndexedSeqOptimized.prefixLengthImpl(IndexedSeqOptimized.scala:41)
	at scala.collection.IndexedSeqOptimized.exists(IndexedSeqOptimized.scala:49)
	at scala.collection.IndexedSeqOptimized.exists$(IndexedSeqOptimized.scala:49)
	at scala.collection.mutable.ArrayBuffer.exists(ArrayBuffer.scala:49)
	at org.apache.spark.rdd.RDD.isBarrier_$lzycompute(RDD.scala:2055)
	at org.apache.spark.rdd.RDD.isBarrier_(RDD.scala:2054)

Response from chatgpt:

this stacktrace is actually very characteristic of a Spark task deserialization / closure serialization problem, and the pattern rdd1.union(rdd2).union(rdd3)... is a classic way to trigger it at scale.

What’s really failing?

Your executor is dying with:

java.lang.StackOverflowError

deep inside java.io.ObjectInputStream.readObject0/defaultReadFields/readArray/...

That means the executor is deserializing something enormous / deeply nested (the “task binary”: the serialized task + closure + referenced objects + parts of the RDD lineage metadata), and the Java deserializer hits recursive depth and blows the thread stack.

This is why you don’t see any “Hudi code” in the trace: the failure happens before your task even starts running your logic — while Spark is reconstructing the task on the executor.

Why does chaining 500 unions cause this?

RDD.union doesn’t merge data immediately — it creates a new RDD node with dependencies on its parents.

When you do:

rdd1.union(rdd2).union(rdd3)...union(rdd500)

you’re building a deeply nested lineage like:

Union( Union( Union( rdd1, rdd2), rdd3), rdd4) ... )

Depth ≈ 500.

At small scale, Spark may get away with it (fewer partitions/tasks, smaller serialized task payloads). At TB scale:

more partitions → more tasks → more task shipping/deserialization events

scheduler/closure serialization overhead grows

the nested object graph representing the RDD dependencies becomes “deep enough” that Java serialization recursion overflows

Fixes (best → fallback)
✅ Fix 1: Use SparkContext.union over a collection (flat union)

This avoids the “nested union of unions” structure.

val finalRdd = spark.sparkContext.union(rddsSeq) // Seq[RDD[Record]]

or in Java:

JavaRDD finalRdd = sc.union(rddList);

This tends to create a single UnionRDD with many parents instead of a deep recursive nesting.

and hence the fix in this patch.

### Summary and Changelog

Fixing rdd unioning during Partitioned RLI bootstrap for large tables. 

### Impact

Smooth RLI initialization for partitioned RLI.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
