### PR TITLE
refactor: simplify the ReflectionUtils#getTopLevelClassesInClasspath

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
@@ -32,6 +32,8 @@ import static org.apache.hudi.common.util.ReflectionUtils.getMethod;
 import static org.apache.hudi.common.util.ReflectionUtils.isSubClass;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests {@link ReflectionUtils}
@@ -56,5 +58,34 @@ public class TestReflectionUtils {
     assertFalse(getMethod(HoodieStorage.class,
         "listDirectEntries", StoragePathFilter.class).isPresent());
     assertFalse(getMethod(HoodieStorage.class, "nonExistentMethod").isPresent());
+  }
+
+  @Test
+  void testGetTopLevelClassesInClasspath() {
+    long classCount = ReflectionUtils.getTopLevelClassesInClasspath(ReflectionUtils.class).count();
+    assertTrue(classCount > 0, "Should find at least one class in the package");
+  }
+
+  @Test
+  void testGetTopLevelClassesInClasspathContainsExpectedClasses() {
+    java.util.List<String> classes = ReflectionUtils.getTopLevelClassesInClasspath(ReflectionUtils.class)
+        .collect(java.util.stream.Collectors.toList());
+
+    assertTrue(classes.stream().anyMatch(c -> c.contains("ReflectionUtils")),
+        "Should contain ReflectionUtils class");
+  }
+
+  @Test
+  void testGetTopLevelClassesInClasspathWithArrayClass() {
+    java.util.stream.Stream<String> stream = ReflectionUtils.getTopLevelClassesInClasspath(String[].class);
+    assertNotNull(stream, "Should return a non-null stream");
+    assertEquals(0, stream.count(), "Should return an empty stream for array classes");
+  }
+
+  @Test
+  void testGetTopLevelClassesInClasspathWithPrimitiveArrayClass() {
+    java.util.stream.Stream<String> stream = ReflectionUtils.getTopLevelClassesInClasspath(int[].class);
+    assertNotNull(stream, "Should return a non-null stream");
+    assertEquals(0, stream.count(), "Should return an empty stream for primitive array classes");
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -130,8 +130,12 @@ public class ReflectionUtils {
    * @return Stream of Class names in package
    */
   public static Stream<String> getTopLevelClassesInClasspath(Class<?> clazz) {
+    Package pkg = clazz.getPackage();
+    if (pkg == null) {
+      return Stream.empty();
+    }
+    String packageName = pkg.getName();
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-    String packageName = clazz.getPackage().getName();
     String path = packageName.replace('.', '/');
 
     try {

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +38,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
 /**
@@ -140,20 +145,82 @@ public class ReflectionUtils {
 
     try {
       return Collections.list(classLoader.getResources(path)).stream()
-              .map(url -> {
-                try {
-                  return new File(url.toURI());
-                } catch (URISyntaxException e) {
-                  LOG.error("Unable to resolve URI: {}", url, e);
-                  return null;
-                }
-              })
-              .filter(Objects::nonNull)
-              .flatMap(dir -> findClasses(dir, packageName).stream());
+              .flatMap(url -> getClassesFromResource(url, packageName).stream());
     } catch (IOException e) {
       LOG.error("Unable to fetch resources for package {}", packageName, e);
       return Stream.empty();
     }
+  }
+
+  /**
+   * Gets classes from a resource URL, handling both file system and JAR resources.
+   *
+   * @param url         The resource URL
+   * @param packageName The package name
+   * @return List of class names
+   */
+  private static List<String> getClassesFromResource(URL url, String packageName) {
+    String protocol = url.getProtocol();
+    if ("file".equals(protocol)) {
+      try {
+        File directory = new File(url.toURI());
+        return findClasses(directory, packageName);
+      } catch (URISyntaxException e) {
+        LOG.error("Unable to resolve URI: {}", url, e);
+        return Collections.emptyList();
+      }
+    } else if ("jar".equals(protocol)) {
+      return findClassesInJar(url, packageName);
+    } else {
+      LOG.warn("Unsupported protocol: {}", protocol);
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Finds all classes in a JAR file for a given package.
+   *
+   * @param url         The JAR URL
+   * @param packageName The package name
+   * @return List of class names
+   */
+  private static List<String> findClassesInJar(URL url, String packageName) {
+    List<String> classes = new ArrayList<>();
+    String path = packageName.replace('.', '/');
+
+    try {
+      String jarPath = url.getPath();
+      if (jarPath.startsWith("jar:")) {
+        jarPath = jarPath.substring(4);
+      }
+      int separatorIndex = jarPath.indexOf("!");
+      if (separatorIndex != -1) {
+        jarPath = jarPath.substring(0, separatorIndex);
+      }
+
+      jarPath = URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name());
+
+      try (JarFile jarFile = new JarFile(jarPath)) {
+        jarFile.stream()
+            .map(JarEntry::getName)
+            .filter(name -> name.startsWith(path) && name.endsWith(".class"))
+            .filter(name -> {
+              String relativePath = name.substring(path.length());
+              if (relativePath.startsWith("/")) {
+                relativePath = relativePath.substring(1);
+              }
+              return !relativePath.contains("/");
+            })
+            .forEach(name -> {
+              String className = name.replace('/', '.').substring(0, name.length() - 6);
+              classes.add(className);
+            });
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to read JAR file from URL: {}", url, e);
+    }
+
+    return classes;
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes https://github.com/apache/hudi/issues/14554

### Summary and Changelog

Simplified the ReflectionUtils#getTopLevelClassesInClasspath method, reduced nested blocks and using explicit early return on failure.

### Impact

None

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
