### PR TITLE
chore(ci): Use non-archive repo for maven binary download

### DIFF
--- a/packaging/bundle-validation/Dockerfile
+++ b/packaging/bundle-validation/Dockerfile
@@ -34,10 +34,10 @@ RUN printf "\ntaskmanager.numberOfTaskSlots: 2\n" >> $FLINK_HOME/conf/flink-conf
 RUN printf "\nlocalhost\n" >> $FLINK_HOME/conf/workers
 
 # install maven
-RUN wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz
+RUN wget -t=3 https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.tar.gz
 RUN mkdir -p /usr/share/maven
-RUN tar xzvf apache-maven-3.6.3-bin.tar.gz -C /usr/share/maven
-ENV MAVEN_HOME=/usr/share/maven/apache-maven-3.6.3
+RUN tar xzvf apache-maven-3.9.12-bin.tar.gz -C /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven/apache-maven-3.9.12
 ENV PATH=$MAVEN_HOME/bin:$PATH
 RUN mvn --version
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

`archive.apache.org` seems to be a low-bandwidth, rate-limited server intended for historical reference, not for active CI/CD builds.

We are getting a bunch of operation timeout errors when trying to download the binary here:

```log
#13 [ 8/19] RUN if [[ /opt/bundle-validation/spark-3.5.0-bin-hadoop3 =~ 'spark-3.2' ]] || [[ /opt/bundle-validation/spark-3.5.0-bin-hadoop3 =~ 'spark-3.3' ]];     then printf "\nspark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog\n" >> /opt/bundle-validation/spark-3.5.0-bin-hadoop3/conf/spark-defaults.conf; fi
#13 DONE 0.1s

#14 [ 9/19] RUN printf "\ntaskmanager.numberOfTaskSlots: 2\n" >> /opt/bundle-validation/flink-1.18.0/conf/flink-conf.yaml
#14 DONE 0.1s

#15 [10/19] RUN printf "\nlocalhost\n" >> /opt/bundle-validation/flink-1.18.0/conf/workers
#15 DONE 0.1s

#16 [11/19] RUN wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
#16 0.146 Connecting to archive.apache.org (65.108.204.189:443)
#16 134.7 wget: can't connect to remote host (65.108.204.189): Operation timed out
#16 ERROR: process "/bin/sh -c wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz" did not complete successfully: exit code: 1
```

Switching to `repo.apache.org` which seems to be more stable.

#### `archive.apache.org`

```shell
$ dig  archive.apache.org

; <<>> DiG 9.10.6 <<>> archive.apache.org
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 11801
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;archive.apache.org.		IN	A

;; ANSWER SECTION:
archive.apache.org.	1800	IN	A	65.108.204.189

;; Query time: 15 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Fri Dec 26 16:43:18 +08 2025
;; MSG SIZE  rcvd: 63
````

```shell
ab -n 5 -c 1 -k https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz

This is ApacheBench, Version 2.3 <$Revision: 1913912 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking archive.apache.org (be patient).....done


Server Software:        Apache
Server Hostname:        archive.apache.org
Server Port:            443
SSL/TLS Protocol:       TLSv1.2,ECDHE-RSA-AES256-GCM-SHA384,2048,256
Server Temp Key:        ECDH X25519 253 bits
TLS Server Name:        archive.apache.org

Document Path:          /dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
Document Length:        9506321 bytes

Concurrency Level:      1
Time taken for tests:   5.915 seconds
Complete requests:      5
Failed requests:        0
Keep-Alive requests:    5
Total transferred:      47533136 bytes
HTML transferred:       47531605 bytes
Requests per second:    0.85 [#/sec] (mean)
Time per request:       1183.041 [ms] (mean)
Time per request:       1183.041 [ms] (mean, across all concurrent requests)
Transfer rate:          7847.42 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0  115 257.0      0     575
Processing:   742 1068 642.6    807    2216
Waiting:      186  191   7.1    190     203
Total:        742 1183 899.4    807    2791

Percentage of the requests served within a certain time (ms)
  50%    788
  66%    827
  75%    827
  80%   2791
  90%   2791
  95%   2791
  98%   2791
  99%   2791
 100%   2791 (longest request)
```

#### `repo.apache.org`

```shell
$ dig repo.maven.apache.org

; <<>> DiG 9.10.6 <<>> repo.maven.apache.org
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 32062
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;repo.maven.apache.org.		IN	A

;; ANSWER SECTION:
repo.maven.apache.org.	6661	IN	CNAME	repo.apache.maven.org.
repo.apache.maven.org.	45	IN	CNAME	repo.apache.maven.org.cdn.cloudflare.net.
repo.apache.maven.org.cdn.cloudflare.net. 60 IN	A 104.18.19.12
repo.apache.maven.org.cdn.cloudflare.net. 60 IN	A 104.18.18.12
```

```shell
$ ab -n 5 -c 1 -k https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.tar.gz

This is ApacheBench, Version 2.3 <$Revision: 1913912 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking repo.maven.apache.org (be patient).....done


Server Software:        cloudflare
Server Hostname:        repo.maven.apache.org
Server Port:            443
SSL/TLS Protocol:       TLSv1.2,ECDHE-ECDSA-CHACHA20-POLY1305,256,256
Server Temp Key:        ECDH X25519 253 bits
TLS Server Name:        repo.maven.apache.org

Document Path:          /maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.tar.gz
Document Length:        9233336 bytes

Concurrency Level:      1
Time taken for tests:   0.936 seconds
Complete requests:      5
Failed requests:        0
Keep-Alive requests:    5
Total transferred:      46169010 bytes
HTML transferred:       46166680 bytes
Requests per second:    5.34 [#/sec] (mean)
Time per request:       187.165 [ms] (mean)
Time per request:       187.165 [ms] (mean, across all concurrent requests)
Transfer rate:          48178.75 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0   15  33.1      0      74
Processing:   142  172  28.0    175     214
Waiting:       30   33   2.8     35      37
Total:        142  187  48.7    189     260

Percentage of the requests served within a certain time (ms)
  50%    165
  66%    214
  75%    214
  80%    260
  90%    260
  95%    260
  98%    260
  99%    260
 100%    260 (longest request)
```

#### Hash comparison of binary from both URLs

```shell
$ curl -sL https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz | md5sum
9792c717f5845d952907d5144b8253c3  -
$ curl -sL https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | md5sum
9792c717f5845d952907d5144b8253c3  -
```


### Summary and Changelog

1. Bumped `apache-maven` binary from **3.6.3** -> **3.9.12**
2. Added retries, i.e. 3 retires before failing when downloading `apache-maven` binary
3. Download `apache-maven` binary from `repo.apache.org` instead of `archive.apache.org`

### Impact

More stable CI / docker test stages

### Risk Level

None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
