### PR TITLE
fix(schema): Fix creation of HoodieSchema from avro string not delega…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -895,7 +895,7 @@ public class HoodieSchema implements Serializable {
 
       try {
         Schema avroSchema = avroParser.parse(jsonSchema);
-        return new HoodieSchema(avroSchema);
+        return fromAvroSchema(avroSchema);
       } catch (Exception e) {
         throw new HoodieAvroSchemaException("Failed to parse schema: " + jsonSchema, e);
       }
@@ -913,7 +913,7 @@ public class HoodieSchema implements Serializable {
 
       try {
         Schema avroSchema = avroParser.parse(inputStream);
-        return new HoodieSchema(avroSchema);
+        return fromAvroSchema(avroSchema);
       } catch (IOException e) {
         throw new HoodieIOException("Failed to parse schema from InputStream", e);
       } catch (Exception e) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
@@ -980,4 +980,66 @@ public class TestHoodieSchema {
     assertTrue(deserializedSchema instanceof HoodieSchema.Timestamp);
     assertEquals(HoodieSchema.TimePrecision.MICROS, ((HoodieSchema.Timestamp) deserializedSchema).getPrecision());
   }
+
+  @Test
+  public void testParseLogicalTypesCreatesCorrectSubclasses() {
+    // Test that parsing schemas with logical types creates the correct subclass instances
+
+    // Test decimal on BYTES
+    String decimalBytes = "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":2}";
+    HoodieSchema parsedDecimalBytes = HoodieSchema.parse(decimalBytes);
+    assertInstanceOf(HoodieSchema.Decimal.class, parsedDecimalBytes);
+    HoodieSchema.Decimal decBytes = (HoodieSchema.Decimal) parsedDecimalBytes;
+    assertEquals(10, decBytes.getPrecision());
+    assertEquals(2, decBytes.getScale());
+    assertFalse(decBytes.isFixed());
+
+    // Test decimal on FIXED
+    String decimalFixed = "{\"type\":\"fixed\",\"name\":\"DecimalFixed\",\"size\":16,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":2}";
+    HoodieSchema parsedDecimalFixed = HoodieSchema.parse(decimalFixed);
+    assertInstanceOf(HoodieSchema.Decimal.class, parsedDecimalFixed);
+    HoodieSchema.Decimal decFixed = (HoodieSchema.Decimal) parsedDecimalFixed;
+    assertEquals(10, decFixed.getPrecision());
+    assertEquals(2, decFixed.getScale());
+    assertTrue(decFixed.isFixed());
+    assertEquals(16, decFixed.getFixedSize());
+
+    // Test timestamp-millis
+    String timestampMillis = "{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}";
+    HoodieSchema parsedTimestampMillis = HoodieSchema.parse(timestampMillis);
+    assertInstanceOf(HoodieSchema.Timestamp.class, parsedTimestampMillis);
+    HoodieSchema.Timestamp tsMillis = (HoodieSchema.Timestamp) parsedTimestampMillis;
+    assertEquals(HoodieSchema.TimePrecision.MILLIS, tsMillis.getPrecision());
+    assertTrue(tsMillis.isUtcAdjusted());
+
+    // Test timestamp-micros
+    String timestampMicros = "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}";
+    HoodieSchema parsedTimestampMicros = HoodieSchema.parse(timestampMicros);
+    assertInstanceOf(HoodieSchema.Timestamp.class, parsedTimestampMicros);
+    HoodieSchema.Timestamp tsMicros = (HoodieSchema.Timestamp) parsedTimestampMicros;
+    assertEquals(HoodieSchema.TimePrecision.MICROS, tsMicros.getPrecision());
+    assertTrue(tsMicros.isUtcAdjusted());
+
+    // Test local-timestamp-millis
+    String localTimestampMillis = "{\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}";
+    HoodieSchema parsedLocalTimestampMillis = HoodieSchema.parse(localTimestampMillis);
+    assertInstanceOf(HoodieSchema.Timestamp.class, parsedLocalTimestampMillis);
+    HoodieSchema.Timestamp localTsMillis = (HoodieSchema.Timestamp) parsedLocalTimestampMillis;
+    assertEquals(HoodieSchema.TimePrecision.MILLIS, localTsMillis.getPrecision());
+    assertFalse(localTsMillis.isUtcAdjusted());
+
+    // Test time-millis
+    String timeMillis = "{\"type\":\"int\",\"logicalType\":\"time-millis\"}";
+    HoodieSchema parsedTimeMillis = HoodieSchema.parse(timeMillis);
+    assertInstanceOf(HoodieSchema.Time.class, parsedTimeMillis);
+    HoodieSchema.Time tmMillis = (HoodieSchema.Time) parsedTimeMillis;
+    assertEquals(HoodieSchema.TimePrecision.MILLIS, tmMillis.getPrecision());
+
+    // Test time-micros
+    String timeMicros = "{\"type\":\"long\",\"logicalType\":\"time-micros\"}";
+    HoodieSchema parsedTimeMicros = HoodieSchema.parse(timeMicros);
+    assertInstanceOf(HoodieSchema.Time.class, parsedTimeMicros);
+    HoodieSchema.Time tmMicros = (HoodieSchema.Time) parsedTimeMicros;
+    assertEquals(HoodieSchema.TimePrecision.MICROS, tmMicros.getPrecision());
+  }
 }


### PR DESCRIPTION
…ting to the correct inner class type

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

When creating a HoodieSchema from a avro/json schema string, a logical type, e.g. DECIMAL, TIME type will not be resolved to the correct `HoodieSchema` inner class type.

This will lead to `ClassCastExceptions` when trying to retrieve logical type details. e.g.

```java
String decimalBytes = "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":2}";
HoodieSchema decimalSchema = HoodieSchema.createDecimal(10, 2);
assertTrue(decimalSchema.toString().equals(decimalBytes));
assertDoesNotThrow (() -> (HoodieSchema.Decimal) decimalSchema);
assertDoesNotThrow (() -> (HoodieSchema.Decimal) HoodieSchema.parse(decimalBytes)); // ClassCastException thrown here
```

Error:
```log
Caused by: java.lang.ClassCastException: org.apache.hudi.common.schema.HoodieSchema cannot be cast to org.apache.hudi.common.schema.HoodieSchema$Decimal
	at org.apache.hudi.common.schema.TestHoodieSchemaComparatorForSchemaEvolution.lambda$testLogicalTypesWithDifferentPrimitiveTypes$1(TestHoodieSchemaComparatorForSchemaEvolution.java:241)
	at org.junit.jupiter.api.AssertDoesNotThrow.assertDoesNotThrow(AssertDoesNotThrow.java:71)
	... 6 more

```

Test to replicate this:

```java
String decimalBytes = "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":2}";
HoodieSchema parsedDecimalBytes = HoodieSchema.parse(decimalBytes);
assertInstanceOf(HoodieSchema.Decimal.class, parsedDecimalBytes);  // Error will be thrown here
HoodieSchema.Decimal decBytes = (HoodieSchema.Decimal) parsedDecimalBytes;
assertEquals(10, decBytes.getPrecision());
assertEquals(2, decBytes.getScale());
assertFalse(decBytes.isFixed());
``` 

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Ensure that `parse` calls `fromAvroSchema`, going through the factory function so that it resolves to the correct inner type.
- Added tests to verify this fix

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
HoodieSchema parsed from strings will now resolve to the correct inner class type.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
