### PR TITLE
refactor: Add Lombok annotations to hudi-kafka-connect

### DIFF
--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>kryo-shaded</artifactId>
         </dependency>
 
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/HoodieSinkConnector.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/HoodieSinkConnector.java
@@ -18,11 +18,11 @@
 
 package org.apache.hudi.connect;
 
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,18 +32,14 @@ import java.util.Map;
 /**
  * HudiSinkConnector is a Kafka Connect Connector implementation
  * that ingest data from Kafka to Hudi.
+ *
  */
+@NoArgsConstructor // No-arg constructor. It is instantiated by Connect framework.
+@Slf4j
 public class HoodieSinkConnector extends SinkConnector {
 
   public static final String VERSION = "0.1.0";
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieSinkConnector.class);
   private Map<String, String> configProps;
-
-  /**
-   * No-arg constructor. It is instantiated by Connect framework.
-   */
-  public HoodieSinkConnector() {
-  }
 
   @Override
   public String version() {
@@ -72,7 +68,7 @@ public class HoodieSinkConnector extends SinkConnector {
 
   @Override
   public void stop() {
-    LOG.info(String.format("Shutting down Hudi Sink connector %s", configProps.get("name")));
+    log.info("Shutting down Hudi Sink connector {}", configProps.get("name"));
   }
 
   @Override

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/KafkaConnectFileIdPrefixProvider.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/KafkaConnectFileIdPrefixProvider.java
@@ -23,20 +23,19 @@ import org.apache.hudi.connect.utils.KafkaConnectUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.FileIdPrefixProvider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class KafkaConnectFileIdPrefixProvider extends FileIdPrefixProvider {
 
   public static final String KAFKA_CONNECT_PARTITION_ID = "hudi.kafka.connect.partition";
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectFileIdPrefixProvider.class);
 
   private final String kafkaPartition;
 
   public KafkaConnectFileIdPrefixProvider(TypedProperties props) {
     super(props);
     if (!props.containsKey(KAFKA_CONNECT_PARTITION_ID)) {
-      LOG.error("Fatal error due to Kafka Connect Partition Id is not set");
+      log.error("Fatal error due to Kafka Connect Partition Id is not set");
       throw new HoodieException("Kafka Connect Partition Key " + KAFKA_CONNECT_PARTITION_ID + " not provided");
     }
     this.kafkaPartition = props.getProperty(KAFKA_CONNECT_PARTITION_ID);
@@ -48,8 +47,7 @@ public class KafkaConnectFileIdPrefixProvider extends FileIdPrefixProvider {
     // to generate a fixed sized hash.
     String rawFileIdPrefix = kafkaPartition + partitionPath;
     String hashedPrefix = KafkaConnectUtils.hashDigest(rawFileIdPrefix);
-    LOG.info("CreateFileId for Kafka Partition " + kafkaPartition + " : " + partitionPath + " = " + rawFileIdPrefix
-        + " === " + hashedPrefix);
+    log.info("CreateFileId for Kafka Partition {} : {} = {} === {}", kafkaPartition, partitionPath, rawFileIdPrefix, hashedPrefix);
     return hashedPrefix;
   }
 }

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/kafka/KafkaControlProducer.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/kafka/KafkaControlProducer.java
@@ -20,14 +20,13 @@ package org.apache.hudi.connect.kafka;
 
 import org.apache.hudi.connect.ControlMessage;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
@@ -36,9 +35,8 @@ import java.util.Properties;
  * Control Topic that coordinates transactions
  * across Participants.
  */
+@Slf4j
 public class KafkaControlProducer {
-
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaControlProducer.class);
 
   private final String bootstrapServers;
   private final String controlTopicName;

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/CoordinatorEvent.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/CoordinatorEvent.java
@@ -20,16 +20,21 @@ package org.apache.hudi.connect.transaction;
 
 import org.apache.hudi.connect.ControlMessage;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * The events within the Coordinator that trigger
  * the state changes in the state machine of
  * the Coordinator.
  */
+@Getter
 public class CoordinatorEvent {
 
   private final CoordinatorEventType eventType;
   private final String topicName;
   private final String commitTime;
+  @Setter
   private ControlMessage message;
 
   public CoordinatorEvent(CoordinatorEventType eventType,
@@ -38,26 +43,6 @@ public class CoordinatorEvent {
     this.eventType = eventType;
     this.topicName = topicName;
     this.commitTime = commitTime;
-  }
-
-  public CoordinatorEventType getEventType() {
-    return eventType;
-  }
-
-  public String getTopicName() {
-    return topicName;
-  }
-
-  public String getCommitTime() {
-    return commitTime;
-  }
-
-  public ControlMessage getMessage() {
-    return message;
-  }
-
-  public void setMessage(ControlMessage message) {
-    this.message = message;
   }
 
   /**

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/TransactionInfo.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/TransactionInfo.java
@@ -20,15 +20,20 @@ package org.apache.hudi.connect.transaction;
 
 import org.apache.hudi.connect.writers.ConnectWriter;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Stores all the state for the current Transaction within a
  * {@link TransactionParticipant}.
  * @param <T> The type of status returned by the underlying writer.
  */
+@Getter
 public class TransactionInfo<T> {
 
   private final String commitTime;
   private final ConnectWriter<T> writer;
+  @Setter
   private long expectedKafkaOffset;
   private boolean commitInitiated;
 
@@ -37,26 +42,6 @@ public class TransactionInfo<T> {
     this.writer = writer;
     this.expectedKafkaOffset = 0;
     this.commitInitiated = false;
-  }
-
-  public String getCommitTime() {
-    return commitTime;
-  }
-
-  public ConnectWriter<T> getWriter() {
-    return writer;
-  }
-
-  public long getExpectedKafkaOffset() {
-    return expectedKafkaOffset;
-  }
-
-  public boolean isCommitInitiated() {
-    return commitInitiated;
-  }
-
-  public void setExpectedKafkaOffset(long expectedKafkaOffset) {
-    this.expectedKafkaOffset = expectedKafkaOffset;
   }
 
   public void commitInitiated() {

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/utils/KafkaConnectUtils.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/utils/KafkaConnectUtils.java
@@ -39,13 +39,12 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
@@ -67,9 +66,8 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 /**
  * Helper methods for Kafka.
  */
+@Slf4j
 public class KafkaConnectUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectUtils.class);
   private static final String HOODIE_CONF_PREFIX = "hoodie.";
   public static final String HADOOP_CONF_DIR = "HADOOP_CONF_DIR";
   public static final String HADOOP_HOME = "HADOOP_HOME";
@@ -82,10 +80,10 @@ public class KafkaConnectUtils {
       String hadoopHomePath = System.getenv(HADOOP_HOME);
       DEFAULT_HADOOP_CONF_FILES.addAll(getHadoopConfigFiles(hadoopConfigPath, hadoopHomePath));
       if (!DEFAULT_HADOOP_CONF_FILES.isEmpty()) {
-        LOG.info(String.format("Found Hadoop default config files %s", DEFAULT_HADOOP_CONF_FILES));
+        log.info("Found Hadoop default config files {}", DEFAULT_HADOOP_CONF_FILES);
       }
     } catch (IOException e) {
-      LOG.error("An error occurred while getting the default Hadoop configuration. "
+      log.error("An error occurred while getting the default Hadoop configuration. "
               + "Please use hadoop.conf.dir or hadoop.home to configure Hadoop environment variables", e);
     }
   }
@@ -127,7 +125,7 @@ public class KafkaConnectUtils {
       Map<String, KafkaFuture<TopicDescription>> values = result.values();
       KafkaFuture<TopicDescription> topicDescription = values.get(topicName);
       int numPartitions = topicDescription.get().partitions().size();
-      LOG.info(String.format("Latest number of partitions for topic %s is %s", topicName, numPartitions));
+      log.info("Latest number of partitions for topic {} is {}", topicName, numPartitions);
       return numPartitions;
     } catch (Exception exception) {
       throw new HoodieException("Fatal error fetching the latest partition of kafka topic name" + topicName, exception);
@@ -221,7 +219,7 @@ public class KafkaConnectUtils {
     try {
       md = MessageDigest.getInstance("MD5");
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("Fatal error selecting hash algorithm", e);
+      log.error("Fatal error selecting hash algorithm", e);
       throw new HoodieException(e);
     }
     byte[] digest = Objects.requireNonNull(md).digest(getUTF8Bytes(stringToHash));

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
@@ -29,10 +29,9 @@ import org.apache.hudi.keygen.KeyGenerator;
 import org.apache.hudi.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.AvroConvertor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -43,12 +42,12 @@ import java.util.List;
  * converting them to {@link HoodieRecord}s that can be written to Hudi by
  * the derived implementations of this class.
  */
+@Slf4j
 public abstract class AbstractConnectWriter implements ConnectWriter<WriteStatus> {
 
   public static final String KAFKA_AVRO_CONVERTER = "io.confluent.connect.avro.AvroConverter";
   public static final String KAFKA_JSON_CONVERTER = "org.apache.kafka.connect.json.JsonConverter";
   public static final String KAFKA_STRING_CONVERTER = "org.apache.kafka.connect.storage.StringConverter";
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractConnectWriter.class);
   protected final String instantTime;
 
   private final KeyGenerator keyGenerator;

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectWriterProvider.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectWriterProvider.java
@@ -41,10 +41,9 @@ import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
 import org.apache.hudi.schema.SchemaProvider;
 import org.apache.hudi.storage.StorageConfiguration;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.common.TopicPartition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 
@@ -52,9 +51,8 @@ import java.util.Collections;
  * Provides the Hudi Writer for the {@link org.apache.hudi.connect.transaction.TransactionParticipant}
  * to write the incoming records to Hudi.
  */
+@Slf4j
 public class KafkaConnectWriterProvider implements ConnectWriterProvider<WriteStatus> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectWriterProvider.class);
 
   private final KafkaConnectConfigs connectConfigs;
   private final HoodieEngineContext context;

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestConnectTransactionCoordinator.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestConnectTransactionCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.helper.MockConnectTransactionServices;
 import org.apache.hudi.helper.MockKafkaControlAgent;
 
+import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,6 +108,7 @@ public class TestConnectTransactionCoordinator {
   private static class MockParticipant implements TransactionParticipant {
 
     private final MockKafkaControlAgent kafkaControlAgent;
+    @Getter
     private final TopicPartition partition;
     private final CountDownLatch latch;
     private final TestScenarios testScenario;
@@ -146,11 +148,6 @@ public class TestConnectTransactionCoordinator {
 
     @Override
     public void processRecords() {
-    }
-
-    @Override
-    public TopicPartition getPartition() {
-      return partition;
     }
 
     @Override

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestConnectTransactionParticipant.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestConnectTransactionParticipant.java
@@ -28,6 +28,7 @@ import org.apache.hudi.helper.MockKafkaConnect;
 import org.apache.hudi.helper.MockKafkaControlAgent;
 import org.apache.hudi.helper.TestHudiWriterProvider;
 
+import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -194,9 +195,12 @@ public class TestConnectTransactionParticipant {
     }
 
     private final KafkaControlAgent kafkaControlAgent;
+    @Getter
     private final TopicPartition partition;
 
+    @Getter
     private Option<ControlMessage> lastReceivedWriteStatusEvent;
+    @Getter
     private long committedKafkaOffset;
 
     public MockCoordinator(KafkaControlAgent kafkaControlAgent) {
@@ -229,14 +233,6 @@ public class TestConnectTransactionParticipant {
       }
     }
 
-    public Option<ControlMessage> getLastReceivedWriteStatusEvent() {
-      return lastReceivedWriteStatusEvent;
-    }
-
-    public long getCommittedKafkaOffset() {
-      return committedKafkaOffset;
-    }
-
     @Override
     public void start() {
       kafkaControlAgent.registerTransactionCoordinator(this);
@@ -245,11 +241,6 @@ public class TestConnectTransactionParticipant {
     @Override
     public void stop() {
       kafkaControlAgent.deregisterTransactionCoordinator(this);
-    }
-
-    @Override
-    public TopicPartition getPartition() {
-      return partition;
     }
 
     @Override

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/helper/MockKafkaConnect.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/helper/MockKafkaConnect.java
@@ -20,6 +20,8 @@ package org.apache.hudi.helper;
 
 import org.apache.hudi.connect.transaction.TransactionParticipant;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -44,8 +46,11 @@ public class MockKafkaConnect implements SinkTaskContext {
 
   private final TopicPartition testPartition;
 
+  @Setter
   private TransactionParticipant participant;
+  @Getter
   private long currentKafkaOffset;
+  @Getter
   private boolean isPaused;
   private boolean isResetOffset;
 
@@ -56,20 +61,8 @@ public class MockKafkaConnect implements SinkTaskContext {
     isResetOffset = false;
   }
 
-  public void setParticipant(TransactionParticipant participant) {
-    this.participant = participant;
-  }
-
-  public boolean isPaused() {
-    return isPaused;
-  }
-
   public boolean isResumed() {
     return !isPaused;
-  }
-
-  public long getCurrentKafkaOffset() {
-    return currentKafkaOffset;
   }
 
   @Override

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/helper/TestHudiWriterProvider.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/helper/TestHudiWriterProvider.java
@@ -22,6 +22,8 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.connect.writers.ConnectWriter;
 import org.apache.hudi.connect.writers.ConnectWriterProvider;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.util.List;
@@ -30,12 +32,10 @@ import java.util.List;
  * Helper class the provides a Hudi writer and
  * maintains stats that are used for test validation.
  */
+@NoArgsConstructor
 public class TestHudiWriterProvider implements ConnectWriterProvider<WriteStatus>  {
 
   private TestHudiWriter currentWriter;
-
-  public TestHudiWriterProvider() {
-  }
 
   public int getLatestNumberWrites() {
     return (currentWriter != null) ? currentWriter.numberRecords : 0;
@@ -51,6 +51,7 @@ public class TestHudiWriterProvider implements ConnectWriterProvider<WriteStatus
     return currentWriter;
   }
 
+  @Getter
   private static class TestHudiWriter implements ConnectWriter<WriteStatus> {
 
     private int numberRecords;
@@ -59,14 +60,6 @@ public class TestHudiWriterProvider implements ConnectWriterProvider<WriteStatus
     public TestHudiWriter() {
       this.numberRecords = 0;
       this.isClosed = false;
-    }
-
-    public int getNumberRecords() {
-      return numberRecords;
-    }
-
-    public boolean isClosed() {
-      return isClosed;
     }
 
     @Override

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/writers/TestAbstractConnectWriter.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/writers/TestAbstractConnectWriter.java
@@ -34,6 +34,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.KeyGenerator;
 import org.apache.hudi.schema.SchemaProvider;
 
+import lombok.Getter;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -147,15 +148,12 @@ public class TestAbstractConnectWriter {
 
   private static class AbstractHudiConnectWriterTestWrapper extends AbstractConnectWriter {
 
+    @Getter
     private List<HoodieRecord> writtenRecords;
 
     public AbstractHudiConnectWriterTestWrapper(KafkaConnectConfigs connectConfigs, KeyGenerator keyGenerator, SchemaProvider schemaProvider) {
       super(connectConfigs, keyGenerator, schemaProvider, "000");
       writtenRecords = new ArrayList<>();
-    }
-
-    public List<HoodieRecord> getWrittenRecords() {
-      return writtenRecords;
     }
 
     @Override


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR refactors the `hudi-kafka-connect` module to reduce boilerplate code by leveraging Project Lombok annotations. Specifically, it replaces explicit `Logger` instantiation, manual getter/setter methods, and empty constructors with their equivalent Lombok annotations (`@Slf4j`, `@Getter`, `@Setter`,`@NoArgsConstructor`, `@AllArgsConstructor`, `@Data`, `@Value`, `@ToString`).

This improves code readability and maintainability without altering the runtime logic.

### Summary and Changelog

This change introduces the Lombok dependency to the `hudi-kafka-connect` module and refactors several classes to utilize Lombok annotations.

- Added lombok annotations wherever possible to `hudi-kafka-connect` module.

### Impact

- **Public API:** None.
- **User Experience:** No visible change for end-users.
- **Performance:** No impact (compile-time code generation).
- **Code Health:** Reduces lines of code and standardizes logging/accessor patterns.

### Risk Level

none

(This is a pure refactoring change involving standard library annotations; no business logic was modified.)

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
