### PR TITLE
refactor: Remove old code and comments after deprecating Scala 2.11 support

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkValidatorUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkValidatorUtils.java
@@ -153,7 +153,7 @@ public class SparkValidatorUtils {
    * Get records from specified list of data files.
    */
   public static Dataset<Row> readRecordsForBaseFiles(SQLContext sqlContext, List<String> baseFilePaths) {
-    return sqlContext.read().parquet(JavaScalaConverters.<String>convertJavaListToScalaSeq(baseFilePaths));
+    return sqlContext.read().parquet(JavaScalaConverters.convertJavaListToScalaSeq(baseFilePaths));
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertDataInternalWriterHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertDataInternalWriterHelper.java
@@ -129,26 +129,23 @@ public class BulkInsertDataInternalWriterHelper {
       boolean shouldDropPartitionColumns = writeConfig.shouldDropPartitionColumns();
       if (shouldDropPartitionColumns) {
         // Drop the partition columns from the row
-        // Using the deprecated JavaConversions to be compatible with scala versions < 2.12. Once hudi support for scala versions < 2.12 is
-        // stopped, can move this to JavaConverters.seqAsJavaList(...)
         List<String> partitionCols = JavaScalaConverters.convertScalaListToJavaList(HoodieDatasetBulkInsertHelper.getPartitionPathCols(this.writeConfig));
-        Set<Integer> partitionIdx = new HashSet<Integer>();
+        Set<Integer> partitionIdx = new HashSet<>();
         for (String col : partitionCols) {
           partitionIdx.add(this.structType.fieldIndex(col));
         }
 
         // Relies on InternalRow::toSeq(...) preserving the column ordering based on the supplied schema
-        // Using the deprecated JavaConversions to be compatible with scala versions < 2.12.
         List<Object> cols = JavaScalaConverters.convertScalaListToJavaList(row.toSeq(structType));
         int idx = 0;
-        List<Object> newCols = new ArrayList<Object>();
+        List<Object> newCols = new ArrayList<>();
         for (Object o : cols) {
           if (!partitionIdx.contains(idx)) {
             newCols.add(o);
           }
           idx += 1;
         }
-        InternalRow newRow = InternalRow.fromSeq(JavaScalaConverters.<Object>convertJavaListToScalaSeq(newCols));
+        InternalRow newRow = InternalRow.fromSeq(JavaScalaConverters.convertJavaListToScalaSeq(newCols));
         handle.write(newRow);
       } else {
         handle.write(row);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FileSystemRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FileSystemRelation.scala
@@ -107,8 +107,6 @@ class FileSystemRelation(val sqlContext: SQLContext,
       }))
     }))
 
-    // Using deprecated `JavaConversions` to be compatible with scala versions < 2.12.
-    // Can replace with JavaConverters.seqAsJavaList(...) once the support for scala versions < 2.12 is stopped
     sqlContext.createDataFrame(data.asJava, schema).rdd
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/TimelineRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/TimelineRelation.scala
@@ -111,8 +111,6 @@ class TimelineRelation(val sqlContext: SQLContext,
       }
     }))
 
-    // Using deprecated `JavaConversions` to be compatible with scala versions < 2.12.
-    // Can replace with JavaConverters.seqAsJavaList(...) once the support for scala versions < 2.12 is stopped
     sqlContext.createDataFrame(data.asJava, schema).rdd
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/ColumnStatsIndexHelper.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/ColumnStatsIndexHelper.java
@@ -239,12 +239,12 @@ public class ColumnStatsIndexHelper {
                 indexRow.add(colMetadata.getNullCount());
               });
 
-              return Row$.MODULE$.apply(JavaScalaConverters.<Object>convertJavaListToScalaSeq(indexRow));
+              return Row$.MODULE$.apply(JavaScalaConverters.convertJavaListToScalaSeq(indexRow));
             })
             .filter(Objects::nonNull);
 
     StructType indexSchema = ColumnStatsIndexSupport$.MODULE$.composeIndexSchema(
-        JavaScalaConverters.<String>convertJavaListToScalaSeq(columnNames),
+        JavaScalaConverters.convertJavaListToScalaSeq(columnNames),
         JavaScalaConverters.convertJavaListToScalaList(columnNames),
           StructType$.MODULE$.apply(orderedColumnSchemas)
     )._1;

--- a/packaging/bundle-validation/service/write.scala
+++ b/packaging/bundle-validation/service/write.scala
@@ -17,7 +17,7 @@
  */
 
 import org.apache.hudi.QuickstartUtils._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import org.apache.spark.sql.SaveMode._
 import org.apache.hudi.DataSourceReadOptions._
 import org.apache.hudi.DataSourceWriteOptions._


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16653

There are leftover code and comments for Scala 2.11 support.

### Summary and Changelog

This PR refactors the code for Scala 2.12 and above and remove TODO comments for Scala 2.11 compatibility.

### Impact

Code cleanup.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
