### PR TITLE
fix: Revert "feat: Support MDT compaction configs of frequency seconds and trigger strategy (#17603)"

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2618,14 +2618,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS);
   }
 
-  public String getMetadataCompactionTriggerStrategy() {
-    return getString(HoodieMetadataConfig.COMPACT_TRIGGER_STRATEGY);
-  }
-
-  public int getMetadataMaxDeltaSecondsBeforeCompaction() {
-    return getInt(HoodieMetadataConfig.COMPACT_TIME_DELTA_SECONDS);
-  }
-
   public boolean isMetadataAsyncIndex() {
     return getBooleanOrDefault(HoodieMetadataConfig.ASYNC_INDEX_ENABLE);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -75,7 +75,6 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
-import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
 import org.apache.hudi.util.Lazy;
 
@@ -220,8 +219,6 @@ public class HoodieMetadataWriteUtils {
             .withLogCompactionEnabled(writeConfig.isLogCompactionEnabledOnMetadata())
             // Below config is only used if isLogCompactionEnabled is set.
             .withLogCompactionBlocksThreshold(writeConfig.getMetadataLogCompactBlocksThreshold())
-            .withInlineCompactionTriggerStrategy(CompactionTriggerStrategy.valueOf(writeConfig.getMetadataCompactionTriggerStrategy()))
-            .withMaxDeltaSecondsBeforeCompaction(writeConfig.getMetadataMaxDeltaSecondsBeforeCompaction())
             .build())
         .withStorageConfig(HoodieStorageConfig.newBuilder().hfileMaxFileSize(MDT_MAX_HFILE_SIZE_BYTES)
             .logFileMaxSize(maxLogFileSizeBytes)

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -116,26 +116,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Controls how often the metadata table is compacted.");
 
-  // Max number of seconds before compaction occurs
-  public static final ConfigProperty<String> COMPACT_TIME_DELTA_SECONDS = ConfigProperty
-      .key(METADATA_PREFIX + ".compact.max.delta.seconds")
-      .defaultValue(String.valueOf(2 * 60 * 60))
-      .markAdvanced()
-      .sinceVersion("1.2.0")
-      .withDocumentation("Number of elapsed seconds after the last compaction, before scheduling a "
-      + "new one (for metadata table). "
-      + "This config takes effect only for the compaction triggering strategy based on the elapsed time, "
-      + "i.e., TIME_ELAPSED, NUM_AND_TIME, and NUM_OR_TIME.");
-
-  // Compaction trigger strategy
-  public static final ConfigProperty<String> COMPACT_TRIGGER_STRATEGY = ConfigProperty
-      .key(METADATA_PREFIX +  ".compact.trigger.strategy")
-      .defaultValue("NUM_COMMITS")
-      .markAdvanced()
-      .sinceVersion("1.2.0")
-      .withDocumentation("Controls how compaction scheduling is triggered for metadata table,"
-      + "by time or num delta commits or combination of both. ");
-
   public static final ConfigProperty<String> ENABLE_LOG_COMPACTION_ON_METADATA_TABLE = ConfigProperty
       .key(METADATA_PREFIX + ".log.compaction.enable")
       .defaultValue("false")


### PR DESCRIPTION
This reverts commit 22a55c6d176f0513f57b5276ab9173b3ccaa79a0.

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
