### PR TITLE
perf: optimize removeCommitMetadata method in HoodieCDCLogger

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCDCLogger.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCDCLogger.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.io;
 
-import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieRecord;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Around 35-40% of put time in HoodieCDCLogger is removeCommitMetadata. This is because for each record schema comparison is called. 
Before:
<img width="663" height="172" alt="Selection_074" src="https://github.com/user-attachments/assets/fd07c702-cedb-47be-a6c8-c67d53c620d3" />

After:
<img width="776" height="165" alt="Selection_076" src="https://github.com/user-attachments/assets/3ab7a0ca-731d-449d-804d-aeaf375837f4" />


### Summary and Changelog

Added the logic to construct record based on schema without heavy comparison.

### Impact

Performance improve for CDC.

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
