### PR TITLE
chore(ci): Update Java 11 image for Azure CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # thrift
 # maven
 # java8
-FROM apachehudi/hudi-ci-bundle-validation-base:azure_ci_test_base_java11
+FROM apachehudi/hudi-ci-bundle-validation-base:azure_ci_test_base_java11_v2
 
 CMD ["java", "-version"]
 

--- a/packaging/bundle-validation/azure/Dockerfile
+++ b/packaging/bundle-validation/azure/Dockerfile
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM --platform=linux/amd64 adoptopenjdk/openjdk11:alpine
+FROM --platform=linux/amd64 maven:3.9-eclipse-temurin-11-alpine
 
-RUN apk add --no-cache --upgrade bash curl jq git maven
+RUN apk add --no-cache --upgrade bash curl jq git
 
 # Install thrift 0.13.0 from source (compiler only, skip library)
 RUN apk add --no-cache libstdc++ \

--- a/packaging/bundle-validation/azure/build.sh
+++ b/packaging/bundle-validation/azure/build.sh
@@ -17,5 +17,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-docker build -t hudi-ci-bundle-validation-base:azure_ci_test_base_java11 .
-docker image tag hudi-ci-bundle-validation-base:azure_ci_test_base_java11 apachehudi/hudi-ci-bundle-validation-base:azure_ci_test_base_java11
+docker build -t hudi-ci-bundle-validation-base:azure_ci_test_base_java11_v2 .
+docker image tag hudi-ci-bundle-validation-base:azure_ci_test_base_java11_v2 apachehudi/hudi-ci-bundle-validation-base:azure_ci_test_base_java11_v2


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`adoptopenjdk/openjdk11:alpine` base image for Azure CI has outdated maven.  Use `maven:3.9-eclipse-temurin-11-alpine` instead to get the latest maven.

### Summary and Changelog

This PR updated the Java 11 image for Azure CI.  The image has been pushed to the docker hub.

### Impact

Use new maven release

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
