### PR TITLE
test: Fix flaky test testLatestCheckpointCarryOverWithMultipleWriters

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -298,6 +298,12 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     meta.reloadActiveTimeline();
     int totalCommits = meta.getCommitsTimeline().filterCompletedInstants().countInstants();
 
+    // Capture the checkpoint after backfillJob.sync() to calculate expected final checkpoint
+    HoodieCommitMetadata commitMetadataAfterBackfill = getLatestMetadata(meta);
+    String checkpointAfterBackfill = CheckpointUtils.getCheckpoint(commitMetadataAfterBackfill).getCheckpointKey();
+    int expectedNextCheckpointNum = Integer.parseInt(checkpointAfterBackfill) + 1;
+    String expectedFinalCheckpoint = String.format("%05d", expectedNextCheckpointNum);
+
     // add a new commit to timeline which may not have the checkpoint in extra metadata
     addCommitToTimeline(meta);
     meta.reloadActiveTimeline();
@@ -307,7 +313,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     new HoodieDeltaStreamer(cfgBackfillJob, jsc).sync(); // if deltastreamer checkpoint fetch does not walk back to older commits, this sync will fail
     meta.reloadActiveTimeline();
     Assertions.assertEquals(totalCommits + 2, meta.getCommitsTimeline().filterCompletedInstants().countInstants());
-    verifyCommitMetadataCheckpoint(meta, "00008");
+    verifyCommitMetadataCheckpoint(meta, expectedFinalCheckpoint);
   }
 
   private void verifyCommitMetadataCheckpoint(HoodieTableMetaClient metaClient, String expectedCheckpoint) throws IOException {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses


Fixes #17721, flaky test `TestHoodieDeltaStreamerWithMultiWriter#testLatestCheckpointCarryOverWithMultipleWriters` which was intermittently failing due to a hardcoded checkpoint assertion.

### Summary and Changelog

The test asserted a hardcoded checkpoint value `"00008"`, but the actual checkpoint varies depending on how many commits are produced during the prep phase. The prep phase uses `assertAtleastNCompactionCommits(3, ...)` which is a non-deterministic "at least N" condition - the actual number of commits (and thus the checkpoint) can be 3, 4, 5, or more depending on timing and thread scheduling in continuous mode.

- Capture the checkpoint value after `backfillJob.sync()` to determine the current state
- Calculate the expected final checkpoint dynamically by incrementing the captured checkpoint
- Replace the hardcoded `"00008"` assertion with the dynamically calculated value

### Impact

None. Test reliability improvement only.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable