### PR TITLE
fix: Handle hudi table reads when databaseName is not set during initTable

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING
 import org.apache.hudi.common.table.timeline.TimelineUtils
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -211,8 +212,10 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       // Save all the table config to the hoodie.properties.
       val properties = TypedProperties.fromMap(tableConfigs.asJava)
 
+      val databaseFromIdentifier = table.identifier.database.getOrElse(
+        spark.sessionState.catalog.getCurrentDatabase)
       val catalogDatabaseName = formatName(spark,
-        table.identifier.database.getOrElse(spark.sessionState.catalog.getCurrentDatabase))
+        if (StringUtils.isNullOrEmpty(databaseFromIdentifier)) "default" else databaseFromIdentifier)
 
       val (recordName, namespace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(table.identifier.table)
       val schema = SchemaConverters.toAvroType(dataSchema, nullable = false, recordName, namespace)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes an issue where Hudi tables fail to load with IllegalArgumentException: "is not a Hudi table" when hoodie.database.name is not set in the table config during initialization. This occurs because when both table.identifier.database and getCurrentDatabase are null/empty during table initialization, the database name is not defaulted to "default", causing inconsistent behavior between table creation and querying. 

### Summary and Changelog

Tables initialized without an explicit database name now correctly default to "default" database, preventing subsequent read failures.

### Impact

No public API changes. This is an internal fix to ensure consistent behavior.

### Risk Level

Low

### Documentation Update

None. 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
