### PR TITLE
refactor: Remove org.jetbrains.annotations imports

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -45,9 +45,9 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StorageSchemes;
 
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -164,7 +164,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     };
   }
 
-  private static @NotNull String getLockServiceClassName(String scheme) {
+  private static @Nonnull String getLockServiceClassName(String scheme) {
     Option<StorageSchemes> schemeOptional = StorageSchemes.getStorageLockImplementationIfExists(scheme);
     if (schemeOptional.isPresent()) {
       return schemeOptional.get().getStorageLockClass();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
@@ -28,7 +28,8 @@ import org.apache.hudi.common.util.hash.HashID;
 import org.apache.hudi.exception.HoodieClusteringException;
 
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -165,7 +166,7 @@ public class ConsistentBucketIdentifier extends BucketIdentifier {
    * @param bucket parent bucket
    * @return lists of children buckets
    */
-  public Option<List<ConsistentHashingNode>> splitBucket(@NotNull ConsistentHashingNode bucket) {
+  public Option<List<ConsistentHashingNode>> splitBucket(@Nonnull ConsistentHashingNode bucket) {
     ConsistentHashingNode formerBucket = getFormerBucket(bucket.getValue());
 
     long mid = (long) formerBucket.getValue() + bucket.getValue()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -44,7 +44,8 @@ import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -275,7 +276,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
     return hoodieRollbackRequests;
   }
 
-  @NotNull
+  @Nonnull
   private List<HoodieRollbackRequest> getHoodieRollbackRequests(String partitionPath, List<StoragePath> filesToDeletedStatus) {
     return filesToDeletedStatus.stream()
         .map(pathInfo -> {
@@ -370,7 +371,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
     return fullPaths.stream().map(StoragePath::new);
   }
 
-  @NotNull
+  @Nonnull
   private static StoragePathFilter getPathFilter(String basefileExtension, String commit) {
     return (path) -> {
       if (path.toString().endsWith(basefileExtension)) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -97,7 +97,8 @@ import org.apache.hudi.testutils.MetadataMergeWriteStatus;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -439,7 +440,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
             .withProperties(properties).build();
   }
 
-  @NotNull
+  @Nonnull
   protected Set<String> verifyRecordKeys(List<HoodieRecord> expectedRecords, List<WriteStatus> allStatus, List<GenericRecord> records) {
     for (WriteStatus status : allStatus) {
       StoragePath filePath = new StoragePath(basePath, status.getStat().getPath());

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/log/block/HoodieFlinkAvroDataBlock.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/log/block/HoodieFlinkAvroDataBlock.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
 import org.apache.hudi.storage.StorageConfiguration;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.Map;
@@ -35,9 +35,9 @@ import java.util.Properties;
 public class HoodieFlinkAvroDataBlock extends HoodieAvroDataBlock {
 
   public HoodieFlinkAvroDataBlock(
-      @NotNull List<HoodieRecord> records,
-      @NotNull Map<HeaderMetadataType, String> header,
-      @NotNull String keyField) {
+      @Nonnull List<HoodieRecord> records,
+      @Nonnull Map<HeaderMetadataType, String> header,
+      @Nonnull String keyField) {
     super(records, header, keyField);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/client/transaction/lock/NoopLockProvider.java
+++ b/hudi-common/src/main/java/org/apache/hudi/client/transaction/lock/NoopLockProvider.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.lock.LockProvider;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +43,7 @@ public class NoopLockProvider implements LockProvider<ReentrantReadWriteLock>, S
   }
 
   @Override
-  public boolean tryLock(long time, @NotNull TimeUnit unit) throws InterruptedException {
+  public boolean tryLock(long time, @Nonnull TimeUnit unit) throws InterruptedException {
     return true;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineLoaderV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineLoaderV1.java
@@ -41,9 +41,10 @@ import org.apache.hudi.storage.StoragePathInfo;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineLoaderV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineLoaderV2.java
@@ -35,7 +35,8 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
@@ -42,7 +42,8 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.types.Row;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.List;
@@ -151,7 +152,7 @@ public final class HoodieFlinkQuickstart {
     streamTableEnv.executeSql(createSource);
   }
 
-  @NotNull List<Row> insertData() throws InterruptedException, TableNotExistException {
+  @Nonnull List<Row> insertData() throws InterruptedException, TableNotExistException {
     // insert data
     String insertInto = String.format("insert into %s select * from source", tableName);
     execInsertSql(streamTableEnv, insertInto);
@@ -164,7 +165,7 @@ public final class HoodieFlinkQuickstart {
     return execSelectSql(streamTableEnv, String.format("select * from %s", tableName), 10);
   }
 
-  @NotNull List<Row> updateData() throws InterruptedException, TableNotExistException {
+  @Nonnull List<Row> updateData() throws InterruptedException, TableNotExistException {
     // update data
     String insertInto = String.format("insert into %s select * from source", tableName);
     execInsertSql(getStreamTableEnv(), insertInto);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionEvaluators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/ExpressionEvaluators.java
@@ -31,7 +31,8 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -221,7 +222,7 @@ public class ExpressionEvaluators {
       }
     }
 
-    protected abstract boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type);
+    protected abstract boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type);
   }
 
   /**
@@ -235,7 +236,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    protected boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    protected boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object minVal = columnStats.getMinVal();
       Object maxVal = columnStats.getMaxVal();
       if (minVal == null || maxVal == null) {
@@ -263,7 +264,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    protected boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    protected boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object minVal = columnStats.getMinVal();
       Object maxVal = columnStats.getMaxVal();
       if (minVal == null || maxVal == null) {
@@ -322,7 +323,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    public boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    public boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object minVal = columnStats.getMinVal();
       if (minVal == null) {
         return false;
@@ -342,7 +343,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    protected boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    protected boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object maxVal = columnStats.getMaxVal();
       if (maxVal == null) {
         return false;
@@ -362,7 +363,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    protected boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    protected boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object minVal = columnStats.getMinVal();
       if (minVal == null) {
         return false;
@@ -382,7 +383,7 @@ public class ExpressionEvaluators {
     }
 
     @Override
-    protected boolean eval(@NotNull Object val, ColumnStats columnStats, LogicalType type) {
+    protected boolean eval(@Nonnull Object val, ColumnStats columnStats, LogicalType type) {
       Object maxVal = columnStats.getMaxVal();
       if (maxVal == null) {
         return false;
@@ -553,7 +554,7 @@ public class ExpressionEvaluators {
     return vals.toArray();
   }
 
-  private static int compare(@NotNull Object val1, @NotNull Object val2, LogicalType logicalType) {
+  private static int compare(@Nonnull Object val1, @Nonnull Object val2, LogicalType logicalType) {
     switch (logicalType.getTypeRoot()) {
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIME_WITHOUT_TIME_ZONE:
@@ -580,7 +581,7 @@ public class ExpressionEvaluators {
     }
   }
 
-  private static BigDecimal getBigDecimal(@NotNull Object value) {
+  private static BigDecimal getBigDecimal(@Nonnull Object value) {
     if (value instanceof BigDecimal) {
       return (BigDecimal) value;
     } else if (value instanceof Double) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
@@ -44,7 +44,8 @@ import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelUpdate;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupTableReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupTableReader.java
@@ -25,7 +25,8 @@ import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.table.data.RowData;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
@@ -36,9 +36,9 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.IOException;
@@ -204,7 +204,7 @@ public class GCSStorageLockClient implements StorageLockClient {
     }
   }
 
-  private @NotNull Pair<LockGetResult, Option<StorageLockFile>> getLockFileFromBlob(Blob blob) {
+  private @Nonnull Pair<LockGetResult, Option<StorageLockFile>> getLockFileFromBlob(Blob blob) {
     try (InputStream inputStream = Channels.newInputStream(blob.reader())) {
       return Pair.of(LockGetResult.SUCCESS,
           Option.of(StorageLockFile.createFromStream(inputStream, String.valueOf(blob.getGeneration()))));

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
@@ -67,13 +67,14 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -53,9 +53,10 @@ import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -590,7 +591,7 @@ public class RequestHandler {
     }
 
     @Override
-    public void handle(@NotNull Context context) throws Exception {
+    public void handle(@Nonnull Context context) throws Exception {
       ugi.doAs((PrivilegedExceptionAction<Void>) () -> {
         boolean success = true;
         long beginTs = System.currentTimeMillis();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.HoodieSparkTable;
@@ -34,7 +35,6 @@ import org.apache.hudi.table.HoodieSparkTable;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -231,7 +231,7 @@ public class HoodieClusteringJob {
     }
   }
 
-  @TestOnly
+  @VisibleForTesting
   public Option<String> doSchedule() throws Exception {
     return this.doSchedule(jsc);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieIndexer.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIndexException;
@@ -36,7 +37,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,7 +220,7 @@ public class HoodieIndexer {
     }, "Indexer failed");
   }
 
-  @TestOnly
+  @VisibleForTesting
   public Option<String> doSchedule() throws Exception {
     return this.scheduleIndexing(jsc);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/util/BloomFilterData.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/util/BloomFilterData.java
@@ -19,7 +19,7 @@
 
 package org.apache.hudi.utilities.util;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -44,7 +44,7 @@ public class BloomFilterData implements Comparable<BloomFilterData> {
   }
 
   @Override
-  public int compareTo(@NotNull BloomFilterData o) {
+  public int compareTo(@Nonnull BloomFilterData o) {
     return this.toString().compareTo(o.toString());
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17678.  This PR removes `org.jetbrains.annotations` imports that cause issues.

### Summary and Changelog

This PR replaces `org.jetbrains.annotations` usage with `javax.annotation` instead.

### Impact

Refactoring

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
